### PR TITLE
Add changes to correct NAT api function behaviour

### DIFF
--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -181,7 +181,7 @@ func (eGW *EdgeGateway) AddNATRule(network *types.OrgVDCNetwork, natType, extern
 	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, "any", internalIP, "any", "any", "")
 }
 
-// Deprecated: Use eGW.AddNetworkNATMapping()
+// Deprecated: Use eGW.AddNATRule()
 func (eGW *EdgeGateway) AddNATMapping(natType, externalIP, internalIP string) (Task, error) {
 	return eGW.AddNATPortMapping(natType, externalIP, "any", internalIP, "any", "any", "")
 }

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -177,14 +177,25 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 
 }
 
+func (eGW *EdgeGateway) AddNetworkNATMapping(network *types.OrgVDCNetwork, natType, externalIP, internalIP string) (Task, error) {
+	return eGW.AddNetworkNATPortMapping(network, natType, externalIP, "any", internalIP, "any", "any", "")
+}
+
+func (eGW *EdgeGateway) AddNetworkNATPortMapping(network *types.OrgVDCNetwork, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
+	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType)
+}
+
+// Deprecated: Use eGW.AddNetworkNATMapping()
 func (eGW *EdgeGateway) AddNATMapping(natType, externalIP, internalIP string) (Task, error) {
 	return eGW.AddNATPortMapping(natType, externalIP, "any", internalIP, "any", "any", "")
 }
 
+// Deprecated: Use eGW.AddNetworkNATPortMapping()
 func (eGW *EdgeGateway) AddNATPortMapping(natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
 	return eGW.AddNATPortMappingWithUplink(nil, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType)
 }
 
+// Deprecated: creates not good behaviour of functionality
 func (eGW *EdgeGateway) getFirstUplink() types.Reference {
 	var uplink types.Reference
 	for _, gi := range eGW.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
@@ -241,6 +252,7 @@ func (eGW *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 	if network != nil {
 		uplinkRef = network.HREF
 	} else {
+		// TODO: remove when method used this removed
 		uplinkRef = eGW.getFirstUplink().HREF
 	}
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -186,7 +186,7 @@ func (eGW *EdgeGateway) AddNATMapping(natType, externalIP, internalIP string) (T
 	return eGW.AddNATPortMapping(natType, externalIP, "any", internalIP, "any", "any", "")
 }
 
-// Deprecated: Use eGW.AddNetworkNATPortMapping()
+// Deprecated: Use eGW.AddNATPortMappingWithUplink()
 func (eGW *EdgeGateway) AddNATPortMapping(natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
 	return eGW.AddNATPortMappingWithUplink(nil, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType)
 }

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -177,7 +177,7 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 
 }
 
-func (eGW *EdgeGateway) AddNetworkNATMapping(network *types.OrgVDCNetwork, natType, externalIP, internalIP string) (Task, error) {
+func (eGW *EdgeGateway) AddNATRule(network *types.OrgVDCNetwork, natType, externalIP, internalIP string) (Task, error) {
 	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, "any", internalIP, "any", "any", "")
 }
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -178,11 +178,7 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort s
 }
 
 func (eGW *EdgeGateway) AddNetworkNATMapping(network *types.OrgVDCNetwork, natType, externalIP, internalIP string) (Task, error) {
-	return eGW.AddNetworkNATPortMapping(network, natType, externalIP, "any", internalIP, "any", "any", "")
-}
-
-func (eGW *EdgeGateway) AddNetworkNATPortMapping(network *types.OrgVDCNetwork, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
-	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType)
+	return eGW.AddNATPortMappingWithUplink(network, natType, externalIP, "any", internalIP, "any", "any", "")
 }
 
 // Deprecated: Use eGW.AddNetworkNATMapping()

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -35,7 +35,11 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	task, err := edge.AddNATMapping("DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
+	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
+	check.Assert(err, IsNil)
+	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
+
+	task, err := edge.AddNetworkNATMapping(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
@@ -56,7 +60,12 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	task, err := edge.AddNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
+
+	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
+	check.Assert(err, IsNil)
+	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
+
+	task, err := edge.AddNetworkNATPortMapping(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -65,7 +65,7 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
 
-	task, err := edge.AddNetworkNATPortMapping(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
+	task, err := edge.AddNATPortMappingWithUplink(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -43,6 +43,22 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+	found := false
+	var rule *types.NatRule
+	for _, r := range edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
+		if r.RuleType == "DNAT" && r.GatewayNatRule.Interface.Name == orgVdcNetwork.OrgVDCNetwork.Name {
+			found = true
+			rule = r
+		}
+	}
+
+	check.Assert(found, Equals, true)
+	check.Assert(rule.GatewayNatRule.TranslatedIP, Equals, vcd.config.VCD.InternalIp)
+	check.Assert(rule.GatewayNatRule.OriginalIP, Equals, vcd.config.VCD.ExternalIp)
+
 	task, err = edge.RemoveNATMapping("DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
@@ -69,6 +85,26 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+	found := false
+	var rule *types.NatRule
+	for _, r := range edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
+		if r.RuleType == "DNAT" && r.GatewayNatRule.Interface.Name == orgVdcNetwork.OrgVDCNetwork.Name {
+			found = true
+			rule = r
+		}
+	}
+
+	check.Assert(found, Equals, true)
+	check.Assert(rule.GatewayNatRule.TranslatedIP, Equals, vcd.config.VCD.InternalIp)
+	check.Assert(rule.GatewayNatRule.TranslatedPort, Equals, "77")
+	check.Assert(rule.GatewayNatRule.OriginalIP, Equals, vcd.config.VCD.ExternalIp)
+	check.Assert(rule.GatewayNatRule.OriginalPort, Equals, "1177")
+	check.Assert(rule.GatewayNatRule.Protocol, Equals, "tcp")
+	check.Assert(rule.GatewayNatRule.IcmpSubType, Equals, "")
+
 	task, err = edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -39,7 +39,7 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network)
 
-	task, err := edge.AddNetworkNATMapping(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
+	task, err := edge.AddNATRule(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/pull/224

This small changes fixes issue with NAT api functions. New functions requires network which will be used to apply rule. Currently implementation would take first network form edge gtw.

* deprecate old functions
* add property to new functions to require network
* update unit tests

