### PR TITLE
Introduce race condition tests for VM and vApp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ test: fmtcheck
 testrace:
 	@go list $(TEST) | xargs -n1 go test -race $(TESTARGS)
 
+# This will include tests guarded by build tag concurrent with race detector
+testconcurrent:
+	cd govcd && go test -race -tags "concurrent" -check.vv -check.f "Test.*Concurrent" .
+
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,6 +41,13 @@ cd govcd
 go test -check.f Test_SetOvf -check.vv .
 ```
 
+To run tests with `concurency` build tag (omitted by default) and Go race detector:
+
+```bash
+make testconcurrent
+```
+__Note__. At the moment they are failing because go-vcloud-director is not thread safe.
+
 ## How to write a test
 
 go-vcloud-director tests are written using [check.v1](https://labix.org/gocheck), an auxiliary library for tests that provides several methods to help developers write comprehensive tests.

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -1,0 +1,35 @@
+// +build concurrent
+
+package govcd
+
+import (
+	"sync"
+
+	. "gopkg.in/check.v1"
+)
+
+// Test_VAPPRefreshConcurrent is meant to prove and show that structures across
+// go-vcloud-director are not thread-safe. Go tests must be run with -race flag
+// to capture race condition. It is also guarded by `concurrent` build tag and
+// is not run by default.
+//
+// Run with go test -race -tags "concurrent" -check.vv -check.f Test_VAPPRefreshConcurrent .
+func (vcd *TestVCD) Test_VAPPRefreshConcurrent(check *C) {
+	var waitgroup sync.WaitGroup
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+	vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
+	check.Assert(err, IsNil)
+
+	for counter := 0; counter < 5; counter++ {
+		waitgroup.Add(1)
+		go func() {
+			_ = vapp.Refresh()
+			waitgroup.Done()
+			// check.Assert(err, IsNil)
+		}()
+	}
+	waitgroup.Wait()
+}

--- a/govcd/vm_concurrent_test.go
+++ b/govcd/vm_concurrent_test.go
@@ -1,0 +1,43 @@
+// +build concurrent
+
+package govcd
+
+import (
+	"sync"
+
+	. "gopkg.in/check.v1"
+)
+
+// Test_VMRefreshConcurrent is meant to prove and show that structures across
+// go-vcloud-director are not thread-safe. Go tests must be run with -race flag
+// to capture race condition. It is also guarded by `concurrent` build tag and
+// is not run by default.
+//
+// Run with go test -race -tags "concurrent" -check.vv -check.f Test_VMRefreshConcurrent .
+func (vcd *TestVCD) Test_VMRefreshConcurrent(check *C) {
+	var waitgroup sync.WaitGroup
+
+	// Find VApp
+	if vcd.vapp.VApp == nil {
+		check.Skip("skipping test because no vApp is found")
+	}
+
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+	vm := NewVM(&vcd.client.Client)
+	vm.VM = &vmType
+
+	for counter := 0; counter < 5; counter++ {
+		waitgroup.Add(1)
+		go func() {
+			_ = vm.Refresh()
+			waitgroup.Done()
+			// check.Assert(err, IsNil)
+		}()
+	}
+	waitgroup.Wait()
+
+}


### PR DESCRIPTION
Adding concurrent tests to prove #180.

They are guarded by `concurrent` build tag and will not be executed by default, but should be useful in future once we start to improve on structures.

To run them with Go race detector one can do:
```bash
cd govcd && go test -race -tags "concurrent" -check.vv -check.f Test_VMRefreshConcurrent .
cd govcd && go test -race -tags "concurrent" -check.vv -check.f Test_VAPPRefreshConcurrent .
```

Similar output is expected:
```
START: vapp_concurrent_test.go:17: TestVCD.Test_VAPPRefreshConcurrent
==================
WARNING: DATA RACE
Write at 0x00c0000c2d00 by goroutine 37:
  github.com/vmware/go-vcloud-director/v2/govcd.(*VApp).Refresh()
      /Users/dserplis/Documents/vmware/go-vcloud-director/govcd/vapp.go:96 +0x54f
  github.com/vmware/go-vcloud-director/v2/govcd.(*TestVCD).Test_VAPPRefreshConcurrent.func1()
      /Users/dserplis/Documents/vmware/go-vcloud-director/govcd/vapp_concurrent_test.go:29 +0x38

Previous write at 0x00c0000c2d00 by goroutine 34:
  [failed to restore the stack]

Goroutine 37 (running) created at:
  github.com/vmware/go-vcloud-director/v2/govcd.(*TestVCD).Test_VAPPRefreshConcurrent()
      /Users/dserplis/Documents/vmware/go-vcloud-director/govcd/vapp_concurrent_test.go:28 +0x248
  runtime.call32()
      /usr/local/Cellar/go/1.12.4/libexec/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/Cellar/go/1.12.4/libexec/src/reflect/value.go:308 +0xc0
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /Users/dserplis/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127/check.go:781 +0x978
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /Users/dserplis/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127/check.go:675 +0xb7

Goroutine 34 (running) created at:
  github.com/vmware/go-vcloud-director/v2/govcd.(*TestVCD).Test_VAPPRefreshConcurrent()
      /Users/dserplis/Documents/vmware/go-vcloud-director/govcd/vapp_concurrent_test.go:28 +0x248
  runtime.call32()
      /usr/local/Cellar/go/1.12.4/libexec/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/Cellar/go/1.12.4/libexec/src/reflect/value.go:308 +0xc0
  gopkg.in/check%2ev1.(*suiteRunner).forkTest.func1()
      /Users/dserplis/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127/check.go:781 +0x978
  gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1()
      /Users/dserplis/go/pkg/mod/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127/check.go:675 +0xb7
==================
```
