### PR TITLE
Fixed bug where ispublished is not used by VCD API.

### DIFF
--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -49,7 +49,7 @@ func (vcd *TestVCD) Test_UpdateCatalog(check *C) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err := org.CreateCatalog(TestUpdateCatalog, TestUpdateCatalog, true)
+	adminCatalog, err := org.CreateCatalog(TestUpdateCatalog, TestUpdateCatalog)
 	check.Assert(err, IsNil)
 	// After a successful creation, the entity is added to the cleanup list.
 	// If something fails after this point, the entity will be removed
@@ -76,7 +76,7 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 		err = adminCatalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err = org.CreateCatalog(TestDeleteCatalog, TestDeleteCatalog, true)
+	adminCatalog, err = org.CreateCatalog(TestDeleteCatalog, TestDeleteCatalog)
 	check.Assert(err, IsNil)
 	// After a successful creation, the entity is added to the cleanup list.
 	// If something fails after this point, the entity will be removed

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -168,13 +168,12 @@ func (adminOrg *AdminOrg) Refresh() error {
 // the given organization. Returns an AdminCatalog that contains a creation
 // task.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
-func (adminOrg *AdminOrg) CreateCatalog(Name, Description string, isPublished bool) (AdminCatalog, error) {
+func (adminOrg *AdminOrg) CreateCatalog(Name, Description string) (AdminCatalog, error) {
 
 	vcomp := &types.AdminCatalog{
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
 		Name:        Name,
 		Description: Description,
-		IsPublished: isPublished,
 	}
 
 	catalogHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -228,7 +228,7 @@ func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	catalog, err = org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc, true)
+	catalog, err = org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
 	check.Assert(err, IsNil)
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
 	check.Assert(catalog.AdminCatalog.Name, Equals, TestCreateCatalog)
@@ -244,6 +244,7 @@ func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(catalog.AdminCatalog.Name, Equals, copyCatalog.AdminCatalog.Name)
 	check.Assert(catalog.AdminCatalog.Description, Equals, copyCatalog.AdminCatalog.Description)
+	check.Assert(catalog.AdminCatalog.IsPublished, Equals, false)
 	err = catalog.Delete(true, true)
 	check.Assert(err, IsNil)
 }


### PR DESCRIPTION
Bug fix not attribute which is not used by VCD API.

Ref: #106 

Signed-off-by: Vaidotas Bauzys <vbauzys@vmware.com>