### PR TITLE
Rename pointer receiver name vdcCli -> vcdCli

### DIFF
--- a/govcd/query.go
+++ b/govcd/query.go
@@ -23,19 +23,19 @@ func NewResults(cli *Client) *Results {
 	}
 }
 
-func (vdcCli *VCDClient) Query(params map[string]string) (Results, error) {
+func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 
-	req := vdcCli.Client.NewRequest(params, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
+	req := vcdCli.Client.NewRequest(params, "GET", vcdCli.QueryHREF, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
-	return getResult(&vdcCli.Client, req)
+	return getResult(&vcdCli.Client, req)
 }
 
-func (vdcCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	req := vdcCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", vdcCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdcCli.Client.APIVersion)
+func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, "GET", vcdCli.QueryHREF, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
-	return getResult(&vdcCli.Client, req)
+	return getResult(&vcdCli.Client, req)
 }
 
 func (vdc *Vdc) Query(params map[string]string) (Results, error) {

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -29,7 +29,7 @@ func NewVApp(cli *Client) *VApp {
 	}
 }
 
-func (vdcCli *VCDClient) NewVApp(client *Client) VApp {
+func (vcdCli *VCDClient) NewVApp(client *Client) VApp {
 	newvapp := NewVApp(client)
 	return *newvapp
 }


### PR DESCRIPTION
This PR is to simply fix a typo which is spread the pointer receiver variable names for `VCDClient`.
It changes `func (vdcCli *VCDClient)...` to `func (vcdCli *VCDClient)...` everywhere.

We already agreed in https://github.com/vmware/go-vcloud-director/pull/174#discussion_r272956903 but I split it into separate PR for clear history.

```bash
grep -RF "func (vdcCli " * | wc -l
0
```