### PR TITLE
Add vapp network dhcp

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1116,7 +1116,7 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 	}
 
 	if networkSettings.Gateway == "" {
-		return errors.New("network gateway ip is missing")
+		return errors.New("network gateway IP is missing")
 	}
 
 	if networkSettings.NetMask == "" {
@@ -1155,7 +1155,7 @@ func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 	}
 
 	if !isNetworkFound {
-		return Task{}, fmt.Errorf("network to remove: %s, isn't found", networkName)
+		return Task{}, fmt.Errorf("network to remove %s, wasn't found", networkName)
 	}
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -34,14 +34,18 @@ func (vdcCli *VCDClient) NewVApp(client *Client) VApp {
 
 // struct type used to pass information for vApp network creation
 type VappNetworkSettings struct {
-	Name             string
-	Gateway          string
-	NetMask          string
-	DNS1             string
-	DNS2             string
-	DNSSuffix        string
-	GuestVLANAllowed bool
-	IPRange          []*types.IPRange
+	Name                 string
+	Gateway              string
+	NetMask              string
+	DNS1                 string
+	DNS2                 string
+	DNSSuffix            string
+	GuestVLANAllowed     bool
+	StaticIPRanges       []*types.IPRange
+	DHCPIsEnabled        bool
+	DHCPMaxLeaseTime     int
+	DHCPDefaultLeaseTime int
+	DHCPIPRange          *types.IPRange
 }
 
 // Returns the vdc where the vapp resides in.
@@ -1085,10 +1089,13 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 			Configuration: &types.NetworkConfiguration{
 				FenceMode:        "isolated",
 				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
+				Features: &types.NetworkFeatures{DhcpService: &types.DhcpService{IsEnabled: newIsolatedNetworkSettings.DHCPIsEnabled,
+					DefaultLeaseTime: newIsolatedNetworkSettings.DHCPDefaultLeaseTime,
+					MaxLeaseTime:     newIsolatedNetworkSettings.DHCPMaxLeaseTime, IPRange: newIsolatedNetworkSettings.DHCPIPRange}},
 				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
 					Netmask: newIsolatedNetworkSettings.NetMask, DNS1: newIsolatedNetworkSettings.DNS1,
 					DNS2: newIsolatedNetworkSettings.DNS2, DNSSuffix: newIsolatedNetworkSettings.DNSSuffix, IsEnabled: true,
-					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.IPRange}}},
+					IPRanges: &types.IPRanges{IPRange: newIsolatedNetworkSettings.StaticIPRanges}}},
 			},
 			IsDeployed: false,
 		})

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1103,7 +1103,7 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 		return Task{}, err
 	}
 
-	// for case when range is one ip address
+	// for case when range is one ip address. E.g. 192.168.1.1-192.168.1.1
 	if newIsolatedNetworkSettings.DHCPIPRange != nil && newIsolatedNetworkSettings.DHCPIPRange.EndAddress == "" {
 		newIsolatedNetworkSettings.DHCPIPRange.EndAddress = newIsolatedNetworkSettings.DHCPIPRange.StartAddress
 	}

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1141,12 +1141,21 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 // Removes vApp isolated network
 func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 
-	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+	if networkName == "" {
+		return Task{}, fmt.Errorf("network name can't be empty")
+	}
 
+	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
+	isNetworkFound := false
 	for index, networkConfig := range networkConfigurations {
 		if networkConfig.NetworkName == networkName {
+			isNetworkFound = true
 			networkConfigurations = append(networkConfigurations[:index], networkConfigurations[index+1:]...)
 		}
+	}
+
+	if !isNetworkFound {
+		return Task{}, fmt.Errorf("network to remove: %s, isn't found", networkName)
 	}
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -156,13 +156,13 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				IPAddressAllocationMode: "POOL",
 			},
 		)
+		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
+			&types.NetworkAssignment{
+				InnerNetwork:     vappNetworkName,
+				ContainerNetwork: vappNetworkName,
+			},
+		)
 	}
