### PR TITLE
Updates Issue #33 Replace one-letter identifiers

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -6,7 +6,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
-	"net/url"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -96,11 +96,11 @@ func GetConfigStruct() (TestConfig, error) {
 // TestConfig struct can be obtained by calling GetConfigStruct. Throws an error
 // if endpoint given is not a valid url.
 func GetTestVCDFromYaml(g TestConfig) (*VCDClient, error) {
-	u, err := url.ParseRequestURI(g.Provider.Url)
+	url, err := neturl.ParseRequestURI(g.Provider.Url)
 	if err != nil {
 		return &VCDClient{}, fmt.Errorf("could not parse Url: %s", err)
 	}
-	vcdClient := NewVCDClient(*u, true)
+	vcdClient := NewVCDClient(*url, true)
 	return vcdClient, nil
 }
 

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -13,13 +13,13 @@ import (
 
 type CatalogItem struct {
 	CatalogItem *types.CatalogItem
-	c           *Client
+	client      *Client
 }
 
-func NewCatalogItem(c *Client) *CatalogItem {
+func NewCatalogItem(cli *Client) *CatalogItem {
 	return &CatalogItem{
 		CatalogItem: new(types.CatalogItem),
-		c:           c,
+		client:      cli,
 	}
 }
 
@@ -30,14 +30,14 @@ func (ci *CatalogItem) GetVAppTemplate() (VAppTemplate, error) {
 		return VAppTemplate{}, fmt.Errorf("error decoding catalogitem response: %s", err)
 	}
 
-	req := ci.c.NewRequest(map[string]string{}, "GET", *url, nil)
+	req := ci.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(ci.c.Http.Do(req))
+	resp, err := checkResp(ci.client.Http.Do(req))
 	if err != nil {
 		return VAppTemplate{}, fmt.Errorf("error retreiving vapptemplate: %s", err)
 	}
 
-	cat := NewVAppTemplate(ci.c)
+	cat := NewVAppTemplate(ci.client)
 
 	if err = decodeBody(resp, cat.VAppTemplate); err != nil {
 		return VAppTemplate{}, fmt.Errorf("error decoding vapptemplate response: %s", err)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -9,7 +9,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"regexp"
 	"time"
 
@@ -19,18 +19,18 @@ import (
 
 type EdgeGateway struct {
 	EdgeGateway *types.EdgeGateway
-	c           *Client
+	client      *Client
 }
 
-func NewEdgeGateway(c *Client) *EdgeGateway {
+func NewEdgeGateway(cli *Client) *EdgeGateway {
 	return &EdgeGateway{
 		EdgeGateway: new(types.EdgeGateway),
-		c:           c,
+		client:      cli,
 	}
 }
 
-func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []interface{}) (Task, error) {
-	newedgeconfig := e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
+func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []interface{}) (Task, error) {
+	newedgeconfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 	util.GovcdLogger.Printf("[DEBUG] EDGE GATEWAY: %#v", newedgeconfig)
 	util.GovcdLogger.Printf("[DEBUG] EDGE GATEWAY SERVICE: %#v", newedgeconfig.GatewayDhcpService)
 	newdchpservice := &types.GatewayDhcpService{}
@@ -39,20 +39,20 @@ func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []inter
 	} else {
 		newdchpservice.IsEnabled = newedgeconfig.GatewayDhcpService.IsEnabled
 
-		for _, v := range newedgeconfig.GatewayDhcpService.Pool {
+		for _, poolService := range newedgeconfig.GatewayDhcpService.Pool {
 
 			// Kludgy IF to avoid deleting DNAT rules not created by us.
 			// If matches, let's skip it and continue the loop
-			if v.Network.HREF == network.HREF {
+			if poolService.Network.HREF == network.HREF {
 				continue
 			}
 
-			newdchpservice.Pool = append(newdchpservice.Pool, v)
+			newdchpservice.Pool = append(newdchpservice.Pool, poolService)
 		}
 	}
 
-	for _, v := range dhcppool {
-		data := v.(map[string]interface{})
+	for _, item := range dhcppool {
+		data := item.(map[string]interface{})
 
 		if data["default_lease_time"] == nil {
 			data["default_lease_time"] = 3600
@@ -88,20 +88,20 @@ func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []inter
 
 	var resp *http.Response
 	for {
-		b := bytes.NewBufferString(xml.Header + string(output))
+		buffer := bytes.NewBufferString(xml.Header + string(output))
 
-		s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-		s.Path += "/action/configureServices"
+		apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+		apiEndpoint.Path += "/action/configureServices"
 
-		req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
-		util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", s.Path)
-		util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", b)
+		req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+		util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
+		util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
 		req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-		resp, err = checkResp(e.c.Http.Do(req))
+		resp, err = checkResp(eGW.client.Http.Do(req))
 		if err != nil {
-			if v, _ := regexp.MatchString("is busy completing an operation.$", err.Error()); v {
+			if match, _ := regexp.MatchString("is busy completing an operation.$", err.Error()); match {
 				time.Sleep(3 * time.Second)
 				continue
 			}
@@ -110,7 +110,7 @@ func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []inter
 		break
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -121,21 +121,21 @@ func (e *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []inter
 
 }
 
-func (e *EdgeGateway) RemoveNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
-	return e.RemoveNATPortMapping(nattype, externalIP, port, internalIP, port)
+func (eGW *EdgeGateway) RemoveNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
+	return eGW.RemoveNATPortMapping(nattype, externalIP, port, internalIP, port)
 }
 
-func (e *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
+func (eGW *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
 	// Find uplink interface
 	var uplink types.Reference
-	for _, gi := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
+	for _, gi := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
 		if gi.InterfaceType != "uplink" {
 			continue
 		}
 		uplink = *gi.Network
 	}
 
-	newedgeconfig := e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
+	newedgeconfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 
 	// Take care of the NAT service
 	newnatservice := &types.NatService{}
@@ -145,19 +145,19 @@ func (e *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort str
 	newnatservice.Policy = newedgeconfig.NatService.Policy
 	newnatservice.ExternalIP = newedgeconfig.NatService.ExternalIP
 
-	for _, v := range newedgeconfig.NatService.NatRule {
+	for _, natRule := range newedgeconfig.NatService.NatRule {
 
 		// Kludgy IF to avoid deleting DNAT rules not created by us.
 		// If matches, let's skip it and continue the loop
-		if v.RuleType == nattype &&
-			v.GatewayNatRule.OriginalIP == externalIP &&
-			v.GatewayNatRule.OriginalPort == externalPort &&
-			v.GatewayNatRule.Interface.HREF == uplink.HREF {
-			util.GovcdLogger.Printf("[DEBUG] REMOVING %s Rule: %#v", v.RuleType, v.GatewayNatRule)
+		if natRule.RuleType == nattype &&
+			natRule.GatewayNatRule.OriginalIP == externalIP &&
+			natRule.GatewayNatRule.OriginalPort == externalPort &&
+			natRule.GatewayNatRule.Interface.HREF == uplink.HREF {
+			util.GovcdLogger.Printf("[DEBUG] REMOVING %s Rule: %#v", natRule.RuleType, natRule.GatewayNatRule)
 			continue
 		}
-		util.GovcdLogger.Printf("[DEBUG] KEEPING %s Rule: %#v", v.RuleType, v.GatewayNatRule)
-		newnatservice.NatRule = append(newnatservice.NatRule, v)
+		util.GovcdLogger.Printf("[DEBUG] KEEPING %s Rule: %#v", natRule.RuleType, natRule.GatewayNatRule)
+		newnatservice.NatRule = append(newnatservice.NatRule, natRule)
 	}
 
 	newedgeconfig.NatService = newnatservice
@@ -172,24 +172,24 @@ func (e *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort str
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-	s.Path += "/action/configureServices"
+	apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+	apiEndpoint.Path += "/action/configureServices"
 
-	req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
-	util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", s.Path)
-	util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", b)
+	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+	util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
+	util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		util.GovcdLogger.Printf("[DEBUG] Error is: %#v", err)
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -200,17 +200,17 @@ func (e *EdgeGateway) RemoveNATPortMapping(nattype, externalIP, externalPort str
 
 }
 
-func (e *EdgeGateway) AddNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
-	return e.AddNATPortMapping(nattype, externalIP, port, internalIP, port)
+func (eGW *EdgeGateway) AddNATMapping(nattype, externalIP, internalIP, port string) (Task, error) {
+	return eGW.AddNATPortMapping(nattype, externalIP, port, internalIP, port)
 }
 
-func (e *EdgeGateway) AddNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
-	return e.AddNATPortMappingWithUplink(nil, nattype, externalIP, externalPort, internalIP, internalPort)
+func (eGW *EdgeGateway) AddNATPortMapping(nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
+	return eGW.AddNATPortMappingWithUplink(nil, nattype, externalIP, externalPort, internalIP, internalPort)
 }
 
-func (e *EdgeGateway) getFirstUplink() types.Reference {
+func (eGW *EdgeGateway) getFirstUplink() types.Reference {
 	var uplink types.Reference
-	for _, gi := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
+	for _, gi := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
 		if gi.InterfaceType != "uplink" {
 			continue
 		}
@@ -219,17 +219,17 @@ func (e *EdgeGateway) getFirstUplink() types.Reference {
 	return uplink
 }
 
-func (e *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
+func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, nattype, externalIP, externalPort string, internalIP, internalPort string) (Task, error) {
 	// if a network is provided take it, otherwise find first uplink on the edgegateway
 	var uplinkRef string
 
 	if network != nil {
 		uplinkRef = network.HREF
 	} else {
-		uplinkRef = e.getFirstUplink().HREF
+		uplinkRef = eGW.getFirstUplink().HREF
 	}
 
-	newedgeconfig := e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
+	newedgeconfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 
 	// Take care of the NAT service
 	newnatservice := &types.NatService{}
@@ -242,20 +242,20 @@ func (e *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, 
 		newnatservice.Policy = newedgeconfig.NatService.Policy
 		newnatservice.ExternalIP = newedgeconfig.NatService.ExternalIP
 
-		for _, v := range newedgeconfig.NatService.NatRule {
+		for _, natRule := range newedgeconfig.NatService.NatRule {
 
 			// Kludgy IF to avoid deleting DNAT rules not created by us.
 			// If matches, let's skip it and continue the loop
-			if v.RuleType == nattype &&
-				v.GatewayNatRule.OriginalIP == externalIP &&
-				v.GatewayNatRule.OriginalPort == externalPort &&
-				v.GatewayNatRule.TranslatedIP == internalIP &&
-				v.GatewayNatRule.TranslatedPort == internalPort &&
-				v.GatewayNatRule.Interface.HREF == uplinkRef {
+			if natRule.RuleType == nattype &&
+				natRule.GatewayNatRule.OriginalIP == externalIP &&
+				natRule.GatewayNatRule.OriginalPort == externalPort &&
+				natRule.GatewayNatRule.TranslatedIP == internalIP &&
+				natRule.GatewayNatRule.TranslatedPort == internalPort &&
+				natRule.GatewayNatRule.Interface.HREF == uplinkRef {
 				continue
 			}
 
-			newnatservice.NatRule = append(newnatservice.NatRule, v)
+			newnatservice.NatRule = append(newnatservice.NatRule, natRule)
 		}
 	}
 
@@ -288,24 +288,24 @@ func (e *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, 
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-	s.Path += "/action/configureServices"
+	apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+	apiEndpoint.Path += "/action/configureServices"
 
-	req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
-	util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", s.Path)
-	util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", b)
+	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+	util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
+	util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		util.GovcdLogger.Printf("[DEBUG] Error is: %#v", err)
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -316,8 +316,8 @@ func (e *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, 
 
 }
 
-func (e *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.FirewallRule) (Task, error) {
-	err := e.Refresh()
+func (eGW *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.FirewallRule) (Task, error) {
+	err := eGW.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error: %v\n", err)
 	}
@@ -339,20 +339,20 @@ func (e *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.F
 
 	var resp *http.Response
 	for {
-		b := bytes.NewBufferString(xml.Header + string(output))
+		buffer := bytes.NewBufferString(xml.Header + string(output))
 
-		s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-		s.Path += "/action/configureServices"
+		apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+		apiEndpoint.Path += "/action/configureServices"
 
-		req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
-		util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", s.Path)
-		util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", b)
+		req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
+		util.GovcdLogger.Printf("[DEBUG] POSTING TO URL: %s", apiEndpoint.Path)
+		util.GovcdLogger.Printf("[DEBUG] XML TO SEND:\n%s", buffer)
 
 		req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-		resp, err = checkResp(e.c.Http.Do(req))
+		resp, err = checkResp(eGW.client.Http.Do(req))
 		if err != nil {
-			if v, _ := regexp.MatchString("is busy completing an operation.$", err.Error()); v {
+			if match, _ := regexp.MatchString("is busy completing an operation.$", err.Error()); match {
 				time.Sleep(3 * time.Second)
 				continue
 			}
@@ -361,7 +361,7 @@ func (e *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.F
 		break
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -371,26 +371,26 @@ func (e *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.F
 	return *task, nil
 }
 
-func (e *EdgeGateway) Refresh() error {
+func (eGW *EdgeGateway) Refresh() error {
 
-	if e.EdgeGateway == nil {
+	if eGW.EdgeGateway == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
+	url, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
 
-	req := e.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := eGW.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error retreiving Edge Gateway: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	e.EdgeGateway = &types.EdgeGateway{}
+	eGW.EdgeGateway = &types.EdgeGateway{}
 
-	if err = decodeBody(resp, e.EdgeGateway); err != nil {
+	if err = decodeBody(resp, eGW.EdgeGateway); err != nil {
 		return fmt.Errorf("error decoding Edge Gateway response: %s", err)
 	}
 
@@ -398,22 +398,22 @@ func (e *EdgeGateway) Refresh() error {
 	return nil
 }
 
-func (e *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error) {
+func (eGW *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error) {
 
 	// Refresh EdgeGateway rules
-	err := e.Refresh()
+	err := eGW.Refresh()
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
 
 	var uplinkif string
-	for _, gifs := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
+	for _, gifs := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
 		if gifs.InterfaceType == "uplink" {
 			uplinkif = gifs.Network.HREF
 		}
 	}
 
-	newedgeconfig := e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
+	newedgeconfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 
 	// Take care of the NAT service
 	newnatservice := &types.NatService{}
@@ -424,32 +424,32 @@ func (e *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error)
 	newnatservice.Policy = newedgeconfig.NatService.Policy
 	newnatservice.ExternalIP = newedgeconfig.NatService.ExternalIP
 
-	for k, v := range newedgeconfig.NatService.NatRule {
+	for N, natRule := range newedgeconfig.NatService.NatRule {
 
 		// Kludgy IF to avoid deleting DNAT rules not created by us.
 		// If matches, let's skip it and continue the loop
-		if v.RuleType == "DNAT" &&
-			v.GatewayNatRule.OriginalIP == external &&
-			v.GatewayNatRule.TranslatedIP == internal &&
-			v.GatewayNatRule.OriginalPort == "any" &&
-			v.GatewayNatRule.TranslatedPort == "any" &&
-			v.GatewayNatRule.Protocol == "any" &&
-			v.GatewayNatRule.Interface.HREF == uplinkif {
+		if natRule.RuleType == "DNAT" &&
+			natRule.GatewayNatRule.OriginalIP == external &&
+			natRule.GatewayNatRule.TranslatedIP == internal &&
+			natRule.GatewayNatRule.OriginalPort == "any" &&
+			natRule.GatewayNatRule.TranslatedPort == "any" &&
+			natRule.GatewayNatRule.Protocol == "any" &&
+			natRule.GatewayNatRule.Interface.HREF == uplinkif {
 			continue
 		}
 
 		// Kludgy IF to avoid deleting SNAT rules not created by us.
 		// If matches, let's skip it and continue the loop
-		if v.RuleType == "SNAT" &&
-			v.GatewayNatRule.OriginalIP == internal &&
-			v.GatewayNatRule.TranslatedIP == external &&
-			v.GatewayNatRule.Interface.HREF == uplinkif {
+		if natRule.RuleType == "SNAT" &&
+			natRule.GatewayNatRule.OriginalIP == internal &&
+			natRule.GatewayNatRule.TranslatedIP == external &&
+			natRule.GatewayNatRule.Interface.HREF == uplinkif {
 			continue
 		}
 
 		// If doesn't match the above IFs, it's something we need to preserve,
 		// let's add it to the new NatService struct
-		newnatservice.NatRule = append(newnatservice.NatRule, newedgeconfig.NatService.NatRule[k])
+		newnatservice.NatRule = append(newnatservice.NatRule, newedgeconfig.NatService.NatRule[N])
 
 	}
 
@@ -464,33 +464,33 @@ func (e *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error)
 	newfwservice.DefaultAction = newedgeconfig.FirewallService.DefaultAction
 	newfwservice.LogDefaultAction = newedgeconfig.FirewallService.LogDefaultAction
 
-	for k, v := range newedgeconfig.FirewallService.FirewallRule {
+	for N, fwRule := range newedgeconfig.FirewallService.FirewallRule {
 
 		// Kludgy IF to avoid deleting inbound FW rules not created by us.
 		// If matches, let's skip it and continue the loop
-		if v.Policy == "allow" &&
-			v.Protocols.Any == true &&
-			v.DestinationPortRange == "Any" &&
-			v.SourcePortRange == "Any" &&
-			v.SourceIP == "Any" &&
-			v.DestinationIP == external {
+		if fwRule.Policy == "allow" &&
+			fwRule.Protocols.Any == true &&
+			fwRule.DestinationPortRange == "Any" &&
+			fwRule.SourcePortRange == "Any" &&
+			fwRule.SourceIP == "Any" &&
+			fwRule.DestinationIP == external {
 			continue
 		}
 
 		// Kludgy IF to avoid deleting outbound FW rules not created by us.
 		// If matches, let's skip it and continue the loop
-		if v.Policy == "allow" &&
-			v.Protocols.Any == true &&
-			v.DestinationPortRange == "Any" &&
-			v.SourcePortRange == "Any" &&
-			v.SourceIP == internal &&
-			v.DestinationIP == "Any" {
+		if fwRule.Policy == "allow" &&
+			fwRule.Protocols.Any == true &&
+			fwRule.DestinationPortRange == "Any" &&
+			fwRule.SourcePortRange == "Any" &&
+			fwRule.SourceIP == internal &&
+			fwRule.DestinationIP == "Any" {
 			continue
 		}
 
 		// If doesn't match the above IFs, it's something we need to preserve,
 		// let's add it to the new FirewallService struct
-		newfwservice.FirewallRule = append(newfwservice.FirewallRule, newedgeconfig.FirewallService.FirewallRule[k])
+		newfwservice.FirewallRule = append(newfwservice.FirewallRule, newedgeconfig.FirewallService.FirewallRule[N])
 
 	}
 
@@ -507,21 +507,21 @@ func (e *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error)
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-	s.Path += "/action/configureServices"
+	apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+	apiEndpoint.Path += "/action/configureServices"
 
-	req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -532,22 +532,22 @@ func (e *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, error)
 
 }
 
-func (e *EdgeGateway) Create1to1Mapping(internal, external, description string) (Task, error) {
+func (eGW *EdgeGateway) Create1to1Mapping(internal, external, description string) (Task, error) {
 
 	// Refresh EdgeGateway rules
-	err := e.Refresh()
+	err := eGW.Refresh()
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
 
 	var uplinkif string
-	for _, gifs := range e.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
+	for _, gifs := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
 		if gifs.InterfaceType == "uplink" {
 			uplinkif = gifs.Network.HREF
 		}
 	}
 
-	newedgeconfig := e.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
+	newedgeconfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 
 	snat := &types.NatRule{
 		Description: description,
@@ -622,21 +622,21 @@ func (e *EdgeGateway) Create1to1Mapping(internal, external, description string) 
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-	s.Path += "/action/configureServices"
+	apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+	apiEndpoint.Path += "/action/configureServices"
 
-	req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -647,9 +647,9 @@ func (e *EdgeGateway) Create1to1Mapping(internal, external, description string) 
 
 }
 
-func (e *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConfiguration) (Task, error) {
+func (eGW *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConfiguration) (Task, error) {
 
-	err := e.Refresh()
+	err := eGW.Refresh()
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
@@ -661,22 +661,22 @@ func (e *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConfig
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
-	util.GovcdLogger.Printf("[DEBUG] ipsecVPN configuration: %s", b)
+	buffer := bytes.NewBufferString(xml.Header + string(output))
+	util.GovcdLogger.Printf("[DEBUG] ipsecVPN configuration: %s", buffer)
 
-	s, _ := url.ParseRequestURI(e.EdgeGateway.HREF)
-	s.Path += "/action/configureServices"
+	apiEndpoint, _ := neturl.ParseRequestURI(eGW.EdgeGateway.HREF)
+	apiEndpoint.Path += "/action/configureServices"
 
-	req := e.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := eGW.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.edgeGatewayServiceConfiguration+xml")
 
-	resp, err := checkResp(e.c.Http.Do(req))
+	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
 	}
 
-	task := NewTask(e.c)
+	task := NewTask(eGW.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -11,7 +11,7 @@ import (
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -20,36 +20,36 @@ import (
 // OrgVDCNetwork an org vdc network client
 type OrgVDCNetwork struct {
 	OrgVDCNetwork *types.OrgVDCNetwork
-	c             *Client
+	client        *Client
 }
 
 // NewOrgVDCNetwork creates an org vdc network client
 func NewOrgVDCNetwork(c *Client) *OrgVDCNetwork {
 	return &OrgVDCNetwork{
 		OrgVDCNetwork: new(types.OrgVDCNetwork),
-		c:             c,
+		client:        c,
 	}
 }
 
-func (o *OrgVDCNetwork) Refresh() error {
-	if o.OrgVDCNetwork.HREF == "" {
+func (orgVdcNet *OrgVDCNetwork) Refresh() error {
+	if orgVdcNet.OrgVDCNetwork.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(o.OrgVDCNetwork.HREF)
+	url, _ := neturl.ParseRequestURI(orgVdcNet.OrgVDCNetwork.HREF)
 
-	req := o.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := orgVdcNet.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(o.c.Http.Do(req))
+	resp, err := checkResp(orgVdcNet.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error retrieving task: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	o.OrgVDCNetwork = &types.OrgVDCNetwork{}
+	orgVdcNet.OrgVDCNetwork = &types.OrgVDCNetwork{}
 
-	if err = decodeBody(resp, o.OrgVDCNetwork); err != nil {
+	if err = decodeBody(resp, orgVdcNet.OrgVDCNetwork); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 
@@ -57,21 +57,21 @@ func (o *OrgVDCNetwork) Refresh() error {
 	return nil
 }
 
-func (o *OrgVDCNetwork) Delete() (Task, error) {
-	err := o.Refresh()
+func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
+	err := orgVdcNet.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("Error refreshing network: %s", err)
 	}
-	pathArr := strings.Split(o.OrgVDCNetwork.HREF, "/")
-	s, _ := url.ParseRequestURI(o.OrgVDCNetwork.HREF)
-	s.Path = "/api/admin/network/" + pathArr[len(pathArr)-1]
+	pathArr := strings.Split(orgVdcNet.OrgVDCNetwork.HREF, "/")
+	apiEndpoint, _ := neturl.ParseRequestURI(orgVdcNet.OrgVDCNetwork.HREF)
+	apiEndpoint.Path = "/api/admin/network/" + pathArr[len(pathArr)-1]
 
 	var resp *http.Response
 	for {
-		req := o.c.NewRequest(map[string]string{}, "DELETE", *s, nil)
-		resp, err = checkResp(o.c.Http.Do(req))
+		req := orgVdcNet.client.NewRequest(map[string]string{}, "DELETE", *apiEndpoint, nil)
+		resp, err = checkResp(orgVdcNet.client.Http.Do(req))
 		if err != nil {
-			if v, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); v {
+			if match, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); match {
 				time.Sleep(3 * time.Second)
 				continue
 			}
@@ -80,7 +80,7 @@ func (o *OrgVDCNetwork) Delete() (Task, error) {
 		break
 	}
 
-	task := NewTask(o.c)
+	task := NewTask(orgVdcNet.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -90,10 +90,10 @@ func (o *OrgVDCNetwork) Delete() (Task, error) {
 	return *task, nil
 }
 
-func (v *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) error {
-	for _, av := range v.Vdc.Link {
+func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) error {
+	for _, av := range vdc.Vdc.Link {
 		if av.Rel == "add" && av.Type == "application/vnd.vmware.vcloud.orgVdcNetwork+xml" {
-			u, err := url.ParseRequestURI(av.HREF)
+			url, err := neturl.ParseRequestURI(av.HREF)
 			//return fmt.Errorf("Test output: %#v")
 
 			if err != nil {
@@ -109,13 +109,13 @@ func (v *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) error {
 
 			var resp *http.Response
 			for {
-				b := bytes.NewBufferString(xml.Header + string(output))
-				util.GovcdLogger.Printf("[DEBUG] VCD Client configuration: %s", b)
-				req := v.c.NewRequest(map[string]string{}, "POST", *u, b)
+				buffer := bytes.NewBufferString(xml.Header + string(output))
+				util.GovcdLogger.Printf("[DEBUG] VCD Client configuration: %s", buffer)
+				req := vdc.client.NewRequest(map[string]string{}, "POST", *url, buffer)
 				req.Header.Add("Content-Type", av.Type)
-				resp, err = checkResp(v.c.Http.Do(req))
+				resp, err = checkResp(vdc.client.Http.Do(req))
 				if err != nil {
-					if v, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); v {
+					if match, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); match {
 						time.Sleep(3 * time.Second)
 						continue
 					}
@@ -123,11 +123,11 @@ func (v *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) error {
 				}
 				break
 			}
-			newstuff := NewOrgVDCNetwork(v.c)
+			newstuff := NewOrgVDCNetwork(vdc.client)
 			if err = decodeBody(resp, newstuff.OrgVDCNetwork); err != nil {
 				return fmt.Errorf("error decoding orgvdcnetwork response: %s", err)
 			}
-			task := NewTask(v.c)
+			task := NewTask(vdc.client)
 			for _, t := range newstuff.OrgVDCNetwork.Tasks.Task {
 				task.Task = t
 				err = task.WaitTaskCompletion()

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -12,27 +12,27 @@ import (
 
 type Results struct {
 	Results *types.QueryResultRecordsType
-	c       *Client
+	client  *Client
 }
 
-func NewResults(c *Client) *Results {
+func NewResults(client *Client) *Results {
 	return &Results{
 		Results: new(types.QueryResultRecordsType),
-		c:       c,
+		client:  client,
 	}
 }
 
-func (c *VCDClient) Query(params map[string]string) (Results, error) {
+func (cli *VCDClient) Query(params map[string]string) (Results, error) {
 
-	req := c.Client.NewRequest(params, "GET", c.QueryHREF, nil)
+	req := cli.Client.NewRequest(params, "GET", cli.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
 
-	resp, err := checkResp(c.Client.Http.Do(req))
+	resp, err := checkResp(cli.Client.Http.Do(req))
 	if err != nil {
 		return Results{}, fmt.Errorf("error retreiving query: %s", err)
 	}
 
-	results := NewResults(&c.Client)
+	results := NewResults(&cli.Client)
 
 	if err = decodeBody(resp, results.Results); err != nil {
 		return Results{}, fmt.Errorf("error decoding query results: %s", err)

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -104,9 +104,9 @@ func getOrgHREF(vcdClient *VCDClient, orgname string) (string, error) {
 		return "", fmt.Errorf("error decoding response: %s", err)
 	}
 	// Look for orgname within OrgList
-	for _, a := range orgList.Org {
-		if a.Name == orgname {
-			return a.HREF, nil
+	for _, org := range orgList.Org {
+		if org.Name == orgname {
+			return org.HREF, nil
 		}
 	}
 	return "", fmt.Errorf("Couldn't find org with name: %s", orgname)

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -6,44 +6,44 @@ package govcd
 
 import (
 	"fmt"
-	"net/url"
+	neturl "net/url"
 	"time"
 
 	types "github.com/vmware/go-vcloud-director/types/v56"
 )
 
 type Task struct {
-	Task *types.Task
-	c    *Client
+	Task   *types.Task
+	client *Client
 }
 
 func NewTask(c *Client) *Task {
 	return &Task{
-		Task: new(types.Task),
-		c:    c,
+		Task:   new(types.Task),
+		client: c,
 	}
 }
 
-func (t *Task) Refresh() error {
+func (task *Task) Refresh() error {
 
-	if t.Task == nil {
+	if task.Task == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(t.Task.HREF)
+	url, _ := neturl.ParseRequestURI(task.Task.HREF)
 
-	req := t.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := task.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(t.c.Http.Do(req))
+	resp, err := checkResp(task.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error retrieving task: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	t.Task = &types.Task{}
+	task.Task = &types.Task{}
 
-	if err = decodeBody(resp, t.Task); err != nil {
+	if err = decodeBody(resp, task.Task); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 
@@ -51,22 +51,22 @@ func (t *Task) Refresh() error {
 	return nil
 }
 
-func (t *Task) WaitTaskCompletion() error {
+func (task *Task) WaitTaskCompletion() error {
 
-	if t.Task == nil {
+	if task.Task == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
 	for {
-		err := t.Refresh()
+		err := task.Refresh()
 		if err != nil {
 			return fmt.Errorf("error retreiving task: %s", err)
 		}
 
 		// If task is not in a waiting status we're done, check if there's an error and return it.
-		if t.Task.Status != "queued" && t.Task.Status != "preRunning" && t.Task.Status != "running" {
-			if t.Task.Status == "error" {
-				return fmt.Errorf("task did not complete succesfully: %s", t.Task.Description)
+		if task.Task.Status != "queued" && task.Task.Status != "preRunning" && task.Task.Status != "running" {
+			if task.Task.Status == "error" {
+				return fmt.Errorf("task did not complete succesfully: %s", task.Task.Description)
 			}
 			return nil
 		}

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"net/url"
+	neturl "net/url"
 
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
@@ -16,34 +16,34 @@ import (
 )
 
 type VApp struct {
-	VApp *types.VApp
-	c    *Client
+	VApp   *types.VApp
+	client *Client
 }
 
-func NewVApp(c *Client) *VApp {
+func NewVApp(client *Client) *VApp {
 	return &VApp{
-		VApp: new(types.VApp),
-		c:    c,
+		VApp:   new(types.VApp),
+		client: client,
 	}
 }
 
-func (v *VCDClient) NewVApp(c *Client) VApp {
-	newvapp := NewVApp(c)
+func (cli *VCDClient) NewVApp(client *Client) VApp {
+	newvapp := NewVApp(client)
 	return *newvapp
 }
 
 // Returns the vdc where the vapp resides in.
-func (v *VApp) getParentVDC() (Vdc, error) {
-	for _, a := range v.VApp.Link {
-		if a.Type == "application/vnd.vmware.vcloud.vdc+xml" {
-			u, err := url.ParseRequestURI(a.HREF)
+func (vapp *VApp) getParentVDC() (Vdc, error) {
+	for _, link := range vapp.VApp.Link {
+		if link.Type == "application/vnd.vmware.vcloud.vdc+xml" {
+			url, err := neturl.ParseRequestURI(link.HREF)
 			if err != nil {
 				return Vdc{}, fmt.Errorf("Cannot parse HREF : %v", err)
 			}
-			req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
-			resp, err := checkResp(v.c.Http.Do(req))
+			req := vapp.client.NewRequest(map[string]string{}, "GET", *url, nil)
+			resp, err := checkResp(vapp.client.Http.Do(req))
 
-			vdc := NewVdc(v.c)
+			vdc := NewVdc(vapp.client)
 			if err = decodeBody(resp, vdc.Vdc); err != nil {
 				return Vdc{}, fmt.Errorf("error decoding task response: %s", err)
 			}
@@ -53,26 +53,26 @@ func (v *VApp) getParentVDC() (Vdc, error) {
 	return Vdc{}, fmt.Errorf("Could not find a parent Vdc")
 }
 
-func (v *VApp) Refresh() error {
+func (vapp *VApp) Refresh() error {
 
-	if v.VApp.HREF == "" {
+	if vapp.VApp.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(v.VApp.HREF)
+	url, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
 
-	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error retrieving task: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	v.VApp = &types.VApp{}
+	vapp.VApp = &types.VApp{}
 
-	if err = decodeBody(resp, v.VApp); err != nil {
+	if err = decodeBody(resp, vapp.VApp); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 
@@ -80,16 +80,16 @@ func (v *VApp) Refresh() error {
 	return nil
 }
 
-func (v *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, name string, acceptalleulas bool) (Task, error) {
+func (vapp *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, name string, acceptalleulas bool) (Task, error) {
 
 	vcomp := &types.ReComposeVAppParams{
 		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
 		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
 		Deploy:      false,
-		Name:        v.VApp.Name,
+		Name:        vapp.VApp.Name,
 		PowerOn:     false,
-		Description: v.VApp.Description,
+		Description: vapp.VApp.Description,
 		SourcedItem: &types.SourcedCompositionItemParam{
 			Source: &types.Reference{
 				HREF: vapptemplate.VAppTemplate.Children.VM[0].HREF,
@@ -126,23 +126,23 @@ func (v *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTem
 
 	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/action/recomposeVApp"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/action/recomposeVApp"
 
 	util.GovcdLogger.Printf("[TRACE] Recompose XML: %s", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.recomposeVAppParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error instantiating a new VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding task response: %s", err)
@@ -151,12 +151,12 @@ func (v *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTem
 	return *task, nil
 }
 
-func (v *VApp) RemoveVM(vm VM) error {
+func (vapp *VApp) RemoveVM(vm VM) error {
 
-	v.Refresh()
-	task := NewTask(v.c)
-	if v.VApp.Tasks != nil {
-		for _, t := range v.VApp.Tasks.Task {
+	vapp.Refresh()
+	task := NewTask(vapp.client)
+	if vapp.VApp.Tasks != nil {
+		for _, t := range vapp.VApp.Tasks.Task {
 			task.Task = t
 			err := task.WaitTaskCompletion()
 			if err != nil {
@@ -176,21 +176,21 @@ func (v *VApp) RemoveVM(vm VM) error {
 
 	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/action/recomposeVApp"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/action/recomposeVApp"
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.recomposeVAppParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error instantiating a new vApp: %s", err)
 	}
 
-	task = NewTask(v.c)
+	task = NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
@@ -204,19 +204,19 @@ func (v *VApp) RemoveVM(vm VM) error {
 	return nil
 }
 
-func (v *VApp) PowerOn() (Task, error) {
+func (vapp *VApp) PowerOn() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/powerOn"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/powerOn"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error powering on vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -227,19 +227,19 @@ func (v *VApp) PowerOn() (Task, error) {
 
 }
 
-func (v *VApp) PowerOff() (Task, error) {
+func (vapp *VApp) PowerOff() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/powerOff"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/powerOff"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error powering off vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -250,19 +250,19 @@ func (v *VApp) PowerOff() (Task, error) {
 
 }
 
-func (v *VApp) Reboot() (Task, error) {
+func (vapp *VApp) Reboot() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/reboot"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/reboot"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error rebooting vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -273,19 +273,19 @@ func (v *VApp) Reboot() (Task, error) {
 
 }
 
-func (v *VApp) Reset() (Task, error) {
+func (vapp *VApp) Reset() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/reset"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/reset"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error resetting vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -296,19 +296,19 @@ func (v *VApp) Reset() (Task, error) {
 
 }
 
-func (v *VApp) Suspend() (Task, error) {
+func (vapp *VApp) Suspend() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/suspend"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/suspend"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error suspending vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -319,19 +319,19 @@ func (v *VApp) Suspend() (Task, error) {
 
 }
 
-func (v *VApp) Shutdown() (Task, error) {
+func (vapp *VApp) Shutdown() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/power/action/shutdown"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/power/action/shutdown"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error shutting down vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -342,7 +342,7 @@ func (v *VApp) Shutdown() (Task, error) {
 
 }
 
-func (v *VApp) Undeploy() (Task, error) {
+func (vapp *VApp) Undeploy() (Task, error) {
 
 	vu := &types.UndeployVAppParams{
 		Xmlns:               "http://www.vmware.com/vcloud/v1.5",
@@ -356,21 +356,21 @@ func (v *VApp) Undeploy() (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/action/undeploy"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/action/undeploy"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.undeployVAppParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -381,7 +381,7 @@ func (v *VApp) Undeploy() (Task, error) {
 
 }
 
-func (v *VApp) Deploy() (Task, error) {
+func (vapp *VApp) Deploy() (Task, error) {
 
 	vu := &types.DeployVAppParams{
 		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
@@ -395,21 +395,21 @@ func (v *VApp) Deploy() (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/action/deploy"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/action/deploy"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.deployVAppParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -420,18 +420,18 @@ func (v *VApp) Deploy() (Task, error) {
 
 }
 
-func (v *VApp) Delete() (Task, error) {
+func (vapp *VApp) Delete() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
 
-	req := v.c.NewRequest(map[string]string{}, "DELETE", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "DELETE", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error deleting vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -442,18 +442,18 @@ func (v *VApp) Delete() (Task, error) {
 
 }
 
-func (v *VApp) RunCustomizationScript(computername, script string) (Task, error) {
-	return v.Customize(computername, script, false)
+func (vapp *VApp) RunCustomizationScript(computername, script string) (Task, error) {
+	return vapp.Customize(computername, script, false)
 }
 
-func (v *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
@@ -462,7 +462,7 @@ func (v *VApp) Customize(computername, script string, changeSid bool) (Task, err
 		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 
-		HREF:                v.VApp.Children.VM[0].HREF,
+		HREF:                vapp.VApp.Children.VM[0].HREF,
 		Type:                "application/vnd.vmware.vcloud.guestCustomizationSection+xml",
 		Info:                "Specifies Guest OS Customization Settings",
 		Enabled:             true,
@@ -480,21 +480,21 @@ func (v *VApp) Customize(computername, script string, changeSid bool) (Task, err
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/guestCustomizationSection/"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/guestCustomizationSection/"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.guestCustomizationSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -504,29 +504,29 @@ func (v *VApp) Customize(computername, script string, changeSid bool) (Task, err
 	return *task, nil
 }
 
-func (v *VApp) GetStatus() (string, error) {
-	err := v.Refresh()
+func (vapp *VApp) GetStatus() (string, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return "", fmt.Errorf("error refreshing vapp: %v", err)
 	}
-	return types.VAppStatuses[v.VApp.Status], nil
+	return types.VAppStatuses[vapp.VApp.Status], nil
 }
 
-func (v *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
+func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
 
 	networkConnectionSection := &types.NetworkConnectionSection{}
 
-	if v.VApp.Children.VM[0].HREF == "" {
+	if vapp.VApp.Children.VM[0].HREF == "" {
 		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF + "/networkConnectionSection/")
+	url, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF + "/networkConnectionSection/")
 
-	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return networkConnectionSection, fmt.Errorf("error retrieving task: %s", err)
 	}
@@ -539,15 +539,15 @@ func (v *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection, e
 	return networkConnectionSection, nil
 }
 
-func (v *VApp) ChangeCPUcount(size int) (Task, error) {
+func (vapp *VApp) ChangeCPUcount(size int) (Task, error) {
 
-	err := v.Refresh()
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
@@ -555,7 +555,7 @@ func (v *VApp) ChangeCPUcount(size int) (Task, error) {
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		VCloudHREF:      v.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
+		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
 		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
 		AllocationUnits: "hertz * 10^6",
 		Description:     "Number of Virtual CPUs",
@@ -566,7 +566,7 @@ func (v *VApp) ChangeCPUcount(size int) (Task, error) {
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
-			HREF: v.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
+			HREF: vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",
 			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
 		},
@@ -579,21 +579,21 @@ func (v *VApp) ChangeCPUcount(size int) (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/virtualHardwareSection/cpu"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/virtualHardwareSection/cpu"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -604,21 +604,21 @@ func (v *VApp) ChangeCPUcount(size int) (Task, error) {
 
 }
 
-func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	vdc, err := v.getParentVDC()
+	vdc, err := vapp.getParentVDC()
 	storageprofileref, err := vdc.FindStorageProfileReference(name)
 
 	newprofile := &types.VM{
-		Name:           v.VApp.Children.VM[0].Name,
+		Name:           vapp.VApp.Children.VM[0].Name,
 		StorageProfile: &storageprofileref,
 		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
 	}
@@ -630,20 +630,20 @@ func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
 
 	util.GovcdLogger.Printf("[DEBUG] VCD Client configuration: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.vm+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -654,13 +654,13 @@ func (v *VApp) ChangeStorageProfile(name string) (Task, error) {
 
 }
 
-func (v *VApp) ChangeVMName(name string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) ChangeVMName(name string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
@@ -676,20 +676,20 @@ func (v *VApp) ChangeVMName(name string) (Task, error) {
 
 	util.GovcdLogger.Printf("[DEBUG] VCD Client configuration: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.vm+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -700,27 +700,27 @@ func (v *VApp) ChangeVMName(name string) (Task, error) {
 
 }
 
-func (v *VApp) DeleteMetadata(key string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/metadata/" + key
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/metadata/" + key
 
-	req := v.c.NewRequest(map[string]string{}, "DELETE", *s, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "DELETE", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error deleting Metadata: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -730,13 +730,13 @@ func (v *VApp) DeleteMetadata(key string) (Task, error) {
 	return *task, nil
 }
 
-func (v *VApp) AddMetadata(key, value string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) AddMetadata(key, value string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
@@ -756,21 +756,21 @@ func (v *VApp) AddMetadata(key, value string) (Task, error) {
 
 	util.GovcdLogger.Printf("[DEBUG] NetworkXML: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/metadata/" + key
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/metadata/" + key
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.metadata.value+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -781,22 +781,22 @@ func (v *VApp) AddMetadata(key, value string) (Task, error) {
 
 }
 
-func (v *VApp) SetOvf(parameters map[string]string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	if v.VApp.Children.VM[0].ProductSection == nil {
+	if vapp.VApp.Children.VM[0].ProductSection == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children with ProductSection, aborting customization")
 	}
 
 	for key, value := range parameters {
-		for _, ovf_value := range v.VApp.Children.VM[0].ProductSection.Property {
+		for _, ovf_value := range vapp.VApp.Children.VM[0].ProductSection.Property {
 			if ovf_value.Key == key {
 				ovf_value.Value = &types.Value{Value: value}
 				break
@@ -807,7 +807,7 @@ func (v *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	newmetadata := &types.ProductSectionList{
 		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
 		Ovf:            "http://schemas.dmtf.org/ovf/envelope/1",
-		ProductSection: v.VApp.Children.VM[0].ProductSection,
+		ProductSection: vapp.VApp.Children.VM[0].ProductSection,
 	}
 
 	output, err := xml.MarshalIndent(newmetadata, "  ", "    ")
@@ -817,21 +817,21 @@ func (v *VApp) SetOvf(parameters map[string]string) (Task, error) {
 
 	util.GovcdLogger.Printf("[DEBUG] NetworkXML: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/productSections"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/productSections"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.productSections+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -842,17 +842,17 @@ func (v *VApp) SetOvf(parameters map[string]string) (Task, error) {
 
 }
 
-func (v *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
-	err := v.Refresh()
+func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
 
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
-	networksection, err := v.GetNetworkConnectionSection()
+	networksection, err := vapp.GetNetworkConnectionSection()
 
 	for index, network := range networks {
 		// Determine what type of address is requested for the vApp
@@ -896,21 +896,21 @@ func (v *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string)
 
 	util.GovcdLogger.Printf("[DEBUG] NetworkXML: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/networkConnectionSection/"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/networkConnectionSection/"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -920,15 +920,15 @@ func (v *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string)
 	return *task, nil
 }
 
-func (v *VApp) ChangeMemorySize(size int) (Task, error) {
+func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 
-	err := v.Refresh()
+	err := vapp.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated
-	if v.VApp.Children == nil {
+	if vapp.VApp.Children == nil {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
@@ -936,7 +936,7 @@ func (v *VApp) ChangeMemorySize(size int) (Task, error) {
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		VCloudHREF:      v.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
+		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
 		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
 		AllocationUnits: "byte * 2^20",
 		Description:     "Memory Size",
@@ -947,7 +947,7 @@ func (v *VApp) ChangeMemorySize(size int) (Task, error) {
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
-			HREF: v.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
+			HREF: vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
 			Rel:  "edit",
 			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
 		},
@@ -960,21 +960,21 @@ func (v *VApp) ChangeMemorySize(size int) (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.Children.VM[0].HREF)
-	s.Path += "/virtualHardwareSection/memory"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.Children.VM[0].HREF)
+	apiEndpoint.Path += "/virtualHardwareSection/memory"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -985,21 +985,21 @@ func (v *VApp) ChangeMemorySize(size int) (Task, error) {
 
 }
 
-func (v *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
+func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 
 	networkConfig := &types.NetworkConfigSection{}
 
-	if v.VApp.HREF == "" {
+	if vapp.VApp.HREF == "" {
 		return networkConfig, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(v.VApp.HREF + "/networkConfigSection/")
+	url, _ := neturl.ParseRequestURI(vapp.VApp.HREF + "/networkConfigSection/")
 
-	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := vapp.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConfigSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return networkConfig, fmt.Errorf("error retrieving task: %s", err)
 	}
@@ -1012,7 +1012,7 @@ func (v *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 	return networkConfig, nil
 }
 
-func (v *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
+func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
 
 	networkConfig := &types.NetworkConfigSection{
 		Info:  "Configuration parameters for logical networks",
@@ -1042,21 +1042,21 @@ func (v *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task,
 
 	util.GovcdLogger.Printf("[DEBUG] RAWNETWORK Config NetworkXML: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VApp.HREF)
-	s.Path += "/networkConfigSection/"
+	apiEndpoint, _ := neturl.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint.Path += "/networkConfigSection/"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vapp.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkconfigsection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error adding vApp Network: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vapp.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -14,44 +14,44 @@ import (
 
 type VAppTemplate struct {
 	VAppTemplate *types.VAppTemplate
-	c            *Client
+	client       *Client
 }
 
-func NewVAppTemplate(c *Client) *VAppTemplate {
+func NewVAppTemplate(client *Client) *VAppTemplate {
 	return &VAppTemplate{
 		VAppTemplate: new(types.VAppTemplate),
-		c:            c,
+		client:       client,
 	}
 }
 
-func (v *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateParams) error {
+func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateParams) error {
 	output, err := xml.MarshalIndent(template, "", "  ")
 	if err != nil {
 		return fmt.Errorf("Error finding VAppTemplate: %#v", err)
 	}
 	requestData := bytes.NewBufferString(xml.Header + string(output))
 
-	vdcHref, err := url.ParseRequestURI(v.Vdc.HREF)
+	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)
 	if err != nil {
 		return fmt.Errorf("error getting vdc href: %v", err)
 	}
 	vdcHref.Path += "/action/instantiateVAppTemplate"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *vdcHref, requestData)
+	req := vdc.client.NewRequest(map[string]string{}, "POST", *vdcHref, requestData)
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vdc.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error instantiating a new template: %s", err)
 	}
 
-	vapptemplate := NewVAppTemplate(v.c)
+	vapptemplate := NewVAppTemplate(vdc.client)
 	if err = decodeBody(resp, vapptemplate.VAppTemplate); err != nil {
 		return fmt.Errorf("error decoding orgvdcnetwork response: %s", err)
 	}
-	task := NewTask(v.c)
-	for _, t := range vapptemplate.VAppTemplate.Tasks.Task {
-		task.Task = t
+	task := NewTask(vdc.client)
+	for _, taskItem := range vapptemplate.VAppTemplate.Tasks.Task {
+		task.Task = taskItem
 		err = task.WaitTaskCompletion()
 		if err != nil {
 			return fmt.Errorf("Error performing task: %#v", err)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -72,11 +72,11 @@ func (vcd *TestVCD) Test_NewVdc(check *C) {
 		check.Assert(vcd.vdc.Vdc.ResourceEntities[0].ResourceEntity[0].HREF, Equals, "http://localhost:4444/api/vAppTemplate/vappTemplate-22222222-2222-2222-2222-222222222222")
 	*/
 
-	for _, v := range vcd.vdc.Vdc.AvailableNetworks {
-		for _, v2 := range v.Network {
-			check.Assert(v2.Name, Not(Equals), "")
-			check.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.network+xml")
-			check.Assert(v2.HREF, Not(Equals), "")
+	for _, networks := range vcd.vdc.Vdc.AvailableNetworks {
+		for _, reference := range networks.Network {
+			check.Assert(reference.Name, Not(Equals), "")
+			check.Assert(reference.Type, Equals, "application/vnd.vmware.vcloud.network+xml")
+			check.Assert(reference.HREF, Not(Equals), "")
 		}
 	}
 
@@ -90,10 +90,10 @@ func (vcd *TestVCD) Test_NewVdc(check *C) {
 		check.Assert(vcd.vdc.Vdc.IsEnabled, Equals, true)
 	*/
 
-	for _, v := range vcd.vdc.Vdc.VdcStorageProfiles {
-		for _, v2 := range v.VdcStorageProfile {
-			check.Assert(v2.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
-			check.Assert(v2.HREF, Not(Equals), "")
+	for _, storageProfiles := range vcd.vdc.Vdc.VdcStorageProfiles {
+		for _, reference := range storageProfiles.VdcStorageProfile {
+			check.Assert(reference.Type, Equals, "application/vnd.vmware.vcloud.vdcStorageProfile+xml")
+			check.Assert(reference.HREF, Not(Equals), "")
 		}
 	}
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"net/url"
+	neturl "net/url"
 	"strconv"
 
 	types "github.com/vmware/go-vcloud-director/types/v56"
@@ -16,45 +16,45 @@ import (
 )
 
 type VM struct {
-	VM *types.VM
-	c  *Client
+	VM     *types.VM
+	client *Client
 }
 
-func NewVM(c *Client) *VM {
+func NewVM(client *Client) *VM {
 	return &VM{
-		VM: new(types.VM),
-		c:  c,
+		VM:     new(types.VM),
+		client: client,
 	}
 }
 
-func (v *VM) GetStatus() (string, error) {
-	err := v.Refresh()
+func (vm *VM) GetStatus() (string, error) {
+	err := vm.Refresh()
 	if err != nil {
 		return "", fmt.Errorf("error refreshing VM: %v", err)
 	}
-	return types.VAppStatuses[v.VM.Status], nil
+	return types.VAppStatuses[vm.VM.Status], nil
 }
 
-func (v *VM) Refresh() error {
+func (vm *VM) Refresh() error {
 
-	if v.VM.HREF == "" {
+	if vm.VM.HREF == "" {
 		return fmt.Errorf("cannot refresh VM, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(v.VM.HREF)
+	url, _ := neturl.ParseRequestURI(vm.VM.HREF)
 
-	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := vm.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return fmt.Errorf("error retrieving task: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
 	// elements in slices.
-	v.VM = &types.VM{}
+	vm.VM = &types.VM{}
 
-	if err = decodeBody(resp, v.VM); err != nil {
+	if err = decodeBody(resp, vm.VM); err != nil {
 		return fmt.Errorf("error decoding task response VM: %s", err)
 	}
 
@@ -62,21 +62,21 @@ func (v *VM) Refresh() error {
 	return nil
 }
 
-func (v *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
+func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
 
 	networkConnectionSection := &types.NetworkConnectionSection{}
 
-	if v.VM.HREF == "" {
+	if vm.VM.HREF == "" {
 		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	u, _ := url.ParseRequestURI(v.VM.HREF + "/networkConnectionSection/")
+	url, _ := neturl.ParseRequestURI(vm.VM.HREF + "/networkConnectionSection/")
 
-	req := v.c.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := vm.client.NewRequest(map[string]string{}, "GET", *url, nil)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return networkConnectionSection, fmt.Errorf("error retrieving task: %s", err)
 	}
@@ -89,23 +89,23 @@ func (v *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, err
 	return networkConnectionSection, nil
 }
 
-func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
+func (cli *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
 
-	u, err := url.ParseRequestURI(vmhref)
+	url, err := neturl.ParseRequestURI(vmhref)
 
 	if err != nil {
 		return VM{}, fmt.Errorf("error decoding vm HREF: %s", err)
 	}
 
 	// Querying the VApp
-	req := c.Client.NewRequest(map[string]string{}, "GET", *u, nil)
+	req := cli.Client.NewRequest(map[string]string{}, "GET", *url, nil)
 
-	resp, err := checkResp(c.Client.Http.Do(req))
+	resp, err := checkResp(cli.Client.Http.Do(req))
 	if err != nil {
 		return VM{}, fmt.Errorf("error retrieving VM: %s", err)
 	}
 
-	newvm := NewVM(&c.Client)
+	newvm := NewVM(&cli.Client)
 
 	if err = decodeBody(resp, newvm.VM); err != nil {
 		return VM{}, fmt.Errorf("error decoding VM response: %s", err)
@@ -115,19 +115,19 @@ func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
 
 }
 
-func (v *VM) PowerOn() (Task, error) {
+func (vm *VM) PowerOn() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/power/action/powerOn"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/power/action/powerOn"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error powering on VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -138,19 +138,19 @@ func (v *VM) PowerOn() (Task, error) {
 
 }
 
-func (v *VM) PowerOff() (Task, error) {
+func (vm *VM) PowerOff() (Task, error) {
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/power/action/powerOff"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/power/action/powerOff"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, nil)
+	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, nil)
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error powering off VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -161,9 +161,9 @@ func (v *VM) PowerOff() (Task, error) {
 
 }
 
-func (v *VM) ChangeCPUcount(size int) (Task, error) {
+func (vm *VM) ChangeCPUcount(size int) (Task, error) {
 
-	err := v.Refresh()
+	err := vm.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
@@ -172,7 +172,7 @@ func (v *VM) ChangeCPUcount(size int) (Task, error) {
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		VCloudHREF:      v.VM.HREF + "/virtualHardwareSection/cpu",
+		VCloudHREF:      vm.VM.HREF + "/virtualHardwareSection/cpu",
 		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
 		AllocationUnits: "hertz * 10^6",
 		Description:     "Number of Virtual CPUs",
@@ -183,7 +183,7 @@ func (v *VM) ChangeCPUcount(size int) (Task, error) {
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
-			HREF: v.VM.HREF + "/virtualHardwareSection/cpu",
+			HREF: vm.VM.HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",
 			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
 		},
@@ -196,21 +196,21 @@ func (v *VM) ChangeCPUcount(size int) (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/virtualHardwareSection/cpu"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/virtualHardwareSection/cpu"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -221,13 +221,13 @@ func (v *VM) ChangeCPUcount(size int) (Task, error) {
 
 }
 
-func (v *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
-	err := v.Refresh()
+func (vm *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
+	err := vm.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
 
-	networksection, err := v.GetNetworkConnectionSection()
+	networksection, err := vm.GetNetworkConnectionSection()
 
 	for index, network := range networks {
 		// Determine what type of address is requested for the vApp
@@ -277,21 +277,21 @@ func (v *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (
 
 	util.GovcdLogger.Printf("[DEBUG] NetworkXML: %s", output)
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/networkConnectionSection/"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/networkConnectionSection/"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.networkConnectionSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM Network: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -301,9 +301,9 @@ func (v *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (
 	return *task, nil
 }
 
-func (v *VM) ChangeMemorySize(size int) (Task, error) {
+func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 
-	err := v.Refresh()
+	err := vm.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
@@ -312,7 +312,7 @@ func (v *VM) ChangeMemorySize(size int) (Task, error) {
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		VCloudHREF:      v.VM.HREF + "/virtualHardwareSection/memory",
+		VCloudHREF:      vm.VM.HREF + "/virtualHardwareSection/memory",
 		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
 		AllocationUnits: "byte * 2^20",
 		Description:     "Memory Size",
@@ -323,7 +323,7 @@ func (v *VM) ChangeMemorySize(size int) (Task, error) {
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
-			HREF: v.VM.HREF + "/virtualHardwareSection/memory",
+			HREF: vm.VM.HREF + "/virtualHardwareSection/memory",
 			Rel:  "edit",
 			Type: "application/vnd.vmware.vcloud.rasdItem+xml",
 		},
@@ -336,21 +336,21 @@ func (v *VM) ChangeMemorySize(size int) (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/virtualHardwareSection/memory"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/virtualHardwareSection/memory"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.rasdItem+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -361,12 +361,12 @@ func (v *VM) ChangeMemorySize(size int) (Task, error) {
 
 }
 
-func (v *VM) RunCustomizationScript(computername, script string) (Task, error) {
-	return v.Customize(computername, script, false)
+func (vm *VM) RunCustomizationScript(computername, script string) (Task, error) {
+	return vm.Customize(computername, script, false)
 }
 
-func (v *VM) Customize(computername, script string, changeSid bool) (Task, error) {
-	err := v.Refresh()
+func (vm *VM) Customize(computername, script string, changeSid bool) (Task, error) {
+	err := vm.Refresh()
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
@@ -376,7 +376,7 @@ func (v *VM) Customize(computername, script string, changeSid bool) (Task, error
 		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
 		Xmlns: "http://www.vmware.com/vcloud/v1.5",
 
-		HREF:                v.VM.HREF,
+		HREF:                vm.VM.HREF,
 		Type:                "application/vnd.vmware.vcloud.guestCustomizationSection+xml",
 		Info:                "Specifies Guest OS Customization Settings",
 		Enabled:             true,
@@ -394,21 +394,21 @@ func (v *VM) Customize(computername, script string, changeSid bool) (Task, error
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/guestCustomizationSection/"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/guestCustomizationSection/"
 
-	req := v.c.NewRequest(map[string]string{}, "PUT", *s, b)
+	req := vm.client.NewRequest(map[string]string{}, "PUT", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.guestCustomizationSection+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error customizing VM: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
@@ -418,7 +418,7 @@ func (v *VM) Customize(computername, script string, changeSid bool) (Task, error
 	return *task, nil
 }
 
-func (v *VM) Undeploy() (Task, error) {
+func (vm *VM) Undeploy() (Task, error) {
 
 	vu := &types.UndeployVAppParams{
 		Xmlns:               "http://www.vmware.com/vcloud/v1.5",
@@ -432,21 +432,21 @@ func (v *VM) Undeploy() (Task, error) {
 
 	util.GovcdLogger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
-	b := bytes.NewBufferString(xml.Header + string(output))
+	buffer := bytes.NewBufferString(xml.Header + string(output))
 
-	s, _ := url.ParseRequestURI(v.VM.HREF)
-	s.Path += "/action/undeploy"
+	apiEndpoint, _ := neturl.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/action/undeploy"
 
-	req := v.c.NewRequest(map[string]string{}, "POST", *s, b)
+	req := vm.client.NewRequest(map[string]string{}, "POST", *apiEndpoint, buffer)
 
 	req.Header.Add("Content-Type", "application/vnd.vmware.vcloud.undeployVAppParams+xml")
 
-	resp, err := checkResp(v.c.Http.Do(req))
+	resp, err := checkResp(vm.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error undeploy vApp: %s", err)
 	}
 
-	task := NewTask(v.c)
+	task := NewTask(vm.client)
 
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)


### PR DESCRIPTION
Replaced one-letter identifiers from struct fields, function arguments, and local variables.

Now the mysterious combinations of identifiers such as `c.c.` are appropriately identified as catalogs and clients. Same clarity has been reached for other identifiers "v", "s", etc. I have left behind only some "i" identifiers in very short and clear blocks of code.

Related issue: #33 

Signed-off-by: Giuseppe Maxia
