### PR TITLE
Cleaned up connection

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -21,7 +21,7 @@ type Client struct {
 	APIVersion    string      // The API version required
 	VCDToken      string      // Access Token (authorization header)
 	VCDAuthHeader string      // Authorization header
-	VCDVDCHREF    url.URL     // HREF of the backend VDC you're using
+	HREF    	  url.URL    		 // HREF of the VCD Endpoint you're using
 	Http          http.Client // HttpClient is the client to use. Default will be used if not provided.
 }
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -3,7 +3,6 @@ package govcd
 import (
 	"crypto/tls"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,18 +11,10 @@ import (
 )
 
 type VCDClient struct {
-	OrgHREF     url.URL // vCloud Director OrgRef
-	Org         Org     // Org
-	OrgVdc      Vdc     // Org vDC
 	Client      Client  // Client for the underlying VCD instance
 	sessionHREF url.URL // HREF for the session API
 	QueryHREF   url.URL // HREF for the query API
 	Mutex       sync.Mutex
-}
-
-// Session object for session response
-type session struct {
-	Link []*types.Link `xml:"Link"`
 }
 
 type supportedVersions struct {
@@ -33,9 +24,10 @@ type supportedVersions struct {
 	} `xml:"VersionInfo"`
 }
 
+
 func (c *VCDClient) vcdloginurl() error {
 
-	s := c.Client.VCDVDCHREF
+	s := c.Client.HREF
 	s.Path += "/versions"
 
 	// No point in checking for errors here
@@ -63,6 +55,9 @@ func (c *VCDClient) vcdloginurl() error {
 	return nil
 }
 
+
+// VCD authorize creates a session if the username, password, and
+// org is valid.
 func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 
 	if user == "" {
@@ -96,98 +91,21 @@ func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 	c.Client.VCDToken = resp.Header.Get("x-vcloud-authorization")
 	c.Client.VCDAuthHeader = "x-vcloud-authorization"
 
-	session := new(session)
-	err = decodeBody(resp, session)
+	// Gets Query HREF for future use
+	u := c.Client.HREF
+	u.Path += "/query"
+	c.QueryHREF = u
 
-	if err != nil {
-		fmt.Errorf("error decoding session response: %s", err)
-	}
-
-	org_found := false
-	// Loop in the session struct to find the organization and query api.
-	for _, s := range session.Link {
-		if s.Type == "application/vnd.vmware.vcloud.org+xml" && s.Rel == "down" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a Organization in current session, %v", err)
-			}
-			c.OrgHREF = *u
-			org_found = true
-		}
-		if s.Type == "application/vnd.vmware.vcloud.query.queryList+xml" && s.Rel == "down" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a Query API in current session, %v", err)
-			}
-			c.QueryHREF = *u
-		}
-	}
-	if !org_found {
-		return fmt.Errorf("couldn't find a Organization in current session")
-	}
-
-	// Loop in the session struct to find the session url.
-	session_found := false
-	for _, s := range session.Link {
-		if s.Rel == "remove" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a logout HREF in current session, %v", err)
-			}
-			c.sessionHREF = *u
-			session_found = true
-		}
-	}
-	if !session_found {
-		return fmt.Errorf("couldn't find a logout HREF in current session")
-	}
 	return nil
 }
 
