### PR TITLE
Toggle hardware assisted CPU virtualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 FEATURES:
 
-* Added metadata add/remove functions to VM
+* Added metadata add/remove functions to VM.
+* Added ability to do vCD version checks and comparison [#174](https://github.com/vmware/go-vcloud-director/pull/174)
+using VCDClient.APIVCDMaxVersionIs(string) and VCDClient.APIClientVersionIs(string).
+* Added ability to override currently used vCD API version WithAPIVersion(string) [#174](https://github.com/vmware/go-vcloud-director/pull/174).
+* Added ability to enable nested hypervisor option for VM with VM.ToggleNestedHypervisor(bool) [#219](https://github.com/terraform-providers/terraform-provider-vcd/issues/219).
+
 
 BREAKING CHANGES:
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -565,7 +565,7 @@ func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 		return Task{}, fmt.Errorf("unable to toggle hardware virtualization: %s", err)
 	}
 	if vmStatus != "POWERED_OFF" {
-		return Task{}, fmt.Errorf("hardware virtualization can be changed on powered of VM, status: %s", vmStatus)
+		return Task{}, fmt.Errorf("hardware virtualization can be changed from powered off state, status: %s", vmStatus)
 	}
 
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -560,14 +560,21 @@ func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 // CPU virtualization for the VM. It can only be performed on a powered off VM and
 // will return an error otherwise. This is mainly useful for hypervisor nesting.
 func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
+	vmStatus, err := vm.GetStatus()
+	if err != nil {
+		return Task{}, fmt.Errorf("unable to toggle hardware virtualization: %s", err)
+	}
+	if vmStatus != "POWERED_OFF" {
+		return Task{}, fmt.Errorf("hardware virtualization can be changed on powered of VM, status: %s", vmStatus)
+	}
+
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	if isEnabled {
 		apiEndpoint.Path += "/action/enableNestedHypervisor"
-		return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-			"", "error enabling hypervisor nesting feature for VM: %s", nil)
+	} else {
+		apiEndpoint.Path += "/action/disableNestedHypervisor"
 	}
-
-	apiEndpoint.Path += "/action/disableNestedHypervisor"
+	errMessage := fmt.Sprintf("error toggling hypervisor nesting feature to %t for VM: %%s", isEnabled)
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		"", "error disabling hypervisor nesting feature for VM: %s", nil)
+		"", errMessage, nil)
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -567,7 +567,7 @@ func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 			"", "error enabling hypervisor nesting feature for VM: %s", nil)
 	}
 
-	apiEndpoint.Path += "/action/enableNestedHypervisor"
+	apiEndpoint.Path += "/action/disableNestedHypervisor"
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
 		"", "error disabling hypervisor nesting feature for VM: %s", nil)
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -555,3 +555,19 @@ func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 	return vm.client.ExecuteRequestWithoutResponse(apiEndpoint.String(), http.MethodPost,
 		"", "error asnwering question: %s", answer)
 }
+
+// ToggleNestedHypervisor allows to either enable or disable hardware assisted CPU virtualization
+// which is mainly used for hypervisor nesting in VMs. It can only be performed on a powered off
+// VM and will return an error otherwise.
+func (vm *VM) ToggleNestedHypervisor(isEnabled bool) (Task, error) {
+	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
+	if isEnabled {
+		apiEndpoint.Path += "/action/enableNestedHypervisor"
+		return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+			"", "error enabling hypervisor nesting feature for VM: %s", nil)
+	}
+
+	apiEndpoint.Path += "/action/enableNestedHypervisor"
+	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		"", "error disabling hypervisor nesting feature for VM: %s", nil)
+}

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -556,10 +556,10 @@ func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 		"", "error asnwering question: %s", answer)
 }
 
