### PR TITLE
fixed errors in test files to allow 'make test' to run

### DIFF
--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -8,18 +8,11 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_FindCatalogItem(c *C) {
-
-	// Get the Org populated
-	testServer.Response(200, nil, orgExample)
-	org, err := s.vdc.GetVDCOrg()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
+func (vcd *TestVCD) Test_FindCatalogItem(c *C) {
 
 	// Populate Catalog
 	testServer.Response(200, nil, catalogExample)
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -8,18 +8,11 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_GetVAppTemplate(c *C) {
-
-	// Get the Org populated
-	testServer.Response(200, nil, orgExample)
-	org, err := s.vdc.GetVDCOrg()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
+func (vcd *TestVCD) Test_GetVAppTemplate(c *C) {
 
 	// Populate Catalog
 	testServer.Response(200, nil, catalogExample)
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -10,15 +10,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_Refresh(c *C) {
+func (vcd *TestVCD) Test_Refresh(c *C) {
 
-	// Get the Org populated
 	testServer.ResponseMap(2, testutil.ResponseMap{
 		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
 		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
 	})
 
-	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
 	_ = testServer.WaitRequests(2)
 	testServer.Flush()
 
@@ -35,13 +34,13 @@ func (s *TestVCD) Test_Refresh(c *C) {
 
 }
 
-func (s *S) Test_NATMapping(c *C) {
+func (vcd *TestVCD) Test_NATMapping(c *C) {
 	testServer.ResponseMap(2, testutil.ResponseMap{
 		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
 		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
 	})
 
-	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
 	_ = testServer.WaitRequests(2)
 	testServer.Flush()
 
@@ -70,13 +69,13 @@ func (s *S) Test_NATMapping(c *C) {
 
 }
 
-func (s *S) Test_NATPortMapping(c *C) {
+func (vcd *TestVCD) Test_NATPortMapping(c *C) {
 	testServer.ResponseMap(2, testutil.ResponseMap{
 		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
 		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
 	})
 
-	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
 	_ = testServer.WaitRequests(2)
 	testServer.Flush()
 
@@ -105,14 +104,14 @@ func (s *S) Test_NATPortMapping(c *C) {
 
 }
 
-func (s *S) Test_1to1Mappings(c *C) {
+func (vcd *TestVCD) Test_1to1Mappings(c *C) {
 
 	testServer.ResponseMap(2, testutil.ResponseMap{
 		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
 		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
 	})
 
-	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
 	_ = testServer.WaitRequests(2)
 	testServer.Flush()
 
@@ -141,13 +140,13 @@ func (s *S) Test_1to1Mappings(c *C) {
 
 }
 
-func (s *S) Test_AddIpsecVPN(c *C) {
+func (vcd *TestVCD) Test_AddIpsecVPN(c *C) {
 	testServer.ResponseMap(2, testutil.ResponseMap{
 		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
 		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
 	})
 
-	edge, err := s.vdc.FindEdgeGateway("M916272752-5793")
+	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
 	_ = testServer.WaitRequests(2)
 	testServer.Flush()
 
@@ -196,15 +195,15 @@ func (s *S) Test_AddIpsecVPN(c *C) {
 
 var edgegatewayqueryresultsExample = `
 <QueryResultRecords xmlns="http://www.vmware.com/vcloud/v1.5" name="edgeGateway" page="1" pageSize="25" total="1" href="http://localhost:4444/api/admin/vdc/00000000-0000-0000-0000-000000000000/edgeGateways?page=1&amp;pageSize=25&amp;format=records" type="application/vnd.vmware.vcloud.query.records+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.6.32.3/api/v1.5/schema/master.xsd">
-    <Link rel="alternate" href="http://localhost:4444/api/admin/vdc/00000000-0000-0000-0000-000000000000/edgeGateways?page=1&amp;pageSize=25&amp;format=references" type="application/vnd.vmware.vcloud.query.references+xml"/>
-    <Link rel="alternate" href="http://localhost:4444/api/admin/vdc/00000000-0000-0000-0000-000000000000/edgeGateways?page=1&amp;pageSize=25&amp;format=idrecords" type="application/vnd.vmware.vcloud.query.idrecords+xml"/>
+    <Link rel="alternate" href="http://localhost:4444/api/admin/vdc/00000000-0000-0000-0000-000000000001/edgeGateways?page=1&amp;pageSize=25&amp;format=references" type="application/vnd.vmware.vcloud.query.references+xml"/>
+    <Link rel="alternate" href="http://localhost:4444/api/admin/vdc/00000000-0000-0000-0000-000000000001/edgeGateways?page=1&amp;pageSize=25&amp;format=idrecords" type="application/vnd.vmware.vcloud.query.idrecords+xml"/>
     <EdgeGatewayRecord gatewayStatus="READY" haStatus="UP" isBusy="false" name="M916272752-5793" numberOfExtNetworks="1" numberOfOrgNetworks="2" vdc="http://localhost:4444/api/vdc/00000000-0000-0000-0000-000000000000" href="http://localhost:4444/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000" isSyslogServerSettingInSync="true" taskStatus="success" taskOperation="networkConfigureEdgeGatewayServices" task="http://localhost:4444/api/task/eca0d70f-36e0-428a-93c2-311b792f3326" taskDetails=" "/>
 </QueryResultRecords>
 `
 
 var edgegatewayExample = `
 <EdgeGateway xmlns="http://www.vmware.com/vcloud/v1.5" status="1" name="M916272752-5793" id="urn:vcloud:gateway:00000000-0000-0000-0000-000000000000" href="http://localhost:4444/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000" type="application/vnd.vmware.admin.edgeGateway+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.6.32.3/api/v1.5/schema/master.xsd">
-    <Link rel="up" href="http://localhost:4444/api/vdc/214cd6b2-3f7a-4ee5-9b0a-52b4001a4a84" type="application/vnd.vmware.vcloud.vdc+xml"/>
+    <Link rel="up" href="http://localhost:4444/api/vdc/00000000-0000-0000-0000-000000000001" type="application/vnd.vmware.vcloud.vdc+xml"/>
     <Link rel="edgeGateway:redeploy" href="http://localhost:4444/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/redeploy"/>
     <Link rel="edgeGateway:configureServices" href="http://localhost:4444/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices" type="application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml"/>
     <Link rel="edgeGateway:reapplyServices" href="http://localhost:4444/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/reapplyServices"/>

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -8,18 +8,11 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_FindCatalog(c *C) {
-
-	// Get the Org populated
-	testServer.Response(200, nil, orgExample)
-	org, err := s.vdc.GetVDCOrg()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
+func (vcd *TestVCD) Test_FindCatalog(c *C) {
 
 	// Find Catalog
 	testServer.Response(200, nil, catalogExample)
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 	c.Assert(err, IsNil)

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -10,14 +10,13 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_NetRefresh(c *C) {
+func (vcd *TestVCD) Test_NetRefresh(c *C) {
 
-	// Get the Org populated
 	testServer.ResponseMap(1, testutil.ResponseMap{
 		"/api/network/44444444-4444-4444-4444-4444444444444": testutil.Response{200, nil, orgvdcnetExample},
 	})
 
-	network, err := s.vdc.FindVDCNetwork("networkName")
+	network, err := vcd.vdc.FindVDCNetwork("networkName")
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -10,14 +10,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_Query(c *C) {
+func (vcd *TestVCD) Test_Query(c *C) {
 
 	// Get the Org populated
 	testServer.ResponseMap(1, testutil.ResponseMap{
 		"/api/query?type=vm": testutil.Response{200, nil, queryVmExample},
 	})
 
-	results, err := s.client.Query(map[string]string{"type": "vm"})
+	results, err := vcd.client.Query(map[string]string{"type": "vm"})
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 

--- a/govcd/task_test.go
+++ b/govcd/task_test.go
@@ -8,10 +8,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_WaitTaskCompletion(c *C) {
+func (vcd *TestVCD) Test_WaitTaskCompletion(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Deploy()
+	task, err := vcd.vapp.Deploy()
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 	c.Assert(err, IsNil)

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -11,7 +11,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_ComposeVApp(c *C) {
+func (vcd *TestVCD) Test_ComposeVApp(c *C) {
 
 	testServer.ResponseMap(7, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
@@ -23,18 +23,14 @@ func (s *TestVCD) Test_ComposeVApp(c *C) {
 		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                 testutil.Response{200, nil, vappExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -46,16 +42,16 @@ func (s *TestVCD) Test_ComposeVApp(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	status, err := s.vapp.GetStatus()
+	status, err := vcd.vapp.GetStatus()
 
 	c.Assert(err, IsNil)
 	c.Assert(status, Equals, "POWERED_OFF")
@@ -64,10 +60,10 @@ func (s *TestVCD) Test_ComposeVApp(c *C) {
 
 }
 
-func (s *S) Test_PowerOn(c *C) {
+func (vcd *TestVCD) Test_PowerOn(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.PowerOn()
+	task, err := vcd.vapp.PowerOn()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -75,10 +71,10 @@ func (s *S) Test_PowerOn(c *C) {
 
 }
 
-func (s *S) Test_PowerOff(c *C) {
+func (vcd *TestVCD) Test_PowerOff(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.PowerOff()
+	task, err := vcd.vapp.PowerOff()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -86,10 +82,10 @@ func (s *S) Test_PowerOff(c *C) {
 
 }
 
-func (s *S) Test_Reboot(c *C) {
+func (vcd *TestVCD) Test_Reboot(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Reboot()
+	task, err := vcd.vapp.Reboot()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -97,7 +93,7 @@ func (s *S) Test_Reboot(c *C) {
 
 }
 
-func (s *S) Test_SetOvf(c *C) {
+func (vcd *TestVCD) Test_SetOvf(c *C) {
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
 		"/api/network/44444444-4444-4444-4444-4444444444444":                  testutil.Response{200, nil, orgvdcnetExample},
@@ -110,12 +106,11 @@ func (s *S) Test_SetOvf(c *C) {
 	})
 
 	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
+	org := vcd.org
 
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
@@ -132,19 +127,19 @@ func (s *S) Test_SetOvf(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
 	var test map[string]string
 	test = make(map[string]string)
 	test["guestinfo.hostname"] = "testhostname"
-	task, err = s.vapp.SetOvf(test)
+	task, err = vcd.vapp.SetOvf(test)
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -153,7 +148,7 @@ func (s *S) Test_SetOvf(c *C) {
 
 }
 
-func (s *S) Test_AddMetadata(c *C) {
+func (vcd *TestVCD) Test_AddMetadata(c *C) {
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
 		"/api/network/44444444-4444-4444-4444-4444444444444":                  testutil.Response{200, nil, orgvdcnetExample},
@@ -165,18 +160,14 @@ func (s *S) Test_AddMetadata(c *C) {
 		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/metadata/key":      testutil.Response{200, nil, taskExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -188,16 +179,16 @@ func (s *S) Test_AddMetadata(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.AddMetadata("key", "value")
+	task, err = vcd.vapp.AddMetadata("key", "value")
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -206,7 +197,7 @@ func (s *S) Test_AddMetadata(c *C) {
 
 }
 
-func (s *S) Test_ChangeStorageProfile(c *C) {
+func (vcd *TestVCD) Test_ChangeStorageProfile(c *C) {
 
 	testServer.ResponseMap(9, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
@@ -220,18 +211,14 @@ func (s *S) Test_ChangeStorageProfile(c *C) {
 		"/api/vdc/00000000-0000-0000-0000-000000000000":                       testutil.Response{200, nil, vdcExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -243,16 +230,16 @@ func (s *S) Test_ChangeStorageProfile(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.ChangeStorageProfile("storageProfile2")
+	task, err = vcd.vapp.ChangeStorageProfile("storageProfile2")
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -261,7 +248,7 @@ func (s *S) Test_ChangeStorageProfile(c *C) {
 
 }
 
-func (s *S) Test_ChangeVMName(c *C) {
+func (vcd *TestVCD) Test_ChangeVMName(c *C) {
 
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
@@ -274,18 +261,14 @@ func (s *S) Test_ChangeVMName(c *C) {
 		"/api/vApp/vm-00000000-0000-0000-0000-000000000000":                   testutil.Response{200, nil, taskExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -297,16 +280,16 @@ func (s *S) Test_ChangeVMName(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.ChangeVMName("My-vm")
+	task, err = vcd.vapp.ChangeVMName("My-vm")
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -315,10 +298,10 @@ func (s *S) Test_ChangeVMName(c *C) {
 
 }
 
-func (s *S) Test_Reset(c *C) {
+func (vcd *TestVCD) Test_Reset(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Reset()
+	task, err := vcd.vapp.Reset()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -326,10 +309,10 @@ func (s *S) Test_Reset(c *C) {
 
 }
 
-func (s *S) Test_Suspend(c *C) {
+func (vcd *TestVCD) Test_Suspend(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Suspend()
+	task, err := vcd.vapp.Suspend()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -337,10 +320,10 @@ func (s *S) Test_Suspend(c *C) {
 
 }
 
-func (s *S) Test_Shutdown(c *C) {
+func (vcd *TestVCD) Test_Shutdown(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Shutdown()
+	task, err := vcd.vapp.Shutdown()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -348,10 +331,10 @@ func (s *S) Test_Shutdown(c *C) {
 
 }
 
-func (s *S) Test_Undeploy(c *C) {
+func (vcd *TestVCD) Test_Undeploy(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Undeploy()
+	task, err := vcd.vapp.Undeploy()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -359,10 +342,10 @@ func (s *S) Test_Undeploy(c *C) {
 
 }
 
-func (s *S) Test_Deploy(c *C) {
+func (vcd *TestVCD) Test_Deploy(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Deploy()
+	task, err := vcd.vapp.Deploy()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -370,10 +353,10 @@ func (s *S) Test_Deploy(c *C) {
 
 }
 
-func (s *S) Test_Delete(c *C) {
+func (vcd *TestVCD) Test_Delete(c *C) {
 
 	testServer.Response(200, nil, taskExample)
-	task, err := s.vapp.Delete()
+	task, err := vcd.vapp.Delete()
 	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
@@ -381,7 +364,7 @@ func (s *S) Test_Delete(c *C) {
 
 }
 
-func (s *S) Test_RunCustomizationScript(c *C) {
+func (vcd *TestVCD) Test_RunCustomizationScript(c *C) {
 
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                                testutil.Response{200, nil, orgExample},
@@ -394,18 +377,14 @@ func (s *S) Test_RunCustomizationScript(c *C) {
 		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/guestCustomizationSection/": testutil.Response{200, nil, taskExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -417,16 +396,16 @@ func (s *S) Test_RunCustomizationScript(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.RunCustomizationScript("computername", "this is my script")
+	task, err = vcd.vapp.RunCustomizationScript("computername", "this is my script")
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -435,7 +414,7 @@ func (s *S) Test_RunCustomizationScript(c *C) {
 
 }
 
-func (s *S) Test_ChangeCPUcount(c *C) {
+func (vcd *TestVCD) Test_ChangeCPUcount(c *C) {
 
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                                testutil.Response{200, nil, orgExample},
@@ -448,18 +427,14 @@ func (s *S) Test_ChangeCPUcount(c *C) {
 		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/virtualHardwareSection/cpu": testutil.Response{200, nil, taskExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -471,16 +446,16 @@ func (s *S) Test_ChangeCPUcount(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.ChangeCPUcount(2)
+	task, err = vcd.vapp.ChangeCPUcount(2)
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")
@@ -489,7 +464,7 @@ func (s *S) Test_ChangeCPUcount(c *C) {
 
 }
 
-func (s *S) Test_ChangeMemorySize(c *C) {
+func (vcd *TestVCD) Test_ChangeMemorySize(c *C) {
 
 	testServer.ResponseMap(8, testutil.ResponseMap{
 		"/api/org/11111111-1111-1111-1111-111111111111":                                   testutil.Response{200, nil, orgExample},
@@ -502,18 +477,14 @@ func (s *S) Test_ChangeMemorySize(c *C) {
 		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/virtualHardwareSection/memory": testutil.Response{200, nil, taskExample},
 	})
 
-	// Get the Org populated
-	org, err := s.vdc.GetVDCOrg()
-	c.Assert(err, IsNil)
-
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 	networks = append(networks, net.OrgVDCNetwork)
 	c.Assert(err, IsNil)
 
 	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
+	cat, err := vcd.org.FindCatalog("Public Catalog")
 	c.Assert(err, IsNil)
 
 	// Populate Catalog Item
@@ -525,16 +496,16 @@ func (s *S) Test_ChangeMemorySize(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get StorageProfileReference
-	storageprofileref, err := s.vdc.FindStorageProfileReference("storageProfile1")
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
 	c.Assert(err, IsNil)
 
 	// Compose VApp
-	task, err := s.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
+	task, err := vcd.vapp.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(s.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
+	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
 
-	task, err = s.vapp.ChangeMemorySize(4096)
+	task, err = vcd.vapp.ChangeMemorySize(4096)
 
 	c.Assert(err, IsNil)
 	c.Assert(task.Task.Status, Equals, "success")

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 )
 
-func (s *TestVCD) Test_FindVDCNetwork(c *C) {
+func (vcd *TestVCD) Test_FindVDCNetwork(c *C) {
 
 	testServer.Response(200, nil, orgvdcnetExample)
 
-	net, err := s.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork("networkName")
 
 	_ = testServer.WaitRequest()
 
@@ -24,37 +24,24 @@ func (s *TestVCD) Test_FindVDCNetwork(c *C) {
 	c.Assert(net.OrgVDCNetwork.HREF, Equals, "http://localhost:4444/api/network/cb0f4c9e-1a46-49d4-9fcb-d228000a6bc1")
 
 	// find Invalid Network
-	net, err = s.vdc.FindVDCNetwork("INVALID")
+	net, err = vcd.vdc.FindVDCNetwork("INVALID")
 	c.Assert(err, NotNil)
 }
 
-func (s *TestVCD) Test_GetVDCOrg(c *C) {
-
-	testServer.Response(200, nil, orgExample)
-
-	org, err := s.vdc.GetVDCOrg()
-
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(org, NotNil)
-	c.Assert(org.Org.HREF, Equals, "http://localhost:4444/api/org/23bd2339-c55f-403c-baf3-13109e8c8d57")
-}
-
-func (s *TestVCD) Test_NewVdc(c *C) {
+func (vcd *TestVCD) Test_NewVdc(c *C) {
 
 	testServer.Response(200, nil, vdcExample)
-	err := s.vdc.Refresh()
+	err := vcd.vdc.Refresh()
 	_ = testServer.WaitRequest()
 	c.Assert(err, IsNil)
 
-	c.Assert(s.vdc.Vdc.Link[0].Rel, Equals, "up")
-	c.Assert(s.vdc.Vdc.Link[0].Type, Equals, "application/vnd.vmware.vcloud.org+xml")
-	c.Assert(s.vdc.Vdc.Link[0].HREF, Equals, "http://localhost:4444/api/org/11111111-1111-1111-1111-111111111111")
+	c.Assert(vcd.vdc.Vdc.Link[0].Rel, Equals, "up")
+	c.Assert(vcd.vdc.Vdc.Link[0].Type, Equals, "application/vnd.vmware.vcloud.org+xml")
+	c.Assert(vcd.vdc.Vdc.Link[0].HREF, Equals, "http://localhost:4444/api/org/11111111-1111-1111-1111-111111111111")
 
-	c.Assert(s.vdc.Vdc.AllocationModel, Equals, "AllocationPool")
+	c.Assert(vcd.vdc.Vdc.AllocationModel, Equals, "AllocationPool")
 
-	for _, v := range s.vdc.Vdc.ComputeCapacity {
+	for _, v := range vcd.vdc.Vdc.ComputeCapacity {
 		c.Assert(v.CPU.Units, Equals, "MHz")
 		c.Assert(v.CPU.Allocated, Equals, int64(30000))
 		c.Assert(v.CPU.Limit, Equals, int64(30000))
@@ -69,11 +56,11 @@ func (s *TestVCD) Test_NewVdc(c *C) {
 		c.Assert(v.Memory.Overhead, Equals, int64(95))
 	}
 
-	c.Assert(s.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Name, Equals, "vAppTemplate")
-	c.Assert(s.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Type, Equals, "application/vnd.vmware.vcloud.vAppTemplate+xml")
-	c.Assert(s.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-22222222-2222-2222-2222-222222222222")
+	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Name, Equals, "vAppTemplate")
+	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Type, Equals, "application/vnd.vmware.vcloud.vAppTemplate+xml")
+	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-22222222-2222-2222-2222-222222222222")
 
-	for _, v := range s.vdc.Vdc.AvailableNetworks {
+	for _, v := range vcd.vdc.Vdc.AvailableNetworks {
 		for _, v2 := range v.Network {
 			c.Assert(v2.Name, Equals, "networkName")
 			c.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.network+xml")
@@ -81,13 +68,13 @@ func (s *TestVCD) Test_NewVdc(c *C) {
 		}
 	}
 
-	c.Assert(s.vdc.Vdc.NicQuota, Equals, 0)
-	c.Assert(s.vdc.Vdc.NetworkQuota, Equals, 20)
-	c.Assert(s.vdc.Vdc.UsedNetworkCount, Equals, 0)
-	c.Assert(s.vdc.Vdc.VMQuota, Equals, 0)
-	c.Assert(s.vdc.Vdc.IsEnabled, Equals, true)
+	c.Assert(vcd.vdc.Vdc.NicQuota, Equals, 0)
+	c.Assert(vcd.vdc.Vdc.NetworkQuota, Equals, 20)
+	c.Assert(vcd.vdc.Vdc.UsedNetworkCount, Equals, 0)
+	c.Assert(vcd.vdc.Vdc.VMQuota, Equals, 0)
+	c.Assert(vcd.vdc.Vdc.IsEnabled, Equals, true)
 
-	for _, v := range s.vdc.Vdc.VdcStorageProfiles {
+	for _, v := range vcd.vdc.Vdc.VdcStorageProfiles {
 		for i, v2 := range v.VdcStorageProfile {
 			c.Assert(v2.Name, Equals, "storageProfile"+strconv.Itoa(i+1))
 			c.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
@@ -97,7 +84,7 @@ func (s *TestVCD) Test_NewVdc(c *C) {
 
 }
 
-func (s *TestVCD) Test_FindVApp(c *C) {
+func (vcd *TestVCD) Test_FindVApp(c *C) {
 
 	// testServer.Response(200, nil, vappExample)
 
@@ -112,7 +99,7 @@ func (s *TestVCD) Test_FindVApp(c *C) {
 		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, vappExample},
 	})
 
-	_, err := s.vdc.FindVAppByName("myVApp")
+	_, err := vcd.vdc.FindVAppByName("myVApp")
 
 	_ = testServer.WaitRequests(2)
 
@@ -123,7 +110,7 @@ func (s *TestVCD) Test_FindVApp(c *C) {
 		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, vappExample},
 	})
 
-	_, err = s.vdc.FindVAppByID("urn:vcloud:vapp:00000000-0000-0000-0000-000000000000")
+	_, err = vcd.vdc.FindVAppByID("urn:vcloud:vapp:00000000-0000-0000-0000-000000000000")
 
 	_ = testServer.WaitRequests(2)
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -9,7 +9,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *TestVCD) Test_FindVMByHREF(c *C) {
+func (vcd *TestVCD) Test_FindVMByHREF(c *C) {
 
 	// Get the Org populated
 	testServer.ResponseMap(1, testutil.ResponseMap{
@@ -17,7 +17,7 @@ func (s *TestVCD) Test_FindVMByHREF(c *C) {
 	})
 
 	vm_href := vcdu_api.String() + "/vApp/vm-11111111-1111-1111-1111-111111111111"
-	vm, err := s.client.FindVMByHREF(vm_href)
+	vm, err := vcd.client.FindVMByHREF(vm_href)
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 


### PR DESCRIPTION
The previous tests written by the govcloudair guys were pretty buggy. This commit allows users to run "make test", and "go test" without running into errors. Now it should be easy to reorganize and reformat test code, and also write test code. Also a fixed a test errors from my last pull request. First off I dealt with the variable S still being in some of the test code. These instances are all changed to TestVCD. Then I changed all methods that use getVdcOrg to just use the org within the TestVCD variable. I also added a Vapp element to the TestVCD struct to keep it consistent to the old vca tests, since all the test code was written for vca. Fixing the current test problems is the first step to changing the structure of testing.

Signed-off-by: auppunda <auppunda@gmail.com>