### PR TITLE
Improve error message

### DIFF
--- a/govcd/system.go
+++ b/govcd/system.go
@@ -122,5 +122,5 @@ func getOrgHREF(vcdClient *VCDClient, orgName string) (string, error) {
 			return org.HREF, nil
 		}
 	}
-	return "", fmt.Errorf("couldn't find org with name: %s", orgName)
+	return "", fmt.Errorf("couldn't find org with name: %s. Please check Org name as it is case sensitive", orgName)
 }


### PR DESCRIPTION
Previous provider non intentionally wasn't case sensitive and users still expect it is and faces error. As usual no one reads documentation :)
Due previous request and this one #150 I improved error message to be more explicit.