-func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
-
-	req := c.Client.NewRequest(map[string]string{}, "GET", c.OrgHREF, nil)
-	req.Header.Add("Accept", "application/*+xml;version=5.5")
-
-	// TODO: wrap into checkresp to parse error
-	resp, err := checkResp(c.Client.Http.Do(req))
-	if err != nil {
-		return Org{}, fmt.Errorf("error retreiving org: %s", err)
-	}
-
-	org := NewOrg(&c.Client)
-
-	if err = decodeBody(resp, org.Org); err != nil {
-		return Org{}, fmt.Errorf("error decoding org response: %s", err)
-	}
-
-	// Get the VDC ref from the Org
-	for _, s := range org.Org.Link {
-		if s.Type == "application/vnd.vmware.vcloud.vdc+xml" && s.Rel == "down" {
-			if vcdname != "" && s.Name != vcdname {
-				continue
-			}
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return Org{}, err
-			}
-			c.Client.VCDVDCHREF = *u
-		}
-	}
-
-	if &c.Client.VCDVDCHREF == nil {
-		return Org{}, fmt.Errorf("error finding the organization VDC HREF")
-	}
-
-	return *org, nil
-}
-
+// NewVCDClient returns a new VCDClient object with endpoint vcdEndpoint.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 
 	return &VCDClient{
 		Client: Client{
 			APIVersion: "5.5",
-			VCDVDCHREF: vcdEndpoint,
+			HREF: vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
@@ -202,32 +120,20 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 }
 
 // Authenticate is an helper function that performs a login in vCloud Director.
-func (c *VCDClient) Authenticate(username, password, org, vdcname string) (Org, Vdc, error) {
+func (c *VCDClient) Authenticate(username, password, org string) (error) {
 
 	// LoginUrl
 	err := c.vcdloginurl()
 	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error finding LoginUrl: %s", err)
+		return fmt.Errorf("error finding LoginUrl: %s", err)
 	}
 	// Authorize
 	err = c.vcdauthorize(username, password, org)
 	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error authorizing: %s", err)
+		return fmt.Errorf("error authorizing: %s", err)
 	}
 
-	// Get Org
-	o, err := c.RetrieveOrg(vdcname)
-	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error acquiring Org: %s", err)
-	}
-
-	vdc, err := c.Client.retrieveVDC()
-
-	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error retrieving the organization VDC")
-	}
-
-	return o, vdc, nil
+	return nil
 }
 
 // Disconnect performs a disconnection from the vCloud Director API endpoint.

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -33,6 +33,33 @@ func (v *VCDClient) NewVApp(c *Client) VApp {
 	return *newvapp
 }
 
