### PR TITLE
Add logic to support a Jenkins multi-branch pipeline with build/test …

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,5 @@
 # Testing in go-vcloud-director
-To run tests in go-vcloud-director, users must use a yaml file specifying information about the users vcd. Users can set the `VCLOUD_CONFIG` environmental variable with the path.
+To run tests in go-vcloud-director, users must use a yaml file specifying information about the users vcd. Users can set the `GOVCD_CONFIG` environmental variable with the path.
 
 ```
 export GOVCD_CONFIG=your/path/to/test-configuration.yaml

--- a/support/Dockerfile.jenkins
+++ b/support/Dockerfile.jenkins
@@ -1,0 +1,18 @@
+FROM golang:latest
+
+ARG build_user=root
+ARG build_uid=0
+ARG build_gid=0
+
+ENV HOME /home/${build_user}
+
+# Creates the build user with the provided UID/GID
+# values to prevent filesystem permissions issues
+RUN if [ "${build_uid}" != "0" ]; then \
+    groupadd -g ${build_gid} ${build_user}; \
+    useradd -c "Build user" -d $HOME -u ${build_uid} \
+        -g ${build_gid} -m ${build_user}; \
+    fi
+
+# Switch to the new build user
+USER ${build_user}

--- a/support/Jenkinsfile
+++ b/support/Jenkinsfile
@@ -1,0 +1,117 @@
+// Jenkins multi-branch pipeline build script. 
+//
+// Requirements:
+// * At least one executor node labeled 'docker' with 
+//   support for building and running Docker containers.
+// * A Jenkins file-type credential named 'go-vcloud-director-connection'
+//   with the contents of a GOVCD_CONFIG file.
+
+// Global variable to hold methods from the 'lib.groovy' file. 
+externalMethods = null
+
+// Pipeline definition.
+pipeline {
+    agent { 
+        node { 
+            // Label on Jenkins node that runs this test. 
+            label 'docker'
+        }
+    }
+    environment {
+        DEFAULT_GOVCD_CONFIG_CREDENTIALS_ID = 'go-vcloud-director-connection'
+    }
+    parameters {
+        string(name: 'GOVCD_CONFIG_CREDENTIALS_ID', defaultValue: 'Default',
+            description: 'A Jenkins file-type credential ID with the contents of a GOVCD_CONFIG file.'
+        )
+        string(name: 'OVERRIDE_GIT_REPOSITORY', defaultValue: '',
+            description: 'The full git repository URL to clone from instead of the default.'
+        )
+        string(name: 'OVERRIDE_GIT_TREEISH', defaultValue: '',
+            description: 'The branch name or commit SHA to test from OVERRIDE_GIT_REPOSITORY.'
+        )
+        string(name: 'OVERRIDE_GIT_CREDENTIALS_ID', defaultValue: '',
+            description: 'A Jenkins credential ID to use when cloning from OVERRIDE_GIT_REPOSITORY.'
+        )
+        text(name: 'GOVCD_CONFIG_CONTENTS', defaultValue: '',
+            description: 'The contents of a GOVCD_CONFIG file to use for samples and system tests.'
+        )
+    }
+    stages {
+        stage('checkout') {
+            steps {
+                script {
+                    // Remove and checkout current branch from git using built-in
+                    // Jenkins commands exposed in groovy. Use parameters to determine
+                    // if a different git repo or branch should be checked out and tested.
+                    deleteDir()
+
+                    def overrideGit = false
+                    if (params.OVERRIDE_GIT_REPOSITORY != null) {
+                        if (params.OVERRIDE_GIT_REPOSITORY != '') {
+                            overrideGit = true
+                        }
+                    }
+
+                    if (overrideGit == false) {
+                        checkout scm
+                    } else {
+                        def gitTreeish = params.OVERRIDE_GIT_TREEISH
+                        def gitRemoteConfig = [:]
+                        gitRemoteConfig['url'] = params.OVERRIDE_GIT_REPOSITORY
+
+                        if (params.OVERRIDE_GIT_CREDENTIALS_ID != '') {
+                            gitRemoteConfig['credentialsId'] = params.OVERRIDE_GIT_CREDENTIALS_ID
+                        }
+                        
+                        checkout([
+                            $class: 'GitSCM',
+                            branches: [[name: gitTreeish]],
+                            userRemoteConfigs: [gitRemoteConfig]
+                        ])
+                    }
+
+                    // Print configuration for later debugging. 
+                    sh "git config --list"
+                    sh "git branch"
+                }
+            }
+        }
+        stage('prepare') {
+            steps {
+                script {
+                    // All code is available now, load the methods to do real work
+                    externalMethods = load 'support/lib.groovy'
+                }
+            }
+        }
+        stage('build') {
+            steps {
+                script {
+                    // Run this method from the lib.groovy file
+                    externalMethods.build()
+                }
+            }
+        }
+    }
+    post { 
+        failure { 
+            echo "Job failed! System test environment will not be cleared."
+            script {
+                if (externalMethods != null) {
+                    // Run this method from the lib.groovy file
+                    externalMethods.cleanupWorkspace()
+                }
+            }
+        }
+        success { 
+            echo "Job succeeded! Cleaning up system test environment"
+            script {
+                if (externalMethods != null) {
+                    // Run these methods from the lib.groovy file
+                    externalMethods.cleanupWorkspace()
+                }
+            }
+        }
+    }
+}

--- a/support/build.sh
+++ b/support/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Build"
+go version

--- a/support/lib.groovy
+++ b/support/lib.groovy
@@ -1,0 +1,58 @@
+// This file contains methods used by Jenkinsfile to support the
+// Jenkins pipeline. The contents are loaded after the target
+// git repository is checked out.
+
+// Declare global variables so they can be used in all pipeline methods. 
+credentialsArray = []
+environmentArray = []
+temporaryFiles = []
+
+// Process job parameters and determine which credentials or environment
+// variables are required for proper processing.
+def init() {
+    // Determine if a credentials ID has been provided, or if the default should be used.
+    def govcdConfigCredentialsID = params.GOVCD_CONFIG_CREDENTIALS_ID
+    if (govcdConfigCredentialsID.toLowerCase() == 'default') {
+        govcdConfigCredentialsID = env.DEFAULT_GOVCD_CONFIG_CREDENTIALS_ID
+    }
+
+    // Check for a parameter containing the GOVCD_CONFIG content
+    // Write that to a file if available, or use a Jenkins credential file
+    if (env.GOVCD_CONFIG_CONTENTS != null && env.GOVCD_CONFIG_CONTENTS != "") {
+        def tmpdir = pwd(tmp:true)
+        def vcdPath = "${tmpdir}/jenkins_govcd_config"
+
+        println "Write GOVCD_CONFIG_CONTENTS to ${vcdPath}"
+        writeFile(file: vcdPath, text: env.GOVCD_CONFIG_CONTENTS)
+        environmentArray << "GOVCD_CONFIG=${vcdPath}"
+        temporaryFiles << vcdPath
+    } else if (govcdConfigCredentialsID.toLowerCase() != "") {
+        // Ensure the path to a VCD parameters file is loaded into the appropriate
+        // environment variable for testing scripts to use.
+        credentialsArray << [
+            $class: 'FileBinding', 
+            credentialsId: govcdConfigCredentialsID,
+            variable: 'GOVCD_CONFIG'
+        ]
+    }
+}
+
+def build() {
+    withEnv(environmentArray) {
+        sh "support/run_in_docker.sh support/build.sh"
+    }
+}
+
+def cleanupWorkspace() {
+    // Remove temporary files
+    temporaryFiles.each {
+        println "Remove ${it}"
+        sh "if [ -f ${it} ]; then rm ${it}; fi"
+    }
+}
+
+// Call the init method to ensure the environment and credentials are ready. 
+init()
+
+// Return a reference to this file to allow the pipeline to call methods. 
+return this

--- a/support/run_in_docker.sh
+++ b/support/run_in_docker.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+SHOME=`dirname $0`
+cd $SHOME
+
+SRCROOT=`cd ..; pwd`
+cd $SRCROOT
+
+# Build the Docker image using the current uid/gid so
+# repeat iterations of the Jenkins environment can 
+# properly cleanup the workspace.
+DOCKER_BUILD=`docker build -q \
+    --build-arg build_user=${USER} \
+    --build-arg build_uid=$(id -u) \
+    --build-arg build_gid=$(id -g) \
+    -f support/Dockerfile.jenkins \
+    support`
+DOCKER_IMAGE=`echo $DOCKER_BUILD | awk -F: '{print $2}'`
+
+# Include VCD_CONNECTION as a mounted file and environment variable
+VCD_ARGS=""
+if [ "$GOVCD_CONFIG" != "" ]; then
+    VCD_ARGS="-eGOVCD_CONFIG=$GOVCD_CONFIG -v$GOVCD_CONFIG:$GOVCD_CONFIG"
+fi
+
+# Run the Docker container with source code mounted along
+# with additional files and environment variables
+docker run --rm \
+    $VCD_ARGS \
+    -v$SRCROOT:$SRCROOT \
+    -w$SRCROOT \
+    $DOCKER_IMAGE \
+    /bin/bash -c "$*"
+
+EC=$?
+if [ $EC -ne 0 ]; then
+    exit $EC
+fi


### PR DESCRIPTION
The new support directory includes files to enable a Jenkins MultiBranch Pipeline job based on this repository.

support/build.sh -> Should be updated to include build operations
support/Dockerfile.jenkins -> A Dockerfile specifically meant for use in Jenkins
support/Jenkinsfile -> Defines the Jenkins pipeline included job parameters and operations
support/lib.groovy -> External file that allows the pipeline to load updated functionality from external pull requests
support/run_in_docker.sh -> Utility script to build the Docker image and then run a support script inside of it on the fly