### PR TITLE
Add API for adding isolated vApp network

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -92,7 +92,13 @@ func (vapp *VApp) Refresh() error {
 	return nil
 }
 
-func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName string, vapptemplate VAppTemplate, name string, acceptalleulas bool) (Task, error) {
+// Function create vm in vApp using vApp template
+// orgVdcNetworks - adds org VDC networks to be available for vApp. Can be empty.
+// vappNetworkName - adds vApp network to be available for vApp. Can be empty.
+// vappTemplate - vApp Template which will be used for VM creation.
+// name - name for VM.
+// acceptAllEulas - setting allows to automatically accept or not Eulas.
+func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName string, vappTemplate VAppTemplate, name string, acceptAllEulas bool) (Task, error) {
 
 	vcomp := &types.ReComposeVAppParams{
 		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
@@ -104,19 +110,19 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 		Description: vapp.VApp.Description,
 		SourcedItem: &types.SourcedCompositionItemParam{
 			Source: &types.Reference{
-				HREF: vapptemplate.VAppTemplate.Children.VM[0].HREF,
+				HREF: vappTemplate.VAppTemplate.Children.VM[0].HREF,
 				Name: name,
 			},
 			InstantiationParams: &types.InstantiationParams{
 				NetworkConnectionSection: &types.NetworkConnectionSection{
-					Type: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.Type,
-					HREF: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.HREF,
+					Type: vappTemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.Type,
+					HREF: vappTemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.HREF,
 					Info: "Network config for sourced item",
-					PrimaryNetworkConnectionIndex: vapptemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.PrimaryNetworkConnectionIndex,
+					PrimaryNetworkConnectionIndex: vappTemplate.VAppTemplate.Children.VM[0].NetworkConnectionSection.PrimaryNetworkConnectionIndex,
 				},
 			},
 		},
-		AllEULAsAccepted: acceptalleulas,
+		AllEULAsAccepted: acceptAllEulas,
 	}
 
 	for index, orgVdcNetwork := range orgVdcNetworks {
@@ -1047,7 +1053,7 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 	return networkConfig, nil
 }
 
-// Function adds existing vDC network to vApp
+// Function adds existing VDC network to vApp
 func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
 
 	networkConfigurations := []types.VAppNetworkConfiguration{}

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -136,14 +136,16 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 		)
 	}
 
-	vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
-		&types.NetworkConnection{
-			Network:                 vappNetworkName,
-			NetworkConnectionIndex:  len(orgVdcNetworks),
-			IsConnected:             true,
-			IPAddressAllocationMode: "POOL",
-		},
-	)
+	if vappNetworkName != "" {
+		vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
+			&types.NetworkConnection{
+				Network:                 vappNetworkName,
+				NetworkConnectionIndex:  len(orgVdcNetworks),
+				IsConnected:             true,
+				IPAddressAllocationMode: "POOL",
+			},
+		)
+	}
 	vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
 		&types.NetworkAssignment{
 			InnerNetwork:     vappNetworkName,

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1136,7 +1136,7 @@ func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppN
 
 	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
-		return Task{}, fmt.Errorf("error removing vApp Network: %s", err)
+		return Task{}, fmt.Errorf("error updating vApp Network: %s", err)
 	}
 
 	task := NewTask(vapp.client)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -32,6 +32,18 @@ func (vdcCli *VCDClient) NewVApp(client *Client) VApp {
 	return *newvapp
 }
 
