### PR TITLE
Dump failing HTTP operations

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -79,6 +79,7 @@ func parseErr(resp *http.Response) error {
 		return fmt.Errorf("error parsing error body for non-200 request: %s", err)
 	}
 
+	util.LogHttpOperations()
 	return fmt.Errorf("API Error: %d: %s", errBody.MajorErrorCode, errBody.Message)
 }
 
@@ -89,11 +90,13 @@ func decodeBody(resp *http.Response, out interface{}) error {
 
 	util.ProcessResponseOutput(util.CallFuncName(), resp, fmt.Sprintf("%s", body))
 	if err != nil {
+		util.LogHttpOperations()
 		return err
 	}
 
 	// Unmarshal the XML.
 	if err = xml.Unmarshal(body, &out); err != nil {
+		util.LogHttpOperations()
 		return err
 	}
 
@@ -115,9 +118,11 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 		return resp, nil
 	// Invalid request, parse the XML error returned and return it.
 	case i == 400 || i == 401 || i == 403 || i == 404 || i == 405 || i == 406 || i == 409 || i == 415 || i == 500 || i == 503 || i == 504:
+		util.LogHttpOperations()
 		return nil, parseErr(resp)
 	// Unhandled response.
 	default:
+		util.LogHttpOperations()
 		return nil, fmt.Errorf("unhandled API response, please report this issue, status code: %s", resp.Status)
 	}
 }

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -13,7 +13,7 @@ To enable logging, you should use
 
 ```go
 util.EnableLogging = true
-util.SetLog()
+util.InitLogging()
 ```
 
 When enabled, the default output for logging is a file named `go-vcloud-director.log`.
@@ -54,6 +54,17 @@ During the request and response processing, any password or authentication token
 
 ```go
 util.LogPasswords = true
+```
+
+## Emergency logging of HTTP operations
+
+When logging is **disabled**, there is an emergency stack that keeps in memory the latest N HTTP operations (4 by default). When a failure occurs, this stack is written to the log, which gets updated on-the-fly.
+
+If you want also this emergency system to be disabled, you can add this code to your client:
+
+```go
+util. EnableHttpStack = false
+util.InitLogging()
 ```
 
 ## Custom logger

--- a/util/fixed-size-stack.go
+++ b/util/fixed-size-stack.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package util
+
+// FixedSizeStack is a stack that works like a regular stack
+// (LIFO access: last element that is added is pulled out first)
+// but it keeps only a predefined number of items.
+// When the maximum size is reached, the oldest item is purged
+// from the back of the stack.
+
+import (
+	"container/list"
+	"sync"
+)
+
+// The stack is implemented using a double-linked list from
+// Go standard library
+type FixedSizeStack struct {
+	list     *list.List
+	maxItems int
+	mux      sync.Mutex
+}
+
+// NewFixedSizeStack returns a new stack with a predefined
+// size
+func NewFixedSizeStack(wanted_size int) (fss FixedSizeStack) {
+	fss.maxItems = wanted_size
+	fss.list = list.New()
+	return
+}
+
+// The length of the stack is that of the underlying list
+func (fss *FixedSizeStack) Len() int {
+	// Locks so that it is safe to get the length from concurrent goroutines
+	fss.mux.Lock()
+	length := fss.list.Len()
+	fss.mux.Unlock()
+	return length
+}
+
+// Push() inserts an item into the stack.
+// The item can be of any type
+func (fss *FixedSizeStack) Push(item interface{}) {
+	// Locks so that it is safe to push from concurrent goroutines
+	fss.mux.Lock()
+	// Purges the oldest element if size exceeds
+	// maximum allowed storage
+	if fss.list.Len() >= fss.maxItems {
+		// removes item from the back
+		fss.list.Remove(fss.list.Back())
+	}
+	fss.list.PushFront(item)
+	fss.mux.Unlock()
+}
+
+// Pop() returns the object stored as .Value in the top list element
+// Client calls will need to cast the object to the expected type.
+// e.g.:
+//     type MyType struct { ... }
+//     var lastOne MyType
+//     lastOne = fss.Pop().(MyType)
+func (fss *FixedSizeStack) Pop() interface{} {
+	// Locks so that it is safe to pop from concurrent goroutines
+	fss.mux.Lock()
+	latest := fss.list.Front().Value
+	// After extracting the item, we remove the first
+	// list element
+	fss.list.Remove(fss.list.Front())
+	fss.mux.Unlock()
+	return latest
+}