-	vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
-		&types.NetworkAssignment{
-			InnerNetwork:     vappNetworkName,
-			ContainerNetwork: vappNetworkName,
-		},
-	)
 
 	output, _ := xml.MarshalIndent(vcomp, "  ", "    ")
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -1082,6 +1083,11 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 // Function allows to create isolated network for vApp. This is equivalent to vCD UI function - vApp network creation.
 func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSettings) (Task, error) {
 
+	err := validateNetworkConfigSettings(newIsolatedNetworkSettings)
+	if err != nil {
+		return Task{}, err
+	}
+
 	networkConfigurations := vapp.VApp.NetworkConfigSection.NetworkConfig
 	networkConfigurations = append(networkConfigurations,
 		types.VAppNetworkConfiguration{
@@ -1102,6 +1108,34 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 
 	return updateNetworkConfigurations(vapp, networkConfigurations)
 
+}
+
+func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
+	if networkSettings.Name == "" {
+		return errors.New("network name is missing")
+	}
+
+	if networkSettings.Gateway == "" {
+		return errors.New("network gateway ip is missing")
+	}
+
+	if networkSettings.NetMask == "" {
+		return errors.New("network mask config is missing")
+	}
+
+	if networkSettings.NetMask == "" {
+		return errors.New("network mask config is missing")
+	}
+
+	if networkSettings.DHCPIsEnabled && networkSettings.DHCPIPRange == nil {
+		return errors.New("network DHCP ip range config is missing")
+	}
+
+	if networkSettings.DHCPIPRange.StartAddress == "" {
+		return errors.New("network DHCP ip range start address is missing")
+	}
+
+	return nil
 }
 
 // Removes vApp isolated network

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1072,7 +1072,11 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 // Function adds existing VDC network to vApp
 func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
 
-	networkConfigurations := []types.VAppNetworkConfiguration{}
+	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	if err != nil {
+		return Task{}, fmt.Errorf("error getting vApp networks: %#v", err)
+	}
+	networkConfigurations := vAppNetworkConfig.NetworkConfig
 
 	for _, network := range orgvdcnetworks {
 		networkConfigurations = append(networkConfigurations,

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -342,6 +342,7 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 		DNSSuffix:            dnsSuffix,
 		StaticIPRanges:       []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
 		GuestVLANAllowed:     true,
+		AddDHCPService:       true,
 		DHCPIsEnabled:        true,
 		DHCPMaxLeaseTime:     maxLeaseTime,
 		DHCPDefaultLeaseTime: defaultLeaseTime,

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -334,19 +334,15 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	const maxLeaseTime = 3500
 	const defaultLeaseTime = 2400
 	task, err := vcd.vapp.AddIsolatedNetwork(&VappNetworkSettings{
-		Name:                 networkName,
-		Gateway:              gateway,
-		NetMask:              netmask,
-		DNS1:                 dns1,
-		DNS2:                 dns2,
-		DNSSuffix:            dnsSuffix,
-		StaticIPRanges:       []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
-		GuestVLANAllowed:     true,
-		AddDHCPService:       true,
-		DHCPIsEnabled:        true,
-		DHCPMaxLeaseTime:     maxLeaseTime,
-		DHCPDefaultLeaseTime: defaultLeaseTime,
-		DHCPIPRange:          &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress},
+		Name:             networkName,
+		Gateway:          gateway,
+		NetMask:          netmask,
+		DNS1:             dns1,
+		DNS2:             dns2,
+		DNSSuffix:        dnsSuffix,
+		StaticIPRanges:   []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
+		GuestVLANAllowed: true,
+		DhcpSettings:     &DhcpSettings{IsEnabled: true, MaxLeaseTime: maxLeaseTime, DefaultLeaseTime: defaultLeaseTime, IPRange: &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress}},
 	})
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -329,15 +329,24 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	const dnsSuffix = "biz.biz"
 	const startAddress = "192.168.0.10"
 	const endAddress = "192.168.0.20"
+	const dhcpStartAddress = "192.168.0.30"
+	const dhcpEndAddress = "192.168.0.40"
+	const maxLeaseTime = 3500
+	const defaultLeaseTime = 2400
 	task, err := vcd.vapp.AddIsolatedNetwork(&VappNetworkSettings{
-		Name:             networkName,
-		Gateway:          gateway,
-		NetMask:          netmask,
-		DNS1:             dns1,
-		DNS2:             dns2,
-		DNSSuffix:        dnsSuffix,
-		IPRange:          []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
-		GuestVLANAllowed: true})
+		Name:                 networkName,
+		Gateway:              gateway,
+		NetMask:              netmask,
+		DNS1:                 dns1,
+		DNS2:                 dns2,
+		DNSSuffix:            dnsSuffix,
+		StaticIPRanges:       []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
+		GuestVLANAllowed:     true,
+		DHCPIsEnabled:        true,
+		DHCPMaxLeaseTime:     maxLeaseTime,
+		DHCPDefaultLeaseTime: defaultLeaseTime,
+		DHCPIPRange:          &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress},
+	})
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -362,6 +371,12 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.DNSSuffix, Equals, dnsSuffix)
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.IPRanges.IPRange[0].StartAddress, Equals, startAddress)
 	check.Assert(networkFound.Configuration.IPScopes.IPScope.IPRanges.IPRange[0].EndAddress, Equals, endAddress)
