### PR TITLE
Removed VCDVDCHREF completely and cleaned up vcdclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,10 @@ func (c *Config) Client() (*govcd.VCDClient, error) {
         }
 
         vcdclient := govcd.NewVCDClient(*u, c.Insecure)
-        org, vcd, err := vcdclient.Authenticate(c.User, c.Password, c.Org, c.VDC)
+        err = vcdclient.Authenticate(c.User, c.Password, c.Org)
         if err != nil {
                 return nil, fmt.Errorf("Unable to authenticate: %s", err)
         }
-        vcdclient.Org = org
-        vcdclient.OrgVdc = vcd
         return vcdclient, nil
 }
 
@@ -85,6 +83,8 @@ func main() {
       fmt.Println(err)
       os.Exit(1)
   }
-  fmt.Printf("Org URL: %s\n", client.OrgHREF.String())
+  org := govcd.GetOrgByName(vcdclient, config.Org)
+  vdc := vcdclient.Org.GetVdcByName(config.Vdc)
+  fmt.Printf("Org URL: %s\n", org.Org.HREF)
 }
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,7 +24,9 @@ vcd:
     description: test catalog
     catalogitem: ubuntu
   vapp: vapp
-  storageprofile: Development
+  storageprofile: 
+    storageprofile1: Development
+    storageprofile2: "*"
   network: net
 
 ```

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -21,7 +21,6 @@ type Client struct {
 	APIVersion    string      // The API version required
 	VCDToken      string      // Access Token (authorization header)
 	VCDAuthHeader string      // Authorization header
-	VCDVDCHREF    url.URL     // HREF of the backend VDC you're using
 	VCDHREF       url.URL     // VCD API ENDPOINT
 	Http          http.Client // HttpClient is the client to use. Default will be used if not provided.
 }

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -3,7 +3,6 @@ package govcd
 import (
 	"crypto/tls"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,18 +11,10 @@ import (
 )
 
 type VCDClient struct {
-	OrgHREF     url.URL // vCloud Director OrgRef
-	Org         Org     // Org
-	OrgVdc      Vdc     // Org vDC
 	Client      Client  // Client for the underlying VCD instance
 	sessionHREF url.URL // HREF for the session API
 	QueryHREF   url.URL // HREF for the query API
 	Mutex       sync.Mutex
-}
-
-// Session object for session response
-type session struct {
-	Link []*types.Link `xml:"Link"`
 }
 
 type supportedVersions struct {
@@ -34,13 +25,10 @@ type supportedVersions struct {
 }
 
 func (c *VCDClient) vcdloginurl() error {
-
 	s := c.Client.VCDHREF
 	s.Path += "/versions"
-
 	// No point in checking for errors here
 	req := c.Client.NewRequest(map[string]string{}, "GET", s, nil)
-
 	resp, err := checkResp(c.Client.Http.Do(req))
 	if err != nil {
 		return err
@@ -48,13 +36,10 @@ func (c *VCDClient) vcdloginurl() error {
 	defer resp.Body.Close()
 
 	supportedVersions := new(supportedVersions)
-
 	err = decodeBody(resp, supportedVersions)
-
 	if err != nil {
 		return fmt.Errorf("error decoding versions response: %s", err)
 	}
-
 	u, err := url.Parse(supportedVersions.VersionInfo.LoginUrl)
 	if err != nil {
 		return fmt.Errorf("couldn't find a LoginUrl in versions")
@@ -64,122 +49,33 @@ func (c *VCDClient) vcdloginurl() error {
 }
 
 func (c *VCDClient) vcdauthorize(user, pass, org string) error {
-
 	if user == "" {
 		user = os.Getenv("VCLOUD_USERNAME")
 	}
-
 	if pass == "" {
 		pass = os.Getenv("VCLOUD_PASSWORD")
 	}
-
 	if org == "" {
 		org = os.Getenv("VCLOUD_ORG")
 	}
-
 	// No point in checking for errors here
 	req := c.Client.NewRequest(map[string]string{}, "POST", c.sessionHREF, nil)
-
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
-
 	// Add the Accept header for vCA
 	req.Header.Add("Accept", "application/*+xml;version=5.5")
-
 	resp, err := checkResp(c.Client.Http.Do(req))
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-
 	// Store the authentication header
 	c.Client.VCDToken = resp.Header.Get("x-vcloud-authorization")
 	c.Client.VCDAuthHeader = "x-vcloud-authorization"
-
-	session := new(session)
-	err = decodeBody(resp, session)
-
-	if err != nil {
-		fmt.Errorf("error decoding session response: %s", err)
-	}
-
-	org_found := false
-	// Loop in the session struct to find the organization and query api.
-	for _, s := range session.Link {
-		if s.Type == "application/vnd.vmware.vcloud.org+xml" && s.Rel == "down" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a Organization in current session, %v", err)
-			}
-			c.OrgHREF = *u
-			org_found = true
-		}
-		if s.Type == "application/vnd.vmware.vcloud.query.queryList+xml" && s.Rel == "down" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a Query API in current session, %v", err)
-			}
-			c.QueryHREF = *u
-		}
-	}
-	if !org_found {
-		return fmt.Errorf("couldn't find a Organization in current session")
-	}
-
-	// Loop in the session struct to find the session url.
-	session_found := false
-	for _, s := range session.Link {
-		if s.Rel == "remove" {
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return fmt.Errorf("couldn't find a logout HREF in current session, %v", err)
-			}
-			c.sessionHREF = *u
-			session_found = true
-		}
-	}
-	if !session_found {
-		return fmt.Errorf("couldn't find a logout HREF in current session")
-	}
+	// Get query href
+	c.QueryHREF = c.Client.VCDHREF
+	c.QueryHREF.Path += "/query"
 	return nil
-}
-
-func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
-
-	req := c.Client.NewRequest(map[string]string{}, "GET", c.OrgHREF, nil)
-	req.Header.Add("Accept", "application/*+xml;version=5.5")
-
-	// TODO: wrap into checkresp to parse error
-	resp, err := checkResp(c.Client.Http.Do(req))
-	if err != nil {
-		return Org{}, fmt.Errorf("error retreiving org: %s", err)
-	}
-
-	org := NewOrg(&c.Client)
-
-	if err = decodeBody(resp, org.Org); err != nil {
-		return Org{}, fmt.Errorf("error decoding org response: %s", err)
-	}
-
-	// Get the VDC ref from the Org
-	for _, s := range org.Org.Link {
-		if s.Type == "application/vnd.vmware.vcloud.vdc+xml" && s.Rel == "down" {
-			if vcdname != "" && s.Name != vcdname {
-				continue
-			}
-			u, err := url.Parse(s.HREF)
-			if err != nil {
-				return Org{}, err
-			}
-			c.Client.VCDVDCHREF = *u
-		}
-	}
-
-	if &c.Client.VCDVDCHREF == nil {
-		return Org{}, fmt.Errorf("error finding the organization VDC HREF")
-	}
-
-	return *org, nil
 }
 
 func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
@@ -202,32 +98,18 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 }
 
 // Authenticate is an helper function that performs a login in vCloud Director.
-func (c *VCDClient) Authenticate(username, password, org, vdcname string) (Org, Vdc, error) {
-
+func (c *VCDClient) Authenticate(username, password, org string) error {
 	// LoginUrl
 	err := c.vcdloginurl()
 	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error finding LoginUrl: %s", err)
+		return fmt.Errorf("error finding LoginUrl: %s", err)
 	}
 	// Authorize
 	err = c.vcdauthorize(username, password, org)
 	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error authorizing: %s", err)
+		return fmt.Errorf("error authorizing: %s", err)
 	}
-
-	// Get Org
-	o, err := c.RetrieveOrg(vdcname)
-	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error acquiring Org: %s", err)
-	}
-
-	vdc, err := c.Client.retrieveVDC()
-
-	if err != nil {
-		return Org{}, Vdc{}, fmt.Errorf("error retrieving the organization VDC")
-	}
-
-	return o, vdc, nil
+	return nil
 }
 
 // Disconnect performs a disconnection from the vCloud Director API endpoint.
@@ -235,15 +117,11 @@ func (c *VCDClient) Disconnect() error {
 	if c.Client.VCDToken == "" && c.Client.VCDAuthHeader == "" {
 		return fmt.Errorf("cannot disconnect, client is not authenticated")
 	}
-
 	req := c.Client.NewRequest(map[string]string{}, "DELETE", c.sessionHREF, nil)
-
 	// Add the Accept header for vCA
 	req.Header.Add("Accept", "application/xml;version=5.5")
-
 	// Set Authorization Header
 	req.Header.Add(c.Client.VCDAuthHeader, c.Client.VCDToken)
-
 	if _, err := checkResp(c.Client.Http.Do(req)); err != nil {
 		return fmt.Errorf("error processing session delete for vCloud Director: %s", err)
 	}

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -28,8 +28,11 @@ type TestConfig struct {
 			Catalogitem string `yaml:"catalogitem,omitempty"`
 		}
 		Network        string `yaml:"network,omitempty"`
-		Storageprofile string `yaml:"storageprofile,omitempty"`
-		VApp           string `yaml:"vapp,omitempty"`
+		StorageProfile struct {
+			SP1 string `yaml:"storageprofile1,omitempty"`
+			SP2 string `yaml:"storageprofile2,omitempty"`
+		}
+		VApp string `yaml:"vapp,omitempty"`
 	}
 }
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -99,14 +99,12 @@ func Test(t *testing.T) { TestingT(t) }
 // getting config file, creating vcd, during authentication, or
 // when creating a new vapp. If this method panics, no test
 // case that uses the TestVCD struct is run.
-func (vcd *TestVCD) SetUpSuite(c *C) {
-
+func (vcd *TestVCD) SetUpSuite(test *C) {
 	// this will be removed once all tests are converted to
 	// a real vcd
 	testServer.Start()
 
 	config, err := GetConfigStruct()
-
 	if err != nil {
 		panic(err)
 	}
@@ -117,14 +115,21 @@ func (vcd *TestVCD) SetUpSuite(c *C) {
 		panic(err)
 	}
 	vcd.client = vcdClient
-
 	// org and vdc are the test org and vdc that is used in all other test cases
-	vcd.org, vcd.vdc, err = vcd.client.Authenticate(config.Provider.User, config.Provider.Password, config.VCD.Org, config.VCD.Vdc)
-
+	err = vcd.client.Authenticate(config.Provider.User, config.Provider.Password, config.VCD.Org)
 	if err != nil {
 		panic(err)
 	}
-
+	// set org
+	vcd.org, err = GetOrgByName(vcd.client, config.VCD.Org)
+	if err != nil {
+		panic(err)
+	}
+	// set vdc
+	vcd.vdc, err = vcd.org.GetVdcByName(config.VCD.Vdc)
+	if err != nil {
+		panic(err)
+	}
 	// creates a new VApp for vapp tests
 	vcd.vapp = *NewVApp(&vcd.client.Client)
 }
@@ -132,7 +137,6 @@ func (vcd *TestVCD) SetUpSuite(c *C) {
 // Tests getloginurl with the endpoint given
 // in the config file.
 func TestClient_getloginurl(t *testing.T) {
-
 	config, err := GetConfigStruct()
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -154,7 +158,6 @@ func TestClient_getloginurl(t *testing.T) {
 
 // Tests Authenticate with the vcd credentials given in the config file
 func TestVCDClient_Authenticate(t *testing.T) {
-
 	config, err := GetConfigStruct()
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -163,13 +166,8 @@ func TestVCDClient_Authenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	org, _, err := client.Authenticate(config.Provider.User, config.Provider.Password, config.VCD.Org, config.VCD.Vdc)
+	err = client.Authenticate(config.Provider.User, config.Provider.Password, config.VCD.Org)
 	if err != nil {
 		t.Fatalf("Error authenticating: %v", err)
-	}
-
-	if org.Org.Name != config.VCD.Org {
-		t.Fatalf("org names do not match: %s", org.Org.Name)
 	}
 }

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -630,7 +630,7 @@ func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	vdc, err := v.c.retrieveVDC()
+	vdc, err := v.getParentVDC()
 	storageprofileref, err := vdc.FindStorageProfileReference(name)
 
 	newprofile := &types.VM{

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -28,25 +28,6 @@ func NewVdc(c *Client) *Vdc {
 	}
 }
 
-func (c *Client) retrieveVDC() (Vdc, error) {
-
-	req := c.NewRequest(map[string]string{}, "GET", c.VCDVDCHREF, nil)
-
-	resp, err := checkResp(c.Http.Do(req))
-	if err != nil {
-		return Vdc{}, fmt.Errorf("error retreiving vdc: %s", err)
-	}
-
-	vdc := NewVdc(c)
-
-	if err = decodeBody(resp, vdc.Vdc); err != nil {
-		return Vdc{}, fmt.Errorf("error decoding vdc response: %s", err)
-	}
-
-	// The request was successful
-	return *vdc, nil
-}
-
 func (v *Vdc) Refresh() error {
 
 	if v.Vdc.HREF == "" {

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -103,7 +103,7 @@ func (vcd *TestVCD) Test_ComposeVApp(test *C) {
 	vapptemplate, err := catitem.GetVAppTemplate()
 	test.Assert(err, IsNil)
 	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.Storageprofile)
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
 	test.Assert(err, IsNil)
 	// Compose VApp
 	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "go-vcloud-director-vapp-test", "description")


### PR DESCRIPTION
First commit Changes: Since retrievevdc is reliant on VCDVDCHREF, I changed changeStorageProfiles to call getParentVDC instead and updated the tests. Config file is updated and put into Testing.md. Test_ChangeStorageProfiles uses a real vcd now to just to make sure my additions worked.

Second commit Changes: I removed retrieveOrg, retrieveVdc, and VCDVDCHREF. Also removed the session struct and the looping in the authenticate to find the orghref and the queryhref. Updated README.md to have updated example and updated api_vcd_test.go. Updated discover.go in the samples directory as well.

Signed-off-by: auppunda <auppunda@gmail.com>

