### PR TITLE
Switch module to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-    - "1.11.x"
     - "1.12.x"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
     - "1.11.x"
+    - "1.12.x"
 
 sudo: false
 install: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ contributors.  Typical contribution flow steps are:
 - Open an Issue in go-vcloud-director describing what you propose to do (unless the change is so trivial that an issue is not needed)
 - Wait for discussion and possible direction hints in the issue thread
 - Once you know  which steps to take in your intended contribution, make changes in a topic branch and commit (don't forget to add or modify tests too)
+- Update Go modules files `go.mod` and `go.sum` if you're changing dependencies.
 - Fetch changes from upstream and resolve any merge conflicts so that your topic branch is up-to-date
 - Push all commits to the topic branch in your forked repo
 - Submit a pull request to merge topic branch commits to upstream master
@@ -41,7 +42,7 @@ GitHub](https://help.github.com/categories/collaborating-with-issues-and-pull-re
 Our standard for Golang contributions is to match the format of the [standard
 Go package library](https://golang.org/pkg).  
 
-- Run `go fmt` on all code.
+- Run `go fmt` on all code with latest stable version of Go (`go fmt` results may vary between Go versions).  
 - All public interfaces, functions, and structs must have complete, grammatically correct Godoc comments that explain their purpose and proper usage.
 - Use self-explanatory names for all variables, functions, and interfaces.
 - Add comments for non-obvious features of internal implementations but otherwise let the code explain itself.
@@ -82,8 +83,11 @@ of the repo for pull requests back to go-vcloud-director.
 Make a local clone of the forked repo and add the base go-vcloud-director
 repo as the upstream remote repository.
 
+The project uses Go modules so the path is up to you, but do not forget
+to set `GO111MODULE=on` if you are in `GOPATH`
+
 ``` shell
-# (Put forked code in correct path to ensure Go is happy.)
+
 cd $GOPATH/src/github.com/vmware
 git clone https://github.com/imahacker/go-vcloud-director
 cd go-vcloud-director

--- a/README.md
+++ b/README.md
@@ -15,23 +15,33 @@ details on joining the community.
 
 ### Install and Build ###
 
-Create a standard Golang development tree with bin, pkg, and src directories. 
-Set GOPATH to the root directory. Then:
+This project started using Go [modules](https://github.com/golang/go/wiki/Modules)
+starting with version 2.1 and `vendor` directory is no longer bundled.
+
+As per the [modules documentation](https://github.com/golang/go/wiki/Modules)
+you no longer need to use `GOPATH`. You can clone the branch in any directory
+you like and go will fetch dependencies specified in the `go.mod` file:
 ```
-go get github.com/vmware/go-vcloud-director
-cd $GOPATH/src/github.com/vmware/go-vcloud-director/govcd
+cd ~/Documents/mycode
+git clone https://github.com/vmware/go-vcloud-director.git
+cd go-vcloud-director/govcd
 go build
 ```
-This command only builds a library. There is no executable.
 
-### Example ###
+**Note** Do not forget to set `GO111MODULE=on` if you are in your GOPATH.
+[Read more about this.](https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support)
 
-To show the SDK in action run the example shown below.  
+#### Example code ####
+
+To show the SDK in action run the example:
 ```
-mkdir $GOPATH/src/example
-cd $GOPATH/src/example
+mkdir ~/govcd_example
+go mod init govcd_example
+go get github.com/vmware/go-vcloud-director/v2@master
+go build -o example
 ./example user_name "password" org_name vcd_IP vdc_name 
 ```
+
 Here's the code:
 ```go
 package main
@@ -41,7 +51,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/vmware/go-vcloud-director/govcd"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
-module github.com/vmware/go-vcloud-director
+module github.com/vmware/go-vcloud-director/v2
 
 require (
-	github.com/kr/pretty v0.1.0
-	github.com/kr/text v0.1.0
+	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -15,8 +15,8 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // Client provides a client to vCloud Director, values can be populated automatically using the Authenticate method.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -6,8 +6,8 @@ package govcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -19,8 +19,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 const (

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/util"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type CatalogItem struct {

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // Independent disk

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -7,7 +7,7 @@ package govcd
 import (
 	"fmt"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type EdgeGateway struct {

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -5,7 +5,7 @@
 package govcd
 
 import (
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -14,8 +14,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type MediaItem struct {

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // For each library {entity}, we have two functions: Show{Entity} and Log{Entity}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // Interface for methods in common for Org and AdminOrg

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // OrgVDCNetwork an org vdc network client

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -7,7 +7,7 @@ package govcd
 import (
 	"fmt"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 type Results struct {

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // Creates an Organization based on settings, network, and org name.

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -7,7 +7,7 @@ package govcd
 import (
 	"fmt"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type Task struct {

--- a/govcd/upload.go
+++ b/govcd/upload.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // uploadLink - vCD created temporary upload link

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -12,8 +12,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type VApp struct {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 type VAppTemplate struct {

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type Vdc struct {

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -7,7 +7,7 @@ package govcd
 import (
 	"fmt"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -12,8 +12,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
-	"github.com/vmware/go-vcloud-director/util"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type VM struct {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 

--- a/samples/discover.go
+++ b/samples/discover.go
@@ -46,7 +46,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/vmware/go-vcloud-director/govcd"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 )


### PR DESCRIPTION
Switching project module to `v2` to match semver tags. This should then allow to migrate `terraform-provider-vcd` for modules support. It does three things:

* Changes module name definition in `go.mod`.
* Adds  all the imports from  `v2`.
* Adds Go 1.12.x for Travis testing as it is already released.

It should be tagged as `v2.1.0-alpha.2` or similar after merge to move forwards with `terraform-provider-vcd` module support.

@lvirbalas @vbauzysvmware @dataclouder 


Related issues: ( #139, https://github.com/terraform-providers/terraform-provider-vcd/issues/162 )
