### PR TITLE
Add eject handling question support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## 2.1.0 (February 5, 2019)
+
+ARCHITECTURAL:
+
+* Project switched to using Go modules. It is worth having a
+look at [README.md](README.md) to understand how Go modules impact build and development.
+
+FEATURES:
+
+* New insert and eject media functions 
+
+IMPROVEMENTS:

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -91,15 +91,15 @@ func (cli *Client) NewRequest(params map[string]string, method string, reqUrl ur
 	return cli.NewRequestWitNotEncodedParams(params, nil, method, reqUrl, body)
 }
 
-// parseErr takes an error XML resp and returns a single string for use in error messages.
-func parseErr(resp *http.Response) error {
+// ParseErr takes an error XML resp and returns a single string for use in error messages.
+func ParseErr(resp *http.Response) error {
 
 	errBody := new(types.Error)
 
 	// if there was an error decoding the body, just return that
 	if err := decodeBody(resp, errBody); err != nil {
-		util.Logger.Printf("[parseErr]: unhandled response <--\n%+v\n-->\n", resp)
-		return fmt.Errorf("[parseErr]: error parsing error body for non-200 request: %s (%+v)", err, resp)
+		util.Logger.Printf("[ParseErr]: unhandled response <--\n%+v\n-->\n", resp)
+		return fmt.Errorf("[ParseErr]: error parsing error body for non-200 request: %s (%+v)", err, resp)
 	}
 
 	return fmt.Errorf("API Error: %d: %s", errBody.MajorErrorCode, errBody.Message)
@@ -167,7 +167,7 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 		http.StatusInternalServerError,         // 500
 		http.StatusServiceUnavailable,          // 503
 		http.StatusGatewayTimeout:              // 504
-		return nil, parseErr(resp)
+		return nil, ParseErr(resp)
 	// Unhandled response.
 	default:
 		return nil, fmt.Errorf("unhandled API response, please report this issue, status code: %s", resp.Status)

--- a/govcd/ejecttask.go
+++ b/govcd/ejecttask.go
@@ -53,7 +53,7 @@ func (ejectTask *EjectTask) WaitInspectTaskCompletion(isAnswerYes bool, delay ti
 			return nil
 		}
 
-		question, err := ejectTask.vm.GetQuestions()
+		question, err := ejectTask.vm.GetQuestion()
 		if err != nil {
 			return fmt.Errorf("task did not complete succesfully: %s, quering question for VM failed: %s", ejectTask.Task.Task.Description, err.Error())
 		}

--- a/govcd/ejecttask.go
+++ b/govcd/ejecttask.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type EjectTask struct {
+	*Task
+	vm *VM
+}
+
+// Creates wrapped Task which is dedicated for eject media functionality and
+// provides additional functionality to answer VM questions
+func NewEjectTask(task *Task, vm *VM) *EjectTask {
+	return &EjectTask{
+		task,
+		vm,
+	}
+}
+
+// Checks the status of the task every 3 seconds and returns when the
+// eject task is either completed or failed
+func (ejectTask *EjectTask) WaitTaskCompletion(isAnswerYes bool) error {
+	return ejectTask.WaitInspectTaskCompletion(isAnswerYes, 3*time.Second)
+}
+
+// function which handles answers for ejecting
+func (ejectTask *EjectTask) WaitInspectTaskCompletion(isAnswerYes bool, delay time.Duration) error {
+
+	if ejectTask.Task == nil {
+		return fmt.Errorf("cannot refresh, Object is empty")
+	}
+
+	for {
+		err := ejectTask.Refresh()
+		if err != nil {
+			return fmt.Errorf("error retrieving task: %s", err)
+		}
+
+		// If task is not in a waiting status we're done, check if there's an error and return it.
+		if ejectTask.Task.Task.Status != "queued" && ejectTask.Task.Task.Status != "preRunning" && ejectTask.Task.Task.Status != "running" {
+			if ejectTask.Task.Task.Status == "error" {
+				return fmt.Errorf("task did not complete succesfully: %s", ejectTask.Task.Task.Error.Message)
+			}
+			return nil
+		}
+
+		question, err := ejectTask.vm.GetQuestions()
+		if err != nil {
+			return fmt.Errorf("task did not complete succesfully: %s, quering question for VM failed: %s", ejectTask.Task.Task.Description, err.Error())
+		}
+
+		if question.QuestionId != "" && strings.Contains(question.Question, "Disconnect anyway and override the lock?") {
+			var choiceToUse *types.VmQuestionAnswerChoiceType
+			for _, choice := range question.Choices {
+				if isAnswerYes {
+					if strings.Contains(choice.Text, "yes") {
+						choiceToUse = choice
+					}
+				} else {
+					if strings.Contains(choice.Text, "no") {
+						choiceToUse = choice
+					}
+				}
+			}
+
+			if choiceToUse != nil {
+				err = ejectTask.vm.AnswerQuestion(question.QuestionId, choiceToUse.Id)
+				if err != nil {
+					return fmt.Errorf("task did not complete succesfully: %s, answering question for eject in VM failed: %s", ejectTask.Task.Task.Description, err.Error())
+				}
+			}
+
+		}
+
+		// Sleep for a given period and try again.
+		time.Sleep(delay)
+	}
+}

--- a/govcd/ejecttask.go
+++ b/govcd/ejecttask.go
@@ -19,6 +19,7 @@ type EjectTask struct {
 
 var timeBetweenRefresh = 3 * time.Second
 
+// Question Message from vCD API
 const questionMessage = "Disconnect anyway and override the lock?"
 
 // Creates wrapped Task which is dedicated for eject media functionality and

--- a/govcd/ejecttask.go
+++ b/govcd/ejecttask.go
@@ -17,6 +17,10 @@ type EjectTask struct {
 	vm *VM
 }
 
+var timeBetweenRefresh = 3 * time.Second
+
+const questionMessage = "Disconnect anyway and override the lock?"
+
 // Creates wrapped Task which is dedicated for eject media functionality and
 // provides additional functionality to answer VM questions
 func NewEjectTask(task *Task, vm *VM) *EjectTask {
@@ -29,7 +33,7 @@ func NewEjectTask(task *Task, vm *VM) *EjectTask {
 // Checks the status of the task every 3 seconds and returns when the
 // eject task is either completed or failed
 func (ejectTask *EjectTask) WaitTaskCompletion(isAnswerYes bool) error {
-	return ejectTask.WaitInspectTaskCompletion(isAnswerYes, 3*time.Second)
+	return ejectTask.WaitInspectTaskCompletion(isAnswerYes, timeBetweenRefresh)
 }
 
 // function which handles answers for ejecting
@@ -58,7 +62,7 @@ func (ejectTask *EjectTask) WaitInspectTaskCompletion(isAnswerYes bool, delay ti
 			return fmt.Errorf("task did not complete succesfully: %s, quering question for VM failed: %s", ejectTask.Task.Task.Description, err.Error())
 		}
 
-		if question.QuestionId != "" && strings.Contains(question.Question, "Disconnect anyway and override the lock?") {
+		if question.QuestionId != "" && strings.Contains(question.Question, questionMessage) {
 			var choiceToUse *types.VmQuestionAnswerChoiceType
 			for _, choice := range question.Choices {
 				if isAnswerYes {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -8,12 +8,11 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type VM struct {
@@ -700,10 +699,10 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 
 	req := vm.client.NewRequest(map[string]string{}, "GET", *apiEndpoint, nil)
 
-	resp, err := checkResp(vm.client.Http.Do(req))
+	resp, err := vm.client.Http.Do(req)
 
 	// vCD security feature - on no question return 403 access error
-	if resp.StatusCode == http.StatusForbidden {
+	if http.StatusForbidden == resp.StatusCode {
 		util.Logger.Printf("No question found for VM: %s\n", vm.VM.ID)
 		return types.VmPendingQuestion{}, nil
 	}

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -712,6 +712,10 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 		return types.VmPendingQuestion{}, fmt.Errorf("error getting question: %s", err)
 	}
 
+	if http.StatusOK != resp.StatusCode {
+		return types.VmPendingQuestion{}, fmt.Errorf("error getting question: %s", ParseErr(resp))
+	}
+
 	question := &types.VmPendingQuestion{}
 
 	if err = decodeBody(resp, question); err != nil {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -8,11 +8,12 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	"github.com/vmware/go-vcloud-director/v2/util"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 type VM struct {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -614,7 +614,7 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 	check.Assert(err, IsNil)
 
 	for i := 0; i < 10; i++ {
-		question, err := vm.GetQuestions()
+		question, err := vm.GetQuestion()
 		check.Assert(err, IsNil)
 
 		if question.QuestionId != "" && strings.Contains(question.Question, "Disconnect anyway and override the lock?") {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -8,6 +8,7 @@ package govcd
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -448,7 +449,7 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_HandleInsertOrEjectMedia")
 
 	media, err := FindMediaAsCatalogItem(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
@@ -468,7 +469,7 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	ejectMediaTask, err := vm.HandleEjectMedia(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
 
-	err = ejectMediaTask.WaitTaskCompletion()
+	err = ejectMediaTask.WaitTaskCompletion(true)
 	check.Assert(err, IsNil)
 
 	//verify
@@ -507,7 +508,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_InsertOrEjectMedia")
 
 	media, err := FindMediaAsCatalogItem(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
@@ -560,4 +561,74 @@ func isMediaInjected(items []*types.VirtualHardwareItem) bool {
 		}
 	}
 	return isFound
+}
+
+// Test Insert or Eject Media for VM
+func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
+
+	itemName := "TestAnswerVmQuestion"
+
+	// Find VApp
+	if vcd.vapp.VApp == nil {
+		check.Skip("skipping test because no vApp is found")
+	}
+
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vm := NewVM(&vcd.client.Client)
+	vm.VM = &vmType
+
+	// Upload Media
+	catalog, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
+
+	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	check.Assert(err, IsNil)
+	err = uploadTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_AnswerVmQuestion")
+
+	media, err := FindMediaAsCatalogItem(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	check.Assert(err, IsNil)
+	check.Assert(media, Not(Equals), CatalogItem{})
+
+	insertMediaTask, err := vm.HandleInsertMedia(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	check.Assert(err, IsNil)
+
+	err = insertMediaTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	//verify
+	err = vm.Refresh()
+	check.Assert(err, IsNil)
+	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, true)
+
+	ejectMediaTask, err := vm.HandleEjectMedia(&vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	check.Assert(err, IsNil)
+
+	for i := 0; i < 10; i++ {
+		question, err := vm.GetQuestions()
+		check.Assert(err, IsNil)
+
+		if question.QuestionId != "" && strings.Contains(question.Question, "Disconnect anyway and override the lock?") {
+			err = vm.AnswerQuestion(question.QuestionId, 0)
+			check.Assert(err, IsNil)
+		}
+		time.Sleep(time.Second * 3)
+	}
+
+	err = ejectMediaTask.Task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	//verify
+	err = vm.Refresh()
+	check.Assert(err, IsNil)
+	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2307,6 +2307,7 @@ type VmQuestionAnswer struct {
 	Xmlns      string   `xml:"xmlns,attr,omitempty"`
 	ChoiceId   int      `xml:"ChoiceId"`
 	QuestionId string   `xml:"QuestionId"`
+}
 
 // Represents an independent disk record
 // Reference: vCloud API 27.0 - DiskType
@@ -2333,5 +2334,4 @@ type DiskRecordType struct {
 	IsAttached         bool    `xml:"isAttached,attr,omitempty"`
 	Description        string  `xml:"description,attr,omitempty"`
 	Link               []*Link `xml:"Link,omitempty"`
-
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2298,7 +2298,7 @@ type VmQuestionAnswerChoiceType struct {
 }
 
 // Parameters for VM question answer
-// Reference: vCloud API 27.0 - VmPendingQuestionType
+// Reference: vCloud API 27.0 - VmQuestionAnswerType
 // https://code.vmware.com/apis/287/vcloud#/doc/doc/types/VmQuestionAnswerType.html
 type VmQuestionAnswer struct {
 	XMLName    xml.Name `xml:"VmQuestionAnswer"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2274,3 +2274,35 @@ type MediaInsertOrEjectParams struct {
 	Media           *Reference       `xml:"Media"`
 	VCloudExtension *VCloudExtension `xml:"VCloudExtension,omitempty"`
 }
+
+// Parameters for VM pending questions
+// Reference: vCloud API 27.0 - VmPendingQuestionType
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/VmPendingQuestionType.html
+type VmPendingQuestion struct {
+	XMLName    xml.Name                      `xml:"VmPendingQuestion"`
+	Xmlns      string                        `xml:"xmlns,attr,omitempty"`
+	Type       string                        `xml:"type,attr"`
+	HREF       string                        `xml:"href,attr"`
+	Link       LinkList                      `xml:"Link,omitempty"`
+	Question   string                        `xml:"Question"`
+	QuestionId string                        `xml:"QuestionId"`
+	Choices    []*VmQuestionAnswerChoiceType `xml:"Choices"`
+}
+
+// Parameters for VM question answer choice
+// Reference: vCloud API 27.0 - VmQuestionAnswerChoiceType
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/VmQuestionAnswerChoiceType.html
+type VmQuestionAnswerChoiceType struct {
+	Id   int    `xml:"Id"`
+	Text string `xml:"Text,omitempty"`
+}
+
+// Parameters for VM question answer
+// Reference: vCloud API 27.0 - VmPendingQuestionType
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/VmQuestionAnswerType.html
+type VmQuestionAnswer struct {
+	XMLName    xml.Name `xml:"VmQuestionAnswer"`
+	Xmlns      string   `xml:"xmlns,attr,omitempty"`
+	ChoiceId   int      `xml:"ChoiceId"`
+	QuestionId string   `xml:"QuestionId"`
+}


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/170

After some time figure out that there is possibility to query and answer questions for VM then ejecting mounted media. vCD ask question do you really want eject mounted media when VM is runing. This functionality will be used to improve current existing terraform resource.

Improves API with new functionality:
* new functions to handle VM questions and answers
* eject task which handles media eject question and answers during task
* removed check for VM to be power off for ejecting
* new unitest