### PR TITLE
[51] Fix Go Vet Makefile warnings

### DIFF
--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -665,7 +665,7 @@ func (e *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConfig
 
 	output, err := xml.MarshalIndent(ipsecVPNConfig, "  ", "    ")
 	if err != nil {
-		fmt.Errorf("error marshaling ipsecVPNConfig compose: %s", err)
+		return Task{}, fmt.Errorf("error marshaling ipsecVPNConfig compose: %s", err)
 	}
 
 	debug := os.Getenv("GOVCLOUDAIR_DEBUG")

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1721,7 +1721,7 @@ type QueryResultVAppRecordType struct {
 	MemoryAllocationMB      int    `xml:"memoryAllocationMB,attr,omitempty"`
 	AutoDeleteNotified      bool   `xml:"isAutoDeleteNotified,attr,omitempty"`
 	AutoUndeployNotified    bool   `xml:"isAutoUndeployNotified,attr,omitempty"`
-	VdcEnabled              bool   `xml:"isVdcEnabled, attr,omitempty"`
+	VdcEnabled              bool   `xml:"isVdcEnabled,attr,omitempty"`
 	HonorBootOrder          bool   `xml:"honorBookOrder,attr,omitempty"`
 	HighestSupportedVersion int    `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
 	LowestHardwareVersion   int    `xml:"lowestHardwareVersionInVApp,attr,omitempty"`


### PR DESCRIPTION
closes #51 
Return result of fmt.Errorf call
Remove unnecessary space from struct tag value