### PR TITLE
Fix/revert delete catalog func cause it wasn't working for not admin user

### DIFF
--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -82,7 +82,10 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 
 // slice only numeric part from ID:"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0"
 func getEntityNumericId(catalogId string) string {
-	return catalogId[19:]
+	if catalogId != "" && (len(catalogId) > 19) {
+		return catalogId[19:]
+	}
+	return ""
 }
 
 // Deletes the Catalog, returning an error if the vCD call fails.

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -64,8 +64,7 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 func (catalog *Catalog) Delete(force, recursive bool) error {
 
 	adminCatalogHREF := catalog.client.VCDHREF
-	// slice only numeric part from ID:"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0"
-	adminCatalogHREF.Path += "/admin/catalog/" + catalog.Catalog.ID[19:]
+	adminCatalogHREF.Path += "/admin/catalog/" + getEntityNumericId(catalog.Catalog.ID)
 
 	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
@@ -79,6 +78,11 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 	}
 
 	return nil
+}
+
+// slice only numeric part from ID:"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0"
+func getEntityNumericId(catalogId string) string {
+	return catalogId[19:]
 }
 
 // Deletes the Catalog, returning an error if the vCD call fails.

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -62,17 +62,17 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 // Deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
 func (catalog *Catalog) Delete(force, recursive bool) error {
-	adminCatalogHREF, err := url.ParseRequestURI(catalog.Catalog.HREF)
-	if err != nil {
-		return fmt.Errorf("error parsing admin catalog's href: %v", err)
-	}
+
+	adminCatalogHREF := catalog.client.VCDHREF
+	// slice only numeric part from ID:"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0"
+	adminCatalogHREF.Path += "/admin/catalog/" + catalog.Catalog.ID[19:]
 
 	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
-	}, "DELETE", *adminCatalogHREF, nil)
+	}, "DELETE", adminCatalogHREF, nil)
 
-	_, err = checkResp(catalog.client.Http.Do(req))
+	_, err := checkResp(catalog.client.Http.Do(req))
 
 	if err != nil {
 		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.ID, err)


### PR DESCRIPTION
We missed that previous fix changes causes failure for non admin user. We uses link from catalog entity, but delete api is accessible on /admin/ path only. I added comment for splicing number with example.
