### PR TITLE
Upgrade API version from 5.5 to 27.0

### DIFF
--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -89,7 +89,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 
 	return &VCDClient{
 		Client: Client{
-			APIVersion: "27.0",
+			APIVersion: "27.0", // supported by vCD 8.20, 9.0, 9.1, 9.5
 			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -70,7 +70,7 @@ func (vdcCli *VCDClient) vcdauthorize(user, pass, org string) error {
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/*+xml;version=5.5")
+	req.Header.Add("Accept", "application/*+xml;version="+vdcCli.Client.APIVersion)
 	resp, err := checkResp(vdcCli.Client.Http.Do(req))
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 
 	return &VCDClient{
 		Client: Client{
-			APIVersion: "5.5",
+			APIVersion: "27.0",
 			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{
@@ -126,7 +126,7 @@ func (vdcCli *VCDClient) Disconnect() error {
 	}
 	req := vdcCli.Client.NewRequest(map[string]string{}, "DELETE", vdcCli.sessionHREF, nil)
 	// Add the Accept header for vCA
-	req.Header.Add("Accept", "application/xml;version=5.5")
+	req.Header.Add("Accept", "application/xml;version="+vdcCli.Client.APIVersion)
 	// Set Authorization Header
 	req.Header.Add(vdcCli.Client.VCDAuthHeader, vdcCli.Client.VCDToken)
 	if _, err := checkResp(vdcCli.Client.Http.Do(req)); err != nil {

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -563,6 +563,9 @@ func (eGW *EdgeGateway) Create1to1Mapping(internal, external, description string
 		},
 	}
 
+	if newedgeconfig.NatService == nil {
+		newedgeconfig.NatService = &types.NatService{}
+	}
 	newedgeconfig.NatService.NatRule = append(newedgeconfig.NatService.NatRule, snat)
 
 	dnat := &types.NatRule{

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
+	"time"
 )
 
 // Tests Refresh for Org by updating the org and then asserting if the
@@ -79,6 +80,7 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
+	time.Sleep(3 * time.Second)
 	org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
@@ -120,6 +122,7 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
+	time.Sleep(3 * time.Second)
 	org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -80,8 +80,14 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
-	time.Sleep(3 * time.Second)
-	org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
+	for i := 0; i < 30; i++ {
+		org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
+		if org == (AdminOrg{}) {
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
 }
@@ -122,8 +128,14 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
-	time.Sleep(3 * time.Second)
-	org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
+	for i := 0; i < 30; i++ {
+		org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
+		if org == (AdminOrg{}) {
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -79,17 +79,7 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	// Delete, with force and recursive true
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
-	// Check if org still exists
-	for i := 0; i < 30; i++ {
-		org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
-		if org == (AdminOrg{}) {
-			break
-		} else {
-			time.Sleep(1 * time.Second)
-		}
-	}
-	check.Assert(org, Equals, AdminOrg{})
-	check.Assert(err, IsNil)
+	doesOrgExist(check, vcd)
 }
 
 // Creates a org UPDATEORG, changes the deployed vm quota on the org,
@@ -127,9 +117,14 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	// Delete, with force and recursive true
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
-	// Check if org still exists
+	doesOrgExist(check, vcd)
+}
+
+func doesOrgExist(check *C, vcd *TestVCD) {
+	var org AdminOrg
+	var err error
 	for i := 0; i < 30; i++ {
-		org, err = GetAdminOrgByName(vcd.client, TestUpdateOrg)
+		org, err = GetAdminOrgByName(vcd.client, TestDeleteOrg)
 		if org == (AdminOrg{}) {
 			break
 		} else {

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -26,7 +26,7 @@ func NewResults(cli *Client) *Results {
 func (vdcCli *VCDClient) Query(params map[string]string) (Results, error) {
 
 	req := vdcCli.Client.NewRequest(params, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
 
 	resp, err := checkResp(vdcCli.Client.Http.Do(req))
 	if err != nil {

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -1,6 +1,5 @@
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
- * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -18,9 +18,12 @@ import (
 // settings parameter. The settings variable is defined in types.go.
 // Method will fail unless user has an admin token.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateOrganization.html
-// Organization creation has two bugs https://bugzilla.eng.vmware.com/show_bug.cgi?id=2177355, https://bugzilla.eng.vmware.com/show_bug.cgi?id=2228936 which requires,
-// that creating organization elements are in incorrect order, at least one element(DelayAfterPowerOnSeconds, DeployedVMQuota, StoredVmQuota, UseServerBootSequence, getVdcQuota)
-// is needed then providing generalOrgSettings and VAppLeaseSettings/VAppLeaseSettings provided fully.
+// Organization creation in vCD has two bugs BZ 2177355, BZ 2228936 (fixes are in 9.1.0.3 and 9.5.0.2) which require
+// organization settings to be provided as workarounds.
+// At least one element among DelayAfterPowerOnSeconds, DeployedVMQuota, StoredVmQuota, UseServerBootSequence, getVdcQuota
+// should be set when providing generalOrgSettings.
+// If either VAppLeaseSettings or VAppTemplateLeaseSettings is provided then all elements need to have values, otherwise don't provide them at all.
+// Overall elements must be in the correct order.
 func CreateOrg(vcdClient *VCDClient, name string, fullName string, isEnabled bool, settings *types.OrgSettings) (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -18,6 +18,9 @@ import (
 // settings parameter. The settings variable is defined in types.go.
 // Method will fail unless user has an admin token.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateOrganization.html
+// Organization creation has two bugs https://bugzilla.eng.vmware.com/show_bug.cgi?id=2177355, https://bugzilla.eng.vmware.com/show_bug.cgi?id=2228936 which requires,
+// that creating organization elements are in incorrect order, at least one element(DelayAfterPowerOnSeconds, DeployedVMQuota, StoredVmQuota, UseServerBootSequence, getVdcQuota)
+// is needed then providing generalOrgSettings and VAppLeaseSettings/VAppLeaseSettings provided fully.
 func CreateOrg(vcdClient *VCDClient, name string, fullName string, isEnabled bool, settings *types.OrgSettings) (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -5,7 +5,7 @@
 package govcd
 
 import (
-	types "github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 	"time"
 )
@@ -95,8 +95,14 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
-	time.Sleep(10 * time.Second)
-	org, err = GetAdminOrgByName(vcd.client, TestCreateOrg)
+	for i := 0; i < 30; i++ {
+		org, err = GetAdminOrgByName(vcd.client, TestCreateOrg)
+		if org == (AdminOrg{}) {
+			break
+		} else {
+			time.Sleep(1 * time.Second)
+		}
+	}
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)
 

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	types "github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
+	"time"
 )
 
 // Tests System function GetOrgByName by checking if the org object
@@ -68,6 +69,12 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 			DeleteOnStorageLeaseExpiration: true,
 			StorageLeaseSeconds:            10,
 		},
+		OrgVAppLeaseSettings: &types.VAppLeaseSettings{
+			PowerOffOnRuntimeLeaseExpiration: true,
+			DeploymentLeaseSeconds:           1000000,
+			DeleteOnStorageLeaseExpiration:   true,
+			StorageLeaseSeconds:              1000000,
+		},
 		OrgLdapSettings: &types.OrgLdapSettingsType{
 			OrgLdapMode: "NONE",
 		},
@@ -88,6 +95,7 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	err = org.Delete(true, true)
 	check.Assert(err, IsNil)
 	// Check if org still exists
+	time.Sleep(10 * time.Second)
 	org, err = GetAdminOrgByName(vcd.client, TestCreateOrg)
 	check.Assert(org, Equals, AdminOrg{})
 	check.Assert(err, IsNil)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -555,10 +555,12 @@ type OrgSettings struct {
 	HREF string `xml:"href,attr,omitempty"` // The URI of the entity.
 	Type string `xml:"type,attr,omitempty"` // The MIME type of the entity.
 	//elements
-	Link                    LinkList                   `xml:"Link,omitempty"`                      // A reference to an entity or operation associated with this object.
-	OrgGeneralSettings      *OrgGeneralSettings        `xml:"OrgGeneralSettings,omitempty"`        // General Settings for the org, not-required
+	Link                    LinkList                   `xml:"Link,omitempty"`               // A reference to an entity or operation associated with this object.
+	OrgGeneralSettings      *OrgGeneralSettings        `xml:"OrgGeneralSettings,omitempty"` // General Settings for the org, not-required
+	OrgVAppLeaseSettings    *VAppLeaseSettings         `xml:"VAppLeaseSettings,omitempty"`
 	OrgVAppTemplateSettings *VAppTemplateLeaseSettings `xml:"VAppTemplateLeaseSettings,omitempty"` // Vapp template lease settings, not required
 	OrgLdapSettings         *OrgLdapSettingsType       `xml:"OrgLdapSettings,omitempty"`           //LDAP settings, not-requried, defaults to none
+
 }
 
 // OrgGeneralSettingsType represents the general settings for a vCloud Director organization.
@@ -592,8 +594,27 @@ type VAppTemplateLeaseSettings struct {
 	StorageLeaseSeconds            int  `xml:"StorageLeaseSeconds,omitempty"`
 }
 
+type VAppLeaseSettings struct {
+	HREF string   `xml:"href,attr,omitempty"` // The URI of the entity.
+	Type string   `xml:"type,attr,omitempty"` // The MIME type of the entity.
+	Link LinkList `xml:"Link,omitempty"`      // A reference to an entity or operation associated with this object.
+
+	DeleteOnStorageLeaseExpiration   bool `xml:"DeleteOnStorageLeaseExpiration,allowempty"`
+	DeploymentLeaseSeconds           int  `xml:"DeploymentLeaseSeconds,allowempty"`
+	StorageLeaseSeconds              int  `xml:"StorageLeaseSeconds,allowempty"`
+	PowerOffOnRuntimeLeaseExpiration bool `xml:"PowerOffOnRuntimeLeaseExpiration,allowempty"`
+}
+
+type OrgFederationSettings struct {
+	HREF string   `xml:"href,attr,omitempty"` // The URI of the entity.
+	Type string   `xml:"type,attr,omitempty"` // The MIME type of the entity.
+	Link LinkList `xml:"Link,omitempty"`      // A reference to an entity or operation associated with this object.
+
+	Enabled bool `xml:"Enabled,allowempty"`
+}
+
 // OrgLdapSettingsType represents the ldap settings for a vCloud Director organization.
-// Type: VAppLeaseSettingsType
+// Type: OrgLdapSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents the ldap settings of a vCloud Director organization.
 // Since: 0.9


### PR DESCRIPTION
This changes to Support Vulcan's vCD API version (with compatibility of vCD 8.20+)
Changes
- update hard coded parts
- change API to 27.0
- test updates
- update documentation with issues

Note that newer API has issue creating organization:
Organization creation has two bugs https://bugzilla.eng.vmware.com/show_bug.cgi?id=2177355, https://bugzilla.eng.vmware.com/show_bug.cgi?id=2228936 which requires, that creating organization elements are in incorrect order, at least one element(DelayAfterPowerOnSeconds, DeployedVMQuota, StoredVmQuota, UseServerBootSequence, getVdcQuota) is needed then providing generalOrgSettings and VAppLeaseSettings/VAppLeaseSettings provided fully or not at all.
