### PR TITLE
org_test.go uses a real vcd connection

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -20,14 +20,18 @@ type TestConfig struct {
 		Url      string `yaml:"url"`
 	}
 	VCD struct {
-		Org string `yaml:"org"`
-		Vdc string `yaml:"vdc"`
+		Org     string `yaml:"org"`
+		Vdc     string `yaml:"vdc"`
+		Catalog struct {
+			Name        string `yaml:"name,omitempty"`
+			Description string `yaml:"description,omitempty"`
+		}
 	}
 }
 
 // Test struct for vcloud-director.
 // Test functions use the struct to get
-// an org, vdc, vapp, and client to run 
+// an org, vdc, vapp, and client to run
 // tests on
 type TestVCD struct {
 	client *VCDClient
@@ -109,7 +113,7 @@ func (vcd *TestVCD) SetUpSuite(c *C) {
 
 	// org and vdc are the test org and vdc that is used in all other test cases
 	vcd.org, vcd.vdc, err = vcd.client.Authenticate(config.Provider.User, config.Provider.Password, config.VCD.Org, config.VCD.Vdc)
-	
+
 	if err != nil {
 		panic(err)
 	}

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -8,15 +8,19 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_FindCatalog(c *C) {
+// Tests FindCatalog with Catalog in config file
+func (vcd *TestVCD) Test_FindCatalog(test *C) {
 
 	// Find Catalog
-	testServer.Response(200, nil, catalogExample)
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
-	c.Assert(cat.Catalog.Description, Equals, "vCHS service catalog")
+	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+
+	test.Assert(err, IsNil)
+	test.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
+
+	// checks if user gave a catalog description in config file
+	if vcd.config.VCD.Catalog.Description != "" {
+		test.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
+	}
 
 }
 


### PR DESCRIPTION
Added Catalog to the config file, and changed test_FindCatalog to use it

Signed-off-by: auppunda <auppunda@gmail.com>