### PR TITLE
Add cpu cores support for VM and deprecated func for vApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@ FEATURES:
 IMPROVEMENTS:
 
 * vApp vapp.PowerOn() implicitly waits for vApp to exit "UNRESOLVED" state which occurs shortly after creation and causes vapp.PowerOn() failure.
+* VM has new functions which allows to configure cores for CPU. VM.ChangeCPUCountWithCore()
+
+BREAKING CHANGES:
+
+* Deprecate vApp.ChangeCPUCountWithCore() and vApp.ChangeCPUCount()
+

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -628,7 +628,8 @@ func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection
 // Sets number of available virtual logical processors
 // (i.e. CPUs x cores per socket)
 // https://communities.vmware.com/thread/576209
-func (vapp *VApp) ChangeCPUcount(virtualCpuCount int) (Task, error) {
+// Deprecated: Use vm.ChangeCPUcount()
+func (vapp *VApp) ChangeCPUCount(virtualCpuCount int) (Task, error) {
 	return vapp.ChangeCPUCountWithCore(virtualCpuCount, nil)
 }
 
@@ -636,6 +637,7 @@ func (vapp *VApp) ChangeCPUcount(virtualCpuCount int) (Task, error) {
 // (i.e. CPUs x cores per socket) and cores per socket.
 // Socket count is a result of: virtual logical processors/cores per socket
 // https://communities.vmware.com/thread/576209
+// Deprecated: Use vm.ChangeCPUCountWithCore()
 func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (Task, error) {
 
 	err := vapp.Refresh()

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -203,7 +203,7 @@ func (vcd *TestVCD) Test_ChangeCPUcount(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	task, err := vcd.vapp.ChangeCPUcount(1)
+	task, err := vcd.vapp.ChangeCPUCount(1)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -177,6 +177,7 @@ func (vm *VM) PowerOff() (Task, error) {
 
 // Sets number of available virtual logical processors
 // (i.e. CPUs x cores per socket)
+// Cpu cores count is inherited from template.
 // https://communities.vmware.com/thread/576209
 func (vm *VM) ChangeCPUCount(virtualCpuCount int) (Task, error) {
 	return vm.ChangeCPUCountWithCore(virtualCpuCount, nil)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -175,7 +175,18 @@ func (vm *VM) PowerOff() (Task, error) {
 
 }
 
-func (vm *VM) ChangeCPUcount(size int) (Task, error) {
+// Sets number of available virtual logical processors
+// (i.e. CPUs x cores per socket)
+// https://communities.vmware.com/thread/576209
+func (vm *VM) ChangeCPUCount(virtualCpuCount int) (Task, error) {
+	return vm.ChangeCPUCountWithCore(virtualCpuCount, nil)
+}
+
+// Sets number of available virtual logical processors
+// (i.e. CPUs x cores per socket) and cores per socket.
+// Socket count is a result of: virtual logical processors/cores per socket
+// https://communities.vmware.com/thread/576209
+func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (Task, error) {
 
 	err := vm.Refresh()
 	if err != nil {
@@ -186,16 +197,18 @@ func (vm *VM) ChangeCPUcount(size int) (Task, error) {
 		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
 		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
 		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
+		XmlnsVmw:        "http://www.vmware.com/schema/ovf",
 		VCloudHREF:      vm.VM.HREF + "/virtualHardwareSection/cpu",
 		VCloudType:      "application/vnd.vmware.vcloud.rasdItem+xml",
 		AllocationUnits: "hertz * 10^6",
 		Description:     "Number of Virtual CPUs",
-		ElementName:     strconv.Itoa(size) + " virtual CPU(s)",
+		ElementName:     strconv.Itoa(virtualCpuCount) + " virtual CPU(s)",
 		InstanceID:      4,
 		Reservation:     0,
 		ResourceType:    3,
-		VirtualQuantity: size,
+		VirtualQuantity: virtualCpuCount,
 		Weight:          0,
+		CoresPerSocket:  coresPerSocket,
 		Link: &types.Link{
 			HREF: vm.VM.HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",
@@ -207,8 +220,6 @@ func (vm *VM) ChangeCPUcount(size int) (Task, error) {
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
-
-	util.Logger.Printf("\n\nXML DEBUG: %s\n\n", string(output))
 
 	buffer := bytes.NewBufferString(xml.Header + string(output))
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -325,6 +325,17 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
+	// Cleanup: Detach disk
+	detachDiskTask, err := vm.attachOrDetachDisk(&types.DiskAttachOrDetachParams{
+		Disk: &types.Reference{
+			HREF: disk.Disk.HREF,
+		},
+	}, types.RelDiskDetach)
+	check.Assert(err, IsNil)
+
+	err = detachDiskTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
 }
 
 // Test detach disk from VM
@@ -631,4 +642,61 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 	err = vm.Refresh()
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
+}
+
+func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+
+	currentCpus := 0
+	currentCores := 0
+
+	// save current values
+	if nil != vcd.vapp.VApp.Children.VM[0] && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
+		for _, item := range vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
+			if item.ResourceType == 3 {
+				currentCpus = item.VirtualQuantity
+				currentCores = item.CoresPerSocket
+				break
+			}
+		}
+	}
+
+	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
+
+	cores := 2
+	cpuCount := 4
+
+	task, err := vm.ChangeCPUCountWithCore(cpuCount, &cores)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+
+	err = vm.Refresh()
+	check.Assert(err, IsNil)
+	foundItem := false
+	if nil != vm.VM.VirtualHardwareSection.Item {
+		for _, item := range vm.VM.VirtualHardwareSection.Item {
+			if item.ResourceType == 3 {
+				check.Assert(item.CoresPerSocket, Equals, cores)
+				check.Assert(item.VirtualQuantity, Equals, cpuCount)
+				foundItem = true
+				break
+			}
+		}
+		check.Assert(foundItem, Equals, true)
+	}
+
+	// return tu previous value
+	task, err = vm.ChangeCPUCountWithCore(currentCpus, &currentCores)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -694,7 +694,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 		check.Assert(foundItem, Equals, true)
 	}
 
-	// return tu previous value
+	// return to previous value
 	task, err = vm.ChangeCPUCountWithCore(currentCpus, &currentCores)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()


### PR DESCRIPTION
Ref: terraform-providers/terraform-provider-vcd#174

Add ability to provide core number when change CPU configuration. 
* vApp function deprecated
* add missing functions for VM