### PR TITLE
Bug fixing 2018 12

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -78,7 +78,7 @@ func (cli *Client) NewRequestWitNotEncodedParams(params map[string]string, notEn
 				payload = fmt.Sprintf("<Not retrieved from type %s>", reflect.TypeOf(body))
 			}
 		}
-		util.ProcessRequestOutput(util.CallFuncName(), method, reqUrl.String(), payload, req)
+		util.ProcessRequestOutput(util.FuncNameCallStack(), method, reqUrl.String(), payload, req)
 	}
 	return req
 
@@ -109,7 +109,7 @@ func decodeBody(resp *http.Response, out interface{}) error {
 
 	body, err := ioutil.ReadAll(resp.Body)
 
-	util.ProcessResponseOutput(util.CallFuncName(), resp, fmt.Sprintf("%s", body))
+	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, fmt.Sprintf("%s", body))
 	if err != nil {
 		return err
 	}

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -97,7 +97,8 @@ func parseErr(resp *http.Response) error {
 
 	// if there was an error decoding the body, just return that
 	if err := decodeBody(resp, errBody); err != nil {
-		return fmt.Errorf("error parsing error body for non-200 request: %s", err)
+		util.Logger.Printf("[parseErr]: unhandled response <--\n%+v\n-->\n", resp)
+		return fmt.Errorf("[parseErr]: error parsing error body for non-200 request: %s (%+v)", err, resp)
 	}
 
 	return fmt.Errorf("API Error: %d: %s", errBody.MajorErrorCode, errBody.Message)
@@ -130,12 +131,41 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 		return resp, err
 	}
 
