### PR TITLE
Bug fixes

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -512,6 +512,12 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 					HREF: disk.Disk.HREF,
 				},
 			})
+			if err != nil {
+				vcd.infoCleanup(
+					"removeLeftoverEntries: [ERROR] Detaching %s '%s', VM: '%s|%s': %s\n",
+					entity.EntityType, entity.Name, vmRef.Name, vmRef.HREF, err)
+				return
+			}
 			err = task.WaitTaskCompletion()
 			if err != nil {
 				vcd.infoCleanup(

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -348,6 +348,9 @@ func (vcd *TestVCD) detachIndependentDisk(disk Disk) error {
 				HREF: disk.Disk.HREF,
 			},
 		})
+		if err != nil {
+			return err
+		}
 		err = task.WaitTaskCompletion()
 		if err != nil {
 			return err

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -254,8 +254,8 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	}
 
 	// Find VM
-	vapp := vcd.find_first_vapp()
-	vmType, vmName := vcd.find_first_vm(vapp)
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
@@ -321,6 +321,39 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
+	// Detach disk
+	err = vcd.detachIndependentDisk(Disk{disk.Disk, &vcd.client.Client})
+	check.Assert(err, IsNil)
+}
+
+// Checks whether an independent disk is attached to a VM, and detaches it
+func (vcd *TestVCD) detachIndependentDisk(disk Disk) error {
+
+	// See if the disk is attached to the VM
+	vmRef, err := disk.AttachedVM()
+	if err != nil {
+		return err
+	}
+	// If the disk is attached to the VM, detach disk from the VM
+	if vmRef != nil {
+
+		vm, err := vcd.client.FindVMByHREF(vmRef.HREF)
+		if err != nil {
+			return err
+		}
+
+		// Detach the disk from VM
+		task, err := vm.DetachDisk(&types.DiskAttachOrDetachParams{
+			Disk: &types.Reference{
+				HREF: disk.Disk.HREF,
+			},
+		})
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Test find Disk by Href in VDC struct
@@ -430,8 +463,8 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	}
 
 	// Find VM
-	vapp := vcd.find_first_vapp()
-	vmType, vmName := vcd.find_first_vm(vapp)
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -191,9 +191,18 @@ func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip("Configuration org != 'System'")
 	}
 
+	if vcd.config.VCD.ProviderVdc.Name == "" {
+		check.Skip("No Provider VDC name given for VDC tests")
+	}
+	if vcd.config.VCD.ProviderVdc.StorageProfile == "" {
+		check.Skip("No Storage Profile given for VDC tests")
+	}
+	if vcd.config.VCD.ProviderVdc.NetworkPool == "" {
+		check.Skip("No Network Pool given for VDC tests")
+	}
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, Not(Equals), AdminOrg{})

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -22,7 +22,8 @@ func (vcd *TestVCD) Test_GetOrgByName(check *C) {
 	// Tests Org That doesn't exist
 	org, err = GetOrgByName(vcd.client, INVALID_NAME)
 	check.Assert(org, Equals, Org{})
-	check.Assert(err, IsNil)
+	// When we explicitly search for a non existing item, we expect the error to be not nil
+	check.Assert(err, NotNil)
 }
 
 // Tests System function GetAdminOrgByName by checking if the AdminOrg object
