### PR TITLE
Enhance vapp network with dhcp capabilities

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1116,7 +1116,7 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 	}
 
 	if networkSettings.Gateway == "" {
-		return errors.New("network gateway ip is missing")
+		return errors.New("network gateway IP is missing")
 	}
 
 	if networkSettings.NetMask == "" {
@@ -1155,7 +1155,7 @@ func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 	}
 
 	if !isNetworkFound {
-		return Task{}, fmt.Errorf("network to remove: %s, isn't found", networkName)
+		return Task{}, fmt.Errorf("network to remove %s, wasn't found", networkName)
 	}
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -34,14 +34,18 @@ func (vdcCli *VCDClient) NewVApp(client *Client) VApp {
 
 // struct type used to pass information for vApp network creation
 type VappNetworkSettings struct {
-	Name             string
-	Gateway          string
-	NetMask          string
-	DNS1             string
-	DNS2             string
-	DNSSuffix        string
-	GuestVLANAllowed bool
-	IPRange          []*types.IPRange
+	Name                 string
+	Gateway              string
+	NetMask              string
+	DNS1                 string
+	DNS2                 string
+	DNSSuffix            string
+	GuestVLANAllowed     bool
+	StaticIPRanges       []*types.IPRange
+	DHCPIsEnabled        bool
+	DHCPMaxLeaseTime     int
+	DHCPDefaultLeaseTime int
+	DHCPIPRange          *types.IPRange
 }
 
 // Returns the vdc where the vapp resides in.
@@ -1085,10 +1089,13 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 			Configuration: &types.NetworkConfiguration{
 				FenceMode:        "isolated",
 				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
+				Features: &types.NetworkFeatures{DhcpService: &types.DhcpService{IsEnabled: newIsolatedNetworkSettings.DHCPIsEnabled,
+					DefaultLeaseTime: newIsolatedNetworkSettings.DHCPDefaultLeaseTime,
+					MaxLeaseTime:     newIsolatedNetworkSettings.DHCPMaxLeaseTime, IPRange: newIsolatedNetworkSettings.DHCPIPRange}},
 				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
 					Netmask: newIsolatedNetworkSettings.NetMask, DNS1: newIsolatedNetworkSettings.DNS1,
 					DNS2: newIsolatedNetworkSettings.DNS2, DNSSuffix: newIsolatedNetworkSettings.DNSSuffix, IsEnabled: true,
-					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.IPRange}}},
+					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.StaticIPRanges}}},
 			},
 			IsDeployed: false,
 		})

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1141,12 +1141,21 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 // Removes vApp isolated network
 func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 
-	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+	if networkName == "" {
+		return Task{}, fmt.Errorf("network name can't be empty")
+	}
 
+	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+	isNetworkFound := false
 	for index, networkConfig := range networkConfigurations {
 		if networkConfig.NetworkName == networkName {
+			isNetworkFound = true
 			networkConfigurations = append(networkConfigurations[:index], networkConfigurations[index+1:]...)
 		}
+	}
+
+	if !isNetworkFound {
+		return Task{}, fmt.Errorf("network to remove: %s, isn't found", networkName)
 	}
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -156,13 +156,13 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				IPAddressAllocationMode: "POOL",
 			},
 		)
+		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
+			&types.NetworkAssignment{
+				InnerNetwork:     vappNetworkName,
+				ContainerNetwork: vappNetworkName,
+			},
+		)
 	}
-	vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
-		&types.NetworkAssignment{
-			InnerNetwork:     vappNetworkName,
-			ContainerNetwork: vappNetworkName,
-		},
-	)
 
 	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -1082,6 +1083,11 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 // Function allows to create isolated network for vApp. This is equivalent to vCD UI function - vApp network creation.
 func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSettings) (Task, error) {
 
+	err := validateNetworkConfigSettings(newIsolatedNetworkSettings)
+	if err != nil {
+		return Task{}, err
+	}
+
 	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
 	networkConfigurations = append(networkConfigurations,
 		types.VAppNetworkConfiguration{
@@ -1102,6 +1108,34 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)
 
+}
+
+func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
+	if networkSettings.Name == "" {
+		return errors.New("network name is missing")
+	}
+
+	if networkSettings.Gateway == "" {
+		return errors.New("network gateway ip is missing")
+	}
+
+	if networkSettings.NetMask == "" {
+		return errors.New("network mask config is missing")
+	}
+
+	if networkSettings.NetMask == "" {
+		return errors.New("network mask config is missing")
+	}
+
+	if networkSettings.DHCPIsEnabled && networkSettings.DHCPIPRange == nil {
+		return errors.New("network DHCP ip range config is missing")
+	}
+
+	if networkSettings.DHCPIPRange.StartAddress == "" {
+		return errors.New("network DHCP ip range start address is missing")
+	}
+
+	return nil
 }
 
 // Removes vApp isolated network

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -329,15 +329,24 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	const dnsSuffix = "biz.biz"
 	const startAddress = "192.168.0.10"
 	const endAddress = "192.168.0.20"