--- a/util/fixed-size-stack_test.go
+++ b/util/fixed-size-stack_test.go
@@ -1,0 +1,104 @@
+package util
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+var (
+	howManyOperations int = 100
+	operations        []OperationRec
+)
+
+func fillRequest(N int) (req http.Request) {
+	req.Method = "GET"
+	req.Proto = fmt.Sprintf("req %d", N)
+	req.Header = http.Header{"one": []string{"two"}}
+	return
+}
+
+func fillResponse(N int) (resp http.Response) {
+	resp.Status = "OK 200"
+	resp.Proto = fmt.Sprintf("resp %d", N)
+	resp.Header = http.Header{fmt.Sprintf("key %d", N): []string{fmt.Sprintf("value %d", N)}}
+	return
+}
+
+func fillOperations() {
+	for N := 0; N < howManyOperations; N++ {
+		var op OperationRec
+		op.Caller = fmt.Sprintf("caller %d", N)
+		op.Data = "zzzzzzzzzzzzzzzzzzzzzzzzzzz"
+		if N%2 == 0 {
+			op.OpType = "request"
+			op.Operation = "GET"
+			op.Url = "xxxx/yyyy"
+			req := fillRequest(N)
+			op.Req = &req
+		} else {
+			op.OpType = "response"
+			resp := fillResponse(N)
+			op.Resp = &resp
+		}
+		operations = append(operations, op)
+	}
+}
+
+func okEqualInt(label string, a, b int, t *testing.T) {
+	if a == b {
+		t.Logf("ok - %s %d == %d", label, a, b)
+	} else {
+		t.Logf("not ok - %s %d != %d", label, a, b)
+		t.Fail()
+	}
+}
+
+func okEqualString(label, a, b string, t *testing.T) {
+	if a == b {
+		t.Logf("ok - %s %s == %s", label, a, b)
+	} else {
+		t.Logf("not ok - %s %s != %s", label, a, b)
+		t.Fail()
+	}
+}
+
+func TestInt(t *testing.T) {
+	var maxElements int = 2
+	var maxInput int = 100
+	fss := NewFixedSizeStack(maxElements)
+	for N := 0; N < maxInput; N++ {
+		fss.Push(N)
+	}
+	for J := 1; J < maxElements; J++ {
+		foundInt := fss.Pop().(int)
+		okEqualInt(fmt.Sprintf("last element %d", J), maxInput-J, foundInt, t)
+	}
+}
+
+func TestOps(t *testing.T) {
+	var maxElements int = 4
+	fss := NewFixedSizeStack(maxElements)
+	for _, op := range operations {
+		fss.Push(op)
+	}
+	okEqualInt("FixedSizeStack size", maxElements, fss.Len(), t)
+	for N := 0; N < maxElements; N++ {
+		op1 := fss.Pop().(OperationRec)
+		if op1.OpType == "request" {
+			okEqualString("operation request", fmt.Sprintf("req %d", howManyOperations-1-N), op1.Req.Proto, t)
+		} else {
+			okEqualString("operation response", fmt.Sprintf("resp %d", howManyOperations-1-N), op1.Resp.Proto, t)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	// Build up function
+	fillOperations()
+	// Runs all the tests
+	exitCode := m.Run()
+	// Add teardown function if needed
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
Issue #77 implemented as a Fixed-size stack, based on standard Go double-linked
list. The stack is created with a size limit. When the limit is reached,
the oldest element is purged from the back end.

The stack is enabled when logging is disabled.
When there is a failure, the HTTP processing functions in api.go invoke
the dumping of the stack, which will briefly enable logging and write
down all elements in the stack (by default are 4: two requests and two
responses). The operations are listed in reverse order of execution
(most recent first) with a header that explains that we are emptying the
stack and which element number we are seeing.

Related issue: #77 "Add log setting to dump failing HTTP request/response values using a ring buffer"

Added:
* `fixed-size-stack.go` implements the stack
* `fixed-size-stack_test.go` includes a test for generic data and operations data similar to what we use for HTTP logging.

Changes in existing code:  
* `util.logging` adds integration between logging and FixedSizeStack
* some functions in `api.go` include a call to `util.LogHttpOperations()`

Signed-off-by: Giuseppe Maxia
