### PR TITLE
Add copyright check to Travis operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 #default: fmt test testrace vet
-default: fmtcheck vet build
+default: fmtcheck vet build copyright
 
 # test runs the test suite and vets the code
 test: get-deps fmtcheck
@@ -37,5 +37,10 @@ fmt:
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
+copyright:
+	@echo "==> Checking copyright headers in source files"
+	@sh -c "'$(CURDIR)/scripts/copyright_check.sh'"
+
 build:
+	@echo "==> Building govcd library"
 	cd govcd && go build .

--- a/util/tar_test.go
+++ b/util/tar_test.go
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package util
 
 import (


### PR DESCRIPTION
* Add copyright check to default make ops (it's used by Travis)
* Add missing copyright to util/tar_test.go

Signed-off-by: Giuseppe Maxia