+// struct type used to pass information for vApp network creation
+type VappNetworkSettings struct {
+	Name             string
+	Gateway          string
+	NetMask          string
+	DSN1             string
+	DNS2             string
+	DNSSuffix        string
+	GuestVLANAllowed bool
+	IPRange          []*types.IPRange
+}
+
 // Returns the vdc where the vapp resides in.
 func (vapp *VApp) getParentVDC() (Vdc, error) {
 	for _, link := range vapp.VApp.Link {
@@ -80,7 +92,7 @@ func (vapp *VApp) Refresh() error {
 	return nil
 }
 
-func (vapp *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, name string, acceptalleulas bool) (Task, error) {
+func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName string, vapptemplate VAppTemplate, name string, acceptalleulas bool) (Task, error) {
 
 	vcomp := &types.ReComposeVAppParams{
 		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
@@ -107,10 +119,10 @@ func (vapp *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VApp
 		AllEULAsAccepted: acceptalleulas,
 	}
 
-	for index, orgvdcnetwork := range orgvdcnetworks {
+	for index, orgVdcNetwork := range orgVdcNetworks {
 		vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
 			&types.NetworkConnection{
-				Network:                 orgvdcnetwork.Name,
+				Network:                 orgVdcNetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
 				IPAddressAllocationMode: "POOL",
@@ -118,11 +130,26 @@ func (vapp *VApp) AddVM(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VApp
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
 			&types.NetworkAssignment{
-				InnerNetwork:     orgvdcnetwork.Name,
-				ContainerNetwork: orgvdcnetwork.Name,
+				InnerNetwork:     orgVdcNetwork.Name,
+				ContainerNetwork: orgVdcNetwork.Name,
 			},
 		)
 	}
+
+	vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection = append(vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection.NetworkConnection,
+		&types.NetworkConnection{
+			Network:                 vappNetworkName,
+			NetworkConnectionIndex:  len(orgVdcNetworks),
+			IsConnected:             true,
+			IPAddressAllocationMode: "POOL",
+		},
+	)
+	vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
+		&types.NetworkAssignment{
+			InnerNetwork:     vappNetworkName,
+			ContainerNetwork: vappNetworkName,
+		},
+	)
 
 	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
 
@@ -1018,17 +1045,13 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 	return networkConfig, nil
 }
 
+// Function adds existing vDC network to vApp
 func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
 
-	networkConfig := &types.NetworkConfigSection{
-		Info:  "Configuration parameters for logical networks",
-		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
-		Type:  "application/vnd.vmware.vcloud.networkConfigSection+xml",
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
-	}
+	networkConfigurations := []types.VAppNetworkConfiguration{}
 
 	for _, network := range orgvdcnetworks {
-		networkConfig.NetworkConfig = append(networkConfig.NetworkConfig,
+		networkConfigurations = append(networkConfigurations,
 			types.VAppNetworkConfiguration{
 				NetworkName: network.Name,
 				Configuration: &types.NetworkConfiguration{
@@ -1039,6 +1062,58 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 				},
 			},
 		)
+	}
+
+	return updateNetworkConfigurations(vapp, networkConfigurations)
+}
+
+// Function allows to create isolated network for vApp. This is equivalent to vCD UI function - vApp network creation.
+func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSettings) (Task, error) {
+
+	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+	networkConfigurations = append(networkConfigurations,
+		types.VAppNetworkConfiguration{
+			NetworkName: newIsolatedNetworkSettings.Name,
+			Configuration: &types.NetworkConfiguration{
+				FenceMode:        "isolated",
+				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
+				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
+					Netmask: newIsolatedNetworkSettings.NetMask, DNS1: newIsolatedNetworkSettings.DSN1,
+					DNS2: newIsolatedNetworkSettings.DNS2, DNSSuffix: newIsolatedNetworkSettings.DNSSuffix, IsEnabled: true,
+					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.IPRange}}},
+			},
+			IsDeployed: false,
+		})
+
+	return updateNetworkConfigurations(vapp, networkConfigurations)
+
+}
+
+// Removes vApp isolated network
+func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
+
+	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+
+	for index, networkConfig := range networkConfigurations {
+		if networkConfig.NetworkName == networkName {
+			networkConfigurations = append(networkConfigurations[:index], networkConfigurations[index+1:]...)
+		}
+	}
+
+	return updateNetworkConfigurations(vapp, networkConfigurations)
+}
+
+// Function allows to update vApp network configuration. This works for updating, deleting and adding.
+// Network configuration has to be full with new, changed elements and unchanged.
+// https://opengrok.eng.vmware.com/source/xref/cloud-sp-main.perforce-shark.1700/sp-main/dev-integration/system-tests/SystemTests/src/main/java/com/vmware/cloud/systemtests/util/VAppNetworkUtils.java#createVAppNetwork
+// http://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-92622A15-E588-4FA1-92DA-A22A4757F2A0.html#1_14_12_10_1
+func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppNetworkConfiguration) (Task, error) {
+	networkConfig := &types.NetworkConfigSection{
+		Info:          "Configuration parameters for logical networks",
+		Ovf:           "http://schemas.dmtf.org/ovf/envelope/1",
+		Type:          "application/vnd.vmware.vcloud.networkConfigSection+xml",
+		Xmlns:         "http://www.vmware.com/vcloud/v1.5",
+		NetworkConfig: networkConfigurations,
 	}
 
 	output, err := xml.MarshalIndent(networkConfig, "  ", "    ")
@@ -1059,7 +1134,7 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 
 	resp, err := checkResp(vapp.client.Http.Do(req))
 	if err != nil {
-		return Task{}, fmt.Errorf("error adding vApp Network: %s", err)
+		return Task{}, fmt.Errorf("error removing vApp Network: %s", err)
 	}
 
 	task := NewTask(vapp.client)
@@ -1070,5 +1145,4 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 
 	// The request was successful
 	return *task, nil
-
 }

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -37,7 +37,7 @@ type VappNetworkSettings struct {
 	Name             string
 	Gateway          string
 	NetMask          string
-	DSN1             string
+	DNS1             string
 	DNS2             string
 	DNSSuffix        string
 	GuestVLANAllowed bool
@@ -1080,7 +1080,7 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 				FenceMode:        "isolated",
 				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
 				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
-					Netmask: newIsolatedNetworkSettings.NetMask, DNS1: newIsolatedNetworkSettings.DSN1,
+					Netmask: newIsolatedNetworkSettings.NetMask, DNS1: newIsolatedNetworkSettings.DNS1,
 					DNS2: newIsolatedNetworkSettings.DNS2, DNSSuffix: newIsolatedNetworkSettings.DNSSuffix, IsEnabled: true,
 					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.IPRange}}},
 			},

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -323,7 +323,7 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 		Name:             networkName,
 		Gateway:          gateway,
 		NetMask:          netmask,
