### PR TITLE
Create and delete for external networks

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -447,14 +447,10 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		}
 		return
 	case "externalNetwork":
-		externalNetworkRef, err := GetExternalNetworkByName(vcd.client, entity.Name)
-		if *externalNetworkRef == (types.ExternalNetworkReference{}) {
+		externalNetwork, err := GetExternalNetworkByName2(vcd.client, entity.Name)
+		if err != nil {
 			vcd.infoCleanup(notFoundMsg, "externalNetwork", entity.Name)
 			return
-		}
-		externalNetwork := NewExternalNetwork(&vcd.client.Client)
-		externalNetwork.ExternalNetwork = &types.ExternalNetwork{
-			HREF: externalNetworkRef.HREF,
 		}
 		err = externalNetwork.DeleteWait()
 		if err == nil {

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -53,6 +53,7 @@ const (
 	TestVMAttachOrDetachDisk      = "TestVMAttachOrDetachDisk"
 	TestVMAttachDisk              = "TestVMAttachDisk"
 	TestVMDetachDisk              = "TestVMDetachDisk"
+	TestCreateExternalNetwork     = "TestCreateExternalNetwork"
 )
 
 const (

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -447,7 +447,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		}
 		return
 	case "externalNetwork":
-		externalNetwork, err := GetExternalNetworkByName2(vcd.client, entity.Name)
+		externalNetwork, err := GetExternalNetwork(vcd.client, entity.Name)
 		if err != nil {
 			vcd.infoCleanup(notFoundMsg, "externalNetwork", entity.Name)
 			return

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// Deprecated - use GetExternalNetworkByName2
+// Deprecated - use GetExternalNetwork
 func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
 	externalNetwork := NewExternalNetwork(&vcdClient.Client)
 	err := externalNetwork.GetByName(networkName)
@@ -27,7 +27,7 @@ func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.
 	}, nil
 }
 
-func GetExternalNetworkByName2(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
+func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
 	externalNetwork := NewExternalNetwork(&vcdClient.Client)
 	err := externalNetwork.GetByName(networkName)
 	return externalNetwork, err

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
+// Deprecated - use GetExternalNetworkByName2
 func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
 	externalNetwork := NewExternalNetwork(&vcdClient.Client)
 	err := externalNetwork.GetByName(networkName)
@@ -24,6 +25,12 @@ func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.
 		Type: externalNetwork.ExternalNetwork.Type,
 		Name: externalNetwork.ExternalNetwork.Name,
 	}, nil
+}
+
+func GetExternalNetworkByName2(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
+	externalNetwork := NewExternalNetwork(&vcdClient.Client)
+	err := externalNetwork.GetByName(networkName)
+	return externalNetwork, err
 }
 
 func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.ExternalNetwork) (Task, error) {

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -95,7 +95,8 @@ func getExtension(client *Client) (*types.Extension, error) {
 	return extensions, nil
 }
 
-func queryVirtualCenters(vdcCli *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
+// Find a list of Virtual Centers matching the filter parameter.
+func QueryVirtualCenters(vdcCli *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
 	results, err := vdcCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "virtualCenter",
 		"filter": filter,

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -49,16 +49,6 @@ func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.
 	return &types.ExternalNetworkReference{}, nil
 }
 
-func validateExternalNetwork(externalNetwork *types.ExternalNetwork) error {
-	if externalNetwork.Name == "" {
-		return errors.New("VdcConfiguration missing required field: Name")
-	}
-	if externalNetwork.Xmlns == "" {
-		return errors.New("VdcConfiguration missing required field: Xmlns")
-	}
-	return nil
-}
-
 func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.ExternalNetwork) (Task, error) {
 	err := validateExternalNetwork(externalNetwork)
 	if err != nil {

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -7,7 +7,6 @@ package govcd
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"fmt"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -39,10 +38,9 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.External
 	}
 
 	xmlData := bytes.NewBufferString(xml.Header + string(output))
-	util.Logger.Printf("[TRACE] CreateExternalNetwork - xml payload: %s\n", xmlData)
-	externalnetsHREF := vcdClient.Client.VCDHREF
-	externalnetsHREF.Path += "/admin/extension/externalnets"
-	req := vcdClient.Client.NewRequest(map[string]string{}, "POST", externalnetsHREF, xmlData)
+	externalNetHREF := vcdClient.Client.VCDHREF
+	externalNetHREF.Path += "/admin/extension/externalnets"
+	req := vcdClient.Client.NewRequest(map[string]string{}, "POST", externalNetHREF, xmlData)
 	req.Header.Add("Content-Type", "application/vnd.vmware.admin.vmwexternalnet+xml")
 
 	resp, err := checkResp(vcdClient.Client.Http.Do(req))
@@ -58,21 +56,6 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.External
 	}
 
 	return *task, nil
-}
-
-func getExternalNetworkHref(client *Client) (string, error) {
-	extensions, err := getExtension(client)
-	if err != nil {
-		return "", err
-	}
-
-	for _, extensionLink := range extensions.Link {
-		if extensionLink.Type == "application/vnd.vmware.admin.vmwExternalNetworkReferences+xml" {
-			return extensionLink.HREF, nil
-		}
-	}
-
-	return "", errors.New("external network link isn't found")
 }
 
 func getExtension(client *Client) (*types.Extension, error) {
@@ -93,17 +76,4 @@ func getExtension(client *Client) (*types.Extension, error) {
 	}
 
 	return extensions, nil
-}
-
-// Find a list of Virtual Centers matching the filter parameter.
-func QueryVirtualCenters(vdcCli *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
-	results, err := vdcCli.QueryWithNotEncodedParams(nil, map[string]string{
-		"type":   "virtualCenter",
-		"filter": filter,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return results.Results.VirtualCenterRecord, nil
 }

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// Deprecated - use GetExternalNetwork
+// DEPRECATED please use GetExternalNetwork function instead
 func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
 	externalNetwork := NewExternalNetwork(&vcdClient.Client)
 	err := externalNetwork.GetByName(networkName)

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -7,6 +7,8 @@ package govcd
 import (
 	"fmt"
 	. "gopkg.in/check.v1"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
 )
 
 // Retrieves an external network and checks that its contents are filled as expected
@@ -27,4 +29,82 @@ func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 	expectedType := "application/vnd.vmware.admin.extension.network+xml"
 	check.Assert(externalNetwork.Name, Equals, networkName)
 	check.Assert(externalNetwork.Type, Equals, expectedType)
+}
+
+func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip("Configuration org != 'Sysyem'")
+	}
+	networkName := vcd.config.VCD.ExternalNetwork
+	if networkName == "" {
+		check.Skip("No external network provided")
+	}
+
+	externalNetworkRef, err := GetExternalNetworkByName(vcd.client, networkName)
+	check.Assert(err, IsNil)
+	if *externalNetworkRef != (types.ExternalNetworkReference{}) {
+		externalNetwork := NewExternalNetwork(&vcd.client.Client)
+		externalNetwork.ExternalNetwork = &types.ExternalNetwork{
+			HREF: externalNetworkRef.HREF,
+		}
+		err = externalNetwork.DeleteWait()
+		check.Assert(err, IsNil)
+	}
+
+	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "virtualCenter",
+		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer),
+	})
+	check.Assert(err, IsNil)
+	if len(results.Results.VirtualCenterRecord) == 0 {
+		check.Skip(fmt.Sprintf("No vSphere server found with name '%s'", vcd.config.VCD.VimServer))
+	}
+	vimServerHref := results.Results.VirtualCenterRecord[0].HREF
+
+	externalNetwork := &types.ExternalNetwork{
+		Name:  networkName,
+		Xmlns: "http://www.vmware.com/vcloud/extension/v1.5",
+		Configuration: &types.NetworkConfiguration{
+			Xmlns: "http://www.vmware.com/vcloud/v1.5",
+			IPScopes: &types.IPScopes{
+				IPScope: types.IPScope{
+					Gateway: "192.168.201.1",
+					Netmask: "255.255.255.0",
+					DNS1:    "192.168.202.253",
+					DNS2:    "192.168.202.254",
+					IPRanges: &types.IPRanges{
+						IPRange: []*types.IPRange{
+							&types.IPRange{
+								StartAddress: "192.168.201.3",
+								EndAddress:   "192.168.201.250",
+							},
+						},
+					},
+				},
+			},
+			FenceMode: "isolated",
+		},
+		VimPortGroupRefs: &types.VimObjectRefs{
+			VimObjectRef: []*types.VimObjectRef{
+				&types.VimObjectRef{
+					VimServerRef: &types.Reference{
+						HREF: vimServerHref,
+					},
+					MoRef:         vcd.config.VCD.ExternalNetworkPortGroup,
+					VimObjectType: "DV_PORTGROUP",
+				},
+			},
+		},
+	}
+	task, err := CreateExternalNetwork(vcd.client, externalNetwork)
+	check.Assert(err, IsNil)
+	AddToCleanupList(externalNetwork.Name, "externalNetwork", "", "Test_CreateExternalNetwork")
+	check.Assert(task, Not(Equals), Task{})
+
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	externalNetworkRef, err = GetExternalNetworkByName(vcd.client, networkName)
+	check.Assert(err, IsNil)
+	check.Assert(externalNetworkRef.Name, Equals, networkName)
 }

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -62,8 +62,9 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	vimServerHref := results.Results.VirtualCenterRecord[0].HREF
 
 	externalNetwork := &types.ExternalNetwork{
-		Name:  networkName,
-		Xmlns: "http://www.vmware.com/vcloud/extension/v1.5",
+		Name:        networkName,
+		Description: "Test Create External Network",
+		Xmlns:       "http://www.vmware.com/vcloud/extension/v1.5",
 		Configuration: &types.NetworkConfiguration{
 			Xmlns: "http://www.vmware.com/vcloud/v1.5",
 			IPScopes: &types.IPScopes{

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -87,7 +87,21 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	externalNetworkRef, err := GetExternalNetworkByName(vcd.client, TestCreateExternalNetwork)
+	newExternalNetwork := NewExternalNetwork(&vcd.client.Client)
+	err = newExternalNetwork.GetByName(TestCreateExternalNetwork)
 	check.Assert(err, IsNil)
-	check.Assert(externalNetworkRef.Name, Equals, TestCreateExternalNetwork)
+	check.Assert(newExternalNetwork.ExternalNetwork.Name, Equals, TestCreateExternalNetwork)
+
+	ipScope := newExternalNetwork.ExternalNetwork.Configuration.IPScopes.IPScope
+	check.Assert(ipScope.Gateway, Equals, "192.168.201.1")
+	check.Assert(ipScope.Netmask, Equals, "255.255.255.0")
+	check.Assert(ipScope.DNS1, Equals, "192.168.202.253")
+	check.Assert(ipScope.DNS2, Equals, "192.168.202.254")
+
+	check.Assert(len(ipScope.IPRanges.IPRange), Equals, 1)
+	ipRange := ipScope.IPRanges.IPRange[0]
+	check.Assert(ipRange.StartAddress, Equals, "192.168.201.3")
+	check.Assert(ipRange.EndAddress, Equals, "192.168.201.250")
+
+	check.Assert(newExternalNetwork.ExternalNetwork.Configuration.FenceMode, Equals, "isolated")
 }

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -35,7 +35,7 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 		check.Skip("Configuration org != 'System'")
 	}
 
-	virtualCenters, err := queryVirtualCenters(vcd.client, fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer))
+	virtualCenters, err := QueryVirtualCenters(vcd.client, fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer))
 	check.Assert(err, IsNil)
 	if len(virtualCenters) == 0 {
 		check.Skip(fmt.Sprintf("No vSphere server found with name '%s'", vcd.config.VCD.VimServer))

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	. "gopkg.in/check.v1"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // Retrieves an external network and checks that its contents are filled as expected

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -25,7 +25,7 @@ func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 	check.Assert(err, IsNil)
 	LogExternalNetwork(*externalNetwork)
 	check.Assert(externalNetwork.HREF, Not(Equals), "")
-	expectedType := "application/vnd.vmware.admin.extension.network+xml"
+	expectedType := "application/vnd.vmware.admin.vmwexternalnet+xml"
 	check.Assert(externalNetwork.Name, Equals, networkName)
 	check.Assert(externalNetwork.Type, Equals, expectedType)
 }

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type ExternalNetwork struct {

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/util"
+)
+
+type ExternalNetwork struct {
+	ExternalNetwork *types.ExternalNetwork
+	client          *Client
+}
+
+func NewExternalNetwork(cli *Client) *ExternalNetwork {
+	return &ExternalNetwork{
+		ExternalNetwork: new(types.ExternalNetwork),
+		client:          cli,
+	}
+}
+
+func (externalNetwork *ExternalNetwork) Delete() (Task, error) {
+	util.Logger.Printf("[TRACE] ExternalNetwork.Delete")
+	externalNetworkUrl, err := url.ParseRequestURI(externalNetwork.ExternalNetwork.HREF)
+	if err != nil {
+		return Task{}, fmt.Errorf("error parsing external network url: %s", err)
+	}
+
+	req := externalNetwork.client.NewRequest(map[string]string{}, "DELETE", *externalNetworkUrl, nil)
+	resp, err := checkResp(externalNetwork.client.Http.Do(req))
+	if err != nil {
+		return Task{}, fmt.Errorf("error deleting external network: %s", err)
+	}
+
+	task := NewTask(externalNetwork.client)
+	if err = decodeBody(resp, task.Task); err != nil {
+		return Task{}, fmt.Errorf("error decoding task response: %s", err)
+	}
+	return *task, nil
+}
+
+func (externalNetwork *ExternalNetwork) DeleteWait() error {
+	task, err := externalNetwork.Delete()
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("couldn't finish removing external network %#v", err)
+	}
+	return nil
+}

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -25,6 +25,21 @@ func NewExternalNetwork(cli *Client) *ExternalNetwork {
 	}
 }
 
