### PR TITLE
Fix Issue#140: incomplete VPN setup in EdgeGW test

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -9,13 +9,14 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 // Client provides a client to vCloud Director, values can be populated automatically using the Authenticate method.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -78,7 +78,7 @@ type TestConfig struct {
 		Catalog struct {
 			Name                   string `yaml:"name,omitempty"`
 			Description            string `yaml:"description,omitempty"`
-			Catalogitem            string `yaml:"catalogItem,omitempty"`
+			CatalogItem            string `yaml:"catalogItem,omitempty"`
 			CatalogItemDescription string `yaml:"catalogItemDescription,omitempty"`
 		} `yaml:"catalog"`
 		Network        string `yaml:"network,omitempty"`
@@ -87,7 +87,9 @@ type TestConfig struct {
 			SP2 string `yaml:"storageProfile2,omitempty"`
 		} `yaml:"storageProfile"`
 		ExternalIp      string `yaml:"externalIp,omitempty"`
+		ExternalNetmask string `yaml:"externalNetmask,omitempty"`
 		InternalIp      string `yaml:"internalIp,omitempty"`
+		InternalNetmask string `yaml:"internalNetmask,omitempty"`
 		EdgeGateway     string `yaml:"edgeGateway,omitempty"`
 		ExternalNetwork string `yaml:"externalNetwork,omitempty"`
 		Disk            struct {
@@ -277,7 +279,7 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 	}
 	// creates a new VApp for vapp tests
 	if !skipVappCreation && config.VCD.Network != "" && config.VCD.StorageProfile.SP1 != "" &&
