### PR TITLE
Tests Refactoring Part 2

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,11 +23,15 @@ vcd:
     name: test
     description: test catalog
     catalogitem: ubuntu
+    catalogitemdescription: description
   vapp: vapp
   storageprofile: 
     storageprofile1: Development
     storageprofile2: "*"
   network: net
+  edgegateway: au-edge
+  externalip: 10.150.10.10
+  internalip: 10.0.0.10
 
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,7 +24,6 @@ vcd:
     description: test catalog
     catalogitem: ubuntu
     catalogitemdescription: description
-  vapp: vapp
   storageprofile: 
     storageprofile1: Development
     storageprofile2: "*"
@@ -35,7 +34,7 @@ vcd:
 
 ```
 
-Users must specify their username, password, api_endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, vapp, storageprofile, and network field can be set using the format above. For comprehensive testing just replace each field with your vcd information. 
+Users must specify their username, password, api_endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, catalogitem, storageprofile, network, edgegateway, ip field can be set using the format above. For comprehensive testing just replace each field with your vcd information. 
 
 # Running Tests
 Once you have a config file setup, you can run tests with either the makefile or with go itself.
@@ -51,5 +50,12 @@ To run tests with the makefile:
 make test
 ```
 
+To run a specific test:
+```
+cd govcd
+go test -check.f Test_SetOvf
+```
+
 # Final Words
+Be careful about using our tests as these tests run on a real vcd. If you don't have 1 gb of ram and 2 vcpus available then you should not be running tests that deploy your vm/change memory and cpu. However everything created will be removed at the end of testing.
 Have fun using our SDK!! 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -134,11 +134,23 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		panic(err)
 	}
 	// creates a new VApp for vapp tests
