### PR TITLE
Added implementation for geting external network by names

### DIFF
--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"errors"
+	"fmt"
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
+	"net/url"
+)
+
+func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
+	extNetworkRefs := &types.ExternalNetworkReferences{}
+
+	extNetworkHREF, err := getExternalNetworkHref(vcdClient)
+	if err != nil {
+		return &types.ExternalNetworkReference{}, err
+	}
+
+	extNetworkURL, err := url.ParseRequestURI(extNetworkHREF)
+	if err != nil {
+		return &types.ExternalNetworkReference{}, err
+	}
+
+	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", *extNetworkURL, nil)
+	resp, err := checkResp(vcdClient.Client.Http.Do(req))
+	if err != nil {
+		util.Logger.Printf("[TRACE] error retreiving external networks: %s", err)
+		return &types.ExternalNetworkReference{}, fmt.Errorf("error retreiving external networks: %s", err)
+	}
+
+	if err = decodeBody(resp, extNetworkRefs); err != nil {
+		util.Logger.Printf("[TRACE] error retreiving  external networks: %s", err)
+		return &types.ExternalNetworkReference{}, fmt.Errorf("error decoding extension  external networks: %s", err)
+	}
+
+	for _, netRef := range extNetworkRefs.ExternalNetworkReference {
+		if netRef.Name == networkName {
+			return netRef, nil
+		}
+	}
+
+	return &types.ExternalNetworkReference{}, nil
+}
+
+func getExternalNetworkHref(vcdClient *VCDClient) (string, error) {
+	extensions, err := getExtension(vcdClient)
+	if err != nil {
+		return "", err
+	}
+
+	for _, extensionLink := range extensions.Link {
+		if extensionLink.Type == "application/vnd.vmware.admin.vmwExternalNetworkReferences+xml" {
+			return extensionLink.HREF, nil
+		}
+	}
+
+	return "", errors.New("external network link isn't found")
+}
+
+func getExtension(vcdClient *VCDClient) (*types.Extension, error) {
+	extensions := &types.Extension{}
+
+	extensionHREF := vcdClient.Client.VCDHREF
+	extensionHREF.Path += "/admin/extension/"
+	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", extensionHREF, nil)
+	resp, err := checkResp(vcdClient.Client.Http.Do(req))
+	if err != nil {
+		util.Logger.Printf("[TRACE] error retreiving extension: %s", err)
+		return extensions, fmt.Errorf("error retreiving extension: %s", err)
+	}
+
+	if err = decodeBody(resp, extensions); err != nil {
+		util.Logger.Printf("[TRACE] error retreiving extension list: %s", err)
+		return extensions, fmt.Errorf("error decoding extension list response: %s", err)
+	}
+
+	return extensions, nil
+}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1979,3 +1979,20 @@ type QueryResultOrgVdcStorageProfileRecordType struct {
 	StorageUsedMB           int    `xml:"storageUsedMB,attr,omitempty"`
 	StorageLimitMB          int    `xml:"storageLimitMB,attr,omitempty"`
 }
+
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// Retrieve a list of extension objects and operations.
+// Since: 1.0
+type Extension struct {
+	Link LinkList `xml:"Link,omitempty"` // A reference to an entity or operation associated with this object.
+}
+
+type ExternalNetworkReferences struct {
+	ExternalNetworkReference []*ExternalNetworkReference `xml:"ExternalNetworkReference,omitempty"` // A reference to an entity or operation associated with this object.
+}
+
+type ExternalNetworkReference struct {
+	HREF string `xml:"href,attr"`
+	Type string `xml:"type,attr,omitempty"`
+	Name string `xml:"name,attr,omitempty"`
+}


### PR DESCRIPTION
Added implementation for getting external network by names using extensions.

Ref https://github.com/vmware/go-vcloud-director/issues/110.

Signed-off-by: Vaidotas Bauzys <vbauzys@vmware.com>

