### PR TITLE
Code refactored by removing hard coded values

### DIFF
--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -109,7 +109,7 @@ func (adminCatalog *AdminCatalog) Update() error {
 		Description: adminCatalog.AdminCatalog.Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Catalog:     *reqCatalog,
 		IsPublished: adminCatalog.AdminCatalog.IsPublished,
 	}
@@ -507,7 +507,7 @@ func findFilePath(filesAbsPaths []string, fileName string) string {
 func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName string, itemDescription string) (*url.URL, error) {
 	util.Logger.Printf("[TRACE] createItemForUpload: %s, item name: %v, description: %v \n", createHREF, catalogItemName, itemDescription)
 	reqBody := bytes.NewBufferString(
-		"<UploadVAppTemplateParams xmlns=\"http://www.vmware.com/vcloud/v1.5\" name=\"" + catalogItemName + "\" >" +
+		"<UploadVAppTemplateParams xmlns=\"" + types.XMLNamespaceVCloud + "\" name=\"" + catalogItemName + "\" >" +
 			"<Description>" + itemDescription + "</Description>" +
 			"</UploadVAppTemplateParams>")
 

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -86,7 +86,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 	}
 
 	// Prepare the request payload
-	diskCreateParams.Xmlns = types.NsVCloud
+	diskCreateParams.Xmlns = types.XMLNamespaceVCloud
 
 	disk := NewDisk(vdc.client)
 
@@ -163,7 +163,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 
 	// Prepare the request payload
 	xmlPayload := &types.Disk{
-		Xmlns:          types.NsVCloud,
+		Xmlns:          types.XMLNamespaceVCloud,
 		Description:    newDiskInfo.Description,
 		Size:           newDiskInfo.Size,
 		Name:           newDiskInfo.Name,

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -78,7 +78,7 @@ func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 	}
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:              "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:              types.XMLNamespaceVCloud,
 		GatewayDhcpService: newDchpService,
 	}
 
@@ -164,7 +164,7 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 	newEdgeConfig.NatService = newNatService
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:      "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:      types.XMLNamespaceVCloud,
 		NatService: newNatService,
 	}
 
@@ -303,7 +303,7 @@ func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 	newEdgeConfig.NatService = newNatService
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns:      "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:      types.XMLNamespaceVCloud,
 		NatService: newNatService,
 	}
 
@@ -322,7 +322,7 @@ func (eGW *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types
 	}
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		FirewallService: &types.FirewallService{
 			IsEnabled:        true,
 			DefaultAction:    defaultAction,
@@ -617,7 +617,7 @@ func (eGW *EdgeGateway) RemoveIpsecVPN() (Task, error) {
 		fmt.Printf("error: %v\n", err)
 	}
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
 			IsEnabled: false,
 		},

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -132,7 +132,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	tunnels := make([]*types.GatewayIpsecVpnTunnel, 1)
 	tunnels[0] = tunnel
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
 			IsEnabled: true,
 			Tunnel:    tunnels,

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -132,7 +132,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 	}
 
 	reqBody := bytes.NewBufferString(
-		"<Media xmlns=\"http://www.vmware.com/vcloud/v1.5\" name=\"" + mediaName + "\" imageType=\"" + "iso" + "\" size=\"" + strconv.FormatInt(fileSize, 10) + "\" >" +
+		"<Media xmlns=\"" + types.XMLNamespaceVCloud + "\" name=\"" + mediaName + "\" imageType=\"" + "iso" + "\" size=\"" + strconv.FormatInt(fileSize, 10) + "\" >" +
 			"<Description>" + mediaDescription + "</Description>" +
 			"</Media>")
 

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -166,7 +166,7 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 		Description: Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:   types.XMLNamespaceVCloud,
 		Catalog: *reqCatalog,
 	}
 
