### PR TITLE
Enhance tests to run with Org administrator privs

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -54,6 +54,10 @@ const (
 	TestVMDetachDisk              = "TestVMDetachDisk"
 )
 
+const (
+	TestRequiresSysAdminPrivileges = "Test %s requires system administrator privileges"
+)
+
 // Struct to get info from a config yaml file that the user
 // specifies
 type TestConfig struct {
@@ -481,8 +485,9 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		// [0] = disk's entity name, [1] = disk href
 		disk, err := vcd.vdc.FindDiskByHREF(strings.Split(entity.Name, "|")[1])
 		if err != nil {
-			vcd.infoCleanup("removeLeftoverEntries: [ERROR] Deleting %s '%s', cannot find disk: %s\n",
-				entity.EntityType, entity.Name, err)
+			// If the disk is not found, we just need to show that it was not found, as
+			// it was likely deleted during the regular tests
+			vcd.infoCleanup(notFoundMsg, entity.Name, err)
 			return
 		}
 

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -13,6 +13,9 @@ import (
 func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
+	if !vcd.client.Client.IsSysAdmin {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
 	networkName := vcd.config.VCD.ExternalNetwork
 	if networkName == "" {
 		check.Skip("No external network provided")

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -16,7 +16,7 @@ import (
 func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	adminOrg, err := GetAdminOrgByName(vcd.client, TestRefreshOrg)
 	if adminOrg != (AdminOrg{}) {
@@ -65,7 +65,7 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 // delete org. Fails if org still exists
 func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	org, err := GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	if org != (AdminOrg{}) {
@@ -96,7 +96,7 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 // refetched.
 func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	org, err := GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	if org != (AdminOrg{}) {
@@ -168,7 +168,7 @@ func (vcd *TestVCD) Test_GetVdcByName(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
@@ -191,7 +191,7 @@ func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'System'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
 	if vcd.config.VCD.ProviderVdc.Name == "" {
@@ -344,7 +344,7 @@ func (vcd *TestVCD) Test_FindCatalog(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	// Fetch admin org version of current test org
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
@@ -370,7 +370,7 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	org, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(org, Not(Equals), AdminOrg{})
@@ -405,7 +405,7 @@ func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 // the names and description match, and that no error is returned
 func (vcd *TestVCD) Test_GetAdminCatalog(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'Sysyem'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	// Fetch admin org version of current test org
 	adminOrg, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -155,6 +155,9 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkDirect
 
+	if !vcd.client.Client.IsSysAdmin {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
 	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
 	if err != nil {
 		check.Skip(fmt.Sprintf("Error deleting network : %s", err))

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"fmt"
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
@@ -33,7 +34,7 @@ func (vcd *TestVCD) Test_GetOrgByName(check *C) {
 // if the function finds it or if the error is not nil.
 func (vcd *TestVCD) Test_GetAdminOrgByName(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'System'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	org, err := GetAdminOrgByName(vcd.client, vcd.config.VCD.Org)
 	check.Assert(org, Not(Equals), AdminOrg{})
@@ -50,7 +51,7 @@ func (vcd *TestVCD) Test_GetAdminOrgByName(check *C) {
 // error if the task, fetching the org, or deleting the org fails
 func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	if vcd.skipAdminTests {
-		check.Skip("Configuration org != 'System'")
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	org, err := GetAdminOrgByName(vcd.client, TestCreateOrg)
 	if org != (AdminOrg{}) {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	"fmt"
 	"github.com/vmware/go-vcloud-director/types/v56"
+	"regexp"
 
 	. "gopkg.in/check.v1"
 )
@@ -179,6 +180,12 @@ func (vcd *TestVCD) Test_ChangeStorageProfile(check *C) {
 		check.Skip("Skipping test because second storage profile not given")
 	}
 	task, err := vcd.vapp.ChangeStorageProfile(vcd.config.VCD.StorageProfile.SP2)
+	errStr := fmt.Sprintf("%v", err)
+
+	re := regexp.MustCompile(`error retrieving storage profile`)
+	if re.MatchString(errStr) {
+		check.Skip("Skipping test because second storage profile not found")
+	}
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)


### PR DESCRIPTION
Add checks on tests that require sys admin privileges
    and skip them if we're running as Org administrator.

Use a standardized skip message for all tests that were
    skipped for lack of privileges.

Fix minor bugs

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>