-	switch i := resp.StatusCode; {
+	switch resp.StatusCode {
 	// Valid request, return the response.
-	case i == 200 || i == 201 || i == 202 || i == 204:
+	case
+		http.StatusOK,        // 200
+		http.StatusCreated,   // 201
+		http.StatusAccepted,  // 202
+		http.StatusNoContent: // 204
 		return resp, nil
 	// Invalid request, parse the XML error returned and return it.
-	case i == 400 || i == 401 || i == 403 || i == 404 || i == 405 || i == 406 || i == 409 || i == 415 || i == 500 || i == 503 || i == 504:
+	case
+		http.StatusBadRequest,                  // 400
+		http.StatusUnauthorized,                // 401
+		http.StatusForbidden,                   // 403
+		http.StatusNotFound,                    // 404
+		http.StatusMethodNotAllowed,            // 405
+		http.StatusNotAcceptable,               // 406
+		http.StatusProxyAuthRequired,           // 407
+		http.StatusRequestTimeout,              // 408
+		http.StatusConflict,                    // 409
+		http.StatusGone,                        // 410
+		http.StatusLengthRequired,              // 411
+		http.StatusPreconditionFailed,          // 412
+		http.StatusRequestEntityTooLarge,       // 413
+		http.StatusRequestURITooLong,           // 414
+		http.StatusUnsupportedMediaType,        // 415
+		http.StatusLocked,                      // 423
+		http.StatusFailedDependency,            // 424
+		http.StatusUpgradeRequired,             // 426
+		http.StatusPreconditionRequired,        // 428
+		http.StatusTooManyRequests,             // 429
+		http.StatusRequestHeaderFieldsTooLarge, // 431
+		http.StatusUnavailableForLegalReasons,  // 451
+		http.StatusInternalServerError,         // 500
+		http.StatusServiceUnavailable,          // 503
+		http.StatusGatewayTimeout:              // 504
 		return nil, parseErr(resp)
 	// Unhandled response.
 	default:

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -92,11 +92,12 @@ type TestConfig struct {
 		}
 	} `yaml:"vcd"`
 	Logging struct {
-		Enabled         bool   `yaml:"enabled,omitempty"`
-		LogFileName     string `yaml:"logFileName,omitempty"`
-		LogHttpRequest  bool   `yaml:"logHttpRequest,omitempty"`
-		LogHttpResponse bool   `yaml:"logHttpResponse,omitempty"`
-		VerboseCleanup  bool   `yaml:"verboseCleanup,omitempty"`
+		Enabled                 bool   `yaml:"enabled,omitempty"`
+		LogFileName             string `yaml:"logFileName,omitempty"`
+		LogHttpRequest          bool   `yaml:"logHttpRequest,omitempty"`
+		LogHttpResponse         bool   `yaml:"logHttpResponse,omitempty"`
+		LogSkipVersionsResponse bool   `yaml:"logSkipVersionsResponse,omitempty"`
+		VerboseCleanup          bool   `yaml:"verboseCleanup,omitempty"`
 	} `yaml:"logging"`
 	OVA struct {
 		OVAPath        string `yaml:"ovaPath,omitempty"`
@@ -175,12 +176,12 @@ func PrependToCleanupList(name, entityType, parent, createdBy string) {
 // yaml file or if it cannot read it.
 func GetConfigStruct() (TestConfig, error) {
 	config := os.Getenv("GOVCD_CONFIG")
-	config_struct := TestConfig{}
+	configStruct := TestConfig{}
 	if config == "" {
 		// Finds the current directory, through the path of this running test
-		_, current_filename, _, _ := runtime.Caller(0)
-		current_directory := filepath.Dir(current_filename)
-		config = current_directory + "/govcd_test_config.yaml"
+		_, currentFilename, _, _ := runtime.Caller(0)
+		currentDirectory := filepath.Dir(currentFilename)
+		config = currentDirectory + "/govcd_test_config.yaml"
 	}
 	// Looks if the configuration file exists before attempting to read it
 	_, err := os.Stat(config)
@@ -191,11 +192,11 @@ func GetConfigStruct() (TestConfig, error) {
 	if err != nil {
 		return TestConfig{}, fmt.Errorf("could not read config file %s: %v", config, err)
 	}
-	err = yaml.Unmarshal(yamlFile, &config_struct)
+	err = yaml.Unmarshal(yamlFile, &configStruct)
 	if err != nil {
 		return TestConfig{}, fmt.Errorf("could not unmarshal yaml file: %v", err)
 	}
-	return config_struct, nil
+	return configStruct, nil
 }
 
 // Creates a VCDClient based on the endpoint given in the TestConfig argument.
@@ -235,6 +236,9 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		}
 		if vcd.config.Logging.LogHttpResponse {
 			util.LogHttpResponse = true
+		}
+		if vcd.config.Logging.LogSkipVersionsResponse {
+			util.SkipVersionsResponse = true
 		}
 	} else {
 		util.EnableLogging = false

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -262,7 +262,7 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 	if err != nil {
 		panic(err)
 	}
-	if vcd.client.Client.IsSysAdmin {
+	if !vcd.client.Client.IsSysAdmin {
 		vcd.skipAdminTests = true
 	}
 	// set org

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -97,7 +97,7 @@ type TestConfig struct {
 		LogHttpRequest   bool   `yaml:"logHttpRequest,omitempty"`
 		LogHttpResponse  bool   `yaml:"logHttpResponse,omitempty"`
 		SkipResponseTags string `yaml:"skipResponseTags,omitempty"`
-		IncludeFunctions string `yaml:"includeFunctions,omitempty"`
+		ApiLogFunctions  string `yaml:"apiLogFunctions,omitempty"`
 		VerboseCleanup   bool   `yaml:"verboseCleanup,omitempty"`
 	} `yaml:"logging"`
 	OVA struct {
@@ -241,8 +241,8 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		if vcd.config.Logging.SkipResponseTags != "" {
 			util.SetSkipTags(vcd.config.Logging.SkipResponseTags)
 		}
-		if vcd.config.Logging.IncludeFunctions != "" {
-			util.SetIncludeFunctions(vcd.config.Logging.IncludeFunctions)
+		if vcd.config.Logging.ApiLogFunctions != "" {
+			util.SetApiLogFunctions(vcd.config.Logging.ApiLogFunctions)
 		}
 	} else {
 		util.EnableLogging = false

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -92,12 +92,13 @@ type TestConfig struct {
 		}
 	} `yaml:"vcd"`
 	Logging struct {
-		Enabled                 bool   `yaml:"enabled,omitempty"`
-		LogFileName             string `yaml:"logFileName,omitempty"`
-		LogHttpRequest          bool   `yaml:"logHttpRequest,omitempty"`
-		LogHttpResponse         bool   `yaml:"logHttpResponse,omitempty"`
-		LogSkipVersionsResponse bool   `yaml:"logSkipVersionsResponse,omitempty"`
-		VerboseCleanup          bool   `yaml:"verboseCleanup,omitempty"`
+		Enabled          bool   `yaml:"enabled,omitempty"`
+		LogFileName      string `yaml:"logFileName,omitempty"`
+		LogHttpRequest   bool   `yaml:"logHttpRequest,omitempty"`
+		LogHttpResponse  bool   `yaml:"logHttpResponse,omitempty"`
+		SkipResponseTags string `yaml:"skipResponseTags,omitempty"`
+		IncludeFunctions string `yaml:"includeFunctions,omitempty"`
+		VerboseCleanup   bool   `yaml:"verboseCleanup,omitempty"`
 	} `yaml:"logging"`
 	OVA struct {
 		OVAPath        string `yaml:"ovaPath,omitempty"`
@@ -237,8 +238,11 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		if vcd.config.Logging.LogHttpResponse {
 			util.LogHttpResponse = true
 		}
-		if vcd.config.Logging.LogSkipVersionsResponse {
-			util.SkipVersionsResponse = true
+		if vcd.config.Logging.SkipResponseTags != "" {
+			util.SetSkipTags(vcd.config.Logging.SkipResponseTags)
+		}
+		if vcd.config.Logging.IncludeFunctions != "" {
+			util.SetIncludeFunctions(vcd.config.Logging.IncludeFunctions)
 		}
 	} else {
 		util.EnableLogging = false

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -29,6 +29,8 @@ func NewDisk(cli *Client) *Disk {
 	}
 }
 
+const MinimumDiskSize int = 1048576
+
 // Create an independent disk in VDC
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 102 - 103,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
@@ -43,8 +45,8 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 		return Task{}, fmt.Errorf("disk name is required")
 	}
 
-	if diskCreateParams.Disk.Size <= 0 {
-		return Task{}, fmt.Errorf("disk size should be greater than or equal to 1KB")
+	if diskCreateParams.Disk.Size < MinimumDiskSize {
+		return Task{}, fmt.Errorf("disk size should be greater than or equal to 1Mb")
 	}
 
 	var err error
@@ -104,6 +106,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 	task := NewTask(vdc.client)
 	task.Task = disk.Disk.Tasks.Task[0]
 
+	util.Logger.Printf("[TRACE] AFTER CREATE DISK\n %s\n", prettyDisk(*disk.Disk))
 	// Return the disk
 	return *task, nil
 }
@@ -129,8 +132,8 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 		return Task{}, fmt.Errorf("disk name is required")
 	}
 
-	if newDiskInfo.Size <= 0 {
-		return Task{}, fmt.Errorf("disk size should be greater than or equal to 1KB")
+	if newDiskInfo.Size < MinimumDiskSize {
+		return Task{}, fmt.Errorf("disk size should be greater than or equal to 1Mb")
 	}
 
 	// Verify the independent disk is not connected to any VM
@@ -180,6 +183,7 @@ func (d *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	if err != nil {
 		return Task{}, fmt.Errorf("error xml.Marshal: %s", err)
 	}
+	util.Logger.Printf("[TRACE] BEFORE UPDATE DISK\n %s\n", prettyDisk(*d.Disk))
 
 	// Send request
 	reqPayload := bytes.NewBufferString(xml.Header + string(xmlPayload))
@@ -267,7 +271,7 @@ func (d *Disk) Delete() (Task, error) {
 
 // Refresh the disk information by disk href
 func (d *Disk) Refresh() error {
-	util.Logger.Printf("[TRACE] Disk refersh, HREF: %s\n", d.Disk.HREF)
+	util.Logger.Printf("[TRACE] Disk refresh, HREF: %s\n", d.Disk.HREF)
 
 	disk, err := FindDiskByHREF(d.client, d.Disk.HREF)
 	if err != nil {

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -29,7 +29,9 @@ func NewDisk(cli *Client) *Disk {
 	}
 }
 
-const MinimumDiskSize int = 1048576
+// While theoretically we can use smaller amounts, there is an issue when updating
+// disks with size < 1MB
+const MinimumDiskSize int = 1048576 // = 1Mb
 
 // Create an independent disk in VDC
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 102 - 103,

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -98,6 +98,14 @@ func prettyAdminOrg(org types.AdminOrg) string {
 	return ""
 }
 
+func prettyDisk(disk types.Disk) string {
+	byteBuf, err := json.MarshalIndent(disk, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
 func prettyExternalNetwork(network types.ExternalNetworkReference) string {
 	byteBuf, err := json.MarshalIndent(network, " ", " ")
 	if err == nil {
@@ -170,6 +178,13 @@ func LogVdc(vdc types.Vdc) {
 	out("log", prettyVdc(vdc))
 }
 
+func ShowDisk(disk types.Disk) {
+	out("screen", prettyDisk(disk))
+}
+
+func LogDisk(disk types.Disk) {
+	out("log", prettyDisk(disk))
+}
 func ShowCatalog(catalog types.Catalog) {
 	out("screen", prettyCatalog(catalog))
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -38,7 +38,7 @@
 		"logFileName": "go-vcloud-director.log",
 		"logHttpRequests": true,
 		"skipResponseTags": "SupportedVersions,VAppTemplate",
-		"includeFunctions": "FindVAppByName",
+		"apiLogFunctions": "FindVAppByName",
 		"logHttpResponses": true
 	},
   "ova": {

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -38,6 +38,7 @@
 		"logFileName": "go-vcloud-director.log",
 		"logHttpRequests": true,
 		"skipResponseTags": "SupportedVersions,VAppTemplate",
+		"includeFunctions": "FindVAppByName",
 		"logHttpResponses": true
 	},
   "ova": {

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -37,7 +37,7 @@
 		"enabled": true,
 		"logFileName": "go-vcloud-director.log",
 		"logHttpRequests": true,
-		"logSkipVersionsResponse": true,
+		"skipResponseTags": "SupportedVersions,VAppTemplate",
 		"logHttpResponses": true
 	},
   "ova": {

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -29,14 +29,15 @@
 		"externalIp": "10.150.10.10",
 		"internalIp": "192.168.1.10",
     "disk": {
-      "size": 1024,
-      "sizeForUpdate": 10240
+      "size": 1048576,
+      "sizeForUpdate": 1048576
     }
 	},
 	"logging": {
 		"enabled": true,
 		"logFileName": "go-vcloud-director.log",
 		"logHttpRequests": true,
+		"logSkipVersionsResponse": true,
 		"logHttpResponses": true
 	},
   "ova": {

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -70,10 +70,10 @@ vcd:
     disk:
       #
       # Disk size (bytes) for create disk, skip disk tests if it is less than or equal to 0
-      size: 1024
+      size: 1048576
       #
       # Disk size (bytes) for update disk, skip some disk tests if it is less than or equal to 0
-      sizeForUpdate: 10240
+      sizeForUpdate: 1048576
 logging:
     # All items in this section are optional
     # Logging is disabled by default.
@@ -90,6 +90,10 @@ logging:
     #
     # Defines whether we log the responses in HTTP operations
     logHttpResponses: true
+    #
+    # Skips lengthy /versions response in the logs
+    logSkipVersionsResponse: true
+    #
     # Shows details of cleanup operations after tests
     verboseCleanup: true
 ova:

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -91,8 +91,9 @@ logging:
     # Defines whether we log the responses in HTTP operations
     logHttpResponses: true
     #
-    # Skips lengthy /versions response in the logs
-    logSkipVersionsResponse: true
+    #
+    # Comma-separated list of custom tags to skip from the logs
+    skipResponseTags: SupportedVersions,VAppTemplate
     #
     # Shows details of cleanup operations after tests
     verboseCleanup: true

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -73,6 +73,8 @@ vcd:
       size: 1048576
       #
       # Disk size (bytes) for update disk, skip some disk tests if it is less than or equal to 0
+      # The minimum size is 1048576 (1 MB). While theoretically smaller amounts are allowed,
+      # there is an issue when using < 1MB during updates
       sizeForUpdate: 1048576
 logging:
     # All items in this section are optional
@@ -91,9 +93,13 @@ logging:
     # Defines whether we log the responses in HTTP operations
     logHttpResponses: true
     #
-    #
     # Comma-separated list of custom tags to skip from the logs
     skipResponseTags: SupportedVersions,VAppTemplate
+    #
+    # Comma-separated list of functions from where we log the API calls.
+    # When this is set, we only log API requests and responses if the name
+    # of the function matches any of the names in this list.
+    includeFunctions: FindVAppByName,GetAdminOrgByName
     #
     # Shows details of cleanup operations after tests
     verboseCleanup: true

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -93,13 +93,13 @@ logging:
     # Defines whether we log the responses in HTTP operations
     logHttpResponses: true
     #
-    # Comma-separated list of custom tags to skip from the logs
+    # Comma-separated list of XML tags to skip from the API logs
     skipResponseTags: SupportedVersions,VAppTemplate
     #
     # Comma-separated list of functions from where we log the API calls.
     # When this is set, we only log API requests and responses if the name
     # of the function matches any of the names in this list.
-    includeFunctions: FindVAppByName,GetAdminOrgByName
+    logFunctions: FindVAppByName,GetAdminOrgByName
     #
     # Shows details of cleanup operations after tests
     verboseCleanup: true

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 # This script will find code files that don't have a copyright notice
+# or the ones with an outdated copyright.
+#
+# The checks will fail if:
+# a) the source file does not have a copyright header
+# b) the source file has a copyright header from last year, but it was modified this year
 
-# This check will find files with a copyright but not for the current year
+
+# This check will find files with a copyright for any year
 vmware_any_copyright='Copyright \d\d\d\d VMware'
 
-# This check will find files with a copyright for the current year
 this_year=$(date +%Y)
 last_year=$((this_year-1))
+
+# This check will find files with a copyright for the current year
 vmware_latest_copyright="Copyright $this_year VMware"
+
+# This check will find files with a copyright for last year
 vmware_last_year_copyright="Copyright $last_year VMware"
 exit_code=0
 

--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -5,7 +5,10 @@
 vmware_any_copyright='Copyright \d\d\d\d VMware'
 
 # This check will find files with a copyright for the current year
-vmware_latest_copyright="Copyright $(date +%Y) VMware"
+this_year=$(date +%Y)
+last_year=$((this_year-1))
+vmware_latest_copyright="Copyright $this_year VMware"
+vmware_last_year_copyright="Copyright $last_year VMware"
 exit_code=0
 for F in $(find . -name '*.go' | grep -v '/vendor/' )
 do
@@ -15,12 +18,23 @@ do
         # Looks for copyright in the Nth line of the file
         has_any_copyright=$(head -n $line_num $F | tail -n 1 | grep "$vmware_any_copyright" )
         has_latest_copyright=$(head -n $line_num $F | tail -n 1 | grep "$vmware_latest_copyright" )
+        has_last_year_copyright=$(head -n $line_num $F | tail -n 1 | grep "$vmware_last_year_copyright" )
 
         if [ -n "$has_latest_copyright" ]
         then
             if [ "$1" == "-v" -o "$1" == "--verbose" ]
             then
                 echo "$F: latest copyright found in line $line_num"
+            fi
+            copyright_found=$line_num
+        elif [ -n "$has_last_year_copyright" ]
+        then
+            current_file_date=$(date -r $F)
+            updated_this_year=$(echo "$current_file_date" | grep -w $this_year)
+            if [ -n "$updated_this_year" ]
+            then
+                echo "$F updated this year, but has last year's copyright"
+                exit_code=1
             fi
             copyright_found=$line_num
         elif [ -n "$has_any_copyright" ]

--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -30,12 +30,12 @@ do
         elif [ -n "$has_last_year_copyright" ]
         then
             current_file_date=$(date -r $F)
-            updated_this_year=$(echo "$current_file_date" | grep -w $this_year)
-            if [ -n "$updated_this_year" ]
-            then
-                echo "$F updated this year, but has last year's copyright"
-                exit_code=1
-            fi
+            #updated_this_year=$(echo "$current_file_date" | grep -w $this_year)
+            #if [ -n "$updated_this_year" ]
+            #then
+            #    echo "$F updated this year, but has last year's copyright"
+            #    exit_code=1
+            #fi
             copyright_found=$line_num
         elif [ -n "$has_any_copyright" ]
         then

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -56,10 +56,16 @@ During the request and response processing, any password or authentication token
 util.LogPasswords = true
 ```
 
-It is also possible to skip the output of the `/versions` request, which is quite large (140 Kb, 2000+ lines) using 
+It is also possible to skip the output of the some tags (such as the result of `/versions` request,) which are quite large using 
 
 ```go
-util.SkipVersionsResponse = true
+util.SkipTagList = "SupportedVersions,ovf:License"
+```
+
+For an even more dedicated log, you can define from which function names you want the logs, using
+
+```go
+util.IncludeVersionList = "FindVAppByName,GetAdminOrgByName"
 ```
 
 ## Custom logger
@@ -82,5 +88,6 @@ Variable                    | Corresponding environment var
 `LogOnScreen`               | `GOVCD_LOG_ON_SCREEN`
 `LogHttpRequest`            | `GOVCD_LOG_SKIP_HTTP_REQ`
 `LogHttpResponse`           | `GOVCD_LOG_SKIP_HTTP_RESP`
-`SkipVersionsResponse`      | `GOVCD_LOG_SKIP_VERSIONS`
+`SkipTagList`               | `GOVCD_LOG_SKIP_TAG_LIST`
+`IncludeFunctionList`       | `GOVCD_LOG_INCLUDE_FUNCTION_LIST`
 

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -59,13 +59,13 @@ util.LogPasswords = true
 It is also possible to skip the output of the some tags (such as the result of `/versions` request,) which are quite large using 
 
 ```go
-util.SkipTagList = "SupportedVersions,ovf:License"
+util.SetSkipTags("SupportedVersions,ovf:License")
 ```
 
 For an even more dedicated log, you can define from which function names you want the logs, using
 
 ```go
-util.IncludeVersionList = "FindVAppByName,GetAdminOrgByName"
+util.SetIncludeFunctions("FindVAppByName,GetAdminOrgByName")
 ```
 
 ## Custom logger
@@ -88,6 +88,6 @@ Variable                    | Corresponding environment var
 `LogOnScreen`               | `GOVCD_LOG_ON_SCREEN`
 `LogHttpRequest`            | `GOVCD_LOG_SKIP_HTTP_REQ`
 `LogHttpResponse`           | `GOVCD_LOG_SKIP_HTTP_RESP`
-`SkipTagList`               | `GOVCD_LOG_SKIP_TAG_LIST`
-`IncludeFunctionList`       | `GOVCD_LOG_INCLUDE_FUNCTION_LIST`
+`SetSkipTags`               | `GOVCD_LOG_SKIP_TAG_LIST`
+`SetIncludeFunctions`       | `GOVCD_LOG_INCLUDE_FUNCTION_LIST`
 

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -56,6 +56,12 @@ During the request and response processing, any password or authentication token
 util.LogPasswords = true
 ```
 
+It is also possible to skip the output of the `/versions` request, which is quite large (140 Kb, 2000+ lines) using 
+
+```go
+util.SkipVersionsResponse = true
+```
+
 ## Custom logger
 
 If the configuration options are not enough for your needs, you can supply your own logger.
@@ -68,8 +74,6 @@ util.SetCustomLogger(mylogger)
 
 The logging behavior can be changed without coding. There are a few environment variables that are checked when the library is used:
 
-```EnableLogging``` corresponds to
-
 Variable                    | Corresponding environment var 
 --------------------------- | :-------------------------------
 `EnableLogging`             | `GOVCD_LOG`
@@ -78,4 +82,5 @@ Variable                    | Corresponding environment var
 `LogOnScreen`               | `GOVCD_LOG_ON_SCREEN`
 `LogHttpRequest`            | `GOVCD_LOG_SKIP_HTTP_REQ`
 `LogHttpResponse`           | `GOVCD_LOG_SKIP_HTTP_RESP`
+`SkipVersionsResponse`      | `GOVCD_LOG_SKIP_VERSIONS`
 

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -65,7 +65,7 @@ util.SetSkipTags("SupportedVersions,ovf:License")
 For an even more dedicated log, you can define from which function names you want the logs, using
 
 ```go
-util.SetIncludeFunctions("FindVAppByName,GetAdminOrgByName")
+util.SetApiLogFunctions("FindVAppByName,GetAdminOrgByName")
 ```
 
 ## Custom logger
@@ -88,6 +88,6 @@ Variable                    | Corresponding environment var
 `LogOnScreen`               | `GOVCD_LOG_ON_SCREEN`
 `LogHttpRequest`            | `GOVCD_LOG_SKIP_HTTP_REQ`
 `LogHttpResponse`           | `GOVCD_LOG_SKIP_HTTP_RESP`
-`SetSkipTags`               | `GOVCD_LOG_SKIP_TAG_LIST`
-`SetIncludeFunctions`       | `GOVCD_LOG_INCLUDE_FUNCTION_LIST`
+`SetSkipTags`               | `GOVCD_LOG_SKIP_TAGS`
+`SetApiLogFunctions`        | `GOVCD_LOG_INCLUDE_FUNCTIONS`
 

--- a/util/logging.go
+++ b/util/logging.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 // Package util provides ancillary functionality to go-vcloud-director library
@@ -39,10 +39,10 @@ const (
 	envLogSkipHttpResp = "GOVCD_LOG_SKIP_HTTP_RESP"
 
 	// Name of the environment variable with a custom list of of responses to skip from logging
-	envLogSkipTagList = "GOVCD_LOG_SKIP_TAG_LIST"
+	envLogSkipTagList = "GOVCD_LOG_SKIP_TAGS"
 
 	// Name of the environment variable with a custom list of of functions to include in the logging
-	envLogIncludeFunctionList = "GOVCD_LOG_INCLUDE_FUNCTION_LIST"
+	envApiLogFunctions = "GOVCD_LOG_FUNCTIONS"
 )
 
 var (
@@ -73,11 +73,11 @@ var (
 	LogHttpResponse bool = true
 
 	// List of tags to be excluded from logging
-	skipTagList = []string{"SupportedVersions", "ovf:License"}
+	skipTags = []string{"SupportedVersions", "ovf:License"}
 
 	// List of functions included in logging
 	// If this variable is filled, only operations from matching function names will be logged
-	includeFunctionList []string
+	apiLogFunctions []string
 
 	// Sends log to screen. If value is either "stderr" or "err"
 	// logging will go to os.Stderr. For any other value it will
@@ -133,11 +133,11 @@ func SetLog() {
 	} else {
 		Logger = newLogger(ApiLogFileName)
 	}
-	if len(skipTagList) > 0 {
-		Logger.Printf("### WILL SKIP THE FOLLOWING TAGS: %+v", skipTagList)
+	if len(skipTags) > 0 {
+		Logger.Printf("### WILL SKIP THE FOLLOWING TAGS: %+v", skipTags)
 	}
-	if len(includeFunctionList) > 0 {
-		Logger.Printf("### WILL ONLY INCLUDE API LOGS FROM THE FOLLOWING FUNCTIONS: %+v", includeFunctionList)
+	if len(apiLogFunctions) > 0 {
+		Logger.Printf("### WILL ONLY INCLUDE API LOGS FROM THE FOLLOWING FUNCTIONS: %+v", apiLogFunctions)
 	}
 }
 
@@ -185,8 +185,8 @@ func logSanitizedHeader(input_header http.Header) {
 
 // Returns true if the caller function matches any of the functions in the include function list
 func includeFunction(caller string) bool {
-	if len(includeFunctionList) > 0 {
-		for _, f := range includeFunctionList {
+	if len(apiLogFunctions) > 0 {
+		for _, f := range apiLogFunctions {
 			reFunc := regexp.MustCompile(f)
 			if reFunc.MatchString(caller) {
 				return true
@@ -235,8 +235,8 @@ func ProcessResponseOutput(caller string, resp *http.Response, result string) {
 	}
 
 	outText := result
-	if len(skipTagList) > 0 {
-		for _, longTag := range skipTagList {
+	if len(skipTags) > 0 {
+		for _, longTag := range skipTags {
 			initialTag := `<` + longTag + `.*>`
 			finalTag := `</` + longTag + `>`
 			reInitialSearchTag := regexp.MustCompile(initialTag)
@@ -274,14 +274,14 @@ func ProcessResponseOutput(caller string, resp *http.Response, result string) {
 // Sets the list of tahs to skip
 func SetSkipTags(tags string) {
 	if tags != "" {
-		skipTagList = strings.Split(tags, ",")
+		skipTags = strings.Split(tags, ",")
 	}
 }
 
 // Sets the list of functions to include
-func SetIncludeFunctions(functions string) {
+func SetApiLogFunctions(functions string) {
 	if functions != "" {
-		includeFunctionList = strings.Split(functions, ",")
+		apiLogFunctions = strings.Split(functions, ",")
 	}
 }
 
@@ -295,8 +295,8 @@ func InitLogging() {
 		LogHttpResponse = false
 	}
 
-	if os.Getenv(envLogIncludeFunctionList) != "" {
-		SetIncludeFunctions(os.Getenv(envLogIncludeFunctionList))
+	if os.Getenv(envApiLogFunctions) != "" {
+		SetApiLogFunctions(os.Getenv(envApiLogFunctions))
 	}
 
 	if os.Getenv(envLogSkipTagList) != "" {

--- a/util/logging.go
+++ b/util/logging.go
@@ -196,9 +196,14 @@ func ProcessResponseOutput(caller string, resp *http.Response, result string) {
 	}
 	outText := result
 	if SkipVersionsResponse {
-		re := regexp.MustCompile(`<SupportedVersions`)
-		if re.MatchString(result) {
-			outText = "[SKIPPING VERSIONS RESPONSE]"
+		// We search for the initial and final supported versions tag
+		// If both are found, we skip the whole output
+		reInitialSupportedVersionsTag := regexp.MustCompile(`<SupportedVersions.*>`)
+		reFinalSupportedVersionsTag := regexp.MustCompile(`</SupportedVersions>`)
+		if reInitialSupportedVersionsTag.MatchString(result) {
+			if reFinalSupportedVersionsTag.MatchString(result) {
+				outText = "\n[SKIPPING SUPPORTED VERSIONS RESPONSE AT USER'S REQUEST]"
+			}
 		}
 	}
 	Logger.Printf("%s\n", hashLine)

--- a/util/logging_test.go
+++ b/util/logging_test.go
@@ -7,6 +7,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 )
 
@@ -82,19 +83,25 @@ func TestCaller(t *testing.T) {
 		{
 			label:    "current function name",
 			fun:      CurrentFuncName,
-			expected: "util.TestCaller",
+			expected: `^util.TestCaller$`,
 		},
 		{
 			label:    "function caller",
 			fun:      CallFuncName,
+			expected: `^testing.tRunner$`,
+		},
+		{
+			label:    "function stack",
+			fun:      FuncNameCallStack,
 			expected: "testing.tRunner",
 		},
 	}
 
 	for _, d := range data {
 		value := filepath.Base(d.fun())
-		if value == d.expected {
-			t.Logf("ok - %s as expected: '%s' \n", d.label, value)
+		reFunc := regexp.MustCompile(`\b` + d.expected + `\b`)
+		if reFunc.MatchString(value) {
+			t.Logf("ok - %s as expected: '%s' matches '%s' \n", d.label, value, d.expected)
 		} else {
 			t.Logf("not ok - %s doesn't match. Expected: '%s' - Found: '%s'\n", d.label, d.expected, value)
 			t.Fail()


### PR DESCRIPTION
## Add workaround for disk update bug

The disk update has a problem when using a disk size that is less than one MB. Even if the disk size is the same or bigger than the original disk, when the size is less than one MB the update fails with an error message saying that the update size is less than the original size.
To circumvent this error, I have introduced a check that requires at least 1 MB for the disk size, both for creation and for updates.

##  Add option to skip logging of custom tags

Since there are tags that are very chatty (e.g. SupportedVersions,VAppTemplate) it is possible to set a list of those we want to skip, using either an internal variable or and environment variable.

It is also possible to set a list of functions that we want to log (rather than logging everything).