### PR TITLE
Update Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 language: go
+
+go:
+    - "1.10.x"
+
 sudo: false
 install: false
 
-before_install:
-- go get golang.org/x/tools/cmd/cover
-- go get github.com/mattn/goveralls
-- go get gopkg.in/check.v1
-- go get gopkg.in/yaml.v2
-
 script:
-- make
+    - make
 
 after_success:
-- echo "Build Successful!" 
+    - echo "Build Successful!" 
 after_failure:
-- echo "Build Failed!" 
+    - echo "Build Failed!" 
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 #default: fmt test testrace vet
-default: fmt vet
+default: fmtcheck vet build
 
 # test runs the test suite and vets the code
 test: get-deps fmtcheck
@@ -36,3 +36,6 @@ fmt:
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+
+build:
+	cd govcd && go build .

--- a/vendor/github.com/kr/text/License
+++ b/vendor/github.com/kr/text/License
@@ -1,0 +1,19 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/text/Readme
+++ b/vendor/github.com/kr/text/Readme
@@ -1,0 +1,3 @@
+This is a Go package for manipulating paragraphs of text.
+
+See http://go.pkgdoc.org/github.com/kr/text for full documentation.

--- a/vendor/github.com/kr/text/doc.go
+++ b/vendor/github.com/kr/text/doc.go
@@ -1,0 +1,3 @@
+// Package text provides rudimentary functions for manipulating text in
+// paragraphs.
+package text

--- a/vendor/github.com/kr/text/go.mod
+++ b/vendor/github.com/kr/text/go.mod
@@ -1,0 +1,3 @@
+module "github.com/kr/text"
+
+require "github.com/kr/pty" v1.1.1

--- a/vendor/github.com/kr/text/indent.go
+++ b/vendor/github.com/kr/text/indent.go
@@ -1,0 +1,74 @@
+package text
+
+import (
+	"io"
+)
+
+// Indent inserts prefix at the beginning of each non-empty line of s. The
+// end-of-line marker is NL.
+func Indent(s, prefix string) string {
+	return string(IndentBytes([]byte(s), []byte(prefix)))
+}
+
+// IndentBytes inserts prefix at the beginning of each non-empty line of b.
+// The end-of-line marker is NL.
+func IndentBytes(b, prefix []byte) []byte {
+	var res []byte
+	bol := true
+	for _, c := range b {
+		if bol && c != '\n' {
+			res = append(res, prefix...)
+		}
+		res = append(res, c)
+		bol = c == '\n'
+	}
+	return res
+}
+
+// Writer indents each line of its input.
+type indentWriter struct {
+	w   io.Writer
+	bol bool
+	pre [][]byte
+	sel int
+	off int
+}
+
+// NewIndentWriter makes a new write filter that indents the input
+// lines. Each line is prefixed in order with the corresponding
+// element of pre. If there are more lines than elements, the last
+// element of pre is repeated for each subsequent line.
+func NewIndentWriter(w io.Writer, pre ...[]byte) io.Writer {
+	return &indentWriter{
+		w:   w,
+		pre: pre,
+		bol: true,
+	}
+}
+
+// The only errors returned are from the underlying indentWriter.
+func (w *indentWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if w.bol {
+			var i int
+			i, err = w.w.Write(w.pre[w.sel][w.off:])
+			w.off += i
+			if err != nil {
+				return n, err
+			}
+		}
+		_, err = w.w.Write([]byte{c})
+		if err != nil {
+			return n, err
+		}
+		n++
+		w.bol = c == '\n'
+		if w.bol {
+			w.off = 0
+			if w.sel < len(w.pre)-1 {
+				w.sel++
+			}
+		}
+	}
+	return n, nil
+}

