### PR TITLE
Fix check for enabling Dhcp

### DIFF
--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -35,7 +35,7 @@ func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 	util.Logger.Printf("[DEBUG] EDGE GATEWAY: %#v", newEdgeConfig)
 	util.Logger.Printf("[DEBUG] EDGE GATEWAY SERVICE: %#v", newEdgeConfig.GatewayDhcpService)
 	newDchpService := &types.GatewayDhcpService{}
-	if newEdgeConfig.GatewayDhcpService == nil {
+	if newEdgeConfig.GatewayDhcpService.Pool == nil {
 		newDchpService.IsEnabled = true
 	} else {
 		newDchpService.IsEnabled = newEdgeConfig.GatewayDhcpService.IsEnabled


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/78

Check wasn't working cause entity always existed. Changed check against entities details.

Signed-off-by: Vaidotas Bauzys <vbauzys@vmware.com>