+func getExternalNetworkHref(client *Client) (string, error) {
+	extensions, err := getExtension(client)
+	if err != nil {
+		return "", err
+	}
+
+	for _, extensionLink := range extensions.Link {
+		if extensionLink.Type == "application/vnd.vmware.admin.vmwExternalNetworkReferences+xml" {
+			return extensionLink.HREF, nil
+		}
+	}
+
+	return "", errors.New("external network link isn't found")
+}
+
 func (externalNetwork ExternalNetwork) GetByName(networkName string) error {
 	extNetworkHREF, err := getExternalNetworkHref(externalNetwork.client)
 	if err != nil {
@@ -81,10 +96,10 @@ func (externalNetwork ExternalNetwork) Refresh() error {
 
 func validateExternalNetwork(externalNetwork *types.ExternalNetwork) error {
 	if externalNetwork.Name == "" {
-		return errors.New("External Network missing required field: Name")
+		return errors.New("external Network missing required field: Name")
 	}
 	if externalNetwork.Xmlns == "" {
-		return errors.New("External Network missing required field: Xmlns")
+		return errors.New("external Network missing required field: Xmlns")
 	}
 	return nil
 }

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -47,10 +47,10 @@ func (externalNetwork ExternalNetwork) Refresh() error {
 
 func validateExternalNetwork(externalNetwork *types.ExternalNetwork) error {
 	if externalNetwork.Name == "" {
-		return errors.New("VdcConfiguration missing required field: Name")
+		return errors.New("External Network missing required field: Name")
 	}
 	if externalNetwork.Xmlns == "" {
-		return errors.New("VdcConfiguration missing required field: Xmlns")
+		return errors.New("External Network missing required field: Xmlns")
 	}
 	return nil
 }

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -666,3 +666,16 @@ func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
 	}
 	return Catalog{}, nil
 }
+
+// Find a list of Virtual Centers matching the filter parameter.
+func QueryVirtualCenters(vdcCli *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
+	results, err := vdcCli.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "virtualCenter",
+		"filter": filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results.Results.VirtualCenterRecord, nil
+}

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -33,6 +33,9 @@
 		"externalNetmask": "255.255.224.0",
 		"internalIp": "192.168.1.10",
 		"internalNetmask": "255.255.255.0",
+		"externalNetwork": "myexternalnet",
+		"externalNetworkPortGroup": "dvportgroup-175",
+		"vimServer": "vc9",
         "disk": {
             "size": 1048576,
             "sizeForUpdate": 1048576

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -77,6 +77,12 @@ vcd:
     # An external Network name
     externalNetwork: myexternalnet
     #
+    # A port group name for creating an external network
+    externalNetworkPortGroup: dvportgroup-175
+    #
+    # A vSphere server name for creating an external network
+    vimServer: vc9
+    #
     # Independent disk parameters for testing
     disk:
       #

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -475,8 +475,8 @@ type Task struct {
 // Since: 0.9
 type CapacityWithUsage struct {
 	Units     string `xml:"Units"`
-	Allocated int64  `xml:"Allocated,omitempty"`
-	Limit     int64  `xml:"Limit,omitempty"`
+	Allocated int64  `xml:"Allocated"`
+	Limit     int64  `xml:"Limit"`
 	Reserved  int64  `xml:"Reserved,omitempty"`
 	Used      int64  `xml:"Used,omitempty"`
 	Overhead  int64  `xml:"Overhead,omitempty"`
@@ -2196,19 +2196,20 @@ type VimObjectRef struct {
 }
 
 type VimObjectRefs struct {
-	VimObjectRef []*VimObjectRef
+	VimObjectRef []*VimObjectRef `xml:VimObjectRef`
 }
 
 type ExternalNetwork struct {
 	XMLName          xml.Name              `xml:"VMWExternalNetwork"`
 	Xmlns            string                `xml:"xmlns,attr,omitempty"`
+	XmlnsVCloud      string                `xml:"xmlns:vcloud,attr,omitempty"`
 	HREF             string                `xml:"href,attr,omitempty"`
 	Type             string                `xml:"type,attr,omitempty"`
 	ID               string                `xml:"id,attr,omitempty"`
 	OperationKey     string                `xml:"operationKey,attr,omitempty"`
 	Name             string                `xml:"name,attr"`
+	Description      string                `xml:"vcloud:Description,omitempty"`
 	Configuration    *NetworkConfiguration `xml:"Configuration,omitempty"`
-	Description      string                `xml:"Description,omitempty"`
 	Link             []*Link               `xml:"Link,omitempty"`
 	VimPortGroupRefs *VimObjectRefs        `xml:"VimPortGroupRefs,omitempty"`
 	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2189,16 +2189,31 @@ type ExternalNetworkReference struct {
 	Name string `xml:"name,attr,omitempty"`
 }
 
+// Type: VimObjectRefType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+// Description: Represents the moref and the type of a vSphere object.
+// Since: 0.9
 type VimObjectRef struct {
 	VimServerRef  *Reference `xml:"VimServerRef"`
 	MoRef         string     `xml:"MoRef"`
 	VimObjectType string     `xml:"VimObjectType"`
 }
 
+// Type: VimObjectRefsType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+// Description: List of VimObjectRef elements.
+// Since: 0.9
 type VimObjectRefs struct {
 	VimObjectRef []*VimObjectRef `xml:VimObjectRef`
 }
 
+// Type: VMWExternalNetworkType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
+// Description: External network type.
+// Since: 1.0
 type ExternalNetwork struct {
 	XMLName          xml.Name              `xml:"VMWExternalNetwork"`
 	Xmlns            string                `xml:"xmlns,attr,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -202,6 +202,7 @@ type IPScopes struct {
 // Description: The configurations applied to a network. This is an abstract base type. The concrete types include those for vApp and Organization wide networks.
 // Since: 0.9
 type NetworkConfiguration struct {
+	Xmlns                          string           `xml:"xmlns,attr,omitempty"`
 	BackwardCompatibilityMode      bool             `xml:"BackwardCompatibilityMode"`
 	IPScopes                       *IPScopes        `xml:"IpScopes,omitempty"`
 	ParentNetwork                  *Reference       `xml:"ParentNetwork,omitempty"`
@@ -2007,6 +2008,7 @@ type QueryResultRecordsType struct {
 	NetworkPoolRecord               []*QueryResultNetworkPoolRecordType               `xml:"NetworkPoolRecord"`               // A record representing a network pool
 	DiskRecord                      []*DiskRecordType                                 `xml:"DiskRecord"`                      // A record representing a independent Disk.
 	AdminDiskRecord                 []*DiskRecordType                                 `xml:"AdminDiskRecord"`                 // A record representing a independent Disk.
+	VirtualCenterRecord             []*QueryResultVirtualCenterRecordType             `xml:"VirtualCenterRecord"`             // A record representing a vSphere server
 }
 
 // QueryResultEdgeGatewayRecordType represents an edge gateway record as query result.
@@ -2154,6 +2156,22 @@ type QueryResultNetworkPoolRecordType struct {
 	NetworkPoolType int    `xml:"networkPoolType,attr,omitempty"`
 }
 
+// A record representing a vSphere server
+type QueryResultVirtualCenterRecordType struct {
+	HREF          string `xml:"href,attr,omitempty"`
+	Name          string `xml:"name,attr,omitempty"`
+	IsBusy        bool   `xml:"isBusy,attr,omitempty"`
+	IsEnabled     bool   `xml:"isEnabled,attr,omitempty"`
+	IsSupported   bool   `xml:"isSupported,attr,omitempty"`
+	ListenerState string `xml:"listenerState,attr,omitempty"`
+	Status        string `xml:"stats,attr,omitempty"`
+	Url           string `xml:"url,attr,omitempty"`
+	UserName      string `xml:"userName,attr,omitempty"`
+	VcVersion     string `xml:"vcVersion,attr,omitempty"`
+	UUID          string `xml:"uuid,attr,omitempty"`
+	VsmIP         string `xml:"vsmIP,attr,omitempty"`
+}
+
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Retrieve a list of extension objects and operations.
 // Since: 1.0
@@ -2169,6 +2187,32 @@ type ExternalNetworkReference struct {
 	HREF string `xml:"href,attr"`
 	Type string `xml:"type,attr,omitempty"`
 	Name string `xml:"name,attr,omitempty"`
+}
+
+type VimObjectRef struct {
+	VimServerRef  *Reference `xml:"VimServerRef"`
+	MoRef         string     `xml:"MoRef"`
+	VimObjectType string     `xml:"VimObjectType"`
+}
+
+type VimObjectRefs struct {
+	VimObjectRef []*VimObjectRef
+}
+
+type ExternalNetwork struct {
+	XMLName          xml.Name              `xml:"VMWExternalNetwork"`
+	Xmlns            string                `xml:"xmlns,attr,omitempty"`
+	HREF             string                `xml:"href,attr,omitempty"`
+	Type             string                `xml:"type,attr,omitempty"`
+	ID               string                `xml:"id,attr,omitempty"`
+	OperationKey     string                `xml:"operationKey,attr,omitempty"`
+	Name             string                `xml:"name,attr"`
+	Configuration    *NetworkConfiguration `xml:"Configuration,omitempty"`
+	Description      string                `xml:"Description,omitempty"`
+	Link             []*Link               `xml:"Link,omitempty"`
+	VimPortGroupRefs *VimObjectRefs        `xml:"VimPortGroupRefs,omitempty"`
+	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`
+	VCloudExtension  *VCloudExtension      `xml:"VCloudExtension,omitempty"`
 }
 
 // Type: MediaType

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2156,7 +2156,11 @@ type QueryResultNetworkPoolRecordType struct {
 	NetworkPoolType int    `xml:"networkPoolType,attr,omitempty"`
 }
 
-// A record representing a vSphere server
+// Type: QueryResultVirtualCenterRecordType
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/QueryResultVirtualCenterRecordType.html
+// Description: Type for a single virtualCenter query result in records format.
+// Since: 1.5
 type QueryResultVirtualCenterRecordType struct {
 	HREF          string `xml:"href,attr,omitempty"`
 	Name          string `xml:"name,attr,omitempty"`


### PR DESCRIPTION
## Description

Add methods for creating and deleting an external network.

Related issue: (#129 )

I still need to add a negative test on the create just to make sure it returns the correct error.  I can't validate the fields on the created network without implementing a GET method for it too, which I'm happy to do if you like.  If so I could use guidance on what to do with the existing method (`GetExternalNetworkByName`) since they'd have a similar purpose.