### PR TITLE
Add api support for create, delete and uploadOvf for admin and normal type

### DIFF
--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -62,15 +62,17 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 // Deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
 func (catalog *Catalog) Delete(force, recursive bool) error {
-	adminCatalogHREF := catalog.client.VCDHREF
-	adminCatalogHREF.Path += "/admin/catalog/" + catalog.Catalog.ID[19:]
+	adminCatalogHREF, err := url.ParseRequestURI(catalog.Catalog.HREF)
+	if err != nil {
+		return fmt.Errorf("error parsing admin catalog's href: %v", err)
+	}
 
 	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
-	}, "DELETE", adminCatalogHREF, nil)
+	}, "DELETE", *adminCatalogHREF, nil)
 
-	_, err := checkResp(catalog.client.Http.Do(req))
+	_, err = checkResp(catalog.client.Http.Do(req))
 
 	if err != nil {
 		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.ID, err)

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -61,22 +61,30 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 
 // Deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
-func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
-	adminCatalogHREF := adminCatalog.client.VCDHREF
-	adminCatalogHREF.Path += "/admin/catalog/" + adminCatalog.AdminCatalog.ID[19:]
+func (catalog *Catalog) Delete(force, recursive bool) error {
+	adminCatalogHREF := catalog.client.VCDHREF
+	adminCatalogHREF.Path += "/admin/catalog/" + catalog.Catalog.ID[19:]
 
-	req := adminCatalog.client.NewRequest(map[string]string{
+	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
 	}, "DELETE", adminCatalogHREF, nil)
 
-	_, err := checkResp(adminCatalog.client.Http.Do(req))
+	_, err := checkResp(catalog.client.Http.Do(req))
 
 	if err != nil {
-		return fmt.Errorf("error deleting Catalog %s: %s", adminCatalog.AdminCatalog.ID, err)
+		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.ID, err)
 	}
 
 	return nil
+}
+
+// Deletes the Catalog, returning an error if the vCD call fails.
+// Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
+func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
+	catalog := NewCatalog(adminCatalog.client)
+	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
+	return catalog.Delete(force, recursive)
 }
 
 //   Updates the Catalog definition from current Catalog struct contents.
@@ -85,10 +93,13 @@ func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
 //   a refresh with the admin catalog it gets back from the rest api
 //   Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Catalog.html
 func (adminCatalog *AdminCatalog) Update() error {
+	reqCatalog := &types.Catalog{
+		Name:        adminCatalog.AdminCatalog.Catalog.Name,
+		Description: adminCatalog.AdminCatalog.Description,
+	}
 	vcomp := &types.AdminCatalog{
 		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
-		Name:        adminCatalog.AdminCatalog.Name,
-		Description: adminCatalog.AdminCatalog.Description,
+		Catalog:     *reqCatalog,
 		IsPublished: adminCatalog.AdminCatalog.IsPublished,
 	}
 	adminCatalogHREF, err := url.ParseRequestURI(adminCatalog.AdminCatalog.HREF)
@@ -161,6 +172,16 @@ func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error)
 	}
 
 	return CatalogItem{}, nil
