### PR TITLE
Add cleanup function to test suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -150,10 +150,14 @@ func (vcd *TestVCD) Test_ComposeVApp(check *checks.C) {
 
 	// These tests can fail: we need to make sure that the new entity was created
 	check.Assert(err, checks.IsNil)
-	check.Assert(task.Task.OperationName, checks.Equals, "vdcComposeVapp")
+	check.Assert(task.Task.OperationName, checks.Equals, composeVappName)
 	// Get VApp
 	vapp, err := vcd.vdc.FindVAppByName(temp_vapp_name)
 	check.Assert(err, checks.IsNil)
+
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+    AddToCleanupList(composeVappName, "vapp", "", "Test_ComposeVApp")
 
 	// Once the operation is successful, we won't trigger a failure
 	// until after the vApp deletion
@@ -175,6 +179,8 @@ func (vcd *TestVCD) Test_ComposeVApp(check *checks.C) {
 	no_such_vapp, err := vcd.vdc.FindVAppByName(temp_vapp_name)
 	check.Assert(err, checks.NotNil)
 	check.Assert(no_such_vapp.VApp, checks.IsNil)
+    // If this deletion fails, a further attempt will be made 
+    // by the cleanup function at the end of all tests
 }
 ```
 

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -39,19 +39,22 @@ func (vcd *TestVCD) Test_UpdateCatalog(check *C) {
 	org, err := GetAdminOrgByName(vcd.client, vcd.config.VCD.Org)
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
-	catalog, err := org.FindAdminCatalog(CatalogUpdateTest)
+	catalog, err := org.FindAdminCatalog(TestUpdateCatalog)
 	if catalog != (AdminCatalog{}) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err := org.CreateCatalog(CatalogUpdateTest, CatalogUpdateTest, true)
+	adminCatalog, err := org.CreateCatalog(TestUpdateCatalog, TestUpdateCatalog, true)
 	check.Assert(err, IsNil)
-	check.Assert(adminCatalog.AdminCatalog.Name, Equals, CatalogUpdateTest)
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(TestUpdateCatalog, "catalog", vcd.config.VCD.Org, "Test_UpdateCatalog")
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestUpdateCatalog)
 
-	adminCatalog.AdminCatalog.Description = CatalogCreateDescription
+	adminCatalog.AdminCatalog.Description = TestCreateCatalogDesc
 	err = adminCatalog.Update()
 	check.Assert(err, IsNil)
-	check.Assert(adminCatalog.AdminCatalog.Description, Equals, CatalogCreateDescription)
+	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
 
 	err = adminCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
@@ -63,17 +66,20 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 	org, err := GetAdminOrgByName(vcd.client, vcd.config.VCD.Org)
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
-	adminCatalog, err := org.FindAdminCatalog(CatalogDeleteTest)
+	adminCatalog, err := org.FindAdminCatalog(TestDeleteCatalog)
 	if adminCatalog != (AdminCatalog{}) {
 		err = adminCatalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err = org.CreateCatalog(CatalogDeleteTest, CatalogDeleteTest, true)
+	adminCatalog, err = org.CreateCatalog(TestDeleteCatalog, TestDeleteCatalog, true)
 	check.Assert(err, IsNil)
-	check.Assert(adminCatalog.AdminCatalog.Name, Equals, CatalogDeleteTest)
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(TestDeleteCatalog, "catalog", vcd.config.VCD.Org, "Test_DeleteCatalog")
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestDeleteCatalog)
 	err = adminCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
-	catalog, err := org.FindCatalog(CatalogDeleteTest)
+	catalog, err := org.FindCatalog(TestDeleteCatalog)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, Equals, Catalog{})
 

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -12,24 +12,31 @@ import (
 // Tests Refresh for Org by updating the org and then asserting if the
 // variable is updated.
 func (vcd *TestVCD) Test_RefreshOrg(check *C) {
-	adminOrg, err := GetAdminOrgByName(vcd.client, OrgRefreshTest)
+
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
+	adminOrg, err := GetAdminOrgByName(vcd.client, TestRefreshOrg)
 	if adminOrg != (AdminOrg{}) {
 		err = adminOrg.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	_, err = CreateOrg(vcd.client, OrgRefreshTest, OrgRefreshTest, true, &types.OrgSettings{
+	_, err = CreateOrg(vcd.client, TestRefreshOrg, TestRefreshOrg, true, &types.OrgSettings{
 		OrgLdapSettings: &types.OrgLdapSettingsType{OrgLdapMode: "NONE"},
 	})
 	check.Assert(err, IsNil)
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(TestRefreshOrg, "org", "", "Test_RefreshOrg")
 	// fetch newly created org
-	org, err := GetOrgByName(vcd.client, OrgRefreshTest)
+	org, err := GetOrgByName(vcd.client, TestRefreshOrg)
 	check.Assert(err, IsNil)
-	check.Assert(org.Org.Name, Equals, OrgRefreshTest)
+	check.Assert(org.Org.Name, Equals, TestRefreshOrg)
 	// fetch admin version of org for updating
-	adminOrg, err = GetAdminOrgByName(vcd.client, OrgRefreshTest)
+	adminOrg, err = GetAdminOrgByName(vcd.client, TestRefreshOrg)
 	check.Assert(err, IsNil)
-	check.Assert(adminOrg.AdminOrg.Name, Equals, OrgRefreshTest)
-	adminOrg.AdminOrg.FullName = RefreshOrgFullName
+	check.Assert(adminOrg.AdminOrg.Name, Equals, TestRefreshOrg)
+	adminOrg.AdminOrg.FullName = TestRefreshOrgFullName
 	task, err := adminOrg.Update()
 	check.Assert(err, IsNil)
 	// Wait until update is complete
@@ -38,11 +45,11 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 	// Test Refresh on normal org
 	err = org.Refresh()
 	check.Assert(err, IsNil)
-	check.Assert(org.Org.FullName, Equals, RefreshOrgFullName)
+	check.Assert(org.Org.FullName, Equals, TestRefreshOrgFullName)
 	// Test Refresh on admin org
 	err = adminOrg.Refresh()
 	check.Assert(err, IsNil)
-	check.Assert(adminOrg.AdminOrg.FullName, Equals, RefreshOrgFullName)
+	check.Assert(adminOrg.AdminOrg.FullName, Equals, TestRefreshOrgFullName)
 	// Delete, with force and recursive true
 	err = adminOrg.Delete(true, true)
 	check.Assert(err, IsNil)
@@ -51,22 +58,28 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 // Creates an org DELETEORG and then deletes it to test functionality of
 // delete org. Fails if org still exists
 func (vcd *TestVCD) Test_DeleteOrg(check *C) {
-	org, err := GetAdminOrgByName(vcd.client, OrgDeleteTest)
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
+	org, err := GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	if org != (AdminOrg{}) {
 		err = org.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	_, err = CreateOrg(vcd.client, OrgDeleteTest, OrgDeleteTest, true, &types.OrgSettings{})
+	_, err = CreateOrg(vcd.client, TestDeleteOrg, TestDeleteOrg, true, &types.OrgSettings{})
 	check.Assert(err, IsNil)
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(TestDeleteOrg, "org", "", "Test_DeleteOrg")
 	// fetch newly created org
-	org, err = GetAdminOrgByName(vcd.client, OrgDeleteTest)
+	org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	check.Assert(err, IsNil)
-	check.Assert(org.AdminOrg.Name, Equals, OrgDeleteTest)
+	check.Assert(org.AdminOrg.Name, Equals, TestDeleteOrg)
 	// Delete, with force and recursive true
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
-	org, err = GetAdminOrgByName(vcd.client, OrgDeleteTest)
+	org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
 }
@@ -76,19 +89,23 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 // Fails if the deployedvmquota variable is not changed when the org is
 // refetched.
 func (vcd *TestVCD) Test_UpdateOrg(check *C) {
-	org, err := GetAdminOrgByName(vcd.client, OrgUpdateTest)
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
+	org, err := GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	if org != (AdminOrg{}) {
 		err = org.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	_, err = CreateOrg(vcd.client, OrgUpdateTest, OrgUpdateTest, true, &types.OrgSettings{
+	_, err = CreateOrg(vcd.client, TestUpdateOrg, TestUpdateOrg, true, &types.OrgSettings{
 		OrgLdapSettings: &types.OrgLdapSettingsType{OrgLdapMode: "NONE"},
 	})
 	check.Assert(err, IsNil)
+	AddToCleanupList(TestUpdateOrg, "org", "", "TestUpdateOrg")
 	// fetch newly created org
-	org, err = GetAdminOrgByName(vcd.client, OrgUpdateTest)
+	org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	check.Assert(err, IsNil)
-	check.Assert(org.AdminOrg.Name, Equals, OrgUpdateTest)
+	check.Assert(org.AdminOrg.Name, Equals, TestUpdateOrg)
 	org.AdminOrg.OrgSettings.OrgGeneralSettings.DeployedVMQuota = 100
 	task, err := org.Update()
 	check.Assert(err, IsNil)
@@ -103,7 +120,7 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
-	org, err = GetAdminOrgByName(vcd.client, OrgUpdateTest)
+	org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
 }
@@ -131,6 +148,9 @@ func (vcd *TestVCD) Test_GetVdcByName(check *C) {
 // that doesn't exist. Asserts an error if the function finds it or
 // if the error is not nil.
 func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, Not(Equals), AdminOrg{})
@@ -171,6 +191,9 @@ func (vcd *TestVCD) Test_FindCatalog(check *C) {
 // that doesn't exist. Asserts an error if the function finds it or
 // if the error is not nil.
 func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
 	// Fetch admin org version of current test org
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(adminOrg, Not(Equals), AdminOrg{})
@@ -194,25 +217,29 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 // asserts that the catalog returned contains the right contents or if it fails.
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_CreateCatalog(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
 	org, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
-	catalog, err := org.FindAdminCatalog(CatalogCreateTest)
+	catalog, err := org.FindAdminCatalog(TestCreateCatalog)
 	if catalog != (AdminCatalog{}) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	catalog, err = org.CreateCatalog(CatalogCreateTest, CatalogCreateDescription, true)
+	catalog, err = org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc, true)
 	check.Assert(err, IsNil)
-	check.Assert(catalog.AdminCatalog.Name, Equals, CatalogCreateTest)
-	check.Assert(catalog.AdminCatalog.Description, Equals, CatalogCreateDescription)
+	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
+	check.Assert(catalog.AdminCatalog.Name, Equals, TestCreateCatalog)
+	check.Assert(catalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
 	task.Task = catalog.AdminCatalog.Tasks.Task[0]
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	org, err = GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyCatalog, err := org.FindAdminCatalog(CatalogCreateTest)
+	copyCatalog, err := org.FindAdminCatalog(TestCreateCatalog)
 	check.Assert(copyCatalog, Not(Equals), AdminCatalog{})
 	check.Assert(err, IsNil)
 	check.Assert(catalog.AdminCatalog.Name, Equals, copyCatalog.AdminCatalog.Name)
@@ -224,6 +251,9 @@ func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 // Test for GetAdminCatalog. Gets admin version of Catalog, and asserts that
 // the names and description match, and that no error is returned
 func (vcd *TestVCD) Test_GetAdminCatalog(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
 	// Fetch admin org version of current test org
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(err, IsNil)

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -59,6 +59,9 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 	if err != nil {
 		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
 	}
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(name, "vapp", "", "createTestVapp")
 	err = task.WaitTaskCompletion()
 	if err != nil {
 		return VApp{}, fmt.Errorf("error composing vapp: %v", err)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -127,16 +127,19 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
 	check.Assert(err, IsNil)
 	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, compose_vapp_name, compose_vapp_description, true)
+	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, TestComposeVapp, TestComposeVappDesc, true)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.OperationName, Equals, "vdcComposeVapp")
 	// Get VApp
-	vapp, err := vcd.vdc.FindVAppByName(compose_vapp_name)
+	vapp, err := vcd.vdc.FindVAppByName(TestComposeVapp)
 	check.Assert(err, IsNil)
+	// After a successful creation, the entity is added to the cleanup list.
+	// If something fails after this point, the entity will be removed
+	AddToCleanupList(TestComposeVapp, "vapp", "", "Test_ComposeVApp")
 	// Once the operation is successful, we won't trigger a failure
 	// until after the vApp deletion
-	check.Check(vapp.VApp.Name, Equals, compose_vapp_name)
-	check.Check(vapp.VApp.Description, Equals, compose_vapp_description)
+	check.Check(vapp.VApp.Name, Equals, TestComposeVapp)
+	check.Check(vapp.VApp.Description, Equals, TestComposeVappDesc)
 
 	vapp_status, err := vapp.GetStatus()
 	check.Check(err, IsNil)
@@ -150,7 +153,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	task, err = vapp.Delete()
 	task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-	no_such_vapp, err := vcd.vdc.FindVAppByName(compose_vapp_name)
+	no_such_vapp, err := vcd.vdc.FindVAppByName(TestComposeVapp)
 	check.Assert(err, NotNil)
 	check.Assert(no_such_vapp.VApp, IsNil)
 


### PR DESCRIPTION
* Implements Issue #87 : Clean up all resources created during tests in case of failure. The cleanup is implemented using an array of entities created during the tests. After a successful creation, the entity is added to the list. At the end of the tests, the cleanup function checks whether the entity still exists, and removes it if it still in the system.

* Implements Issue #92 : Adding System check in test Suite

* Implements Issue #93 : Add check for empty Org/Vdc in `SetupTestSuite`

Changes in this pull request:
* Added a call to `AddToCleanupList` after all successful creation of a new entity in the test operations;
* Replaced the existing `TearDownSuite` with the handling of the cleanup list.
* Added a `VerboseCleanup` field to the test configuration options
* Added checks for empty entities in `SetupTestSuite`
* Added test skip statements for when the provided "sysOrg" is not "System"

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>