-		DSN1:             dns1,
+		DNS1:             dns1,
 		DNS2:             dns2,
 		DNSSuffix:        dnsSuffix,
 		IPRange:          []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -333,12 +333,13 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	vcd.vapp.Refresh()
-	networkconfig, err := vcd.vapp.GetNetworkConfig()
+	err = vcd.vapp.Refresh()
+	check.Assert(err, IsNil)
+	networkConfig, err := vcd.vapp.GetNetworkConfig()
 	check.Assert(err, IsNil)
 
 	networkFound := types.VAppNetworkConfiguration{}
-	for _, networkConfig := range networkconfig.NetworkConfig {
+	for _, networkConfig := range networkConfig.NetworkConfig {
 		if networkConfig.NetworkName == networkName {
 			networkFound = networkConfig
 		}
@@ -358,12 +359,13 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	vcd.vapp.Refresh()
-	networkconfig, err = vcd.vapp.GetNetworkConfig()
+	err = vcd.vapp.Refresh()
+	check.Assert(err, IsNil)
+	networkConfig, err = vcd.vapp.GetNetworkConfig()
 	check.Assert(err, IsNil)
 
 	isExist := false
-	for _, networkConfig := range networkconfig.NetworkConfig {
+	for _, networkConfig := range networkConfig.NetworkConfig {
 		if networkConfig.NetworkName == networkName {
 			isExist = true
 		}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -156,7 +156,7 @@ type IPScope struct {
 	DNS1                 string          `xml:"Dns1,omitempty"`                 // Primary DNS server.
 	DNS2                 string          `xml:"Dns2,omitempty"`                 // Secondary DNS server.
 	DNSSuffix            string          `xml:"DnsSuffix,omitempty"`            // DNS suffix.
-	IsEnabled            bool            `xml:"IsEnabled"`                      // Indicates if subnet is enabled or not. Default value is True.
+	IsEnabled            bool            `xml:"IsEnabled,omitempty"`            // Indicates if subnet is enabled or not. Default value is True.
 	IPRanges             *IPRanges       `xml:"IpRanges,omitempty"`             // IP ranges used for static pool allocation in the network.
 	AllocatedIPAddresses *IPAddresses    `xml:"AllocatedIpAddresses,omitempty"` // Read-only list of allocated IP addresses in the network.
 	SubAllocations       *SubAllocations `xml:"SubAllocations,omitempty"`       // Read-only list of IP addresses that are sub allocated to edge gateways.
@@ -203,11 +203,12 @@ type IPScopes struct {
 // Since: 0.9
 type NetworkConfiguration struct {
 	BackwardCompatibilityMode      bool             `xml:"BackwardCompatibilityMode"`
-	Features                       *NetworkFeatures `xml:"Features,omitempty"`
-	ParentNetwork                  *Reference       `xml:"ParentNetwork,omitempty"`
 	IPScopes                       *IPScopes        `xml:"IpScopes,omitempty"`
+	ParentNetwork                  *Reference       `xml:"ParentNetwork,omitempty"`
 	FenceMode                      string           `xml:"FenceMode"`
-	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments"`
+	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
+	Features                       *NetworkFeatures `xml:"Features,omitempty"`
+	GuestVlanAllowed               bool             `xml:"GuestVlanAllowed,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`
@@ -223,10 +224,10 @@ type VAppNetworkConfiguration struct {
 	Type        string `xml:"type,attr,omitempty"`
 	NetworkName string `xml:"networkName,attr"`
 
-	Configuration *NetworkConfiguration `xml:"Configuration"`
-	Description   string                `xml:"Description,omitempty"`
-	IsDeployed    bool                  `xml:"IsDeployed"`
 	Link          *Link                 `xml:"Link,omitempty"`
+	Description   string                `xml:"Description,omitempty"`
+	Configuration *NetworkConfiguration `xml:"Configuration"`
+	IsDeployed    bool                  `xml:"IsDeployed"`
 }
 
 // NetworkConfigSection is container for vApp networks.
@@ -1099,11 +1100,12 @@ type VApp struct {
 	Deployed              bool   `xml:"deployed,attr,omitempty"`              // True if the virtual machine is deployed.
 	OvfDescriptorUploaded bool   `xml:"ovfDescriptorUploaded,attr,omitempty"` // Read-only indicator that the OVF descriptor for this vApp has been uploaded.
 	// Elements
-	Link        LinkList         `xml:"Link,omitempty"`        // A reference to an entity or operation associated with this object.
-	Description string           `xml:"Description,omitempty"` // Optional description.
-	Tasks       *TasksInProgress `xml:"Tasks,omitempty"`       // A list of queued, running, or recently completed tasks associated with this entity.
-	Files       *FilesList       `xml:"Files,omitempty"`       // Represents a list of files to be transferred (uploaded or downloaded). Each File in the list is part of the ResourceEntity.
-	VAppParent  *Reference       `xml:"VAppParent,omitempty"`  // Reserved. Unimplemented.
+	Link                 LinkList              `xml:"Link,omitempty"`                 // A reference to an entity or operation associated with this object.
+	NetworkConfigSection *NetworkConfigSection `xml:"NetworkConfigSection,omitempty"` // Represents vAPP network configuration
+	Description          string                `xml:"Description,omitempty"`          // Optional description.
+	Tasks                *TasksInProgress      `xml:"Tasks,omitempty"`                // A list of queued, running, or recently completed tasks associated with this entity.
+	Files                *FilesList            `xml:"Files,omitempty"`                // Represents a list of files to be transferred (uploaded or downloaded). Each File in the list is part of the ResourceEntity.
+	VAppParent           *Reference            `xml:"VAppParent,omitempty"`           // Reserved. Unimplemented.
 	// TODO: OVF Sections to be implemented
 	// Section OVF_Section `xml:"Section"`
 	DateCreated       string          `xml:"DateCreated,omitempty"`       // Creation date/time of the vApp.


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-vcd/issues/97
New API added to support ability to add and delete vApp isolated network. Supports same capabilities as vCD UI. This functions will be directly used in Terraform vApp network resource.