+}
+
+// Uploads an ova file to a catalog. This method only uploads bits to vCD spool area.
+// Returns errors if any occur during upload from vCD or upload process. On upload fail client may need to
+// remove vCD catalog item which waits for files to be uploaded. Files from ova are extracted to system
+// temp folder "govcd+random number" and left for inspection on error.
+func (adminCatalog *AdminCatalog) UploadOvf(ovaFileName, itemName, description string, uploadPieceSize int64) (UploadTask, error) {
+	catalog := NewCatalog(adminCatalog.client)
+	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
+	return catalog.UploadOvf(ovaFileName, itemName, description, uploadPieceSize)
 }
 
 // Uploads an ova file to a catalog. This method only uploads bits to vCD spool area.

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -369,9 +369,6 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 // asserts that the catalog returned contains the right contents or if it fails.
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_CreateCatalog(check *C) {
-	if vcd.skipAdminTests {
-		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
-	}
 	org, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -73,6 +73,8 @@ const (
 	MimeDisk = "application/vnd.vmware.vcloud.disk+xml"
 	// Mime for insert or eject media
 	MimeMediaInsertOrEjectParams = "application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"
+	// Mime for catalog
+	MimeAdminCatalog = "application/vnd.vmware.admin.catalog+xml"
 )
 
 const (

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -832,14 +832,14 @@ type Catalog struct {
 	ID            string           `xml:"id,attr,omitempty"`
 	OperationKey  string           `xml:"operationKey,attr,omitempty"`
 	Name          string           `xml:"name,attr"`
-	CatalogItems  []*CatalogItems  `xml:"CatalogItems"`
-	DateCreated   string           `xml:"DateCreated"`
-	Description   string           `xml:"Description"`
-	IsPublished   bool             `xml:"IsPublished"`
-	Link          LinkList         `xml:"Link"`
+	CatalogItems  []*CatalogItems  `xml:"CatalogItems,omitempty"`
+	DateCreated   string           `xml:"DateCreated,omitempty"`
+	Description   string           `xml:"Description,omitempty"`
+	IsPublished   bool             `xml:"IsPublished,omitempty"`
+	Link          LinkList         `xml:"Link,omitempty"`
 	Owner         *Owner           `xml:"Owner,omitempty"`
 	Tasks         *TasksInProgress `xml:"Tasks,omitempty"`
-	VersionNumber int64            `xml:"VersionNumber"`
+	VersionNumber int64            `xml:"VersionNumber,omitempty"`
 }
 
 // AdminCatalog represents the Admin view of a Catalog object.
@@ -848,24 +848,13 @@ type Catalog struct {
 // Description: Represents the Admin view of a Catalog object.
 // Since: 0.9
 type AdminCatalog struct {
+	Catalog
 	XMLName                      xml.Name                      `xml:"AdminCatalog"`
 	Xmlns                        string                        `xml:"xmlns,attr"`
-	HREF                         string                        `xml:"href,attr,omitempty"`
-	Type                         string                        `xml:"type,attr,omitempty"`
-	ID                           string                        `xml:"id,attr,omitempty"`
-	OperationKey                 string                        `xml:"operationKey,attr,omitempty"`
-	Name                         string                        `xml:"name,attr"`
-	CatalogItems                 []*CatalogItems               `xml:"CatalogItems,omitempty"`
-	DateCreated                  string                        `xml:"DateCreated,omitempty"`
 	PublishExternalCatalogParams *PublishExternalCatalogParams `xml:"PublishExternalCatalogParams,omitempty"`
 	CatalogStorageProfiles       *CatalogStorageProfiles       `xml:"CatalogStorageProfiles,omitempty"`
 	ExternalCatalogSubscription  *ExternalCatalogSubscription  `xml:"ExternalCatalogSubscriptionParams,omitempty"`
-	Description                  string                        `xml:"Description"`
 	IsPublished                  bool                          `xml:"IsPublished,omitempty"`
-	Link                         LinkList                      `xml:"Link,omitempty"`
-	Owner                        *Owner                        `xml:"Owner,omitempty"`
-	Tasks                        *TasksInProgress              `xml:"Tasks,omitempty"`
-	VersionNumber                int64                         `xml:"VersionNumber"`
 }
 
 // PublishExternalCatalogParamsType represents the configuration parameters of a catalog published externally

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -825,6 +825,7 @@ type CatalogItems struct {
 // Type: CatalogType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents the user view of a Catalog object.
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/CatalogType.html
 // Since: 0.9
 type Catalog struct {
 	HREF          string           `xml:"href,attr,omitempty"`
@@ -846,6 +847,7 @@ type Catalog struct {
 // Type: AdminCatalogType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Represents the Admin view of a Catalog object.
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/AdminCatalogType.html
 // Since: 0.9
 type AdminCatalog struct {
 	Catalog


### PR DESCRIPTION
Write wrappers and a little refactoring to support same functionality for adminOrg, Org, AdminCatalog and Catalog. 

There is not compatibility changes for users or terraform provider.
Now if you have AdminOrg or Org entity you can createCatalog. Also if you have AdminCatalog or Catalog entity you can delete it or uplaodOvf. Previously it was limited to one type of entities.

E.g.

```golang
org, err := govcd.GetOrgByName(client, "my1")
adminOrg, err := govcd.GetAdminOrgByName(client, "my1")
adminCatalog, err:= adminOrg.CreateCatalog("cat1", "aa")
simpleCatalog, err:= org.CreateCatalog("cat2", "aa")
task, err := catalog.UploadOvf("../test-resources/"+config.Ova.OvaTestFileName, testSuiteCatalogOVAItem, "Test suite purpose", 20*1024*1024)
task, err := adminCatalog.UploadOvf("../test-resources/"+config.Ova.OvaTestFileName, testSuiteCatalogOVAItem, "Test suite purpose", 20*1024*1024)
err = catalog.Delete(true, true)
err = adminCatalog.Delete(true, true)
```