### PR TITLE
Fixes Issue #99 error in logging of HTTP requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,12 @@ secrets.yml
 
 # Pycharm IDE
 .idea
+
+# test configuration file
+govcd/govcd_test_config.yaml
+
+# vim bak files
+*~
+
+# test suite log file
+govcd/go-vcloud-director.log


### PR DESCRIPTION
Logging of HTTP requests was removing data when the body object was
not what we thought it was.
There is now a type check to ensure that we don't empty the buffer
when it is not safe.

Related Issue: #99 

Also added unwanted items to .gitignore

Signed-off-by: Giuseppe Maxia
