### PR TITLE
Add network creation and tests

### DIFF
--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -146,7 +146,7 @@ func (cat *Catalog) FindCatalogItem(catalogitem string) (CatalogItem, error) {
 
 				resp, err := checkResp(cat.client.Http.Do(req))
 				if err != nil {
-					return CatalogItem{}, fmt.Errorf("error retreiving catalog: %s", err)
+					return CatalogItem{}, fmt.Errorf("error retrieving catalog: %s", err)
 				}
 
 				cat := NewCatalogItem(cat.client)

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -34,7 +34,7 @@ func (catalogItem *CatalogItem) GetVAppTemplate() (VAppTemplate, error) {
 
 	resp, err := checkResp(catalogItem.client.Http.Do(req))
 	if err != nil {
-		return VAppTemplate{}, fmt.Errorf("error retreiving vapptemplate: %s", err)
+		return VAppTemplate{}, fmt.Errorf("error retrieving vapptemplate: %s", err)
 	}
 
 	cat := NewVAppTemplate(catalogItem.client)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -383,7 +383,7 @@ func (eGW *EdgeGateway) Refresh() error {
 
 	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
-		return fmt.Errorf("error retreiving Edge Gateway: %s", err)
+		return fmt.Errorf("error retrieving Edge Gateway: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -28,12 +28,12 @@ func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.
 	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", *extNetworkURL, nil)
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		util.Logger.Printf("[TRACE] error retreiving external networks: %s", err)
-		return &types.ExternalNetworkReference{}, fmt.Errorf("error retreiving external networks: %s", err)
+		util.Logger.Printf("[TRACE] error retrieving external networks: %s", err)
+		return &types.ExternalNetworkReference{}, fmt.Errorf("error retrieving external networks: %s", err)
 	}
 
 	if err = decodeBody(resp, extNetworkRefs); err != nil {
-		util.Logger.Printf("[TRACE] error retreiving  external networks: %s", err)
+		util.Logger.Printf("[TRACE] error retrieving  external networks: %s", err)
 		return &types.ExternalNetworkReference{}, fmt.Errorf("error decoding extension  external networks: %s", err)
 	}
 
@@ -69,12 +69,12 @@ func getExtension(vcdClient *VCDClient) (*types.Extension, error) {
 	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", extensionHREF, nil)
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		util.Logger.Printf("[TRACE] error retreiving extension: %s", err)
-		return extensions, fmt.Errorf("error retreiving extension: %s", err)
+		util.Logger.Printf("[TRACE] error retrieving extension: %s", err)
+		return extensions, fmt.Errorf("error retrieving extension: %s", err)
 	}
 
 	if err = decodeBody(resp, extensions); err != nil {
-		util.Logger.Printf("[TRACE] error retreiving extension list: %s", err)
+		util.Logger.Printf("[TRACE] error retrieving extension list: %s", err)
 		return extensions, fmt.Errorf("error decoding extension list response: %s", err)
 	}
 

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -1,0 +1,22 @@
+package govcd
+
+import (
+	"fmt"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
+
+	fmt.Printf("Running: %s\n", check.TestName())
+	networkName := vcd.config.VCD.ExternalNetwork
+	if networkName == "" {
+		check.Skip("No external network provided")
+	}
+	externalNetwork, err := GetExternalNetworkByName(vcd.client, networkName)
+	check.Assert(err, IsNil)
+	LogExternalNetwork(*externalNetwork)
+	check.Assert(externalNetwork.HREF, Not(Equals), "")
+	expectedType := "application/vnd.vmware.admin.extension.network+xml"
+	check.Assert(externalNetwork.Name, Equals, networkName)
+	check.Assert(externalNetwork.Type, Equals, expectedType)
+}

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+// Contains auxiliary functions to show library entities structure.
+// Used for debugging and testing.
+package govcd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
+	"time"
+)
+
+// For each library {entity}, we have two functions: Show{Entity} and Log{Entity}
+// The first one shows the contents of the entity on screen
+// The second one logs into the default util.Logger
+// Both functions use JSON as the entity format
+
+// Available entities:
+// org
+// adminOrg
+// vdc
+// catalog
+// catalogItem
+// adminCatalog
+// network
+// externalNetwork
+// vapp
+// task
+
+func out(destination, format string, args ...interface{}) {
+	switch destination {
+	case "screen":
+		fmt.Printf(format, args...)
+	case "log":
+		util.Logger.Printf(format, args...)
+	default:
+		fmt.Printf("Unhandled destination: %s\n", destination)
+	}
+}
+
+func prettyVapp(vapp types.VApp) string {
+	byteBuf, err := json.MarshalIndent(vapp, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyVdc(vdc types.Vdc) string {
+	byteBuf, err := json.MarshalIndent(vdc, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyCatalogItem(catalogItem types.CatalogItem) string {
+	byteBuf, err := json.MarshalIndent(catalogItem, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyCatalog(catalog types.Catalog) string {
+	byteBuf, err := json.MarshalIndent(catalog, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyAdminCatalog(catalog types.AdminCatalog) string {
+	byteBuf, err := json.MarshalIndent(catalog, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyOrg(org types.Org) string {
+	byteBuf, err := json.MarshalIndent(org, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyAdminOrg(org types.AdminOrg) string {
+	byteBuf, err := json.MarshalIndent(org, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyExternalNetwork(network types.ExternalNetworkReference) string {
+	byteBuf, err := json.MarshalIndent(network, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyNetworkConf(conf types.OrgVDCNetwork) string {
+	byteBuf, err := json.MarshalIndent(conf, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func prettyTask(task *types.Task) string {
+	byteBuf, err := json.MarshalIndent(task, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
+func LogNetwork(conf types.OrgVDCNetwork) {
+	out("log", prettyNetworkConf(conf))
+}
+
+func ShowNetwork(conf types.OrgVDCNetwork) {
+	out("screen", prettyNetworkConf(conf))
+}
+
+func LogExternalNetwork(network types.ExternalNetworkReference) {
+	out("log", prettyExternalNetwork(network))
+}
+
+func ShowExternalNetwork(network types.ExternalNetworkReference) {
+	out("screen", prettyExternalNetwork(network))
+}
+
+func LogVapp(vapp types.VApp) {
+	out("log", prettyVapp(vapp))
+}
+
+func ShowVapp(vapp types.VApp) {
+	out("screen", prettyVapp(vapp))
+}
+
+func ShowOrg(org types.Org) {
+	out("screen", prettyOrg(org))
+}
+
+func LogOrg(org types.Org) {
+	out("log", prettyOrg(org))
+}
+
+func ShowAdminOrg(org types.AdminOrg) {
+	out("screen", prettyAdminOrg(org))
+}
+
+func LogAdminOrg(org types.AdminOrg) {
+	out("log", prettyAdminOrg(org))
+}
+
+func ShowVdc(vdc types.Vdc) {
+	out("screen", prettyVdc(vdc))
+}
+
+func LogVdc(vdc types.Vdc) {
+	out("log", prettyVdc(vdc))
+}
+
+func ShowCatalog(catalog types.Catalog) {
+	out("screen", prettyCatalog(catalog))
+}
+
+func LogCatalog(catalog types.Catalog) {
+	out("log", prettyCatalog(catalog))
+}
+
+func ShowCatalogItem(catalogItem types.CatalogItem) {
+	out("screen", prettyCatalogItem(catalogItem))
+}
+
+func LogCatalogItem(catalogItem types.CatalogItem) {
+	out("log", prettyCatalogItem(catalogItem))
+}
+
+func ShowAdminCatalog(catalog types.AdminCatalog) {
+	out("screen", prettyAdminCatalog(catalog))
+}
+
+func LogAdminCatalog(catalog types.AdminCatalog) {
+	out("log", prettyAdminCatalog(catalog))
+}
+
+// Auxiliary function to monitor a task
+// It can be used in association with WaitInspectTaskCompletion
+func outTask(destination string, task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	if task == nil {
+		out(destination, "Task is null\n")
+		return
+	}
+	out(destination, prettyTask(task))
+
+	out(destination, "progress: [%s:%d] %d%%\n", elapsed.Round(1*time.Second), howManyTimes, task.Progress)
+	out(destination, "-------------------------------\n")
+}
+
+func LogTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	outTask("log", task, howManyTimes, elapsed, first, last)
+}
+
+func ShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	outTask("screen", task, howManyTimes, elapsed, first, last)
+}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -76,7 +76,7 @@ func (org *Org) FindCatalog(catalogName string) (Catalog, error) {
 
 			resp, err := checkResp(org.client.Http.Do(req))
 			if err != nil {
-				return Catalog{}, fmt.Errorf("error retreiving catalog: %s", err)
+				return Catalog{}, fmt.Errorf("error retrieving catalog: %s", err)
 			}
 
 			cat := NewCatalog(org.client)
@@ -376,7 +376,7 @@ func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) 
 	req := adminOrg.client.NewRequest(map[string]string{}, "GET", *adminVdcUrl, nil)
 	resp, err := checkResp(adminOrg.client.Http.Do(req))
 	if err != nil {
-		return &Vdc{}, fmt.Errorf("error retreiving vdc: %s", err)
+		return &Vdc{}, fmt.Errorf("error retrieving vdc: %s", err)
 	}
 
 	vdc := NewVdc(adminOrg.client)
@@ -487,7 +487,7 @@ func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, er
 			req := adminOrg.client.NewRequest(map[string]string{}, "GET", *catalogURL, nil)
 			resp, err := checkResp(adminOrg.client.Http.Do(req))
 			if err != nil {
-				return AdminCatalog{}, fmt.Errorf("error retreiving catalog: %s", err)
+				return AdminCatalog{}, fmt.Errorf("error retrieving catalog: %s", err)
 			}
 			adminCatalog := NewAdminCatalog(adminOrg.client)
 			if err = decodeBody(resp, adminCatalog.AdminCatalog); err != nil {
@@ -517,7 +517,7 @@ func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
 			req := adminOrg.client.NewRequest(map[string]string{}, "GET", *catalogURL, nil)
 			resp, err := checkResp(adminOrg.client.Http.Do(req))
 			if err != nil {
-				return Catalog{}, fmt.Errorf("error retreiving catalog: %s", err)
+				return Catalog{}, fmt.Errorf("error retrieving catalog: %s", err)
 			}
 			cat := NewCatalog(adminOrg.client)
 

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
 
@@ -30,4 +31,177 @@ func (vcd *TestVCD) Test_NetRefresh(check *C) {
 	check.Assert(network.OrgVDCNetwork.EdgeGateway, DeepEquals, save_network.OrgVDCNetwork.EdgeGateway)
 	check.Assert(network.OrgVDCNetwork.Status, Equals, save_network.OrgVDCNetwork.Status)
 
+}
+
+// Tests the creation of an Org VDC network connected to an Edge Gateway
+func (vcd *TestVCD) Test_CreateOrgVdcNetworkEGW(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+	networkName := TestCreateOrgVdcNetworkEGW
+
+	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	if err != nil {
+		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
+	}
+
+	edgeGWName := vcd.config.VCD.EdgeGateway
+	if edgeGWName == "" {
+		check.Skip("Edge Gateway not provided")
+	}
+	edgeGateway, err := vcd.vdc.FindEdgeGateway(edgeGWName)
+	if err != nil {
+		check.Skip(fmt.Sprintf("Edge Gateway %s not found", edgeGWName))
+	}
+
+	var networkConfig = types.OrgVDCNetwork{
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Name:  networkName,
+		// Description: "Created by govcd tests",
+		Configuration: &types.NetworkConfiguration{
+			FenceMode: "natRouted",
+			IPScopes: &types.IPScopes{
+				IPScope: types.IPScope{
+					IsInherited: false,
+					Gateway:     "10.10.102.1",
+					Netmask:     "255.255.255.0",
+					IPRanges: &types.IPRanges{
+						IPRange: []*types.IPRange{
+							&types.IPRange{
+								StartAddress: "10.10.102.2",
+								EndAddress:   "10.10.102.100"},
+						},
+					},
+				},
+			},
+			BackwardCompatibilityMode: true,
+		},
+		EdgeGateway: &types.Reference{
+			HREF: edgeGateway.EdgeGateway.HREF,
+			ID:   edgeGateway.EdgeGateway.ID,
+			Name: edgeGateway.EdgeGateway.Name,
+			Type: edgeGateway.EdgeGateway.Type,
+		},
+		IsShared: false,
+	}
+
+	LogNetwork(networkConfig)
+	err = vcd.vdc.CreateOrgVDCNetwork(&networkConfig)
+	if err != nil {
+		fmt.Printf("error creating Network <%s>: %s\n", networkName, err)
+	}
+	check.Assert(err, IsNil)
+	AddToCleanupList(TestCreateOrgVdcNetworkEGW,
+		"network",
+		vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkEGW")
+}
+
+// Tests the creation of an isolated Org VDC network
+func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+	networkName := TestCreateOrgVdcNetworkIso
+
+	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	if err != nil {
+		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
+	}
+
+	var networkConfig = types.OrgVDCNetwork{
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Name:  networkName,
+		// Description: "Created by govcd tests",
+		Configuration: &types.NetworkConfiguration{
+			FenceMode: "isolated",
+			/*One of:
+				bridged (connected directly to the ParentNetwork),
+			  isolated (not connected to any other network),
+			  natRouted (connected to the ParentNetwork via a NAT service)
+			  https://code.vmware.com/apis/287/vcloud#/doc/doc/types/OrgVdcNetworkType.html
+			*/
+			IPScopes: &types.IPScopes{
+				IPScope: types.IPScope{
+					IsInherited: false,
+					Gateway:     "192.168.2.1",
+					Netmask:     "255.255.255.0",
+					DNS1:        "192.168.2.1",
+					DNS2:        "",
+					DNSSuffix:   "",
+					IPRanges: &types.IPRanges{
+						IPRange: []*types.IPRange{
+							&types.IPRange{
+								StartAddress: "192.168.2.2",
+								EndAddress:   "192.168.2.100"},
+						},
+					},
+				},
+			},
+			BackwardCompatibilityMode: true,
+		},
+		IsShared: false,
+	}
+	LogNetwork(networkConfig)
+	err = vcd.vdc.CreateOrgVDCNetwork(&networkConfig)
+	if err != nil {
+		fmt.Printf("error creating Network <%s>: %s\n", networkName, err)
+	}
+	check.Assert(err, IsNil)
+	AddToCleanupList(TestCreateOrgVdcNetworkIso,
+		"network",
+		vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkIso")
+}
+
+// Tests the creation of a Org VDC network connected to an external network
+func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+	networkName := TestCreateOrgVdcNetworkDirect
+
+	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	if err != nil {
+		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
+	}
+
+	if vcd.config.VCD.ExternalNetwork == "" {
+		check.Skip("[Test_CreateOrgVdcNetworkDirect] external network not provided")
+	}
+	externalNetwork, err := GetExternalNetworkByName(vcd.client, vcd.config.VCD.ExternalNetwork)
+	if err != nil {
+		check.Skip("[Test_CreateOrgVdcNetworkDirect] parent network not found")
+	}
+	// Note that there is no IPScope for this type of network
+	var networkConfig = types.OrgVDCNetwork{
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Name:  networkName,
+		Configuration: &types.NetworkConfiguration{
+			FenceMode: "bridged",
+			ParentNetwork: &types.Reference{
+				HREF: externalNetwork.HREF,
+				Name: externalNetwork.Name,
+				Type: externalNetwork.Type,
+			},
+			BackwardCompatibilityMode: true,
+		},
+		IsShared: false,
+	}
+	LogNetwork(networkConfig)
+
+	task, err := vcd.vdc.CreateOrgVDCNetWorkBasic(&networkConfig)
+	if err != nil {
+		fmt.Printf("error creating the network: %s", err)
+	}
+	check.Assert(err, IsNil)
+	if task == (Task{}) {
+		fmt.Printf("NULL task retrieved after network creation")
+	}
+	check.Assert(task.Task.HREF, Not(Equals), "")
+
+	AddToCleanupList(TestCreateOrgVdcNetworkDirect,
+		"network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkDirect")
+
+	// err = task.WaitTaskCompletion()
+	err = task.WaitInspectTaskCompletion(LogTask, 10)
+	if err != nil {
+		fmt.Printf("error performing task: %#v", err)
+	}
+	check.Assert(err, IsNil)
 }

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -30,7 +30,7 @@ func (vdcCli *VCDClient) Query(params map[string]string) (Results, error) {
 
 	resp, err := checkResp(vdcCli.Client.Http.Do(req))
 	if err != nil {
-		return Results{}, fmt.Errorf("error retreiving query: %s", err)
+		return Results{}, fmt.Errorf("error retrieving query: %s", err)
 	}
 
 	results := NewResults(&vdcCli.Client)

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -58,6 +58,8 @@ vcd:
     #
     # A free IP in the Org vDC network
     internalIp: 192.168.1.10
+    # An external Network name
+    externalNetwork: myexternalnet
 logging:
     # All items in this section are optional
     # Logging is disabled by default.
@@ -74,6 +76,8 @@ logging:
     #
     # Defines whether we log the responses in HTTP operations
     logHttpResponses: true
+    # Shows details of cleanup operations after tests
+    verboseCleanup: true
 ova:
   # The ova for uploading catalog item for tests.
   # Default paths are simple ova provided by project

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -56,12 +56,12 @@ func GetOrgByName(vcdClient *VCDClient, orgname string) (Org, error) {
 	}
 	orgHREF, err := url.ParseRequestURI(orgUrl)
 	if err != nil {
-		return Org{}, fmt.Errorf("Error parsing org href: %v", err)
+		return Org{}, fmt.Errorf("error parsing org href: %v", err)
 	}
 	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", *orgHREF, nil)
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		return Org{}, fmt.Errorf("error retreiving org: %s", err)
+		return Org{}, fmt.Errorf("error retrieving org: %s", err)
 	}
 
 	org := NewOrg(&vcdClient.Client)
@@ -87,7 +87,7 @@ func GetAdminOrgByName(vcdClient *VCDClient, orgname string) (AdminOrg, error) {
 	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", orgHREF, nil)
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		return AdminOrg{}, fmt.Errorf("error retreiving org: %s", err)
+		return AdminOrg{}, fmt.Errorf("error retrieving org: %s", err)
 	}
 	org := NewAdminOrg(&vcdClient.Client)
 	if err = decodeBody(resp, org.AdminOrg); err != nil {
@@ -103,7 +103,7 @@ func getOrgHREF(vcdClient *VCDClient, orgname string) (string, error) {
 	req := vcdClient.Client.NewRequest(map[string]string{}, "GET", orgListHREF, nil)
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		return "", fmt.Errorf("error retreiving org list: %s", err)
+		return "", fmt.Errorf("error retrieving org list: %s", err)
 	}
 	orgList := new(types.OrgList)
 	if err = decodeBody(resp, orgList); err != nil {
@@ -115,5 +115,5 @@ func getOrgHREF(vcdClient *VCDClient, orgname string) (string, error) {
 			return org.HREF, nil
 		}
 	}
-	return "", fmt.Errorf("Couldn't find org with name: %s", orgname)
+	return "", fmt.Errorf("couldn't find org with name: %s", orgname)
 }

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	types "github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/types/v56"
 )
 
 type Task struct {
@@ -51,27 +51,60 @@ func (task *Task) Refresh() error {
 	return nil
 }
 
-func (task *Task) WaitTaskCompletion() error {
+// This callback function can be passed to task.WaitInspectTaskCompletion
+// to perform user defined operations
+// * task is the task object being processed
+// * howManyTimes is the number of times the task has been refreshed
+// * elapsed is how much time since the task was initially processed
+// * first is true if this is the first refresh of the task
+// * last is true if the function is being called for the last time.
+type InspectionFunc func(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool)
+
+// Customizable version of WaitTaskCompletion.
+// Users can define the sleeping duration and an optional callback function for
+// extra monitoring.
+func (task *Task) WaitInspectTaskCompletion(inspectionFunc InspectionFunc, delay time.Duration) error {
 
 	if task.Task == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
+	howManyTimesRefreshed := 0
+	startTime := time.Now()
 	for {
+		howManyTimesRefreshed++
+		elapsed := time.Since(startTime)
 		err := task.Refresh()
 		if err != nil {
-			return fmt.Errorf("error retreiving task: %s", err)
+			return fmt.Errorf("error retrieving task: %s", err)
 		}
 
 		// If task is not in a waiting status we're done, check if there's an error and return it.
 		if task.Task.Status != "queued" && task.Task.Status != "preRunning" && task.Task.Status != "running" {
+			if inspectionFunc != nil {
+				inspectionFunc(task.Task, howManyTimesRefreshed, elapsed,
+					// first
+					howManyTimesRefreshed == 1,
+					// last
+					task.Task.Status == "error" || task.Task.Status == "success")
+			}
 			if task.Task.Status == "error" {
 				return fmt.Errorf("task did not complete succesfully: %s", task.Task.Description)
 			}
 			return nil
 		}
 
-		// Sleep for 3 seconds and try again.
-		time.Sleep(3 * time.Second)
+		if inspectionFunc != nil {
+			inspectionFunc(task.Task, howManyTimesRefreshed, elapsed, howManyTimesRefreshed == 1, false)
+		}
+
+		// Sleep for a given period and try again.
+		time.Sleep(delay)
 	}
+}
+
+// Checks the status of the task every 3 seconds and returns when the
+// task is either completed or failed
+func (task *Task) WaitTaskCompletion() error {
+	return task.WaitInspectTaskCompletion(nil, 3*time.Second)
 }

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -32,7 +32,7 @@ func (vdc *Vdc) getVdcVAppbyHREF(vappHREF *url.URL) (*VApp, error) {
 	req := vdc.client.NewRequest(map[string]string{}, "GET", *vappHREF, nil)
 	resp, err := checkResp(vdc.client.Http.Do(req))
 	if err != nil {
-		return &VApp{}, fmt.Errorf("error retreiving VApp: %s", err)
+		return &VApp{}, fmt.Errorf("error retrieving VApp: %s", err)
 	}
 
 	vapp := NewVApp(vdc.client)
@@ -45,6 +45,10 @@ func (vdc *Vdc) getVdcVAppbyHREF(vappHREF *url.URL) (*VApp, error) {
 
 // Undeploys every vapp in the vdc
 func (vdc *Vdc) undeployAllVdcVApps() error {
+	err := vdc.Refresh()
+	if err != nil {
+		return fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, resents := range vdc.Vdc.ResourceEntities {
 		for _, resent := range resents.ResourceEntity {
 			if resent.Type == "application/vnd.vmware.vcloud.vApp+xml" {
@@ -69,6 +73,10 @@ func (vdc *Vdc) undeployAllVdcVApps() error {
 
 // Removes all vapps in the vdc
 func (vdc *Vdc) removeAllVdcVApps() error {
+	err := vdc.Refresh()
+	if err != nil {
+		return fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, resents := range vdc.Vdc.ResourceEntities {
 		for _, resent := range resents.ResourceEntity {
 			if resent.Type == "application/vnd.vmware.vcloud.vApp+xml" {
@@ -78,15 +86,15 @@ func (vdc *Vdc) removeAllVdcVApps() error {
 				}
 				vapp, err := vdc.getVdcVAppbyHREF(vappHREF)
 				if err != nil {
-					return fmt.Errorf("Error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
+					return fmt.Errorf("error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
 				}
 				task, err := vapp.Delete()
 				if err != nil {
-					return fmt.Errorf("Error deleting vapp: %s", err)
+					return fmt.Errorf("error deleting vapp: %s", err)
 				}
 				err = task.WaitTaskCompletion()
 				if err != nil {
-					return fmt.Errorf("Couldn't finish removing vapp %#v", err)
+					return fmt.Errorf("couldn't finish removing vapp %#v", err)
 				}
 			}
 		}
@@ -106,7 +114,7 @@ func (vdc *Vdc) Refresh() error {
 
 	resp, err := checkResp(vdc.client.Http.Do(req))
 	if err != nil {
-		return fmt.Errorf("error retreiving Edge Gateway: %s", err)
+		return fmt.Errorf("error retrieving Edge Gateway: %s", err)
 	}
 
 	// Empty struct before a new unmarshal, otherwise we end up with duplicate
@@ -125,6 +133,10 @@ func (vdc *Vdc) Refresh() error {
 
 func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
+	err := vdc.Refresh()
+	if err != nil {
+		return OrgVDCNetwork{}, fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, an := range vdc.Vdc.AvailableNetworks {
 		for _, reference := range an.Network {
 			if reference.Name == network {
@@ -137,7 +149,7 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
 				resp, err := checkResp(vdc.client.Http.Do(req))
 				if err != nil {
-					return OrgVDCNetwork{}, fmt.Errorf("error retreiving orgvdcnetwork: %s", err)
+					return OrgVDCNetwork{}, fmt.Errorf("error retrieving orgvdcnetwork: %s", err)
 				}
 
 				orgnet := NewOrgVDCNetwork(vdc.client)
@@ -158,6 +170,10 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
 func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error) {
 
+	err := vdc.Refresh()
+	if err != nil {
+		return types.Reference{}, fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, sps := range vdc.Vdc.VdcStorageProfiles {
 		for _, sp := range sps.VdcStorageProfile {
 			if sp.Name == name {
@@ -171,6 +187,10 @@ func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error
 
 func (vdc *Vdc) GetDefaultStorageProfileReference(storageprofiles *types.QueryResultRecordsType) (types.Reference, error) {
 
+	err := vdc.Refresh()
+	if err != nil {
+		return types.Reference{}, fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, spr := range storageprofiles.OrgVdcStorageProfileRecord {
 		if spr.IsDefaultStorageProfile {
 			return types.Reference{HREF: spr.HREF, Name: spr.Name}, nil
@@ -181,6 +201,10 @@ func (vdc *Vdc) GetDefaultStorageProfileReference(storageprofiles *types.QueryRe
 
 func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
+	err := vdc.Refresh()
+	if err != nil {
+		return EdgeGateway{}, fmt.Errorf("error refreshing vdc: %s", err)
+	}
 	for _, av := range vdc.Vdc.Link {
 		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
 			findUrl, err := url.ParseRequestURI(av.HREF)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -135,7 +135,7 @@ type IPAddresses struct {
 	IPAddress string `xml:"IpAddress,omitempty"` // An IP address.
 }
 
-// IPRanges representsa list of IP ranges.
+// IPRanges represents a list of IP ranges.
 // Type: IpRangesType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents a list of IP ranges.
@@ -195,7 +195,8 @@ type IPScopes struct {
 	IPScope IPScope `xml:"IpScope"` // IP scope.
 }
 
-// NetworkConfiguration the configuration applied to a network. This is an abstract base type. The concrete types include thos for vApp and Organization wide networks.
+// NetworkConfiguration is the configuration applied to a network. This is an abstract base type.
+// The concrete types include those for vApp and Organization wide networks.
 // Type: NetworkConfigurationType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: The configurations applied to a network. This is an abstract base type. The concrete types include those for vApp and Organization wide networks.
@@ -212,7 +213,7 @@ type NetworkConfiguration struct {
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`
 }
 
-// VAppNetworkConfiguration representa a vApp network configuration
+// VAppNetworkConfiguration represents a vApp network configuration
 // Type: VAppNetworkConfigurationType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents a vApp network configuration.
@@ -911,7 +912,7 @@ type VMs struct {
  * Types that are completely valid (position, comment, coverage complete)
  */
 
-// ComposeVAppParams represetns vApp composition parameters
+// ComposeVAppParams represents vApp composition parameters
 // Type: ComposeVAppParamsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents vApp composition parameters.
@@ -1008,7 +1009,7 @@ type VMGeneralParams struct {
 	NeedsCustomization bool   `xml:"NeedsCustomization,omitempty"` // True if this VM needs guest customization
 }
 
-// VApp representa a vApp
+// VApp represents a vApp
 // Type: VAppType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents a vApp.
@@ -1082,7 +1083,7 @@ type TypedValue struct {
 // Description: Container for virtual machines included in this vApp.
 // Since: 0.9
 type VAppChildren struct {
-	VM []*VM `xml:"Vm,omitempty"` // Rerpresents a virtual machine.
+	VM []*VM `xml:"Vm,omitempty"` // Represents a virtual machine.
 }
 
 // TasksInProgress is a list of queued, running, or recently completed tasks.
@@ -1382,7 +1383,7 @@ type EdgeGateway struct {
 type GatewayConfiguration struct {
 	Xmlns string `xml:"xmlns,attr,omitempty"`
 	// Elements
-	BackwardCompatibilityMode       bool               `xml:"BackwardCompatibilityMode,omitempty"`       // Compatibilty mode. Default is false. If set to true, will allow users to write firewall rules in the old 1.5 format. The new format does not require to use direction in firewall rules. Also, for firewall rules to allow NAT traffic the filter is applied on the original IP addresses. Once set to true cannot be reverted back to false.
+	BackwardCompatibilityMode       bool               `xml:"BackwardCompatibilityMode,omitempty"`       // Compatibility mode. Default is false. If set to true, will allow users to write firewall rules in the old 1.5 format. The new format does not require to use direction in firewall rules. Also, for firewall rules to allow NAT traffic the filter is applied on the original IP addresses. Once set to true cannot be reverted back to false.
 	GatewayBackingConfig            string             `xml:"GatewayBackingConfig"`                      // Configuration of the vShield edge VM for this gateway. One of: compact, full.
 	GatewayInterfaces               *GatewayInterfaces `xml:"GatewayInterfaces"`                         // List of Gateway interfaces.
 	EdgeGatewayServiceConfiguration *GatewayFeatures   `xml:"EdgeGatewayServiceConfiguration,omitempty"` // Represents Gateway Features.
@@ -1423,9 +1424,9 @@ type GatewayInterface struct {
 // Since: 5.1
 type SubnetParticipation struct {
 	Gateway   string    `xml:"Gateway"`             // Gateway for subnet
-	IPAddress string    `xml:"IpAddress,omitempty"` // Ip Address to be assigned. Keep empty or ommit element for auto assignment
+	IPAddress string    `xml:"IpAddress,omitempty"` // Ip Address to be assigned. Keep empty or omit element for auto assignment
 	IPRanges  *IPRanges `xml:"IpRanges,omitempty"`  // Range of IP addresses available for external interfaces.
-	Netmask   string    `xml:"Netmask"`             // Nestmask for the subnet
+	Netmask   string    `xml:"Netmask"`             // Netmask for the subnet
 }
 
 type EdgeGatewayServiceConfiguration struct {


### PR DESCRIPTION
* Add Org Vdc network basic Creation function that returns a task (allows tight control on the creation)
* Add a customizable task monitoring function (same as WaitTaskCompletion, but with inspection hooks)
* Add monitoring functions for main library entities (monitor.go)
* Add function RemoveOrgVdcNetworkIfExists(networkName)
* Add tests for network creation: with Edge Gateway, with Direct connection to external network, isolated.
* Add parameter for external network in configuration file for tests
* Add clean-up code for networks in api_vcd_test.go
* Add variable to skip vApp creation in tests (used when running a single test that does not involve vApps)
* Fix various spelling mistakes in many code files
* Add test for external network retrieval

Signed-off-by: Giuseppe Maxia

Related issue: #49 

Preparatory work for Terraform provider issues [#96](https://github.com/terraform-providers/terraform-provider-vcd/issues/96) and [#95](https://github.com/terraform-providers/terraform-provider-vcd/issues/95)