--- a/vendor/github.com/kr/text/indent_test.go
+++ b/vendor/github.com/kr/text/indent_test.go
@@ -1,0 +1,119 @@
+package text
+
+import (
+	"bytes"
+	"testing"
+)
+
+type T struct {
+	inp, exp, pre string
+}
+
+var tests = []T{
+	{
+		"The quick brown fox\njumps over the lazy\ndog.\nBut not quickly.\n",
+		"xxxThe quick brown fox\nxxxjumps over the lazy\nxxxdog.\nxxxBut not quickly.\n",
+		"xxx",
+	},
+	{
+		"The quick brown fox\njumps over the lazy\ndog.\n\nBut not quickly.",
+		"xxxThe quick brown fox\nxxxjumps over the lazy\nxxxdog.\n\nxxxBut not quickly.",
+		"xxx",
+	},
+}
+
+func TestIndent(t *testing.T) {
+	for _, test := range tests {
+		got := Indent(test.inp, test.pre)
+		if got != test.exp {
+			t.Errorf("mismatch %q != %q", got, test.exp)
+		}
+	}
+}
+
+type IndentWriterTest struct {
+	inp, exp string
+	pre      []string
+}
+
+var ts = []IndentWriterTest{
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxxThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxaThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxa", "xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxaThe quick brown fox
+xxbjumps over the lazy
+xxcdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxa", "xxb", "xxc", "xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+
+But not quickly.`[1:],
+		`
+xxaThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxx
+xxxBut not quickly.`[1:],
+		[]string{"xxa", "xxx"},
+	},
+}
+
+func TestIndentWriter(t *testing.T) {
+	for _, test := range ts {
+		b := new(bytes.Buffer)
+		pre := make([][]byte, len(test.pre))
+		for i := range test.pre {
+			pre[i] = []byte(test.pre[i])
+		}
+		w := NewIndentWriter(b, pre...)
+		if _, err := w.Write([]byte(test.inp)); err != nil {
+			t.Error(err)
+		}
+		if got := b.String(); got != test.exp {
+			t.Errorf("mismatch %q != %q", got, test.exp)
+			t.Log(got)
+			t.Log(test.exp)
+		}
+	}
+}

--- a/vendor/github.com/kr/text/wrap.go
+++ b/vendor/github.com/kr/text/wrap.go
@@ -1,0 +1,86 @@
+package text
+
+import (
+	"bytes"
+	"math"
+)
+
+var (
+	nl = []byte{'\n'}
+	sp = []byte{' '}
+)
+
+const defaultPenalty = 1e5
+
+// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// raggedness.
+func Wrap(s string, lim int) string {
+	return string(WrapBytes([]byte(s), lim))
+}
+
+// WrapBytes wraps b into a paragraph of lines of length lim, with minimal
+// raggedness.
+func WrapBytes(b []byte, lim int) []byte {
+	words := bytes.Split(bytes.Replace(bytes.TrimSpace(b), nl, sp, -1), sp)
+	var lines [][]byte
+	for _, line := range WrapWords(words, 1, lim, defaultPenalty) {
+		lines = append(lines, bytes.Join(line, sp))
+	}
+	return bytes.Join(lines, nl)
+}
+
+// WrapWords is the low-level line-breaking algorithm, useful if you need more
+// control over the details of the text wrapping process. For most uses, either
+// Wrap or WrapBytes will be sufficient and more convenient.
+//
+// WrapWords splits a list of words into lines with minimal "raggedness",
+// treating each byte as one unit, accounting for spc units between adjacent
+// words on each line, and attempting to limit lines to lim units. Raggedness
+// is the total error over all lines, where error is the square of the
+// difference of the length of the line and lim. Too-long lines (which only
+// happen when a single word is longer than lim units) have pen penalty units
+// added to the error.
+func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
+	n := len(words)
+
+	length := make([][]int, n)
+	for i := 0; i < n; i++ {
+		length[i] = make([]int, n)
+		length[i][i] = len(words[i])
+		for j := i + 1; j < n; j++ {
+			length[i][j] = length[i][j-1] + spc + len(words[j])
+		}
+	}
+
+	nbrk := make([]int, n)
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = math.MaxInt32
+	}
+	for i := n - 1; i >= 0; i-- {
+		if length[i][n-1] <= lim || i == n-1 {
+			cost[i] = 0
+			nbrk[i] = n
+		} else {
+			for j := i + 1; j < n; j++ {
+				d := lim - length[i][j-1]
+				c := d*d + cost[j]
+				if length[i][j-1] > lim {
+					c += pen // too-long lines get a worse penalty
+				}
+				if c < cost[i] {
+					cost[i] = c
+					nbrk[i] = j
+				}
+			}
+		}
+	}
+
+	var lines [][][]byte
+	i := 0
+	for i < n {
+		lines = append(lines, words[i:nbrk[i]])
+		i = nbrk[i]
+	}
+	return lines
+}

--- a/vendor/github.com/kr/text/wrap_test.go
+++ b/vendor/github.com/kr/text/wrap_test.go
@@ -1,0 +1,62 @@
+package text
+
+import (
+	"bytes"
+	"testing"
+)
+
+var text = "The quick brown fox jumps over the lazy dog."
+
+func TestWrap(t *testing.T) {
+	exp := [][]string{
+		{"The", "quick", "brown", "fox"},
+		{"jumps", "over", "the", "lazy", "dog."},
+	}
+	words := bytes.Split([]byte(text), sp)
+	got := WrapWords(words, 1, 24, defaultPenalty)
+	if len(exp) != len(got) {
+		t.Fail()
+	}
+	for i := range exp {
+		if len(exp[i]) != len(got[i]) {
+			t.Fail()
+		}
+		for j := range exp[i] {
+			if exp[i][j] != string(got[i][j]) {
+				t.Fatal(i, exp[i][j], got[i][j])
+			}
+		}
+	}
+}
+
+func TestWrapNarrow(t *testing.T) {
+	exp := "The\nquick\nbrown\nfox\njumps\nover\nthe\nlazy\ndog."
+	if Wrap(text, 5) != exp {
+		t.Fail()
+	}
+}
+
+func TestWrapOneLine(t *testing.T) {
+	exp := "The quick brown fox jumps over the lazy dog."
+	if Wrap(text, 500) != exp {
+		t.Fail()
+	}
+}
+
+func TestWrapBug1(t *testing.T) {
+	cases := []struct {
+		limit int
+		text  string
+		want  string
+	}{
+		{4, "aaaaa", "aaaaa"},
+		{4, "a aaaaa", "a\naaaaa"},
+	}
+
+	for _, test := range cases {
+		got := Wrap(test.text, test.limit)
+		if got != test.want {
+			t.Errorf("Wrap(%q, %d) = %q want %q", test.text, test.limit, got, test.want)
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -10,6 +10,12 @@
 			"tree": true
 		},
 		{
+			"checksumSHA1": "x9dJv+jQhUFN6R6h4fzPjGLvQLg=",
+			"path": "github.com/kr/text",
+			"revision": "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f",
+			"revisionTime": "2018-05-06T08:24:08Z"
+		},
+		{
 			"checksumSHA1": "9gypWnVZJEaH3jMK9KqOp4xgQD4=",
 			"path": "gopkg.in/check.v1",
 			"revision": "788fd78401277ebd861206a03c884797c6ec5541",


### PR DESCRIPTION
* Removed "go get" instructions that are redundant after adding the "vendor" folder.
* Added a "build" section to the default Makefile actions, so that Travis will catch compilation errors.

(There is no issue for this PR)

Signed-off-by: Giuseppe Maxia

