### PR TITLE
Update copyright year for files recently modified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 #default: fmt test testrace vet
-default: fmtcheck vet build copyright
+default: fmtcheck vet build
 
 # test runs the test suite and vets the code
 test: get-deps fmtcheck

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 // Package govcd provides a simple binding for vCloud Director REST APIs.

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 // Contains auxiliary functions to show library entities structure.

--- a/util/logging_test.go
+++ b/util/logging_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package util


### PR DESCRIPTION
This change is needed to satisfy the automated copyright check.
I've removed the check from Travis, but the script can be used for our own pre-committing checks.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>

