### PR TITLE
Tests refactoring part 1

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,5 @@
 # Testing in go-vcloud-director
-To run tests in go-vcloud-director, users must use a yaml file specifying information about the users vcd. Users can set the VCLOUD_CONFIG environmental variable with the path.
+To run tests in go-vcloud-director, users must use a yaml file specifying information about the users vcd. Users can set the `VCLOUD_CONFIG` environmental variable with the path.
 
 ```
 export VCLOUD_CONFIG = $HOME/test.yaml
@@ -24,12 +24,14 @@ vcd:
     description: test catalog
     catalogitem: ubuntu
   vapp: vapp
-  storageprofile: Development
+  storageprofile:
+    storageprofile1: Development
+    storageprofile2: "*"
   network: net
 
 ```
 
-Users must specify their username, password, api_endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, vapp, storageprofile, and network field can be set using the format above. For comprehensive testing just replace each field with your vcd information. 
+Users must specify their username, password, api_endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, vapp, storageprofile, and network field can be set using the format above. For comprehensive testing just replace each field with your vcd information.
 
 # Running Tests
 Once you have a config file setup, you can run tests with either the makefile or with go itself.
@@ -37,7 +39,7 @@ Once you have a config file setup, you can run tests with either the makefile or
 To run tests with go use these commands:
 ```
 cd govcd
-go test -v 
+go test -check.v .
 ```
 
 To run tests with the makefile:

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -23,13 +23,17 @@ type TestConfig struct {
 		Org     string `yaml:"org"`
 		Vdc     string `yaml:"vdc"`
 		Catalog struct {
-			Name        string `yaml:"name,omitempty"`
-			Description string `yaml:"description,omitempty"`
-			Catalogitem string `yaml:"catalogitem,omitempty"`
+			Name                   string `yaml:"name,omitempty"`
+			Description            string `yaml:"description,omitempty"`
+			Catalogitem            string `yaml:"catalogitem,omitempty"`
+			CatalogItemDescription string `yaml:"catalogitemdescription,omitempty"`
 		}
 		Network        string `yaml:"network,omitempty"`
-		Storageprofile string `yaml:"storageprofile,omitempty"`
-		VApp           string `yaml:"vapp,omitempty"`
+		StorageProfile struct {
+			SP1 string `yaml:"storageprofile1,omitempty"`
+			SP2 string `yaml:"storageprofile2,omitempty"`
+		}
+		VApp string `yaml:"vapp,omitempty"`
 	}
 }
 

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -5,34 +5,29 @@
 package govcd
 
 import (
+	"fmt"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_GetVAppTemplate(c *C) {
+func (vcd *TestVCD) Test_GetVAppTemplate(check *C) {
 
-	// Populate Catalog
-	testServer.Response(200, nil, catalogExample)
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
+	fmt.Printf("Running: %s\n", check.TestName())
+	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	if err != nil {
+		check.Skip("Catalog not found. Test can't proceed")
+	}
 
-	// Populate Catalog Item
-	testServer.Response(200, nil, catalogitemExample)
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	check.Assert(err, IsNil)
 
 	// Get VAppTemplate
-	testServer.Response(200, nil, vapptemplateExample)
 	vapptemplate, err := catitem.GetVAppTemplate()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
 
-	c.Assert(err, IsNil)
-	c.Assert(vapptemplate.VAppTemplate.HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5")
-	c.Assert(vapptemplate.VAppTemplate.Name, Equals, "CentOS64-32bit")
-	c.Assert(vapptemplate.VAppTemplate.Description, Equals, "id: cts-6.4-32bit")
-
+	check.Assert(err, IsNil)
+	check.Assert(vapptemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.Catalogitem)
+	if vcd.config.VCD.Catalog.Description != "" {
+		check.Assert(vapptemplate.VAppTemplate.Description, Equals, vcd.config.VCD.Catalog.CatalogItemDescription)
+	}
 }
 
 var catalogitemExample = `

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -5,31 +5,30 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/testutil"
-
+	"fmt"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_NetRefresh(c *C) {
+func (vcd *TestVCD) Test_NetRefresh(check *C) {
 
-	testServer.ResponseMap(1, testutil.ResponseMap{
-		"/api/network/44444444-4444-4444-4444-4444444444444": testutil.Response{200, nil, orgvdcnetExample},
-	})
+	fmt.Printf("Running: %s\n", check.TestName())
 
-	network, err := vcd.vdc.FindVDCNetwork("networkName")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
+	network, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
 
-	c.Assert(err, IsNil)
-	c.Assert(network.OrgVDCNetwork.Name, Equals, "networkName")
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
+	save_network := network
 
-	testServer.Response(200, nil, orgvdcnetExample)
 	err = network.Refresh()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
 
-	c.Assert(err, IsNil)
-	c.Assert(network.OrgVDCNetwork.Name, Equals, "networkName")
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, save_network.OrgVDCNetwork.Name)
+	check.Assert(network.OrgVDCNetwork.HREF, Equals, save_network.OrgVDCNetwork.HREF)
+	check.Assert(network.OrgVDCNetwork.Type, Equals, save_network.OrgVDCNetwork.Type)
+	check.Assert(network.OrgVDCNetwork.ID, Equals, save_network.OrgVDCNetwork.ID)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, save_network.OrgVDCNetwork.Description)
+	check.Assert(network.OrgVDCNetwork.EdgeGateway, DeepEquals, save_network.OrgVDCNetwork.EdgeGateway)
+	check.Assert(network.OrgVDCNetwork.Status, Equals, save_network.OrgVDCNetwork.Status)
 
 }
 

--- a/govcd/task_test.go
+++ b/govcd/task_test.go
@@ -4,25 +4,25 @@
 
 package govcd
 
+/*
+TO BE REMOVED (or reintroduced with different scope) : task completion is tested as part of vdc_test.go
 import (
+	"fmt"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_WaitTaskCompletion(c *C) {
+func (vcd *TestVCD) Test_WaitTaskCompletion(check *C) {
 
-	testServer.Response(200, nil, taskExample)
+	fmt.Printf("Running: %s\n", check.TestName())
+	check.Skip("Disabled: need a reliable way of triggering a task")
+	fmt.Printf("%#v\n", vcd.vapp.VApp)
 	task, err := vcd.vapp.Deploy()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
 
-	testServer.Response(200, nil, taskExample)
 	err = task.WaitTaskCompletion()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-	c.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 
 }
+*/
 
 var taskExample = `
 <Task cancelRequested="false" endTime="2014-11-10T09:09:31.483Z" expiryTime="2015-02-08T09:09:16.627Z" href="http://localhost:4444/api/task/1b8f926c-eff5-4bea-9b13-4e49bdd50c05" id="urn:vcloud:task:1b8f926c-eff5-4bea-9b13-4e49bdd50c05" name="task" operation="Composed Virtual Application Test API GO4(fdb86157-2e1f-4889-9942-0463836d10e1)" operationName="vdcComposeVapp" serviceNamespace="com.vmware.vcloud" startTime="2014-11-10T09:09:16.627Z" status="success" type="application/vnd.vmware.vcloud.task+xml" xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.6.32.3/api/v1.5/schema/master.xsd">

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -268,6 +268,7 @@ func (v *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VA
 				Info: "Configuration parameters for logical networks",
 			},
 		},
+		AllEULAsAccepted: true,
 		SourcedItem: &types.SourcedCompositionItemParam{
 			Source: &types.Reference{
 				HREF: vapptemplate.VAppTemplate.Children.VM[0].HREF,

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -5,80 +5,97 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/testutil"
-	types "github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
-	"strconv"
+	// "strconv"
+	"fmt"
 )
 
-func (vcd *TestVCD) Test_FindVDCNetwork(c *C) {
+func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 
-	testServer.Response(200, nil, orgvdcnetExample)
+	fmt.Printf("Running: %s\n", check.TestName())
 
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
+	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
 
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(net, NotNil)
-	c.Assert(net.OrgVDCNetwork.HREF, Equals, "http://localhost:4444/api/network/cb0f4c9e-1a46-49d4-9fcb-d228000a6bc1")
+	check.Assert(err, IsNil)
+	check.Assert(net, NotNil)
+	check.Assert(net.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
+	check.Assert(net.OrgVDCNetwork.HREF, Not(Equals), "")
 
 	// find Invalid Network
 	net, err = vcd.vdc.FindVDCNetwork("INVALID")
-	c.Assert(err, NotNil)
+	check.Assert(err, NotNil)
 }
 
-func (vcd *TestVCD) Test_NewVdc(c *C) {
+func (vcd *TestVCD) Test_NewVdc(check *C) {
 
-	testServer.Response(200, nil, vdcExample)
+	fmt.Printf("Running: %s\n", check.TestName())
 	err := vcd.vdc.Refresh()
-	_ = testServer.WaitRequest()
-	c.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 
-	c.Assert(vcd.vdc.Vdc.Link[0].Rel, Equals, "up")
-	c.Assert(vcd.vdc.Vdc.Link[0].Type, Equals, "application/vnd.vmware.vcloud.org+xml")
-	c.Assert(vcd.vdc.Vdc.Link[0].HREF, Equals, "http://localhost:4444/api/org/11111111-1111-1111-1111-111111111111")
+	check.Assert(vcd.vdc.Vdc.Link[0].Rel, Equals, "up")
+	check.Assert(vcd.vdc.Vdc.Link[0].Type, Equals, "application/vnd.vmware.vcloud.org+xml")
 
-	c.Assert(vcd.vdc.Vdc.AllocationModel, Equals, "AllocationPool")
+	// fmt.Printf("allocation mem %#v\n\n",vcd.vdc.Vdc.AllocationModel)
+	for _, resource := range vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity {
 
-	for _, v := range vcd.vdc.Vdc.ComputeCapacity {
-		c.Assert(v.CPU.Units, Equals, "MHz")
-		c.Assert(v.CPU.Allocated, Equals, int64(30000))
-		c.Assert(v.CPU.Limit, Equals, int64(30000))
-		c.Assert(v.CPU.Reserved, Equals, int64(15000))
-		c.Assert(v.CPU.Used, Equals, int64(0))
-		c.Assert(v.CPU.Overhead, Equals, int64(0))
-		c.Assert(v.Memory.Units, Equals, "MB")
-		c.Assert(v.Memory.Allocated, Equals, int64(61440))
-		c.Assert(v.Memory.Limit, Equals, int64(61440))
-		c.Assert(v.Memory.Reserved, Equals, int64(61440))
-		c.Assert(v.Memory.Used, Equals, int64(6144))
-		c.Assert(v.Memory.Overhead, Equals, int64(95))
+		// fmt.Printf("res %#v\n",resource)
+		check.Assert(resource.Name, Not(Equals), "")
+		check.Assert(resource.Type, Not(Equals), "")
+		check.Assert(resource.HREF, Not(Equals), "")
 	}
 
-	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Name, Equals, "vAppTemplate")
-	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Type, Equals, "application/vnd.vmware.vcloud.vAppTemplate+xml")
-	c.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-22222222-2222-2222-2222-222222222222")
+	// TODO: find which values are acceptable for AllocationModel
+	// check.Assert(vcd.vdc.Vdc.AllocationModel, Equals, "AllocationPool")
+
+	/*
+		// TODO: Find the conditions that define valid ComputeCapacity
+		for _, v := range vcd.vdc.Vdc.ComputeCapacity {
+			check.Assert(v.CPU.Units, Equals, "MHz")
+			check.Assert(v.CPU.Allocated, Equals, int64(30000))
+			check.Assert(v.CPU.Limit, Equals, int64(30000))
+			check.Assert(v.CPU.Reserved, Equals, int64(15000))
+			check.Assert(v.CPU.Used, Equals, int64(0))
+			check.Assert(v.CPU.Overhead, Equals, int64(0))
+			check.Assert(v.Memory.Units, Equals, "MB")
+			check.Assert(v.Memory.Allocated, Equals, int64(61440))
+			check.Assert(v.Memory.Limit, Equals, int64(61440))
+			check.Assert(v.Memory.Reserved, Equals, int64(61440))
+			check.Assert(v.Memory.Used, Equals, int64(6144))
+			check.Assert(v.Memory.Overhead, Equals, int64(95))
+		}
+	*/
+
+	// Skipping this check, as we can't define the existence of a given vApp template beforehand
+	/*
+		check.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Name, Equals, "vAppTemplate")
+		check.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].Type, Equals, "application/vnd.vmware.vcloud.vAppTemplate+xml")
+		check.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-22222222-2222-2222-2222-222222222222")
+	*/
 
 	for _, v := range vcd.vdc.Vdc.AvailableNetworks {
 		for _, v2 := range v.Network {
-			c.Assert(v2.Name, Equals, "networkName")
-			c.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.network+xml")
-			c.Assert(v2.HREF, Equals, "http://localhost:4444/api/network/44444444-4444-4444-4444-4444444444444")
+			check.Assert(v2.Name, Not(Equals), "")
+			check.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.network+xml")
+			check.Assert(v2.HREF, Not(Equals), "")
 		}
 	}
 
-	c.Assert(vcd.vdc.Vdc.NicQuota, Equals, 0)
-	c.Assert(vcd.vdc.Vdc.NetworkQuota, Equals, 20)
-	c.Assert(vcd.vdc.Vdc.UsedNetworkCount, Equals, 0)
-	c.Assert(vcd.vdc.Vdc.VMQuota, Equals, 0)
-	c.Assert(vcd.vdc.Vdc.IsEnabled, Equals, true)
+	/*
+
+		// Skipping this check, as we don't have precise terms of comparison for this entity
+		check.Assert(vcd.vdc.Vdc.NicQuota, Equals, 0)
+		check.Assert(vcd.vdc.Vdc.NetworkQuota, Equals, 20)
+		check.Assert(vcd.vdc.Vdc.UsedNetworkCount, Equals, 0)
+		check.Assert(vcd.vdc.Vdc.VMQuota, Equals, 0)
+		check.Assert(vcd.vdc.Vdc.IsEnabled, Equals, true)
+	*/
 
 	for _, v := range vcd.vdc.Vdc.VdcStorageProfiles {
-		for i, v2 := range v.VdcStorageProfile {
-			c.Assert(v2.Name, Equals, "storageProfile"+strconv.Itoa(i+1))
-			c.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
-			c.Assert(v2.HREF, Equals, "http://localhost:4444/api/vdcStorageProfile/88888888-8888-8888-8888-88888888888"+strconv.Itoa(i+8))
+		for _, v2 := range v.VdcStorageProfile {
+			check.Assert(v2.Name, Equals, vcd.config.VCD.StorageProfile.SP1)
+			check.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
+			check.Assert(v2.HREF, Not(Equals), "")
 		}
 	}
 
@@ -87,73 +104,71 @@ func (vcd *TestVCD) Test_NewVdc(c *C) {
 // Tests ComposeVApp with given parameters in the config file.
 // Throws an error if networks, catalog, catalog item, and
 // storage preference are omitted from the config file.
-func (vcd *TestVCD) Test_ComposeVApp(test *C) {
+func (vcd *TestVCD) Test_ComposeVApp(check *C) {
+
+	fmt.Printf("Running: %s\n", check.TestName())
+
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
 	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
 	networks = append(networks, net.OrgVDCNetwork)
-	test.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 	// Populate Catalog
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	test.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 	// Populate Catalog Item
 	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
-	test.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()
-	test.Assert(err, IsNil)
+	check.Assert(err, IsNil)
 	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.Storageprofile)
-	test.Assert(err, IsNil)
+	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	check.Assert(err, IsNil)
 	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "go-vcloud-director-vapp-test", "description")
-	test.Assert(err, IsNil)
-	test.Assert(task.Task.OperationName, Equals, "vdcComposeVapp")
+	temp_vapp_name := "go-vcloud-director-vapp-check"
+	temp_vapp_description := "vapp created by tests"
+	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, temp_vapp_name, temp_vapp_description)
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.OperationName, Equals, "vdcComposeVapp")
 	// Get VApp
-	vapp, err := vcd.vdc.FindVAppByName("go-vcloud-director-vapp-test")
-	test.Assert(err, IsNil)
+	vapp, err := vcd.vdc.FindVAppByName(temp_vapp_name)
+	check.Assert(err, IsNil)
+	// Once the operation is successful, we won't trigger a failure
+	// until after the vApp deletion
+	check.Check(vapp.VApp.Name, Equals, temp_vapp_name)
+	check.Check(vapp.VApp.Description, Equals, temp_vapp_description)
 
-	_, err = vapp.GetStatus()
-	test.Assert(err, IsNil)
+	vapp_status, err := vapp.GetStatus()
+	check.Check(err, IsNil)
+	check.Check(vapp_status, Equals, "UNRESOLVED")
 	// Let the VApp creation complete
 	task.WaitTaskCompletion()
+	vapp_status, err = vapp.GetStatus()
+	check.Check(err, IsNil)
+	check.Check(vapp_status, Equals, "POWERED_OFF")
 	// Deleting VApp
 	task, err = vapp.Delete()
 	task.WaitTaskCompletion()
-	test.Assert(err, IsNil)
+	check.Assert(err, IsNil)
+	no_such_vapp, err := vcd.vdc.FindVAppByName(temp_vapp_name)
+	check.Assert(err, NotNil)
+	check.Assert(no_such_vapp.VApp, IsNil)
+
 }
 
-func (vcd *TestVCD) Test_FindVApp(c *C) {
+func (vcd *TestVCD) Test_FindVApp(check *C) {
 
-	// testServer.Response(200, nil, vappExample)
+	first_vapp, err := vcd.vdc.FindVAppByName(vcd.config.VCD.VApp)
 
-	// vapp, err := s.vdc.FindVAppByID("")
+	check.Assert(err, IsNil)
 
-	// _ = testServer.WaitRequest()
-	// testServer.Flush()
-	// c.Assert(err, IsNil)
+	second_vapp, err := vcd.vdc.FindVAppByID(first_vapp.VApp.ID)
 
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000":       testutil.Response{200, nil, vdcExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, vappExample},
-	})
+	check.Assert(err, IsNil)
 
-	_, err := vcd.vdc.FindVAppByName("myVApp")
-
-	_ = testServer.WaitRequests(2)
-
-	c.Assert(err, IsNil)
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000":       testutil.Response{200, nil, vdcExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, vappExample},
-	})
-
-	_, err = vcd.vdc.FindVAppByID("urn:vcloud:vapp:00000000-0000-0000-0000-000000000000")
-
-	_ = testServer.WaitRequests(2)
-
-	c.Assert(err, IsNil)
+	check.Assert(second_vapp.VApp.Name, Equals, first_vapp.VApp.Name)
+	check.Assert(second_vapp.VApp.HREF, Equals, first_vapp.VApp.HREF)
 
 }
 

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -7,7 +7,6 @@ package govcd
 import (
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
-	// "strconv"
 	"fmt"
 )
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -5,25 +5,77 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/testutil"
+	"fmt"
+	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_FindVMByHREF(c *C) {
+func (vcd *TestVCD) find_first_vm(vapp VApp) (types.VM, string) {
+	for _, vm := range vapp.VApp.Children.VM {
+		if vm.Name != "" {
+			return *vm, vm.Name
+		}
+	}
+	return types.VM{}, ""
+}
 
-	// Get the Org populated
-	testServer.ResponseMap(1, testutil.ResponseMap{
-		"/api/vApp/vm-11111111-1111-1111-1111-111111111111": testutil.Response{200, nil, vmExample},
-	})
+func (vcd *TestVCD) find_first_vapp() VApp {
+	client := vcd.client
+	config := vcd.config
+	org, err := GetOrgByName(client, config.VCD.Org)
+	if err != nil {
+		fmt.Println(err)
+		return VApp{}
+	}
+	vdc, err := org.GetVdcByName(config.VCD.Vdc)
+	if err != nil {
+		fmt.Println(err)
+		return VApp{}
+	}
+	wanted_vapp := vcd.config.VCD.VApp
+	vapp_name := ""
+	for _, res := range vdc.Vdc.ResourceEntities {
+		for _, item := range res.ResourceEntity {
+			// Finding a named vApp, if it was defined in config
+			if wanted_vapp != "" {
+				if item.Name == wanted_vapp {
+					vapp_name = item.Name
+					break
+				}
+			} else {
+				// Otherwise, we get the first vApp from the vDC list
+				if item.Type == "application/vnd.vmware.vcloud.vApp+xml" {
+					vapp_name = item.Name
+					break
+				}
+			}
+		}
+	}
+	if wanted_vapp == "" {
+		return VApp{}
+	}
+	vapp, _ := vdc.FindVAppByName(vapp_name)
+	return vapp
+}
 
-	vm_href := vcdu_api.String() + "/vApp/vm-11111111-1111-1111-1111-111111111111"
-	vm, err := vcd.client.FindVMByHREF(vm_href)
-	_ = testServer.WaitRequest()
-	testServer.Flush()
+func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
 
-	c.Assert(err, IsNil)
-	c.Assert(vm.VM.Name, Equals, "testvmxnet")
-	c.Assert(vm.VM.VirtualHardwareSection.Item, NotNil)
+	fmt.Printf("Running: %s\n", check.TestName())
+	vapp := vcd.find_first_vapp()
+	if vapp.VApp.Name == "" {
+		check.Skip("Disabled: No suitable vApp found in vDC")
+	}
+	vm, vm_name := vcd.find_first_vm(vapp)
+	if vm.Name == "" {
+		check.Skip("Disabled: No suitable VM found in vDC")
+	}
+
+	vm_href := vm.HREF
+	new_vm, err := vcd.client.FindVMByHREF(vm_href)
+
+	check.Assert(err, IsNil)
+	check.Assert(new_vm.VM.Name, Equals, vm_name)
+	check.Assert(new_vm.VM.VirtualHardwareSection.Item, NotNil)
 }
 
 var vmExample = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This is the first part of the tests refactoring (Issue#10) to get rid of the mock server in tests.
To simplify the review, I committed each file separately.

The purpose of this task (and a similar one by @auppunda with the remaining tests) is to make the test run with a real vCD, replicating the behavior of the previous test. 
There are more tests that can be created and modified, but that will come later, once the foundation for the test suite is completed.

A general note on the code: the test suite used `check.v1`, which recommends some odd behavior, like not using a name space for the testing library and squash the function names into the test name space. We will address This problem once the present task is complete (Issue#34)

If you are not acquainted with [check.v1](https://labix.org/gocheck) and some of the code looks odd, please ping me for help.