-		config.VCD.Catalog.Name != "" && config.VCD.Catalog.Catalogitem != "" {
+		config.VCD.Catalog.Name != "" && config.VCD.Catalog.CatalogItem != "" {
 		vcd.vapp, err = vcd.createTestVapp(TestSetUpSuite)
 		// If no vApp is created, we skip all vApp tests
 		if vcd.vapp == (VApp{}) || err != nil {

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -9,8 +9,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"io"
 	"io/ioutil"
 	"math"
@@ -20,6 +18,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 const (

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -21,12 +21,12 @@ func (vcd *TestVCD) Test_FindCatalogItem(check *C) {
 	}
 
 	// Find Catalog Item
-	if vcd.config.VCD.Catalog.Catalogitem == "" {
+	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_FindCatalogItem: Catalog Item not given. Test can't proceed")
 	}
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
-	check.Assert(catitem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.Catalogitem)
+	check.Assert(catitem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 	// If given a description in config file then it checks if the descriptions match
 	// Otherwise it skips the assert
 	if vcd.config.VCD.Catalog.CatalogItemDescription != "" {

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1,16 +1,17 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/util"
-	. "gopkg.in/check.v1"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/util"
+	. "gopkg.in/check.v1"
 )
 
 func (vcd *TestVCD) Test_FindCatalogItem(check *C) {

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -1,14 +1,15 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
-	"net/url"
 )
 
 type CatalogItem struct {

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -17,18 +17,18 @@ func (vcd *TestVCD) Test_GetVAppTemplate(check *C) {
 		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
 	}
 
-	if vcd.config.VCD.Catalog.Catalogitem == "" {
+	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
 	}
 
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
 
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()
 
 	check.Assert(err, IsNil)
-	check.Assert(vapptemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.Catalogitem)
+	check.Assert(vapptemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 	if vcd.config.VCD.Catalog.Description != "" {
 		check.Assert(vapptemplate.VAppTemplate.Description, Equals, vcd.config.VCD.Catalog.CatalogItemDescription)
 	}

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -1,11 +1,12 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
+
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -9,10 +9,11 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"net/http"
 	"net/url"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 // Independent disk

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -1,11 +1,12 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -725,6 +726,10 @@ func (eGW *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 	resp, err := checkResp(eGW.client.Http.Do(req))
 	if err != nil {
 		return Task{}, fmt.Errorf("error reconfiguring Edge Gateway: %s", err)
+	}
+
+	if os.Getenv("GOVCD_DEBUG") != "" {
+		util.Logger.Printf("Edge Gateway Service Configuration: %s\n", prettyEdgeGatewayServiceConfiguration(ipsecVPNConfig))
 	}
 
 	task := NewTask(eGW.client)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -737,3 +737,18 @@ func (eGW *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 	return *task, nil
 
 }
+
+// Removes an Edge Gateway VPN, by passing an empty configuration
+func (eGW *EdgeGateway) RemoveIpsecVPN() (Task, error) {
+	err := eGW.Refresh()
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+	}
+	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
+		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
+			IsEnabled: false,
+		},
+	}
+	return eGW.AddIpsecVPN(ipsecVPNConfig)
+}

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -147,7 +147,13 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 		fmt.Printf("%s\n", prettyEdgeGatewayServiceConfiguration(ipsecVPNConfig))
 	}
 
+	// Configures VPN service
 	task, err := edge.AddIpsecVPN(ipsecVPNConfig)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	// Removes VPN service
+	task, err = edge.RemoveIpsecVPN()
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,14 +1,15 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
-	. "gopkg.in/check.v1"
 	"os"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	. "gopkg.in/check.v1"
 )
 
 func (vcd *TestVCD) Test_Refresh(check *C) {

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -7,9 +7,10 @@ package govcd
 import (
 	"errors"
 	"fmt"
+	"net/url"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
-	"net/url"
 )
 
 func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,13 +8,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"io"
 	"net/url"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 type MediaItem struct {

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -1,13 +1,14 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
-	. "gopkg.in/check.v1"
 	"io/ioutil"
 	"os"
+
+	. "gopkg.in/check.v1"
 )
 
 // Tests System function UploadMediaImage by checking if provided standard iso file uploaded.

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -130,6 +130,14 @@ func prettyTask(task *types.Task) string {
 	return ""
 }
 
+func prettyEdgeGatewayServiceConfiguration(conf *types.EdgeGatewayServiceConfiguration) string {
+	byteBuf, err := json.MarshalIndent(conf, " ", " ")
+	if err == nil {
+		return fmt.Sprintf("%s\n", string(byteBuf))
+	}
+	return ""
+}
+
 func LogNetwork(conf types.OrgVDCNetwork) {
 	out("log", prettyNetworkConf(conf))
 }

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -31,6 +31,7 @@ import (
 // externalNetwork
 // vapp
 // task
+// Edge Gateway service configuration
 
 func out(destination, format string, args ...interface{}) {
 	switch destination {
@@ -43,6 +44,7 @@ func out(destination, format string, args ...interface{}) {
 	}
 }
 
+// Returns a vApp structure as JSON
 func prettyVapp(vapp types.VApp) string {
 	byteBuf, err := json.MarshalIndent(vapp, " ", " ")
 	if err == nil {
@@ -51,6 +53,7 @@ func prettyVapp(vapp types.VApp) string {
 	return ""
 }
 
+// Returns a VDC structure as JSON
 func prettyVdc(vdc types.Vdc) string {
 	byteBuf, err := json.MarshalIndent(vdc, " ", " ")
 	if err == nil {
@@ -59,6 +62,7 @@ func prettyVdc(vdc types.Vdc) string {
 	return ""
 }
 
+// Returns a Catalog Item structure as JSON
 func prettyCatalogItem(catalogItem types.CatalogItem) string {
 	byteBuf, err := json.MarshalIndent(catalogItem, " ", " ")
 	if err == nil {
@@ -67,6 +71,7 @@ func prettyCatalogItem(catalogItem types.CatalogItem) string {
 	return ""
 }
 
+// Returns a Catalog structure as JSON
 func prettyCatalog(catalog types.Catalog) string {
 	byteBuf, err := json.MarshalIndent(catalog, " ", " ")
 	if err == nil {
@@ -75,6 +80,7 @@ func prettyCatalog(catalog types.Catalog) string {
 	return ""
 }
 
+// Returns an Admin Catalog structure as JSON
 func prettyAdminCatalog(catalog types.AdminCatalog) string {
 	byteBuf, err := json.MarshalIndent(catalog, " ", " ")
 	if err == nil {
@@ -83,6 +89,7 @@ func prettyAdminCatalog(catalog types.AdminCatalog) string {
 	return ""
 }
 
+// Returns an Org structure as JSON
 func prettyOrg(org types.Org) string {
 	byteBuf, err := json.MarshalIndent(org, " ", " ")
 	if err == nil {
@@ -91,6 +98,7 @@ func prettyOrg(org types.Org) string {
 	return ""
 }
 
+// Returns an Admin Org structure as JSON
 func prettyAdminOrg(org types.AdminOrg) string {
 	byteBuf, err := json.MarshalIndent(org, " ", " ")
 	if err == nil {
@@ -99,6 +107,7 @@ func prettyAdminOrg(org types.AdminOrg) string {
 	return ""
 }
 
+// Returns a Disk structure as JSON
 func prettyDisk(disk types.Disk) string {
 	byteBuf, err := json.MarshalIndent(disk, " ", " ")
 	if err == nil {
@@ -107,6 +116,7 @@ func prettyDisk(disk types.Disk) string {
 	return ""
 }
 
+// Returns an External Network structure as JSON
 func prettyExternalNetwork(network types.ExternalNetworkReference) string {
 	byteBuf, err := json.MarshalIndent(network, " ", " ")
 	if err == nil {
@@ -115,6 +125,7 @@ func prettyExternalNetwork(network types.ExternalNetworkReference) string {
 	return ""
 }
 
+// Returns a Network structure as JSON
 func prettyNetworkConf(conf types.OrgVDCNetwork) string {
 	byteBuf, err := json.MarshalIndent(conf, " ", " ")
 	if err == nil {
@@ -123,6 +134,7 @@ func prettyNetworkConf(conf types.OrgVDCNetwork) string {
 	return ""
 }
 
+// Returns a Task structure as JSON
 func prettyTask(task *types.Task) string {
 	byteBuf, err := json.MarshalIndent(task, " ", " ")
 	if err == nil {
@@ -131,6 +143,7 @@ func prettyTask(task *types.Task) string {
 	return ""
 }
 
+// Returns an Edge Gateway service configuration structure as JSON
 func prettyEdgeGatewayServiceConfiguration(conf *types.EdgeGatewayServiceConfiguration) string {
 	byteBuf, err := json.MarshalIndent(conf, " ", " ")
 	if err == nil {

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -9,9 +9,10 @@ package govcd
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
-	"time"
 )
 
 // For each library {entity}, we have two functions: Show{Entity} and Log{Entity}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -9,11 +9,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 // Interface for methods in common for Org and AdminOrg

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -6,9 +6,10 @@ package govcd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
-	"time"
 )
 
 // Tests Refresh for Org by updating the org and then asserting if the

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,14 +8,15 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 // OrgVDCNetwork an org vdc network client

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	types "github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/types/v56"
 )
 
 type Results struct {

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -27,11 +27,13 @@
 		},
 		"edgeGateway": "myedgegw",
 		"externalIp": "10.150.10.10",
+		"externalNetmask": "255.255.224.0",
 		"internalIp": "192.168.1.10",
-    "disk": {
-      "size": 1048576,
-      "sizeForUpdate": 1048576
-    }
+		"internalNetmask": "255.255.255.0",
+        "disk": {
+            "size": 1048576,
+            "sizeForUpdate": 1048576
+        }
 	},
 	"logging": {
 		"enabled": true,

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -61,8 +61,15 @@ vcd:
     # The IP of the gateway (must exist)
     externalIp: 10.150.10.10
     #
+    # netmask for the external IP (MANDATORY for edge GW VPN)
+    externalNetmask: 255.255.224.0
+    #
     # A free IP in the Org vDC network
     internalIp: 192.168.1.10
+    #
+    # netmask for the internal IP (MANDATORY for edge GW VPN)
+    internalNetmask: 255.255.255.0
+    #
     # An external Network name
     externalNetwork: myexternalnet
     #

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,9 +8,10 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
 	"net/url"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
 )
 
 // Creates an Organization based on settings, network, and org name.

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -1,17 +1,17 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/util"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 type Task struct {

--- a/govcd/upload.go
+++ b/govcd/upload.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,14 +8,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 // uploadLink - vCD created temporary upload link

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -9,10 +9,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/url"
-
-	types "github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"strconv"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 type VApp struct {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -6,9 +6,9 @@ package govcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
 	"regexp"
 
+	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -41,7 +41,7 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 		return VApp{}, fmt.Errorf("error finding catalog : %v", err)
 	}
 	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error finding catalog item : %v", err)
 	}

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,8 +8,9 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	types "github.com/vmware/go-vcloud-director/types/v56"
 	"net/url"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
 )
 
 type VAppTemplate struct {

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -9,11 +9,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
 )
 
 type Vdc struct {

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -118,7 +118,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	check.Assert(cat, Not(Equals), (Catalog{}))
 	check.Assert(err, IsNil)
 	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.Catalogitem)
+	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,11 +1,12 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
 )

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -8,12 +8,12 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/vmware/go-vcloud-director/types/v56"
 	"github.com/vmware/go-vcloud-director/util"
-	"net/http"
 )
 
 type VM struct {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
@@ -8,9 +8,10 @@ package govcd
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/vmware/go-vcloud-director/types/v56"
 	. "gopkg.in/check.v1"
-	"time"
 )
 
 func (vcd *TestVCD) findFirstVm(vapp VApp) (types.VM, string) {


### PR DESCRIPTION
The test `Test_AddIpsecVPN` had two problems (issue #140):
* incomplete definition for VPN (only one side of the tunnel was
mentioned)
* Not checking the task returned by the VPN creation.
Therefore, the test was failing but nobody noticed.

This fix fills the VPN definition with the minimum needed fields
and monitors the result of the task to completion.

It also adds the necessary fields to the test configuration file

IMPORTANT: **DO NOT MERGE** too soon.

While this PR fixes a problem, it also introduces a different one. When this code is merged, the test will actually create a VPN. But the VPN is not deleted, because the Govcd library has not implemented the VPN deletion yet. A side effect of this successful operation is that now the test `Test_1to1Mappings` has a conflict, and fails. We can start reviewing this change, but this change cannot get in without a function that removes the VPN.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>