@@ -375,7 +375,7 @@ func (adminOrg *AdminOrg) Disable() error {
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
 func (adminOrg *AdminOrg) Update() (Task, error) {
 	vcomp := &types.AdminOrg{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        adminOrg.AdminOrg.Name,
 		IsEnabled:   adminOrg.AdminOrg.IsEnabled,
 		FullName:    adminOrg.AdminOrg.FullName,

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -242,7 +242,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	for i, allocationModel := range allocationModels {
 		vdcConfiguration := &types.VdcConfiguration{
 			Name:            fmt.Sprintf("%s%d", TestCreateOrgVdc, i),
-			Xmlns:           "http://www.vmware.com/vcloud/v1.5",
+			Xmlns:           types.XMLNamespaceVCloud,
 			AllocationModel: allocationModel,
 			ComputeCapacity: []*types.ComputeCapacity{
 				&types.ComputeCapacity{

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -54,11 +54,11 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkEGW(check *C) {
 	}
 
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		Name:  networkName,
 		// Description: "Created by govcd tests",
 		Configuration: &types.NetworkConfiguration{
-			FenceMode: "natRouted",
+			FenceMode: types.FenceModeNAT,
 			IPScopes: &types.IPScopes{
 				IPScope: types.IPScope{
 					IsInherited: false,
@@ -107,11 +107,11 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
 	}
 
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		Name:  networkName,
 		// Description: "Created by govcd tests",
 		Configuration: &types.NetworkConfiguration{
-			FenceMode: "isolated",
+			FenceMode: types.FenceModeIsolated,
 			/*One of:
 				bridged (connected directly to the ParentNetwork),
 			  isolated (not connected to any other network),
@@ -173,10 +173,10 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	}
 	// Note that there is no IPScope for this type of network
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 		Name:  networkName,
 		Configuration: &types.NetworkConfiguration{
-			FenceMode: "bridged",
+			FenceMode: types.FenceModeBridged,
 			ParentNetwork: &types.Reference{
 				HREF: externalNetwork.HREF,
 				Name: externalNetwork.Name,

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -25,7 +25,7 @@ import (
 // Overall elements must be in the correct order.
 func CreateOrg(vcdClient *VCDClient, name string, fullName string, description string, settings *types.OrgSettings, isEnabled bool) (Task, error) {
 	vcomp := &types.AdminOrg{
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        name,
 		IsEnabled:   isEnabled,
 		FullName:    fullName,

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -110,9 +110,9 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 	}
 
 	vcomp := &types.ReComposeVAppParams{
-		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Ovf:         types.XMLNamespaceOVF,
+		Xsi:         types.XMLNamespaceXSI,
+		Xmlns:       types.XMLNamespaceVCloud,
 		Deploy:      false,
 		Name:        vapp.VApp.Name,
 		PowerOn:     false,
@@ -140,7 +140,7 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				Network:                 orgVdcNetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
@@ -157,7 +157,7 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 				Network:                 vappNetworkName,
 				NetworkConnectionIndex:  len(orgVdcNetworks),
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,
@@ -192,9 +192,9 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 	}
 
 	vcomp := &types.ReComposeVAppParams{
-		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Ovf:   types.XMLNamespaceOVF,
+		Xsi:   types.XMLNamespaceXSI,
+		Xmlns: types.XMLNamespaceVCloud,
 		DeleteItem: &types.DeleteItem{
 			HREF: vm.VM.HREF,
 		},
@@ -286,7 +286,7 @@ func (vapp *VApp) Shutdown() (Task, error) {
 func (vapp *VApp) Undeploy() (Task, error) {
 
 	vu := &types.UndeployVAppParams{
-		Xmlns:               "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:               types.XMLNamespaceVCloud,
 		UndeployPowerAction: "powerOff",
 	}
 
@@ -301,7 +301,7 @@ func (vapp *VApp) Undeploy() (Task, error) {
 func (vapp *VApp) Deploy() (Task, error) {
 
 	vu := &types.DeployVAppParams{
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:   types.XMLNamespaceVCloud,
 		PowerOn: false,
 	}
 
@@ -336,9 +336,9 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 	}
 
 	vu := &types.GuestCustomizationSection{
-		Ovf:   "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Ovf:   types.XMLNamespaceOVF,
+		Xsi:   types.XMLNamespaceXSI,
+		Xmlns: types.XMLNamespaceVCloud,
 
 		HREF:                vapp.VApp.Children.VM[0].HREF,
 		Type:                types.MimeGuestCustomizationSection,
@@ -431,10 +431,10 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 	}
 
 	newcpu := &types.OVFItem{
-		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
-		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
-		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
-		XmlnsVmw:        "http://www.vmware.com/schema/ovf",
+		XmlnsRasd:       types.XMLNamespaceRASD,
+		XmlnsVCloud:     types.XMLNamespaceVCloud,
+		XmlnsXsi:        types.XMLNamespaceXSI,
+		XmlnsVmw:        types.XMLNamespaceVMW,
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/cpu",
 		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "hertz * 10^6",
@@ -442,7 +442,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 		ElementName:     strconv.Itoa(virtualCpuCount) + " virtual CPU(s)",
 		InstanceID:      4,
 		Reservation:     0,
-		ResourceType:    3,
+		ResourceType:    types.ResourceTypeProcessor,
 		VirtualQuantity: virtualCpuCount,
 		Weight:          0,
 		CoresPerSocket:  coresPerSocket,
@@ -483,7 +483,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	newProfile := &types.VM{
 		Name:           vapp.VApp.Children.VM[0].Name,
 		StorageProfile: &storageProfileRef,
-		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:          types.XMLNamespaceVCloud,
 	}
 
 	// Return the task
@@ -504,7 +504,7 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 
 	newName := &types.VM{
 		Name:  name,
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
+		Xmlns: types.XMLNamespaceVCloud,
 	}
 
 	// Return the task
@@ -554,8 +554,8 @@ func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
 // TODO: Support all MetadataTypedValue types with this function
 func addMetadata(client *Client, key string, value string, requestUri string) (Task, error) {
 	newMetadata := &types.MetadataValue{
-		Xmlns: "http://www.vmware.com/vcloud/v1.5",
-		Xsi:   "http://www.w3.org/2001/XMLSchema-instance",
+		Xmlns: types.XMLNamespaceVCloud,
+		Xsi:   types.XMLNamespaceXSI,
 		TypedValue: &types.TypedValue{
 			XsiType: "MetadataStringValue",
 			Value:   value,
@@ -594,8 +594,8 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	}
 
 	ovf := &types.ProductSectionList{
-		Xmlns:          "http://www.vmware.com/vcloud/v1.5",
-		Ovf:            "http://schemas.dmtf.org/ovf/envelope/1",
+		Xmlns:          types.XMLNamespaceVCloud,
+		Ovf:            types.XMLNamespaceOVF,
 		ProductSection: vapp.VApp.Children.VM[0].ProductSection,
 	}
 
@@ -621,26 +621,26 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 
 	for index, network := range networks {
 		// Determine what type of address is requested for the vApp
-		ipAllocationMode := "NONE"
+		ipAllocationMode := types.IPAllocationModeNone
 		ipAddress := "Any"
 
 		// TODO: Review current behaviour of using DHCP when left blank
 		if ip == "" || ip == "dhcp" || network["ip"] == "dhcp" {
-			ipAllocationMode = "DHCP"
+			ipAllocationMode = types.IPAllocationModeDHCP
 		} else if ip == "allocated" || network["ip"] == "allocated" {
-			ipAllocationMode = "POOL"
+			ipAllocationMode = types.IPAllocationModePool
 		} else if ip == "none" || network["ip"] == "none" {
-			ipAllocationMode = "NONE"
+			ipAllocationMode = types.IPAllocationModeNone
 		} else if ip != "" || network["ip"] != "" {
-			ipAllocationMode = "MANUAL"
+			ipAllocationMode = types.IPAllocationModeManual
 			// TODO: Check a valid IP has been given
 			ipAddress = ip
 		}
 
 		util.Logger.Printf("[DEBUG] Function ChangeNetworkConfig() for %s invoked", network["orgnetwork"])
 
-		networksection.Xmlns = "http://www.vmware.com/vcloud/v1.5"
-		networksection.Ovf = "http://schemas.dmtf.org/ovf/envelope/1"
+		networksection.Xmlns = types.XMLNamespaceVCloud
+		networksection.Ovf = types.XMLNamespaceOVF
 		networksection.Info = "Specifies the available VM network connections"
 
 		networksection.NetworkConnection[index].NeedsCustomization = true
@@ -676,9 +676,9 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 	}
 
 	newMem := &types.OVFItem{
-		XmlnsRasd:       "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
-		XmlnsVCloud:     "http://www.vmware.com/vcloud/v1.5",
-		XmlnsXsi:        "http://www.w3.org/2001/XMLSchema-instance",
+		XmlnsRasd:       types.XMLNamespaceRASD,
+		XmlnsVCloud:     types.XMLNamespaceVCloud,
+		XmlnsXsi:        types.XMLNamespaceXSI,
 		VCloudHREF:      vapp.VApp.Children.VM[0].HREF + "/virtualHardwareSection/memory",
 		VCloudType:      types.MimeRasdItem,
 		AllocationUnits: "byte * 2^20",
@@ -686,7 +686,7 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 		ElementName:     strconv.Itoa(size) + " MB of memory",
 		InstanceID:      5,
 		Reservation:     0,
-		ResourceType:    4,
+		ResourceType:    types.ResourceTypeMemory,
 		VirtualQuantity: size,
 		Weight:          0,
 		Link: &types.Link{
@@ -736,7 +736,7 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 					ParentNetwork: &types.Reference{
 						HREF: network.HREF,
 					},
-					FenceMode: "bridged",
+					FenceMode: types.FenceModeBridged,
 				},
 			},
 		)
@@ -773,7 +773,7 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 		types.VAppNetworkConfiguration{
 			NetworkName: newIsolatedNetworkSettings.Name,
 			Configuration: &types.NetworkConfiguration{
-				FenceMode:        "isolated",
+				FenceMode:        types.FenceModeIsolated,
 				GuestVlanAllowed: newIsolatedNetworkSettings.GuestVLANAllowed,
 				Features:         networkFeatures,
 				IPScopes: &types.IPScopes{IPScope: types.IPScope{IsInherited: false, Gateway: newIsolatedNetworkSettings.Gateway,
@@ -846,9 +846,9 @@ func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppNetworkConfiguration) (Task, error) {
 	networkConfig := &types.NetworkConfigSection{
 		Info:          "Configuration parameters for logical networks",
-		Ovf:           "http://schemas.dmtf.org/ovf/envelope/1",
+		Ovf:           types.XMLNamespaceOVF,
 		Type:          types.MimeNetworkConfigSection,
-		Xmlns:         "http://www.vmware.com/vcloud/v1.5",
+		Xmlns:         types.XMLNamespaceVCloud,
 		NetworkConfig: networkConfigurations,
 	}
 

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -239,7 +239,7 @@ func (vcd *TestVCD) Test_ChangeCPUCountWithCore(check *C) {
 	// save current values
 	if nil != vcd.vapp.VApp.Children.VM[0] && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
 		for _, item := range vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
-			if item.ResourceType == 3 {
+			if item.ResourceType == types.ResourceTypeProcessor {
 				currentCpus = item.VirtualQuantity
 				currentCores = item.CoresPerSocket
 				break
@@ -259,7 +259,7 @@ func (vcd *TestVCD) Test_ChangeCPUCountWithCore(check *C) {
 	foundItem := false
 	if nil != vcd.vapp.VApp.Children.VM[0] && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
 		for _, item := range vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
-			if item.ResourceType == 3 {
+			if item.ResourceType == types.ResourceTypeProcessor {
 				check.Assert(item.CoresPerSocket, Equals, cores)
 				check.Assert(item.VirtualQuantity, Equals, cpuCount)
 				foundItem = true

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -277,9 +277,9 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
 func (vdc *Vdc) ComposeRawVApp(name string) error {
 	vcomp := &types.ComposeVAppParams{
-		Ovf:     "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:     "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:   "http://www.vmware.com/vcloud/v1.5",
+		Ovf:     types.XMLNamespaceOVF,
+		Xsi:     types.XMLNamespaceXSI,
+		Xmlns:   types.XMLNamespaceVCloud,
 		Deploy:  false,
 		Name:    name,
 		PowerOn: false,
@@ -312,9 +312,9 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 	}
 	// Build request XML
 	vcomp := &types.ComposeVAppParams{
-		Ovf:         "http://schemas.dmtf.org/ovf/envelope/1",
-		Xsi:         "http://www.w3.org/2001/XMLSchema-instance",
-		Xmlns:       "http://www.vmware.com/vcloud/v1.5",
+		Ovf:         types.XMLNamespaceOVF,
+		Xsi:         types.XMLNamespaceXSI,
+		Xmlns:       types.XMLNamespaceVCloud,
 		Deploy:      false,
 		Name:        name,
 		PowerOn:     false,
@@ -345,7 +345,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 			types.VAppNetworkConfiguration{
 				NetworkName: orgvdcnetwork.Name,
 				Configuration: &types.NetworkConfiguration{
-					FenceMode: "bridged",
+					FenceMode: types.FenceModeBridged,
 					ParentNetwork: &types.Reference{
 						HREF: orgvdcnetwork.HREF,
 						Name: orgvdcnetwork.Name,
@@ -359,7 +359,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 				Network:                 orgvdcnetwork.Name,
 				NetworkConnectionIndex:  index,
 				IsConnected:             true,
-				IPAddressAllocationMode: "POOL",
+				IPAddressAllocationMode: types.IPAllocationModePool,
 			},
 		)
 		vcomp.SourcedItem.NetworkAssignment = append(vcomp.SourcedItem.NetworkAssignment,

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -734,7 +734,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	// save current values
 	if nil != vcd.vapp.VApp.Children.VM[0] && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection && nil != vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
 		for _, item := range vcd.vapp.VApp.Children.VM[0].VirtualHardwareSection.Item {
-			if item.ResourceType == 3 {
+			if item.ResourceType == types.ResourceTypeProcessor {
 				currentCpus = item.VirtualQuantity
 				currentCores = item.CoresPerSocket
 				break
@@ -760,7 +760,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	foundItem := false
 	if nil != vm.VM.VirtualHardwareSection.Item {
 		for _, item := range vm.VM.VirtualHardwareSection.Item {
-			if item.ResourceType == 3 {
+			if item.ResourceType == types.ResourceTypeProcessor {
 				check.Assert(item.CoresPerSocket, Equals, cores)
 				check.Assert(item.VirtualQuantity, Equals, cpuCount)
 				foundItem = true

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -22,15 +22,6 @@ const (
 )
 
 const (
-	// NsOvf the ovf xml namespace url
-	NsOvf = "http://schemas.dmtf.org/ovf/envelope/1"
-	// NsXMLSchema the xml schema namespace url
-	NsXMLSchema = "http://www.w3.org/2001/XMLSchema-instance"
-	// NsVCloud vcloud xml namespace url
-	NsVCloud = "http://www.vmware.com/vcloud/v1.5"
-)
-
-const (
 	// MimeOrgList mime for org list
 	MimeOrgList = "application/vnd.vmware.vcloud.orgList+xml"
 	// MimeOrg mime for org
@@ -103,4 +94,42 @@ const (
 
 const (
 	VMsCDResourceSubType = "vmware.cdrom.iso"
+)
+
+// https://blogs.vmware.com/vapp/2009/11/virtual-hardware-in-ovf-part-1.html
+
+const (
+	ResourceTypeOther     int = 0
+	ResourceTypeProcessor int = 3
+	ResourceTypeMemory    int = 4
+	ResourceTypeIDE       int = 5
+	ResourceTypeSCSI      int = 6
+	ResourceTypeEthernet  int = 10
+	ResourceTypeFloppy    int = 14
+	ResourceTypeCD        int = 15
+	ResourceTypeDVD       int = 16
+	ResourceTypeDisk      int = 17
+	ResourceTypeUSB       int = 23
+)
+
+const (
+	FenceModeIsolated = "isolated"
+	FenceModeBridged  = "bridged"
+	FenceModeNAT      = "natRouted"
+)
+
+const (
+	IPAllocationModeDHCP   = "DHCP"
+	IPAllocationModeManual = "MANUAL"
+	IPAllocationModeNone   = "NONE"
+	IPAllocationModePool   = "POOL"
+)
+
+const (
+	XMLNamespaceVCloud = "http://www.vmware.com/vcloud/v1.5"
+	XMLNamespaceOVF    = "http://schemas.dmtf.org/ovf/envelope/1"
+	XMLNamespaceVMW    = "http://www.vmware.com/schema/ovf"
+	XMLNamespaceXSI    = "http://www.w3.org/2001/XMLSchema-instance"
+	XMLNamespaceRASD   = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+	XMLNamespaceVSSD   = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData"
 )


### PR DESCRIPTION
Idea is taken from Ref: terraform-providers/terraform-provider-vcd#74 

This PR adds a few constants and uses them to avoid hardcoded string values. New constants for resource types, fence mode, ip allocation mode, namespaces

NOTE: Run these changes on your env and please verify everything works