@@ -32,7 +33,7 @@ func (vcd *TestVCD) Test_GetOrgByName(check *C) {
 // if the function finds it or if the error is not nil.
 func (vcd *TestVCD) Test_GetAdminOrgByName(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip("Configuration org != 'System'")
 	}
 	org, err := GetAdminOrgByName(vcd.client, vcd.config.VCD.Org)
 	check.Assert(org, Not(Equals), AdminOrg{})
@@ -41,7 +42,7 @@ func (vcd *TestVCD) Test_GetAdminOrgByName(check *C) {
 	// Tests Org That doesn't exist
 	org, err = GetAdminOrgByName(vcd.client, INVALID_NAME)
 	check.Assert(org, Equals, AdminOrg{})
-	check.Assert(err, IsNil)
+	check.Assert(err, NotNil)
 }
 
 // Tests the creation of an org with general settings,
@@ -49,7 +50,7 @@ func (vcd *TestVCD) Test_GetAdminOrgByName(check *C) {
 // error if the task, fetching the org, or deleting the org fails
 func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip("Configuration org != 'System'")
 	}
 	org, err := GetAdminOrgByName(vcd.client, TestCreateOrg)
 	if org != (AdminOrg{}) {

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -449,7 +449,7 @@ func (vapp *VApp) RunCustomizationScript(computername, script string) (Task, err
 func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated
@@ -507,7 +507,7 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 func (vapp *VApp) GetStatus() (string, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return "", fmt.Errorf("error refreshing vapp: %v", err)
+		return "", fmt.Errorf("error refreshing vApp: %v", err)
 	}
 	return types.VAppStatuses[vapp.VApp.Status], nil
 }
@@ -543,7 +543,7 @@ func (vapp *VApp) ChangeCPUcount(size int) (Task, error) {
 
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated
@@ -607,7 +607,7 @@ func (vapp *VApp) ChangeCPUcount(size int) (Task, error) {
 func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	if vapp.VApp.Children == nil || len(vapp.VApp.Children.VM) == 0 {
@@ -616,11 +616,11 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 
 	vdc, err := vapp.getParentVDC()
 	if err != nil {
-		return Task{}, fmt.Errorf("error retrieving parent VDC for vapp %s", vapp.VApp.Name)
+		return Task{}, fmt.Errorf("error retrieving parent VDC for vApp %s", vapp.VApp.Name)
 	}
 	storageProfileRef, err := vdc.FindStorageProfileReference(name)
 	if err != nil {
-		return Task{}, fmt.Errorf("error retrieving storage profile %s for vapp %s", name, vapp.VApp.Name)
+		return Task{}, fmt.Errorf("error retrieving storage profile %s for vApp %s", name, vapp.VApp.Name)
 	}
 
 	newProfile := &types.VM{
@@ -631,7 +631,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 
 	output, err := xml.MarshalIndent(newProfile, "  ", "    ")
 	if err != nil {
-		return Task{}, fmt.Errorf("error encoding storage profile change metadata for vapp %s", vapp.VApp.Name)
+		return Task{}, fmt.Errorf("error encoding storage profile change metadata for vApp %s", vapp.VApp.Name)
 	}
 
 	util.Logger.Printf("[DEBUG] VCD Client configuration: %s", output)
@@ -663,7 +663,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -709,7 +709,7 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -739,7 +739,7 @@ func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
 func (vapp *VApp) AddMetadata(key, value string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -790,7 +790,7 @@ func (vapp *VApp) AddMetadata(key, value string) (Task, error) {
 func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -930,7 +930,7 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vapp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
 	}
 
 	// Check if VApp Children is populated

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func (vcd *TestVCD) find_first_vm(vapp VApp) (types.VM, string) {
+func (vcd *TestVCD) findFirstVm(vapp VApp) (types.VM, string) {
 	for _, vm := range vapp.VApp.Children.VM {
 		if vm.Name != "" {
 			return *vm, vm.Name
@@ -22,7 +22,7 @@ func (vcd *TestVCD) find_first_vm(vapp VApp) (types.VM, string) {
 	return types.VM{}, ""
 }
 
-func (vcd *TestVCD) find_first_vapp() VApp {
+func (vcd *TestVCD) findFirstVapp() VApp {
 	client := vcd.client
 	config := vcd.config
 	org, err := GetOrgByName(client, config.VCD.Org)
@@ -35,29 +35,29 @@ func (vcd *TestVCD) find_first_vapp() VApp {
 		fmt.Println(err)
 		return VApp{}
 	}
-	wanted_vapp := vcd.vapp.VApp.Name
-	vapp_name := ""
+	wantedVapp := vcd.vapp.VApp.Name
+	vappName := ""
 	for _, res := range vdc.Vdc.ResourceEntities {
 		for _, item := range res.ResourceEntity {
 			// Finding a named vApp, if it was defined in config
-			if wanted_vapp != "" {
-				if item.Name == wanted_vapp {
-					vapp_name = item.Name
+			if wantedVapp != "" {
+				if item.Name == wantedVapp {
+					vappName = item.Name
 					break
 				}
 			} else {
 				// Otherwise, we get the first vApp from the vDC list
 				if item.Type == "application/vnd.vmware.vcloud.vApp+xml" {
-					vapp_name = item.Name
+					vappName = item.Name
 					break
 				}
 			}
 		}
 	}
-	if wanted_vapp == "" {
+	if wantedVapp == "" {
 		return VApp{}
 	}
-	vapp, _ := vdc.FindVAppByName(vapp_name)
+	vapp, _ := vdc.FindVAppByName(vappName)
 	return vapp
 }
 
@@ -137,11 +137,11 @@ func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	vapp := vcd.find_first_vapp()
+	vapp := vcd.findFirstVapp()
 	if vapp.VApp.Name == "" {
 		check.Skip("Disabled: No suitable vApp found in vDC")
 	}
-	vm, vm_name := vcd.find_first_vm(vapp)
+	vm, vm_name := vcd.findFirstVm(vapp)
 	if vm.Name == "" {
 		check.Skip("Disabled: No suitable VM found in vDC")
 	}
@@ -165,8 +165,8 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.find_first_vapp()
-	vmType, vmName := vcd.find_first_vm(vapp)
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
@@ -256,8 +256,8 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	}
 
 	// Find VM
-	vapp := vcd.find_first_vapp()
-	vmType, vmName := vcd.find_first_vm(vapp)
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
@@ -337,8 +337,8 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	}
 
 	// Find VM
-	vapp := vcd.find_first_vapp()
-	vmType, vmName := vcd.find_first_vm(vapp)
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}


### PR DESCRIPTION
Fix Issue #131 `ChangeStorageProfile` fails if it runs after `AttachedVMDisk`
    This failure occurs because the disk test leaves a disk attached to a VM.
    The fix detaches the disk at the end of the test.

Change snake_case function names to camelCase in vm_test.go

Add checks for configuration items in VDC test.
    Without these checks, the test was failing with unhelpful messages
    when the configuration file did not have the needed section filled.

Fix assertion for error in `Test_GetOrgByName`
    The assertion was checking for a nil error, but when we explicitly
    search for a non-existing item, we expect the error to be set.

Fix several misspelling occurrences of the word "System" in skip messages

Add missing error handling in `ChangeStorageProfile`

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>