+// GetParentVdc returns the vdc the vapp resides in.
+func (v *VApp) getParentVDC() (Vdc, error) {
+	for _, a := range v.VApp.Link {
+		if a.Type == "application/vnd.vmware.vcloud.vdc+xml" {
+			u, err := url.ParseRequestURI(a.HREF)
+
+			if err != nil {
+				return Vdc{}, fmt.Errorf("Cannot parse HREF : %v", err)
+			}
+
+			req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+
+			resp, err := checkResp(v.c.Http.Do(req))
+
+			vdc := NewVdc(v.c)
+
+			if err = decodeBody(resp, vdc.Vdc); err != nil {
+				return Vdc{}, fmt.Errorf("error decoding task response: %s", err)
+			}
+
+			return *vdc, nil
+
+		}
+	}
+	return Vdc{}, fmt.Errorf("Could not find a parent Vdc")
+}
+
 func (v *VApp) Refresh() error {
 
 	if v.VApp.HREF == "" {
@@ -181,108 +208,6 @@ func (v *VApp) RemoveVM(vm VM) error {
 	}
 
 	return nil
-}
-
-func (v *VApp) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string) (Task, error) {
-
-	if vapptemplate.VAppTemplate.Children == nil || orgvdcnetworks == nil {
-		return Task{}, fmt.Errorf("can't compose a new vApp, objects passed are not valid")
-	}
-
-	// Build request XML
-	vcomp := &types.ComposeVAppParams{
-		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
-		Deploy:      false,
-		Name:        name,
-		PowerOn:     false,
-		Description: description,
-		InstantiationParams: &types.InstantiationParams{
-			NetworkConfigSection: &types.NetworkConfigSection{
-				Info: "Configuration parameters for logical networks",
-			},
-		},
-		SourcedItem: &types.SourcedCompositionItemParam{
-			Source: &types.Reference{
-				HREF: vapptemplate.VAppTemplate.Children.VM[0].HREF,
-				Name: vapptemplate.VAppTemplate.Children.VM[0].Name,
-			},
-			InstantiationParams: &types.InstantiationParams{
-				NetworkConnectionSection: &types.NetworkConnectionSection{
-					Type: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.Type,
-					HREF: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.HREF,
-					Info: "Network config for sourced item",
-					PrimaryNetworkConnectionIndex: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.PrimaryNetworkConnectionIndex,
-				},
-			},
-		},
-	}
-
-	for index, orgvdcnetwork := range orgvdcnetworks {
-		vcomp.InstantiationParams.NetworkConfigSection.NetworkConfig = append(vcomp.InstantiationParams.NetworkConfigSection.NetworkConfig,
-			types.VAppNetworkConfiguration{
-				NetworkName: orgvdcnetwork.Name,
-				Configuration: &types.NetworkConfiguration{
-					FenceMode: "bridged",
-					ParentNetwork: &types.Reference{
-						HREF: orgvdcnetwork.HREF,
-						Name: orgvdcnetwork.Name,
-						Type: orgvdcnetwork.Type,
-					},
-				},
-			},
-		)
-		vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
-			&types.NetworkConnection{
-				Network:                 orgvdcnetwork.Name,
-				NetworkConnectionIndex:  index,
-				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
-			},
-		)
-		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
-			&types.NetworkAssignment{
-				InnerNetwork:     orgvdcnetwork.Name,
-				ContainerNetwork: orgvdcnetwork.Name,
-			},
-		)
-	}
-
-	if storageprofileref.HREF != "" {
-		vcomp.SourcedItem.StorageProfile = &storageprofileref
-	}
-
-	output, err := xml.MarshalIndent(vcomp, "  ", "    ")
-	if err != nil {
-		return Task{}, fmt.Errorf("error marshaling vapp compose: %s", err)
-	}
-
-	log.Printf("\n\nXML DEBUG: %s\n\n", string(output))
-
-	b := bytes.NewBufferString(xml.Header + string(output))
-
-	s := v.c.VCDVDCHREF
-	s.Path += "/action/composeVApp"
-
-	req := v.c.NewRequest(map[string]string{}, "POST", s, b)
-
-	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.composeVAppParams+xml")
-
-	resp, err := checkResp(v.c.Http.Do(req))
-	if err != nil {
-		return Task{}, fmt.Errorf("error instantiating a new vApp: %s", err)
-	}
-
-	if err = decodeBody(resp, v.VApp); err != nil {
-		return Task{}, fmt.Errorf("error decoding vApp response: %s", err)
-	}
-
-	task := NewTask(v.c)
-	task.Task = v.VApp.Tasks.Task[0]
-
-	// The request was successful
-	return *task, nil
 }
 
 func (v *VApp) PowerOn() (Task, error) {
@@ -711,7 +636,7 @@ func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	vdc, err := v.c.retrieveVDC()
+	vdc, err := v.getParentVDC()
 	storageprofileref, err := vdc.FindStorageProfileReference(name)
 
 	newprofile := &types.VM{

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	"bytes"
 	"encoding/xml"
+	"net/url"
 	"fmt"
 	types "github.com/vmware/go-vcloud-director/types/v56"
 )
@@ -30,10 +31,15 @@ func (v *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplatePar
 	}
 	b := bytes.NewBufferString(xml.Header + string(output))
 
-	s := v.c.VCDVDCHREF
+	s, err := url.ParseRequestURI(v.Vdc.HREF)
+
+	if err != nil {
+		return fmt.Errorf("error parsing vdc HREF: %v", err)
+	}
+
 	s.Path += "/action/instantiateVAppTemplate"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", s, b)
+	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml")
 
 	resp, err := checkResp(v.c.Http.Do(req))


### PR DESCRIPTION
I removed the reliance on vcdvdcHref, replacing it with vdc.Vdc.HREF. I also removed the retrieveVdc and retrieveOrg as these methods where static and based on the org that the user passes into the authenticate. I removed Org, OrgHref, and OrgVdc from the VCDClient class as well, since we want our api to be connection should not be scoped into a specific org and vdc. I added in a private function getParentVdc to allow a vapp to retrieve its parent VDC without using the vdc saved in the connection when authenticated

Signed-off-by: auppunda <auppunda@gmail.com>