-	vapp, err := vcd.createTestVapp("go-vapp-tests")
-	if err != nil {
-		panic(err)
+	if config.VCD.Network != "" && config.VCD.StorageProfile.SP1 != "" &&
+		config.VCD.Catalog.Name != "" && config.VCD.Catalog.Catalogitem != "" {
+		vcd.vapp, err = vcd.createTestVapp("go-vapp-tests")
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		err = vcd.vdc.ComposeRawVApp("go-vapp-tests")
+		if err != nil {
+			panic(err)
+		}
+		vcd.vapp, err = vcd.vdc.FindVAppByName("go-vapp-tests")
+		if err != nil {
+			panic(err)
+		}
 	}
-	vcd.vapp = vapp
+
 }
 
 func (vcd *TestVCD) TearDownSuite(check *C) {

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -8,28 +8,21 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_FindCatalogItem(c *C) {
-
-	// Populate Catalog
-	testServer.Response(200, nil, catalogExample)
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-
+func (vcd *TestVCD) Test_FindCatalogItem(check *C) {
+	// Fetch Catalog
+	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	// Find Catalog Item
-	testServer.Response(200, nil, catalogitemExample)
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(catitem.CatalogItem.HREF, Equals, "http://localhost:4444/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae")
-	c.Assert(catitem.CatalogItem.Description, Equals, "id: cts-6.4-32bit")
-
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	check.Assert(err, IsNil)
+	check.Assert(catitem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.Catalogitem)
+	// If given a description in config file then it checks if the descriptions match
+	// Otherwise it skips the assert
+	if vcd.config.VCD.Catalog.CatalogItemDescription != "" {
+		check.Assert(catitem.CatalogItem.Description, Equals, vcd.config.VCD.Catalog.CatalogItemDescription)
+	}
 	// Test non-existant catalog item
 	catitem, err = cat.FindCatalogItem("INVALID")
-	c.Assert(err, NotNil)
-
+	check.Assert(err, NotNil)
 }
 
 var catalogExample = `

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -5,29 +5,31 @@
 package govcd
 
 import (
-	"fmt"
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
 
 func (vcd *TestVCD) Test_Refresh(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+		check.Skip("Skipping test because no edgegatway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+	copyEdge := edge
 	err = edge.Refresh()
 	check.Assert(err, IsNil)
-	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+	check.Assert(copyEdge.EdgeGateway.Name, Equals, edge.EdgeGateway.Name)
+	check.Assert(copyEdge.EdgeGateway.HREF, Equals, edge.EdgeGateway.HREF)
 }
 
+// TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_NATMapping(check *C) {
 	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+		check.Skip("Skipping test because no edgegatway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
@@ -43,12 +45,13 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 }
 
+// TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+		check.Skip("Skipping test because no edgegatway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
@@ -63,12 +66,13 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	check.Assert(err, IsNil)
 }
 
+// TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+		check.Skip("Skipping test because no edgegatway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
@@ -83,12 +87,13 @@ func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 	check.Assert(err, IsNil)
 }
 
+// TODO: Add a check checking whether the IPsec VPN was added
 func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	if vcd.config.VCD.Externalip == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+		check.Skip("Skipping test because no edgegatway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -5,159 +5,94 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/testutil"
+	"fmt"
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_Refresh(c *C) {
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
-	})
-
-	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
-	_ = testServer.WaitRequests(2)
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
-	testServer.Response(200, nil, edgegatewayExample)
+func (vcd *TestVCD) Test_Refresh(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	err = edge.Refresh()
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 }
 
-func (vcd *TestVCD) Test_NATMapping(c *C) {
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
-	})
+func (vcd *TestVCD) Test_NATMapping(check *C) {
+	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+	}
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
-	_ = testServer.WaitRequests(2)
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.AddNATMapping("DNAT", "10.0.0.1", "20.0.0.2", "77")
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.RemoveNATMapping("DNAT", "10.0.0.1", "20.0.0.2", "77")
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-
+	task, err := edge.AddNATMapping("DNAT", vcd.config.VCD.Externalip, vcd.config.VCD.Internalip, "77")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = edge.RemoveNATMapping("DNAT", vcd.config.VCD.Externalip, vcd.config.VCD.Internalip, "77")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
-func (vcd *TestVCD) Test_NATPortMapping(c *C) {
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
-	})
-
-	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
-	_ = testServer.WaitRequests(2)
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.AddNATPortMapping("DNAT", "10.0.0.1", "1177", "20.0.0.2", "77")
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.RemoveNATPortMapping("DNAT", "10.0.0.1", "1177", "20.0.0.2", "77")
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-
+func (vcd *TestVCD) Test_NATPortMapping(check *C) {
+	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+	}
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+	task, err := edge.AddNATPortMapping("DNAT", vcd.config.VCD.Externalip, "1177", vcd.config.VCD.Internalip, "77")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.Externalip, "1177", vcd.config.VCD.Internalip, "77")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
-func (vcd *TestVCD) Test_1to1Mappings(c *C) {
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
-	})
-
-	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
-	_ = testServer.WaitRequests(2)
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.Create1to1Mapping("10.0.0.1", "20.0.0.2", "description")
-	_ = testServer.WaitRequests(2)
-
-	c.Assert(err, IsNil)
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
-	_, err = edge.Remove1to1Mapping("10.0.0.1", "20.0.0.2")
-	_ = testServer.WaitRequests(2)
-
-	c.Assert(err, IsNil)
-
+func (vcd *TestVCD) Test_1to1Mappings(check *C) {
+	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+	}
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+	task, err := edge.Create1to1Mapping(vcd.config.VCD.Internalip, vcd.config.VCD.Externalip, "description")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = edge.Remove1to1Mapping(vcd.config.VCD.Internalip, vcd.config.VCD.Externalip)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
-func (vcd *TestVCD) Test_AddIpsecVPN(c *C) {
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/vdc/00000000-0000-0000-0000-000000000000/edgeGateways":  testutil.Response{200, nil, edgegatewayqueryresultsExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000": testutil.Response{200, nil, edgegatewayExample},
-	})
-
-	edge, err := vcd.vdc.FindEdgeGateway("M916272752-5793")
-	_ = testServer.WaitRequests(2)
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(edge.EdgeGateway.Name, Equals, "M916272752-5793")
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
-
+func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
+	if vcd.config.VCD.Externalip == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no valid ip given", check.TestName()))
+	}
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip(fmt.Sprintf("skipping %s because no edgegatway given", check.TestName()))
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	tunnel := &types.GatewayIpsecVpnTunnel{
 		Name:        "Test VPN",
 		Description: "Testing VPN Creation",
@@ -165,15 +100,13 @@ func (vcd *TestVCD) Test_AddIpsecVPN(c *C) {
 			ID:   "",
 			Name: "",
 		},
-		EncryptionProtocol: "SHA256",
-		LocalIPAddress:     "111.111.111.111",
-		LocalID:            "111.111.111.111",
+		EncryptionProtocol: "AES",
+		LocalIPAddress:     vcd.config.VCD.Externalip,
+		LocalID:            vcd.config.VCD.Externalip,
 		IsEnabled:          true,
 	}
-
 	tunnels := make([]*types.GatewayIpsecVpnTunnel, 1)
 	tunnels[0] = tunnel
-
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
@@ -181,16 +114,8 @@ func (vcd *TestVCD) Test_AddIpsecVPN(c *C) {
 			Tunnel:    tunnels,
 		},
 	}
-
 	_, err = edge.AddIpsecVPN(ipsecVPNConfig)
-	_ = testServer.WaitRequests(2)
-
-	c.Assert(err, IsNil)
-
-	testServer.ResponseMap(2, testutil.ResponseMap{
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, edgegatewayExample},
-		"/api/admin/edgeGateway/00000000-0000-0000-0000-000000000000/action/configureServices": testutil.Response{200, nil, taskExample},
-	})
+	check.Assert(err, IsNil)
 }
 
 var edgegatewayqueryresultsExample = `

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -10,8 +10,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Right now it just checks if their is an error while querying
-// Test does not check the contents of the query
+// TODO: Need to add a check to check the contents of the query
 func (vcd *TestVCD) Test_Query(check *C) {
 	// Get the Org populated
 	_, err := vcd.client.Query(map[string]string{"type": "vm"})

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -6,24 +6,16 @@ package govcd
 
 import (
 	// "fmt"
-	"github.com/vmware/go-vcloud-director/testutil"
+	//"github.com/vmware/go-vcloud-director/testutil"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_Query(c *C) {
-
+// Right now it just checks if their is an error while querying
+// Test does not check the contents of the query
+func (vcd *TestVCD) Test_Query(check *C) {
 	// Get the Org populated
-	testServer.ResponseMap(1, testutil.ResponseMap{
-		"/api/query?type=vm": testutil.Response{200, nil, queryVmExample},
-	})
-
-	results, err := vcd.client.Query(map[string]string{"type": "vm"})
-	_ = testServer.WaitRequest()
-	testServer.Flush()
-
-	c.Assert(err, IsNil)
-	c.Assert(results.Results.Total, Equals, 4)
-	c.Assert(len(results.Results.VMRecord), Equals, 4)
+	_, err := vcd.client.Query(map[string]string{"type": "vm"})
+	check.Assert(err, IsNil)
 }
 
 var queryVmExample = `<?xml version="1.0" encoding="UTF-8"?>

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -5,7 +5,7 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/testutil"
+	"fmt"
 	"github.com/vmware/go-vcloud-director/types/v56"
 
 	. "gopkg.in/check.v1"
@@ -13,455 +13,206 @@ import (
 
 // Creates a Vapp, fetches it, gets its vdc, then deletes the vapp
 // Tests the helper function getParentVDC
-func (vcd *TestVCD) TestGetParentVDC(test *C) {
-	vapp, err := vcd.vdc.FindVAppByName(vcd.config.VCD.VApp)
-	test.Assert(err, IsNil)
+func (vcd *TestVCD) TestGetParentVDC(check *C) {
+	vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
+	check.Assert(err, IsNil)
 
 	vdc, err := vapp.getParentVDC()
 
-	test.Assert(err, IsNil)
-	test.Assert(vdc.Vdc.Name, Equals, vcd.vdc.Vdc.Name)
+	check.Assert(err, IsNil)
+	check.Assert(vdc.Vdc.Name, Equals, vcd.vdc.Vdc.Name)
 }
 
-func (vcd *TestVCD) Test_PowerOn(c *C) {
-
-	testServer.Response(200, nil, taskExample)
-	task, err := vcd.vapp.PowerOn()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-}
-
-func (vcd *TestVCD) Test_PowerOff(c *C) {
-
-	testServer.Response(200, nil, taskExample)
-	task, err := vcd.vapp.PowerOff()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-}
-
-func (vcd *TestVCD) Test_Reboot(c *C) {
-
-	testServer.Response(200, nil, taskExample)
-	task, err := vcd.vapp.Reboot()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-}
-
-func (vcd *TestVCD) Test_SetOvf(c *C) {
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                  testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                   testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":               testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5": testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":    testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                 testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/productSections":   testutil.Response{200, nil, taskExample},
-	})
-
-	// Get the Org populated
-	org := vcd.org
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	var test map[string]string
-	test = make(map[string]string)
-	test["guestinfo.hostname"] = "testhostname"
-	task, err = vcd.vapp.SetOvf(test)
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
-
-}
-
-func (vcd *TestVCD) Test_AddMetadata(c *C) {
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                  testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                   testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":               testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5": testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":    testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                 testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/metadata/key":      testutil.Response{200, nil, taskExample},
-	})
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	task, err = vcd.vapp.AddMetadata("key", "value")
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
-
-}
-
-func (vcd *TestVCD) Test_ChangeStorageProfile(test *C) {
+func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
 	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error finding network : %v", err)
+	}
 	networks = append(networks, net.OrgVDCNetwork)
-	test.Assert(err, IsNil)
 	// Populate Catalog
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	test.Assert(err, IsNil)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error finding catalog : %v", err)
+	}
 	// Populate Catalog Item
 	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
-	test.Assert(err, IsNil)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error finding catalog item : %v", err)
+	}
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()
-	test.Assert(err, IsNil)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error finding vapptemplate : %v", err)
+	}
 	// Get StorageProfileReference
 	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
-	test.Assert(err, IsNil)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error finding storage profile: %v", err)
+	}
 	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "go-vcloud-director-vapp-test", "description")
-	test.Assert(err, IsNil)
-	test.Assert(task.Task.OperationName, Equals, "vdcComposeVapp")
-	// Let the VApp creation complete
-	task.WaitTaskCompletion()
-	// Get VApp
-	vapp, err := vcd.vdc.FindVAppByName("go-vcloud-director-vapp-test")
-	test.Assert(err, IsNil)
-
-	task, err = vapp.ChangeStorageProfile(vcd.config.VCD.StorageProfile.SP2)
-	test.Assert(err, IsNil)
+	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, name, "description")
+	if err != nil {
+		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
+	}
 	err = task.WaitTaskCompletion()
-	test.Assert(err, IsNil)
-	// Deleting VApp
-	task, err = vapp.Delete()
-	task.WaitTaskCompletion()
-	test.Assert(err, IsNil)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
+	}
+	// Get VApp
+	vapp, err := vcd.vdc.FindVAppByName(name)
+	if err != nil {
+		return VApp{}, fmt.Errorf("error getting vapp: %v", err)
+	}
+	return vapp, err
 }
 
-func (vcd *TestVCD) Test_ChangeVMName(c *C) {
+// Tests Powering On and Powering Off a VApp. Also tests Deletion
+// of a VApp
+func (vcd *TestVCD) Test_PowerOn(check *C) {
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+}
 
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                       testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                  testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                   testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":               testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5": testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":    testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                 testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000":                   testutil.Response{200, nil, taskExample},
-	})
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	task, err = vcd.vapp.ChangeVMName("My-vm")
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
+func (vcd *TestVCD) Test_Reboot(check *C) {
+	task, _ := vcd.vapp.PowerOn()
+	_ = task.WaitTaskCompletion()
+	task, err := vcd.vapp.Reboot()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 
 }
 
-func (vcd *TestVCD) Test_Reset(c *C) {
+func (vcd *TestVCD) Test_SetOvf(check *C) {
+	var test map[string]string
+	test = make(map[string]string)
+	test["guestinfo.hostname"] = "testhostname"
+	task, err := vcd.vapp.SetOvf(test)
 
-	testServer.Response(200, nil, taskExample)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+
+}
+
+func (vcd *TestVCD) Test_AddMetadata(check *C) {
+	// Add Metadata
+	task, err := vcd.vapp.AddMetadata("key", "value")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+
+}
+
+func (vcd *TestVCD) Test_RunCustomizationScript(check *C) {
+	// Run Script on Test Vapp
+	task, err := vcd.vapp.RunCustomizationScript("computername", "this is my script")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
+func (vcd *TestVCD) Test_ChangeCPUcount(check *C) {
+	task, err := vcd.vapp.ChangeCPUcount(1)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
+func (vcd *TestVCD) Test_ChangeMemorySize(check *C) {
+	task, err := vcd.vapp.ChangeMemorySize(512)
+
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
+func (vcd *TestVCD) Test_ChangeStorageProfile(check *C) {
+	task, err := vcd.vapp.ChangeStorageProfile(vcd.config.VCD.StorageProfile.SP2)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+}
+
+func (vcd *TestVCD) Test_ChangeVMName(check *C) {
+	task, err := vcd.vapp.ChangeVMName("My-vm")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
+func (vcd *TestVCD) Test_Reset(check *C) {
+	task, _ := vcd.vapp.PowerOn()
+	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Reset()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 }
 
-func (vcd *TestVCD) Test_Suspend(c *C) {
-
-	testServer.Response(200, nil, taskExample)
+func (vcd *TestVCD) Test_Suspend(check *C) {
+	task, _ := vcd.vapp.PowerOn()
+	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Suspend()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 
 }
 
-func (vcd *TestVCD) Test_Shutdown(c *C) {
-
-	testServer.Response(200, nil, taskExample)
+func (vcd *TestVCD) Test_Shutdown(check *C) {
+	task, _ := vcd.vapp.PowerOn()
+	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Shutdown()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-}
-
-func (vcd *TestVCD) Test_Undeploy(c *C) {
-
-	testServer.Response(200, nil, taskExample)
-	task, err := vcd.vapp.Undeploy()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 
 }
 
-func (vcd *TestVCD) Test_Deploy(c *C) {
-
-	testServer.Response(200, nil, taskExample)
+func (vcd *TestVCD) Test_Deploy(check *C) {
+	// Deploy
 	task, err := vcd.vapp.Deploy()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 }
 
-func (vcd *TestVCD) Test_Delete(c *C) {
-
-	testServer.Response(200, nil, taskExample)
-	task, err := vcd.vapp.Delete()
-	_ = testServer.WaitRequest()
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
+func (vcd *TestVCD) Test_PowerOff(check *C) {
+	task, _ := vcd.vapp.PowerOn()
+	_ = task.WaitTaskCompletion()
+	task, err := vcd.vapp.PowerOff()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 }
 
-func (vcd *TestVCD) Test_RunCustomizationScript(c *C) {
-
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                                testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                           testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                            testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":                        testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5":          testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":             testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/guestCustomizationSection/": testutil.Response{200, nil, taskExample},
-	})
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	task, err = vcd.vapp.RunCustomizationScript("computername", "this is my script")
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
-
-}
-
-func (vcd *TestVCD) Test_ChangeCPUcount(c *C) {
-
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                                testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                           testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                            testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":                        testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5":          testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":             testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                          testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/virtualHardwareSection/cpu": testutil.Response{200, nil, taskExample},
-	})
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	task, err = vcd.vapp.ChangeCPUcount(2)
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
-
-}
-
-func (vcd *TestVCD) Test_ChangeMemorySize(c *C) {
-
-	testServer.ResponseMap(8, testutil.ResponseMap{
-		"/api/org/11111111-1111-1111-1111-111111111111":                                   testutil.Response{200, nil, orgExample},
-		"/api/network/44444444-4444-4444-4444-4444444444444":                              testutil.Response{200, nil, orgvdcnetExample},
-		"/api/catalog/e8a20fdf-8a78-440c-ac71-0420db59f854":                               testutil.Response{200, nil, catalogExample},
-		"/api/catalogItem/1176e485-8858-4e15-94e5-ae4face605ae":                           testutil.Response{200, nil, catalogitemExample},
-		"/api/vAppTemplate/vappTemplate-40cb9721-5f1a-44f9-b5c3-98c5f518c4f5":             testutil.Response{200, nil, vapptemplateExample},
-		"/api/vdc/00000000-0000-0000-0000-000000000000/action/composeVApp":                testutil.Response{200, nil, instantiatedvappExample},
-		"/api/vApp/vapp-00000000-0000-0000-0000-000000000000":                             testutil.Response{200, nil, vappExample},
-		"/api/vApp/vm-00000000-0000-0000-0000-000000000000/virtualHardwareSection/memory": testutil.Response{200, nil, taskExample},
-	})
-
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork("networkName")
-	networks = append(networks, net.OrgVDCNetwork)
-	c.Assert(err, IsNil)
-
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog("Public Catalog")
-	c.Assert(err, IsNil)
-
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem("CentOS64-32bit")
-	c.Assert(err, IsNil)
-
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	c.Assert(err, IsNil)
-
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference("storageProfile1")
-	c.Assert(err, IsNil)
-
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, "name", "description")
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.OperationName, Equals, "vdcInstantiateVapp")
-	c.Assert(vcd.vapp.VApp.HREF, Equals, "http://localhost:4444/api/vApp/vapp-00000000-0000-0000-0000-000000000000")
-
-	task, err = vcd.vapp.ChangeMemorySize(4096)
-
-	c.Assert(err, IsNil)
-	c.Assert(task.Task.Status, Equals, "success")
-
-	_ = testServer.WaitRequests(8)
-
+func (vcd *TestVCD) Test_Undeploy(check *C) {
+	// Undeploy
+	task, err := vcd.vapp.Undeploy()
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+	// Deploy
+	task, err = vcd.vapp.Deploy()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 }
 
 var instantiatedvappExample = `

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -14,6 +14,9 @@ import (
 // Creates a Vapp, fetches it, gets its vdc, then deletes the vapp
 // Tests the helper function getParentVDC
 func (vcd *TestVCD) TestGetParentVDC(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
 	check.Assert(err, IsNil)
 
@@ -71,6 +74,9 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 // Tests Powering On and Powering Off a VApp. Also tests Deletion
 // of a VApp
 func (vcd *TestVCD) Test_PowerOn(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, err := vcd.vapp.PowerOn()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
@@ -78,7 +84,12 @@ func (vcd *TestVCD) Test_PowerOn(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Find out if there is a way to check if the vapp is on without
+// powering it on.
 func (vcd *TestVCD) Test_Reboot(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, _ := vcd.vapp.PowerOn()
 	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Reboot()
@@ -89,7 +100,11 @@ func (vcd *TestVCD) Test_Reboot(check *C) {
 
 }
 
+// TODO: Add a check checking if the ovf was set properly
 func (vcd *TestVCD) Test_SetOvf(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	var test map[string]string
 	test = make(map[string]string)
 	test["guestinfo.hostname"] = "testhostname"
@@ -102,7 +117,11 @@ func (vcd *TestVCD) Test_SetOvf(check *C) {
 
 }
 
+// TODO: Add a check checking if the metadata was added to the vapp
 func (vcd *TestVCD) Test_AddMetadata(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	// Add Metadata
 	task, err := vcd.vapp.AddMetadata("key", "value")
 	check.Assert(err, IsNil)
@@ -112,7 +131,11 @@ func (vcd *TestVCD) Test_AddMetadata(check *C) {
 
 }
 
+// TODO: Add a check checking if the customization script ran
 func (vcd *TestVCD) Test_RunCustomizationScript(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	// Run Script on Test Vapp
 	task, err := vcd.vapp.RunCustomizationScript("computername", "this is my script")
 	check.Assert(err, IsNil)
@@ -121,14 +144,22 @@ func (vcd *TestVCD) Test_RunCustomizationScript(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Add a check checking if the cpu count did change
 func (vcd *TestVCD) Test_ChangeCPUcount(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, err := vcd.vapp.ChangeCPUcount(1)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Add a check checking if the vapp uses the new memory size
 func (vcd *TestVCD) Test_ChangeMemorySize(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, err := vcd.vapp.ChangeMemorySize(512)
 
 	check.Assert(err, IsNil)
@@ -136,21 +167,37 @@ func (vcd *TestVCD) Test_ChangeMemorySize(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Add a check checking the if the vapp uses the new storage profile
 func (vcd *TestVCD) Test_ChangeStorageProfile(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+	if vcd.config.VCD.StorageProfile.SP2 == "" {
+		check.Skip("Skipping test because second storage profile not given")
+	}
 	task, err := vcd.vapp.ChangeStorageProfile(vcd.config.VCD.StorageProfile.SP2)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 }
 
+// TODO: Add a check checking the vm name
 func (vcd *TestVCD) Test_ChangeVMName(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, err := vcd.vapp.ChangeVMName("My-vm")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Find out if there is a way to check if the vapp is on without
+// powering it on.
 func (vcd *TestVCD) Test_Reset(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, _ := vcd.vapp.PowerOn()
 	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Reset()
@@ -160,7 +207,12 @@ func (vcd *TestVCD) Test_Reset(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Find out if there is a way to check if the vapp is on without
+// powering it on.
 func (vcd *TestVCD) Test_Suspend(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, _ := vcd.vapp.PowerOn()
 	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Suspend()
@@ -171,7 +223,12 @@ func (vcd *TestVCD) Test_Suspend(check *C) {
 
 }
 
+// TODO: Find out if there is a way to check if the vapp is on without
+// powering it on.
 func (vcd *TestVCD) Test_Shutdown(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, _ := vcd.vapp.PowerOn()
 	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.Shutdown()
@@ -183,6 +240,9 @@ func (vcd *TestVCD) Test_Shutdown(check *C) {
 }
 
 func (vcd *TestVCD) Test_Deploy(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	// Deploy
 	task, err := vcd.vapp.Deploy()
 	check.Assert(err, IsNil)
@@ -191,7 +251,12 @@ func (vcd *TestVCD) Test_Deploy(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: Find out if there is a way to check if the vapp is on without
+// powering it on.
 func (vcd *TestVCD) Test_PowerOff(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	task, _ := vcd.vapp.PowerOn()
 	_ = task.WaitTaskCompletion()
 	task, err := vcd.vapp.PowerOff()
@@ -201,13 +266,29 @@ func (vcd *TestVCD) Test_PowerOff(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+// TODO: EVENTUALLY REMOVE THIS REDEPLOY
 func (vcd *TestVCD) Test_Undeploy(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+	// Check if the vapp has been deployed yet
+	err := vcd.vapp.Refresh()
+	check.Assert(err, IsNil)
+	if !vcd.vapp.VApp.Deployed {
+		task, err := vcd.vapp.Deploy()
+		check.Assert(err, IsNil)
+		err = task.WaitTaskCompletion()
+		check.Assert(err, IsNil)
+	}
 	// Undeploy
 	task, err := vcd.vapp.Undeploy()
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 	// Deploy
+	// For some reason it will not work without redeploying
+	// TODO: EVENTUALLY REMOVE THIS REDEPLOY
 	task, err = vcd.vapp.Deploy()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -92,7 +92,6 @@ func (vcd *TestVCD) Test_NewVdc(check *C) {
 
 	for _, v := range vcd.vdc.Vdc.VdcStorageProfiles {
 		for _, v2 := range v.VdcStorageProfile {
-			check.Assert(v2.Name, Equals, vcd.config.VCD.StorageProfile.SP1)
 			check.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
 			check.Assert(v2.HREF, Not(Equals), "")
 		}
@@ -104,7 +103,9 @@ func (vcd *TestVCD) Test_NewVdc(check *C) {
 // Throws an error if networks, catalog, catalog item, and
 // storage preference are omitted from the config file.
 func (vcd *TestVCD) Test_ComposeVApp(check *C) {
-
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp wasn't properly created")
+	}
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	// Populate OrgVDCNetwork
@@ -158,7 +159,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 func (vcd *TestVCD) Test_FindVApp(check *C) {
 
-	first_vapp, err := vcd.vdc.FindVAppByName(vcd.config.VCD.VApp)
+	first_vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
 
 	check.Assert(err, IsNil)
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -32,7 +32,7 @@ func (vcd *TestVCD) find_first_vapp() VApp {
 		fmt.Println(err)
 		return VApp{}
 	}
-	wanted_vapp := vcd.config.VCD.VApp
+	wanted_vapp := vcd.vapp.VApp.Name
 	vapp_name := ""
 	for _, res := range vdc.Vdc.ResourceEntities {
 		for _, item := range res.ResourceEntity {
@@ -59,6 +59,9 @@ func (vcd *TestVCD) find_first_vapp() VApp {
 }
 
 func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp wasn't properly created")
+	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
 	vapp := vcd.find_first_vapp()


### PR DESCRIPTION
This is the second part of the test refactoring that was started by @dataclouder . This part deals with catalog_test.go, edgegateway_test.go, vapp_test.go, and query_test.go. 

The purpose of this pr (and a similar one by @dataclouder  with the remaining tests) is to make the tests run with a real vCD, replicating the behavior of the previous test.

I also didn't specify that I removed the vcd.config.VCD.VApp field because it wasn't needed, as I could use my vcd.vapp vapp that I create in the setup suite

The idea is to compose one vapp for all vapp testing, which the tests set up in the setup suite. It removes the vapp in the teardown suite method. This way we don't need a vapp element in our config file.

For edgegateway_tests, the user needs to provide an external ip and internal ip along with an edge gateway for the tests to be run

Look at https://github.com/vmware/go-vcloud-director/pull/35 for part 1