### PR TITLE
Improve test configuration usability

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -2,40 +2,19 @@
 To run tests in go-vcloud-director, users must use a yaml file specifying information about the users vcd. Users can set the `VCLOUD_CONFIG` environmental variable with the path.
 
 ```
-export VCLOUD_CONFIG=$HOME/test.yaml
+export GOVCD_CONFIG=your/path/to/test-configuration.yaml
 ```
 
-If no environmental variable is set it will default to $HOME/config.yaml.
+If no environmental variable is set it will default to `govcd_test_config.yaml` in the same path where the test files are (`./govcd`.)
 
 ## Example Config file
 
-```yaml
-provider:
-    user: orgadmin_name
-    password: orgadmin_pwd
-    url:  https://api.vcd.api/api
-    # org user chooses to authenticate with
-    org:  System
-vcd:
-    org: org
-    vdc: org-vdc
-    catalog:
-        name: test
-        description: test catalog
-        catalogitem: ubuntu
-        catalogitemdescription: description
-    storageprofile:
-        storageprofile1: Development
-        storageprofile2: "*"
-    vapp: myvapp
-    network: net
-    edgegateway: au-edge
-    externalip: 10.150.10.10
-    internalip: 10.0.0.10
-```
+See `./govcd/sample_govcd_test_config.yaml`.
 
-Users must specify their username, password, api_endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, catalogitem, storageprofile, network, edgegateway, ip field can be set using the format above. For comprehensive testing just replace each field with your vcd information. 
+Users must specify their username, password, API endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, catalog item, storage profile, network, edge gateway, IP fields can be set using the format in the sample.
 Note that all the entities included in the configuration file must exist already and will not be removed or left altered during the tests. Leaving a field blank will skip one or more corresponding tests.
+
+If you are more comfortable with JSON, you can supply the configuration in that format. The field names are the same. See `./govcd/sample_govcd_test_config.json`.
 
 ## Running Tests
 Once you have a config file setup, you can run tests with either the makefile or with go itself.
@@ -59,12 +38,12 @@ To run a specific test:
 
 ```bash
 cd govcd
-go test -check.f Test_SetOvf
+go test -check.f Test_SetOvf -check.vv .
 ```
 
 ## How to write a test
 