+	const dhcpStartAddress = "192.168.0.30"
+	const dhcpEndAddress = "192.168.0.40"
+	const maxLeaseTime = 3500
+	const defaultLeaseTime = 2400
 	task, err := vcd.vapp.AddIsolatedNetwork(&VappNetworkSettings{
-		Name:             networkName,
-		Gateway:          gateway,
-		NetMask:          netmask,
-		DNS1:             dns1,
-		DNS2:             dns2,
-		DNSSuffix:        dnsSuffix,
-		IPRange:          []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
-		GuestVLANAllowed: true})
+		Name:                 networkName,
+		Gateway:              gateway,
+		NetMask:              netmask,
+		DNS1:                 dns1,
+		DNS2:                 dns2,
+		DNSSuffix:            dnsSuffix,
+		StaticIPRanges:       []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
+		GuestVLANAllowed:     true,
+		DHCPIsEnabled:        true,
+		DHCPMaxLeaseTime:     maxLeaseTime,
+		DHCPDefaultLeaseTime: defaultLeaseTime,
+		DHCPIPRange:          &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress},
+	})
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -362,6 +371,12 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.DNSSuffix, Equals, dnsSuffix)
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.IPRanges.IPRange[0].StartAddress, Equals, startAddress)
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.IPRanges.IPRange[0].EndAddress, Equals, endAddress)
+
+	check.Assert(networkFound.Configuration.Features.DhcpService.IsEnabled, Equals, true)
+	check.Assert(networkFound.Configuration.Features.DhcpService.MaxLeaseTime, Equals, maxLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.DefaultLeaseTime, Equals, defaultLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.StartAddress, Equals, dhcpStartAddress)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.EndAddress, Equals, dhcpEndAddress)
 
 	task, err = vcd.vapp.RemoveIsolatedNetwork(networkName)
 	check.Assert(err, IsNil)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -100,15 +100,15 @@ type IPRange struct {
 // Description: Represents a DHCP network service.
 // Since:
 type DhcpService struct {
-	DefaultLeaseTime    int      `xml:"DefaultLeaseTime,omitempty"`    // Default lease in seconds for DHCP addresses.
-	DomainName          string   `xml:"DomainName,omitempty"`          //	The domain name.
-	IPRange             *IPRange `xml:"IpRange"`                       //	IP range for DHCP addresses.
 	IsEnabled           bool     `xml:"IsEnabled"`                     // Enable or disable the service using this flag
+	DefaultLeaseTime    int      `xml:"DefaultLeaseTime,omitempty"`    // Default lease in seconds for DHCP addresses.
 	MaxLeaseTime        int      `xml:"MaxLeaseTime"`                  //	Max lease in seconds for DHCP addresses.
-	PrimaryNameServer   string   `xml:"PrimaryNameServer,omitempty"`   // The primary name server.
+	IPRange             *IPRange `xml:"IpRange"`                       //	IP range for DHCP addresses.
 	RouterIP            string   `xml:"RouterIp,omitempty"`            // Router IP.
-	SecondaryNameServer string   `xml:"SecondaryNameServer,omitempty"` // The secondary name server.
 	SubMask             string   `xml:"SubMask,omitempty"`             // The subnet mask.
+	PrimaryNameServer   string   `xml:"PrimaryNameServer,omitempty"`   // The primary name server.
+	SecondaryNameServer string   `xml:"SecondaryNameServer,omitempty"` // The secondary name server.
+	DomainName          string   `xml:"DomainName,omitempty"`          //	The domain name.
 }
 
 // NetworkFeatures represents features of a network.


### PR DESCRIPTION
Reference: terraform-providers/terraform-provider-vcd#97

Existing API enhanced to support ability to configure DHCP. In UI functionality is visible selecting vapp network and "configure services...".