### PR TITLE
Improve task error messages

### DIFF
--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -125,7 +125,8 @@ func (vcd *TestVCD) Test_DeleteMediaImage(check *C) {
 
 	task, err := mediaItem.Delete()
 	check.Assert(err, IsNil)
-	task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 
 	mediaItem, err = vcd.vdc.FindMediaImage(itemName)
 	check.Assert(err, IsNil)

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -94,9 +94,11 @@ func (vcd *TestVCD) Test_Reboot(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, _ := vcd.vapp.PowerOn()
-	_ = task.WaitTaskCompletion()
-	task, err := vcd.vapp.Reboot()
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = vcd.vapp.Reboot()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -208,9 +210,11 @@ func (vcd *TestVCD) Test_Reset(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, _ := vcd.vapp.PowerOn()
-	_ = task.WaitTaskCompletion()
-	task, err := vcd.vapp.Reset()
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = vcd.vapp.Reset()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -223,9 +227,11 @@ func (vcd *TestVCD) Test_Suspend(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, _ := vcd.vapp.PowerOn()
-	_ = task.WaitTaskCompletion()
-	task, err := vcd.vapp.Suspend()
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = vcd.vapp.Suspend()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -239,9 +245,11 @@ func (vcd *TestVCD) Test_Shutdown(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, _ := vcd.vapp.PowerOn()
-	_ = task.WaitTaskCompletion()
-	task, err := vcd.vapp.Shutdown()
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = vcd.vapp.Shutdown()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -267,9 +275,11 @@ func (vcd *TestVCD) Test_PowerOff(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, _ := vcd.vapp.PowerOn()
-	_ = task.WaitTaskCompletion()
-	task, err := vcd.vapp.PowerOff()
+	task, err := vcd.vapp.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	task, err = vcd.vapp.PowerOff()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -146,13 +146,19 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	check.Check(err, IsNil)
 	check.Check(vapp_status, Equals, "UNRESOLVED")
 	// Let the VApp creation complete
-	task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		panic(err)
+	}
 	vapp_status, err = vapp.GetStatus()
 	check.Check(err, IsNil)
 	check.Check(vapp_status, Equals, "POWERED_OFF")
 	// Deleting VApp
 	task, err = vapp.Delete()
-	task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		panic(err)
+	}
 	check.Assert(err, IsNil)
 	no_such_vapp, err := vcd.vdc.FindVAppByName(TestComposeVapp)
 	check.Assert(err, NotNil)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package types

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package types


### PR DESCRIPTION
When a task fails, its error message was not descriptive.
This change gets the error details from an inner Error object that
the task produces in case of failures. The error codes and description
are added to the message that the task now returns.

Note: Operations that most benefit from this feature are multi stage ones: where we build an entity or start a configuration (e.g. create a network, configure an edge gateway) and then wait for the task completion. Since such operations incur the risk of leaving incomplete entities in the vCD and often they are hard to erase, I chose not to put an automated test for this improvement. We will, however, appreciate it the next time a task fails.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>
