### PR TITLE
removed unnecessary cached data in vcdclient and cleaned up authenticate method

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -22,6 +22,7 @@ type Client struct {
 	VCDToken      string      // Access Token (authorization header)
 	VCDAuthHeader string      // Authorization header
 	VCDVDCHREF    url.URL     // HREF of the backend VDC you're using
+	HREF          url.URL  	  // the api endpoint for VCD
 	Http          http.Client // HttpClient is the client to use. Default will be used if not provided.
 }
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -45,7 +45,7 @@ func (vcd *TestVCD) SetUpSuite(c *C) {
 		"/api/vdc/00000000-0000-0000-0000-000000000000": testutil.Response{201, vcdauthheader, vcdvdc},
 	})
 
-	vcd.org, vcd.vdc, err = vcd.client.Authenticate("username", "password", "organization", "organization vDC")
+	err = vcd.client.Authenticate("username", "password", "organization")
 	vcd.vapp = *NewVApp(&vcd.client.Client)
 	if err != nil {
 		panic(err)
@@ -101,15 +101,12 @@ func TestVCDClient_Authenticate(t *testing.T) {
 		"/api/vdc/00000000-0000-0000-0000-000000000000": testutil.Response{201, vcdauthheader, vcdorg},
 	})
 
-	org, _, err := client.Authenticate("username", "password", "organization", "organization vDC")
+	err = client.Authenticate("username", "password", "organization")
 	testServer.Flush()
 	if err != nil {
 		t.Fatalf("Error authenticating: %v", err)
 	}
 
-	if org.Org.FullName != "Organization (full)" {
-		t.Fatalf("Orgname not parsed, got: %s", org.Org.FullName)
-	}
 }
 
 // status: 200


### PR DESCRIPTION
Removed the org, vdc, orghref from connection. Removed the searching of the session to get the sessionhref, queryhref, and orghref. Removed the retrieve org calls as authenticate no longer returns a org and vdc. It only returns an error if the authentication was unsuccessful

Signed-off-by: auppunda <auppunda@gmail.com>