### PR TITLE
Added in functions to get vdc and orgs by name

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -22,6 +22,7 @@ type Client struct {
 	VCDToken      string      // Access Token (authorization header)
 	VCDAuthHeader string      // Authorization header
 	VCDVDCHREF    url.URL     // HREF of the backend VDC you're using
+	VCDHREF       url.URL     // VCD API ENDPOINT
 	Http          http.Client // HttpClient is the client to use. Default will be used if not provided.
 }
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -35,7 +35,7 @@ type supportedVersions struct {
 
 func (c *VCDClient) vcdloginurl() error {
 
-	s := c.Client.VCDVDCHREF
+	s := c.Client.VCDHREF
 	s.Path += "/versions"
 
 	// No point in checking for errors here
@@ -187,7 +187,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 	return &VCDClient{
 		Client: Client{
 			APIVersion: "5.5",
-			VCDVDCHREF: vcdEndpoint,
+			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -23,6 +23,38 @@ func NewOrg(c *Client) *Org {
 	}
 }
 
+// If user specifies valid vdc name then this returns a vdc object.
+// Otherwise it returns an empty vdc and an error.
+func (o *Org) GetVdcByName(vdcname string) (Vdc, error) {
+	HREF := ""
+	for _, a := range o.Org.Link {
+		if a.Type == "application/vnd.vmware.vcloud.vdc+xml" && a.Name == vdcname {
+			HREF = a.HREF
+			break
+		}
+	}
+	if HREF == "" {
+		return Vdc{}, fmt.Errorf("Error finding VDC from VDCName")
+	}
+
+	u, err := url.ParseRequestURI(HREF)
+	if err != nil {
+		return Vdc{}, fmt.Errorf("Error parsing url: %v", err)
+	}
+	req := o.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	resp, err := checkResp(o.c.Http.Do(req))
+	if err != nil {
+		return Vdc{}, fmt.Errorf("error getting vdc: %s", err)
+	}
+
+	vdc := NewVdc(o.c)
+	if err = decodeBody(resp, vdc.Vdc); err != nil {
+		return Vdc{}, fmt.Errorf("error decoding vdc response: %s", err)
+	}
+	// The request was successful
+	return *vdc, nil
+}
+
 func (o *Org) FindCatalog(catalog string) (Catalog, error) {
 
 	for _, av := range o.Org.Link {

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -8,20 +8,23 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+// Tests org function GetVDCByName
+func (vcd *TestVCD) TestGetVdcByName(test *C) {
+	vdc, err := vcd.org.GetVdcByName(vcd.config.VCD.Vdc)
+	test.Assert(err, IsNil)
+	test.Assert(vdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
+}
+
 // Tests FindCatalog with Catalog in config file
 func (vcd *TestVCD) Test_FindCatalog(test *C) {
-
 	// Find Catalog
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-
 	test.Assert(err, IsNil)
 	test.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
-
 	// checks if user gave a catalog description in config file
 	if vcd.config.VCD.Catalog.Description != "" {
 		test.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
-
 }
 
 var orgExample = `

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -1,0 +1,54 @@
+package govcd
+
+import (
+	"fmt"
+	types "github.com/vmware/go-vcloud-director/types/v56"
+	"net/url"
+)
+
+// If user specifies a valid organization name, then this returns a
+// organization object. Otherwise it returns an error and an empty
+// Org object
+func GetOrgByName(c *VCDClient, orgname string) (Org, error) {
+	OrgHREF, err := getOrgHREF(c, orgname)
+	if err != nil {
+		return Org{}, fmt.Errorf("Cannot find the url of the org: %s", err)
+	}
+	u, err := url.ParseRequestURI(OrgHREF)
+	if err != nil {
+		return Org{}, fmt.Errorf("Error parsing org href: %v", err)
+	}
+	req := c.Client.NewRequest(map[string]string{}, "GET", *u, nil)
+	resp, err := checkResp(c.Client.Http.Do(req))
+	if err != nil {
+		return Org{}, fmt.Errorf("error retreiving org: %s", err)
+	}
+
+	o := NewOrg(&c.Client)
+	if err = decodeBody(resp, o.Org); err != nil {
+		return Org{}, fmt.Errorf("error decoding org response: %s", err)
+	}
+	return *o, nil
+}
+
+// Returns the HREF of the org with the name orgname
+func getOrgHREF(c *VCDClient, orgname string) (string, error) {
+	s := c.Client.VCDHREF
+	s.Path += "/org"
+	req := c.Client.NewRequest(map[string]string{}, "GET", s, nil)
+	resp, err := checkResp(c.Client.Http.Do(req))
+	if err != nil {
+		return "", fmt.Errorf("error retreiving org list: %s", err)
+	}
+	orgList := new(types.OrgList)
+	if err = decodeBody(resp, orgList); err != nil {
+		return "", fmt.Errorf("error decoding response: %s", err)
+	}
+	// Look for orgname within OrgList
+	for _, a := range orgList.Org {
+		if a.Name == orgname {
+			return a.HREF, nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't find org with name: %s", orgname)
+}

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,0 +1,12 @@
+package govcd
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// Tests System function GetOrgByName
+func (vcd *TestVCD) TestGetOrgByName(test *C) {
+	org, err := GetOrgByName(vcd.client, vcd.config.VCD.Org)
+	test.Assert(err, IsNil)
+	test.Assert(org.Org.Name, Equals, vcd.config.VCD.Org)
+}

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -11,6 +11,27 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+// Creates a Vapp, fetches it, gets its vdc, then deletes the vapp
+// Tests the helper function getParentVDC
+func (vcd *TestVCD) TestGetParentVDC(test *C) {
+
+	err := vcd.vdc.ComposeRawVApp("t")
+	test.Assert(err, IsNil)
+
+	v, err := vcd.vdc.FindVAppByName("t")
+	test.Assert(err, IsNil)
+
+	vdc, err := v.getParentVDC()
+
+	test.Assert(err, IsNil)
+	test.Assert(vdc.Vdc.Name, Equals, vcd.vdc.Vdc.Name)
+
+	task, err := v.Delete()
+	task.WaitTaskCompletion()
+	test.Assert(err, IsNil)
+
+}
+
 func (vcd *TestVCD) Test_ComposeVApp(c *C) {
 
 	testServer.ResponseMap(7, testutil.ResponseMap{

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -492,6 +492,16 @@ type Link struct {
 	Rel  string `xml:"rel,attr"`
 }
 
+// OrgList represents a lists of Organizations
+// Type: OrgType
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// Description: Represents a list of vCloud Director organizations.
+// Since: 0.9
+type OrgList struct {
+	Link LinkList `xml:"Link,omitempty"`
+	Org  []*Org   `xml:"Org,omitempty"`
+}
+
 // Org represents the user view of a vCloud Director organization.
 // Type: OrgType
 // Namespace: http://www.vmware.com/vcloud/v1.5


### PR DESCRIPTION
I added in get functions for vdcs and orgs. I added one to be able to get ParentVdc from a vapp, added another to be able to get a vdc from an org, and added a third to be able to get an Org object from a vcdClient connection. Also added in variable VCDHREF to the client, as oncewe remove our reliance on vcdvdchref, we will be using this for functions that need the api endpoint

Signed-off-by: auppunda <auppunda@gmail.com>