### PR TITLE
Add check for vApp template to be valid

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -100,6 +100,14 @@ func (vapp *VApp) Refresh() error {
 // acceptAllEulas - setting allows to automatically accept or not Eulas.
 func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName string, vappTemplate VAppTemplate, name string, acceptAllEulas bool) (Task, error) {
 
+	if vappTemplate == (VAppTemplate{}) || vappTemplate.VAppTemplate == nil {
+		return Task{}, fmt.Errorf("vApp Template can not be empty")
+	}
+
+	if vappTemplate.VAppTemplate.Status != 8 { // status Ready
+		return Task{}, fmt.Errorf("vApp Template shape is not ok")
+	}
+
 	vcomp := &types.ReComposeVAppParams{
 		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
 		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -104,7 +104,9 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 		return Task{}, fmt.Errorf("vApp Template can not be empty")
 	}
 
-	if vappTemplate.VAppTemplate.Status != 8 { // status Ready
+	// Status 8 means The object is resolved and powered off.
+	// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/94b8bd8d-74ff-4fe3-b7a4-41ae31516ed7/1b42f3b5-8b31-4279-8b3f-547f6c7c5aa8/doc/GUID-843BE3AD-5EF6-4442-B864-BCAE44A51867.html
+	if vappTemplate.VAppTemplate.Status != 8 {
 		return Task{}, fmt.Errorf("vApp Template shape is not ok")
 	}
 


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/157

In issue real error is that vApp template returned something but not fully what was expected and govcd panicked. According user issue was that vapp template(OVA) wasn't uploaded successfully. I couldn't recreate same error but got different `null pointer` exception when ova is partly uploaded. I added check that before using vApp template to check it status. Status `8` is parsed from responses - didn't find explanations in documentations. When vApp template was with error then status was `0`.