-go-vcloud-director tests are written using [check.v1](https://labix.org/gocheck), an auxiliary libarry for tests that provides several methods to help developers write comprehensive tests.
+go-vcloud-director tests are written using [check.v1](https://labix.org/gocheck), an auxiliary library for tests that provides several methods to help developers write comprehensive tests.
 
 
 ### Imports
@@ -126,6 +105,11 @@ import (
 func (vcd *TestVCD) Test_GetVAppTemplate(check *checks.C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
+
+    // #0 Check that the data needed for this test is in the configuration
+    if vcd.config.VCD.Catalog.Name == "" {
+		check.Skip("Catalog name not provided. Test can't proceed")
+    }
 
     // #1: preliminary data
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"sync"
 	"time"
 )
@@ -49,14 +48,18 @@ func (c *VCDClient) vcdloginurl() error {
 }
 
 func (c *VCDClient) vcdauthorize(user, pass, org string) error {
+	var missing_items []string
 	if user == "" {
-		user = os.Getenv("VCLOUD_USERNAME")
+		missing_items = append(missing_items, "user")
 	}
 	if pass == "" {
-		pass = os.Getenv("VCLOUD_PASSWORD")
+		missing_items = append(missing_items, "password")
 	}
 	if org == "" {
-		org = os.Getenv("VCLOUD_ORG")
+		missing_items = append(missing_items, "org")
+	}
+	if len(missing_items) > 0 {
+		return fmt.Errorf("Authorization is not possible because of these missing items: %v", missing_items)
 	}
 	// No point in checking for errors here
 	req := c.Client.NewRequest(map[string]string{}, "POST", c.sessionHREF, nil)

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -11,7 +11,14 @@ import (
 func (vcd *TestVCD) Test_FindCatalogItem(check *C) {
 	// Fetch Catalog
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	if err != nil {
+		check.Skip("Test_FindCatalogItem: Catalog not found. Test can't proceed")
+	}
+
 	// Find Catalog Item
+	if vcd.config.VCD.Catalog.Catalogitem == "" {
+		check.Skip("Test_FindCatalogItem: Catalog Item not given. Test can't proceed")
+	}
 	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
 	check.Assert(err, IsNil)
 	check.Assert(catitem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.Catalogitem)

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -14,7 +14,11 @@ func (vcd *TestVCD) Test_GetVAppTemplate(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	if err != nil {
-		check.Skip("Catalog not found. Test can't proceed")
+		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
+	}
+
+	if vcd.config.VCD.Catalog.Catalogitem == "" {
+		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
 	}
 
 	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -25,7 +25,7 @@ func (vcd *TestVCD) Test_Refresh(check *C) {
 
 // TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_NATMapping(check *C) {
-	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
@@ -35,11 +35,11 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	task, err := edge.AddNATMapping("DNAT", vcd.config.VCD.Externalip, vcd.config.VCD.Internalip, "77")
+	task, err := edge.AddNATMapping("DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-	task, err = edge.RemoveNATMapping("DNAT", vcd.config.VCD.Externalip, vcd.config.VCD.Internalip, "77")
+	task, err = edge.RemoveNATMapping("DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -47,7 +47,7 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 
 // TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_NATPortMapping(check *C) {
-	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
@@ -56,11 +56,11 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	task, err := edge.AddNATPortMapping("DNAT", vcd.config.VCD.Externalip, "1177", vcd.config.VCD.Internalip, "77")
+	task, err := edge.AddNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-	task, err = edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.Externalip, "1177", vcd.config.VCD.Internalip, "77")
+	task, err = edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -68,7 +68,7 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 
 // TODO: Add a check for the final state of the mapping
 func (vcd *TestVCD) Test_1to1Mappings(check *C) {
-	if vcd.config.VCD.Externalip == "" || vcd.config.VCD.Internalip == "" {
+	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
@@ -77,11 +77,11 @@ func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	task, err := edge.Create1to1Mapping(vcd.config.VCD.Internalip, vcd.config.VCD.Externalip, "description")
+	task, err := edge.Create1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "description")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-	task, err = edge.Remove1to1Mapping(vcd.config.VCD.Internalip, vcd.config.VCD.Externalip)
+	task, err = edge.Remove1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -89,7 +89,7 @@ func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 
 // TODO: Add a check checking whether the IPsec VPN was added
 func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
-	if vcd.config.VCD.Externalip == "" {
+	if vcd.config.VCD.ExternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
 	if vcd.config.VCD.EdgeGateway == "" {
@@ -106,8 +106,8 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 			Name: "",
 		},
 		EncryptionProtocol: "AES",
-		LocalIPAddress:     vcd.config.VCD.Externalip,
-		LocalID:            vcd.config.VCD.Externalip,
+		LocalIPAddress:     vcd.config.VCD.ExternalIp,
+		LocalID:            vcd.config.VCD.ExternalIp,
 		IsEnabled:          true,
 	}
 	tunnels := make([]*types.GatewayIpsecVpnTunnel, 1)

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -1,0 +1,33 @@
+{
+    "comment": "see sample_govcd_test_config.yaml for fields description",
+	"provider": {
+		"user": "someuser",
+		"password": "somepassword",
+		"url": "https://11.111.1.111/api",
+		"sysOrg": "System"
+	},
+	"vcd": {
+		"org": "myorg",
+		"vdc": "myvdc",
+		"catalog": {
+			"name": "mycat",
+			"catalogItem": "myitem",
+			"description": "my cat for loading",
+			"catalogItemDescription": "my item to create vapps"
+		},
+		"network": "mynet",
+		"storageProfile": {
+			"storageProfile1": "Development",
+			"storageProfile2": "*"
+		},
+		"edgeGateway": "myedgegw",
+		"externalIp": "10.150.10.10",
+		"internalIp": "192.168.1.10"
+	},
+	"logging": {
+		"enabled": true,
+		"logFileName": "go-vcloud-director.log",
+		"logHttpRequests": true,
+		"logHttpResponses": true
+	}
+}

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -1,0 +1,77 @@
+# COPY THIS FILE to govcd_test_config.yaml
+# in the same directory and change the values 
+# to match your environment.
+#
+# All items in this file must exist already
+# (They will not be removed or left altered)
+# The test will create a vApp and remove it at the end
+#
+provider:
+    # vCD administrator credentials
+    # (Providing org credentials will skip some tests)
+    user: someuser
+    password: somepassword
+    #
+    # The vCD address, in the format https://vCD_IP/api
+    # or https://vCD_host_name/api
+    url: https://11.111.1.111/api
+    #
+    # The organization you are authenticating with
+    sysOrg: System
+vcd:
+    # Name of the organization (mandatory)
+    org: myorg
+    #
+    # The virtual data center (mandatory)
+    # The tests will create a vApp here
+    #
+    vdc: myvdc
+    # An Org catalog, possibly containing at least one item
+    catalog:
+        name: mycat
+        #
+        # One item in the catalog. It will be used to compose test vApps
+        catalogItem: myitem
+        #
+        # An optional description for the catalog. Its test will be skipped if omitted.
+        # If provided, it must be the current description of the catalog
+        description: mycat for loading
+        #
+        # An optional description for the catalog item
+        catalogItemDescription: myitem to create vapps
+    #
+    network: mynet
+    #
+    # Storage profiles used in the vDC
+    # One or two can be listed
+    storageProfile:
+        # First storage profile (mandatory)
+        storageProfile1: Development
+        # Second storage profile. If omitted, some tests will be skipped.
+        storageProfile2: "*"
+    # An edge gateway
+    # (see https://pubs.vmware.com/vca/topic/com.vmware.vcloud.api.doc_56/GUID-18B0FB8B-385C-4B6D-982C-4B24D271C646.html)
+    edgeGateway: myedgegw
+    #
+    # The IP of the gateway (must exist)
+    externalIp: 10.150.10.10
+    #
+    # An existing IP in the vdc
+    internalIp: 192.168.1.10
+logging:
+    # All items in this section are optional
+    # Logging is disabled by default.
+    # See ./util/LOGGING.md for more info
+    #
+    # Enables or disables logs
+    enabled: true
+    #
+    # changes the log name
+    logFileName: "go-vcloud-director.log"
+    #
+    # Defines whether we log the requests in HTTP operations
+    logHttpRequests: true
+    #
+    # Defines whether we log the responses in HTTP operations
+    logHttpResponses: true
+

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -159,6 +159,9 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 func (vcd *TestVCD) Test_FindVApp(check *C) {
 
+	if vcd.vapp.VApp == nil {
+		check.Skip("No Vapp provided")
+	}
 	first_vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
 
 	check.Assert(err, IsNil)


### PR DESCRIPTION
Related issue: #48 

Changed configuration file name to govcd_test_config.yaml.
Default location for configuration file is current directory (usually ./govcd)
Updated configuration structure
Updated testing instructions.
Integrated configuration file with logging: optional items will enable logging and change main parameters.

**WARNING**! incompatible changes: field names in configuration file now use camel case.

Updated tests with quick checks for missing elements.

Signed-off-by: Giuseppe Maxia