+
+	check.Assert(networkFound.Configuration.Features.DhcpService.IsEnabled, Equals, true)
+	check.Assert(networkFound.Configuration.Features.DhcpService.MaxLeaseTime, Equals, maxLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.DefaultLeaseTime, Equals, defaultLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.StartAddress, Equals, dhcpStartAddress)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.EndAddress, Equals, dhcpEndAddress)
 
 	task, err = vcd.vapp.RemoveIsolatedNetwork(networkName)
 	check.Assert(err, IsNil)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -243,9 +243,10 @@ func (vm *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) 
 
 	networkSection, err := vm.GetNetworkConnectionSection()
 
+	// changes network config when only matches network name with provided one
 	for _, network := range networks {
 		for index, networkConnection := range networkSection.NetworkConnection {
-			if networkConnection.Network == network["orgnetwork"] {
+			if networkConnection.Network == network["orgnetwork"] { // network name are equal
 				// Determine what type of address is requested for the vApp
 				ipAllocationMode := "NONE"
 				ipAddress := "Any"

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -241,50 +241,52 @@ func (vm *VM) ChangeNetworkConfig(networks []map[string]interface{}, ip string) 
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
 	}
 
-	networksection, err := vm.GetNetworkConnectionSection()
+	networkSection, err := vm.GetNetworkConnectionSection()
 
-	for index, network := range networks {
-		// Determine what type of address is requested for the vApp
-		ipAllocationMode := "NONE"
-		ipAddress := "Any"
+	for _, network := range networks {
+		for index, networkConnection := range networkSection.NetworkConnection {
+			if networkConnection.Network == network["orgnetwork"] {
+				// Determine what type of address is requested for the vApp
+				ipAllocationMode := "NONE"
+				ipAddress := "Any"
 
-		// TODO: Review current behaviour of using DHCP when left blank
-		if ip == "dhcp" || network["ip"].(string) == "dhcp" {
-			ipAllocationMode = "DHCP"
-		} else if ip == "allocated" || network["ip"].(string) == "allocated" {
-			ipAllocationMode = "POOL"
-		} else if ip == "none" || network["ip"].(string) == "none" {
-			ipAllocationMode = "NONE"
-		} else if ip != "" {
-			ipAllocationMode = "MANUAL"
-			// TODO: Check a valid IP has been given
-			ipAddress = ip
-		} else if network["ip"].(string) != "" {
-			ipAllocationMode = "MANUAL"
-			// TODO: Check a valid IP has been given
-			ipAddress = network["ip"].(string)
-		} else if ip == "" {
-			ipAllocationMode = "DHCP"
+				// TODO: Review current behaviour of using DHCP when left blank
+				if ip == "dhcp" || network["ip"].(string) == "dhcp" {
+					ipAllocationMode = "DHCP"
+				} else if ip == "allocated" || network["ip"].(string) == "allocated" {
+					ipAllocationMode = "POOL"
+				} else if ip == "none" || network["ip"].(string) == "none" {
+					ipAllocationMode = "NONE"
+				} else if ip != "" {
+					ipAllocationMode = "MANUAL"
+					// TODO: Check a valid IP has been given
+					ipAddress = ip
+				} else if network["ip"].(string) != "" {
+					ipAllocationMode = "MANUAL"
+					// TODO: Check a valid IP has been given
+					ipAddress = network["ip"].(string)
+				} else if ip == "" {
+					ipAllocationMode = "DHCP"
+				}
+
+				util.Logger.Printf("[DEBUG] Function ChangeNetworkConfig() for %s invoked", network["orgnetwork"])
+
+				networkSection.NetworkConnection[index].NeedsCustomization = true
+				networkSection.NetworkConnection[index].IPAddress = ipAddress
+				networkSection.NetworkConnection[index].IPAddressAllocationMode = ipAllocationMode
+
+				if network["is_primary"] == true {
+					networkSection.PrimaryNetworkConnectionIndex = index
+				}
+			}
 		}
-
-		util.Logger.Printf("[DEBUG] Function ChangeNetworkConfig() for %s invoked", network["orgnetwork"])
-
-		networksection.Xmlns = "http://www.vmware.com/vcloud/v1.5"
-		networksection.Ovf = "http://schemas.dmtf.org/ovf/envelope/1"
-		networksection.Info = "Specifies the available VM network connections"
-
-		networksection.NetworkConnection[index].NeedsCustomization = true
-		networksection.NetworkConnection[index].IPAddress = ipAddress
-		networksection.NetworkConnection[index].IPAddressAllocationMode = ipAllocationMode
-		networksection.NetworkConnection[index].MACAddress = ""
-
-		if network["is_primary"] == true {
-			networksection.PrimaryNetworkConnectionIndex = index
-		}
-
 	}
 
-	output, err := xml.MarshalIndent(networksection, "  ", "    ")
+	networkSection.Xmlns = "http://www.vmware.com/vcloud/v1.5"
+	networkSection.Ovf = "http://schemas.dmtf.org/ovf/envelope/1"
+	networkSection.Info = "Specifies the available VM network connections"
+
+	output, err := xml.MarshalIndent(networkSection, "  ", "    ")
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -100,15 +100,15 @@ type IPRange struct {
 // Description: Represents a DHCP network service.
 // Since:
 type DhcpService struct {
-	DefaultLeaseTime    int      `xml:"DefaultLeaseTime,omitempty"`    // Default lease in seconds for DHCP addresses.
-	DomainName          string   `xml:"DomainName,omitempty"`          //	The domain name.
-	IPRange             *IPRange `xml:"IpRange"`                       //	IP range for DHCP addresses.
 	IsEnabled           bool     `xml:"IsEnabled"`                     // Enable or disable the service using this flag
+	DefaultLeaseTime    int      `xml:"DefaultLeaseTime,omitempty"`    // Default lease in seconds for DHCP addresses.
 	MaxLeaseTime        int      `xml:"MaxLeaseTime"`                  //	Max lease in seconds for DHCP addresses.
-	PrimaryNameServer   string   `xml:"PrimaryNameServer,omitempty"`   // The primary name server.
+	IPRange             *IPRange `xml:"IpRange"`                       //	IP range for DHCP addresses.
 	RouterIP            string   `xml:"RouterIp,omitempty"`            // Router IP.
-	SecondaryNameServer string   `xml:"SecondaryNameServer,omitempty"` // The secondary name server.
 	SubMask             string   `xml:"SubMask,omitempty"`             // The subnet mask.
+	PrimaryNameServer   string   `xml:"PrimaryNameServer,omitempty"`   // The primary name server.
+	SecondaryNameServer string   `xml:"SecondaryNameServer,omitempty"` // The secondary name server.
+	DomainName          string   `xml:"DomainName,omitempty"`          //	The domain name.
 }
 
 // NetworkFeatures represents features of a network.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -257,13 +257,13 @@ type NetworkConfigSection struct {
 // Since: 0.9
 type NetworkConnection struct {
 	Network                 string `xml:"network,attr"`                      // Name of the network to which this NIC is connected.
-	NetworkConnectionIndex  int    `xml:"NetworkConnectionIndex"`            // Virtual slot number associated with this NIC. First slot number is 0.
 	NeedsCustomization      bool   `xml:"needsCustomization,attr,omitempty"` // True if this NIC needs customization.
-	ExternalIPAddress       string `xml:"ExternalIpAddress,omitempty"`       // If the network to which this NIC connects provides NAT services, the external address assigned to this NIC appears here.
+	NetworkConnectionIndex  int    `xml:"NetworkConnectionIndex"`            // Virtual slot number associated with this NIC. First slot number is 0.
 	IPAddress               string `xml:"IpAddress,omitempty"`               // IP address assigned to this NIC.
+	ExternalIPAddress       string `xml:"ExternalIpAddress,omitempty"`       // If the network to which this NIC connects provides NAT services, the external address assigned to this NIC appears here.
 	IsConnected             bool   `xml:"IsConnected"`                       // If the virtual machine is undeployed, this value specifies whether the NIC should be connected upon deployment. If the virtual machine is deployed, this value reports the current status of this NIC's connection, and can be updated to change that connection status.
-	IPAddressAllocationMode string `xml:"IpAddressAllocationMode"`           // IP address allocation mode for this connection. One of: POOL (A static IP address is allocated automatically from a pool of addresses.) DHCP (The IP address is obtained from a DHCP service.) MANUAL (The IP address is assigned manually in the IpAddress element.) NONE (No IP addressing mode specified.)
 	MACAddress              string `xml:"MACAddress,omitempty"`              // MAC address associated with the NIC.
+	IPAddressAllocationMode string `xml:"IpAddressAllocationMode"`           // IP address allocation mode for this connection. One of: POOL (A static IP address is allocated automatically from a pool of addresses.) DHCP (The IP address is obtained from a DHCP service.) MANUAL (The IP address is assigned manually in the IpAddress element.) NONE (No IP addressing mode specified.)
 }
 
 // NetworkConnectionSection the container for the network connections of this virtual machine.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -264,6 +264,7 @@ type NetworkConnection struct {
 	IsConnected             bool   `xml:"IsConnected"`                       // If the virtual machine is undeployed, this value specifies whether the NIC should be connected upon deployment. If the virtual machine is deployed, this value reports the current status of this NIC's connection, and can be updated to change that connection status.
 	MACAddress              string `xml:"MACAddress,omitempty"`              // MAC address associated with the NIC.
 	IPAddressAllocationMode string `xml:"IpAddressAllocationMode"`           // IP address allocation mode for this connection. One of: POOL (A static IP address is allocated automatically from a pool of addresses.) DHCP (The IP address is obtained from a DHCP service.) MANUAL (The IP address is assigned manually in the IpAddress element.) NONE (No IP addressing mode specified.)
+	NetworkAdapterType      string `xml:"NetworkAdapterType,omitempty"`
 }
 
 // NetworkConnectionSection the container for the network connections of this virtual machine.


### PR DESCRIPTION
Reference: [terraform-providers/terraform-provider-vcd#97](https://github.com/terraform-providers/terraform-provider-vcd/issues/97)

Existing functionality needed to be enhance to support Terraform. 
* Fixed validation
* Added ability to ignore sending values, needs explicitly set that DHCP service should be configured - this way we can ignore default values passed down from other services/users and DHCP service configured but no enabled. 