-// ToggleNestedHypervisor allows to either enable or disable hardware assisted CPU virtualization
-// which is mainly used for hypervisor nesting in VMs. It can only be performed on a powered off
-// VM and will return an error otherwise.
-func (vm *VM) ToggleNestedHypervisor(isEnabled bool) (Task, error) {
+// ToggleHardwareVirtualization allows to either enable or disable hardware assisted
+// CPU virtualization for the VM. It can only be performed on a powered off VM and
+// will return an error otherwise. This is mainly useful for hypervisor nesting.
+func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	if isEnabled {
 		apiEndpoint.Path += "/action/enableNestedHypervisor"

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -777,7 +777,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
-func (vcd *TestVCD) Test_VMToggleHWAssistedVirtualization(check *C) {
+func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	vapp := vcd.findFirstVapp()
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
@@ -796,7 +796,7 @@ func (vcd *TestVCD) Test_VMToggleHWAssistedVirtualization(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Try to change the setting on powered on VM to fail
-	_, err = vm.ToggleHWAssistedVirtualization(true)
+	_, err = vm.ToggleHardwareVirtualization(true)
 	check.Assert(err, ErrorMatches, ".*Virtual machine.*must be powered off to update.*")
 
 	// PowerOf
@@ -806,7 +806,7 @@ func (vcd *TestVCD) Test_VMToggleHWAssistedVirtualization(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Perform steps on powered off VM
-	task, err = vm.ToggleHWAssistedVirtualization(true)
+	task, err = vm.ToggleHardwareVirtualization(true)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")
@@ -815,7 +815,7 @@ func (vcd *TestVCD) Test_VMToggleHWAssistedVirtualization(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, true)
 
-	task, err = vm.ToggleHWAssistedVirtualization(false)
+	task, err = vm.ToggleHardwareVirtualization(false)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -777,19 +777,19 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
-func (vcd *TestVCD) Test_VMToggleNestedHypervisor(check *C) {
+func (vcd *TestVCD) Test_VMToggleHWAssistedVirtualization(check *C) {
 	vapp := vcd.findFirstVapp()
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
-
+	// Default nesting status should be false
 	nestingStatus := vmType.NestedHypervisorEnabled
 	check.Assert(nestingStatus, Equals, false)
 
 	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
 
-	task, err := vm.ToggleNestedHypervisor(true)
+	task, err := vm.ToggleHWAssistedVirtualization(true)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")
@@ -799,7 +799,7 @@ func (vcd *TestVCD) Test_VMToggleNestedHypervisor(check *C) {
 
 	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, true)
 
-	task, err = vm.ToggleNestedHypervisor(false)
+	task, err = vm.ToggleHWAssistedVirtualization(false)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -797,7 +797,7 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 
 	// Try to change the setting on powered on VM to fail
 	_, err = vm.ToggleHardwareVirtualization(true)
-	check.Assert(err, ErrorMatches, ".*Virtual machine.*must be powered off to update.*")
+	check.Assert(err, ErrorMatches, ".*hardware virtualization can be changed on powered of.*")
 
 	// PowerOf
 	task, err = vm.PowerOff()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -797,7 +797,7 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 
 	// Try to change the setting on powered on VM to fail
 	_, err = vm.ToggleHardwareVirtualization(true)
-	check.Assert(err, ErrorMatches, ".*hardware virtualization can be changed on powered of.*")
+	check.Assert(err, ErrorMatches, ".*hardware virtualization can be changed from powered off state.*")
 
 	// PowerOf
 	task, err = vm.PowerOff()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -776,3 +776,37 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	err = task.WaitTaskCompletion()
 	check.Assert(task.Task.Status, Equals, "success")
 }
+
+func (vcd *TestVCD) Test_ToggleNestedHypervisor(check *C) {
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+
+	nestingStatus := vmType.NestedHypervisorEnabled
+	check.Assert(nestingStatus, Equals, false)
+
+	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
+
+	task, err := vm.ToggleNestedHypervisor(true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+
+	err = vm.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, true)
+
+	task, err = vm.ToggleNestedHypervisor(false)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(task.Task.Status, Equals, "success")
+
+	err = vm.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, false)
+
+}


### PR DESCRIPTION
This PR addresses https://github.com/terraform-providers/terraform-provider-vcd/issues/219
It allows to enable [hardware assisted CPU virtualization](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-2A98801C-68E8-47AF-99ED-00C63E4857F6.html) which is mainly used for hypervisor nesting (ESXi on ESXi) scenarios. It is a very much needed feature for establishing environment LAB.

While doing this PR I've done some tidying:
~~* `vm.postEmptyAction(string)` abstracts away code duplication from `vm.PowerOn()`, `vm.PowerOff()` and `vm.ToggleHWAssistedVirtualization(bool)` methods.~~ Started using request helpers
* Added tests for new functionality and additionally covers `vm.PowerOn()`, `vm.PowerOff()`
* Added vCD version check and optionally disabled sending `GuestVLANAllowed` if vCD is 8.20 because vCD 8.20 does not support this field.