### PR TITLE
Add tags to all test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 * Refactored code by introducing helper function to handle API calls. New functions ExecuteRequest, ExecuteTaskRequest, ExecuteRequestWithoutResponse
+* Tests files are now all tagged. Running them through Makefile works as before, but manual execution requires specific tags. Run `go test -v .` for tags list.
 
 ## 2.1.0 (March 21, 2019)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ default: fmtcheck vet build
 # test runs the test suite and vets the code
 test: fmtcheck
 	@echo "==> Running Tests"
-	cd govcd && go test -tags "functional" -timeout=45m -check.vv .
+	cd govcd && go test -tags "functional" -timeout=60m -check.vv .
 
 # testrace runs the race checker
 testrace:
@@ -24,9 +24,14 @@ testcatalog:
 testvapp:
 	cd govcd && go test -tags "vapp vm" -timeout 25m -check.vv .
 
-# tests only networking and edge gateway features
+# tests only edge gateway features
+testgateway:
+	cd govcd && go test -tags "gateway" -timeout 15m -check.vv .
+
+# tests only networking features
 testnetwork:
 	cd govcd && go test -tags "network" -timeout 15m -check.vv .
+
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ default: fmtcheck vet build
 # test runs the test suite and vets the code
 test: fmtcheck
 	@echo "==> Running Tests"
-	cd govcd && go test -timeout=45m -check.vv .
+	cd govcd && go test -tags "gocheck" -timeout=45m -check.vv .
 
 # testrace runs the race checker
 testrace:
@@ -14,7 +14,19 @@ testrace:
 
 # This will include tests guarded by build tag concurrent with race detector
 testconcurrent:
-	cd govcd && go test -race -tags "concurrent" -check.vv -check.f "Test.*Concurrent" .
+	cd govcd && go test -race -tags "api concurrent" -timeout 15m -check.vv -check.f "Test.*Concurrent" .
+
+# tests only catalog related features
+testcatalog:
+	cd govcd && go test -tags "catalog" -timeout 15m -check.vv .
+
+# tests only vapp and vm features
+testvapp:
+	cd govcd && go test -tags "vapp vm" -timeout 25m -check.vv .
+
+# tests only networking and edge gateway features
+testnetwork:
+	cd govcd && go test -tags "network" -timeout 15m -check.vv .
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
@@ -40,5 +52,5 @@ copyright:
 
 build:
 	@echo "==> Building govcd library"
-	cd govcd && go build . && go test -c .
+	cd govcd && go build . && go test -tags ALL -c .
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ default: fmtcheck vet build
 # test runs the test suite and vets the code
 test: fmtcheck
 	@echo "==> Running Tests"
-	cd govcd && go test -tags "gocheck" -timeout=45m -check.vv .
+	cd govcd && go test -tags "functional" -timeout=45m -check.vv .
 
 # testrace runs the race checker
 testrace:

--- a/TESTING.md
+++ b/TESTING.md
@@ -153,13 +153,13 @@ Tests that integrate in the functional suite use the tag `functional`. Using tha
 at once.
 We define as `functional` the tests that need a live vCD to run.
 
-Note that as of today (April 2019) we only have functional tests, but we plan to add more, which can be, for example,
+Note that as of today we only have functional tests, but we plan to add more, which can be, for example,
 `unit` tests (will test internal assumptions without using a vCD), or tests that take much time (such as performance,
 endurance, or memory leakage) or require repeated tests over a long period. For this reason, the set of tests that we
 want to run always is the functional suite. For everything else we need to decide whether it's safe or desirable to run
 them together or separately.
 
-The build tag line should also contain the tag `ALL` which will run all the tests, non only the functional suite.
+The build tag line should also contain the tag `ALL` which will run all the tests, not only the functional suite.
 This includes tests that use a different framework. At the moment, this is useful to run a global compilation test.
 Depending on which additional tests we will implement, we may change the dependency on the `ALL` tag if we detect
 clashes between frameworks.

--- a/TESTING.md
+++ b/TESTING.md
@@ -149,11 +149,28 @@ All tests need to have a build tag. The tag should be the first line of the file
 package govcd
 ```
 
-Tests that integrate in the existing suite use the tag `functional`. Using that tag, we can run all functional tests at once.
-The build tag line should also contain the tag `ALL` which will run all the tests, non only the functional suite. This includes tests that may use a different framework.
-Finally, each test file needs a tag for the feature we are testing, such as `catalog`, `vapp`, `network`, and so on. This allows us to run tests for a single feature without having to use complex regular expressions to match all wanted function names. A feature tag can be shared among several files (for example, catalog and catalog item tests both run under the `catalog` tag).
+Tests that integrate in the functional suite use the tag `functional`. Using that tag, we can run all functional tests
+at once.
+We define as `functional` the tests that need a live vCD to run.
 
-If the test file defines a new function tag (i.e. one that has not been used before) the file should also implement an `init` function that sets the tag in the global tag list.
+Note that as of today (April 2019) we only have functional tests, but we plan to add more, which can be, for example,
+`unit` tests (will test internal assumptions without using a vCD), or tests that take much time (such as performance,
+endurance, or memory leakage) or require repeated tests over a long period. For this reason, the set of tests that we
+want to run always is the functional suite. For everything else we need to decide whether it's safe or desirable to run
+them together or separately.
+
+The build tag line should also contain the tag `ALL` which will run all the tests, non only the functional suite.
+This includes tests that use a different framework. At the moment, this is useful to run a global compilation test.
+Depending on which additional tests we will implement, we may change the dependency on the `ALL` tag if we detect
+clashes between frameworks.
+
+Finally, each test file needs a tag for the feature we are testing, such as `catalog`, `vapp`, `network`, and so on.
+This allows us to run tests for a single feature without having to use complex regular expressions to match all wanted
+function names. A feature tag can be shared among several files (for example, catalog and catalog item tests both run
+under the `catalog` tag).
+
+If the test file defines a new feature tag (i.e. one that has not been used before) the file should also implement an
+`init` function that sets the tag in the global tag list.
 This information is used by the main tag test in `api_test.go` to determine which tags were activated.
 
 ```go

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,7 @@ To run tests with go use these commands:
 
 ```bash
 cd govcd
-go test -tags "gocheck" -check.v .
+go test -tags "functional" -check.v .
 ```
 
 If you want to see more details during the test run, use `-check.vv` instead of `-check.v`.
@@ -65,25 +65,25 @@ $ go test -v .
 
         At least one of the following tags should be defined:
 
-           * ALL :      Runs all the tests
-           * gocheck:   Runs all the tests that use check.v1
-           * gotest:    Runs unit tests that do not need a live vCD
+           * ALL :       Runs all the tests
+           * functional: Runs all the tests that use check.v1
+           * unit:       Runs unit tests that do not need a live vCD
 
-           * catalog:   Runs catalog related tests (also catalog_item, media)
-           * disk:      Runs disk related tests
-           * extension: Runs extension related tests
-           * network:   Runs network and edge gateway related tests
-           * org:       Runs org related tests
-           * query:     Runs query related tests
-           * system:    Runs system related tests
-           * task:      Runs task related tests
-           * vapp:      Runs vapp related tests
-           * vdc:       Runs vdc related tests
-           * vm:        Runs vm related tests
+           * catalog:    Runs catalog related tests (also catalog_item, media)
+           * disk:       Runs disk related tests
+           * extension:  Runs extension related tests
+           * network:    Runs network and edge gateway related tests
+           * org:        Runs org related tests
+           * query:      Runs query related tests
+           * system:     Runs system related tests
+           * task:       Runs task related tests
+           * vapp:       Runs vapp related tests
+           * vdc:        Runs vdc related tests
+           * vm:         Runs vm related tests
 
         Examples:
 
-        go test -tags gocheck -check.vv -timeout=45m .
+        go test -tags functional -check.vv -timeout=45m .
         go test -tags catalog -check.vv -timeout=45m .
         go test -tags "query extension" -check.vv -timeout=45m .
 FAIL
@@ -138,6 +138,29 @@ This entity is initialized when the test starts. You can assume that the variabl
 
 The `check` variable is our interface with the `check.v1` package. We can do several things with it, such as skipping a test, probing a condition, declare success or failure, and more.
 
+
+### Adding build tags.
+
+All tests need to have a build tag. The tag should be the first line of the file, followed by a blank line
+
+```go
+// +build functional featurename ALL
+
+package govcd
+```
+
+Tests that integrate in the existing suite use the tag `functional`. Using that tag, we can run all functional tests at once.
+The build tag line should also contain the tag `ALL` which will run all the tests, non only the functional suite. This includes tests that may use a different framework.
+Finally, each test file needs a tag for the feature we are testing, such as `catalog`, `vapp`, `network`, and so on. This allows us to run tests for a single feature without having to use complex regular expressions to match all wanted function names. A feature tag can be shared among several files (for example, catalog and catalog item tests both run under the `catalog` tag).
+
+If the test file defines a new function tag (i.e. one that has not been used before) the file should also implement an `init` function that sets the tag in the global tag list.
+This information is used by the main tag test in `api_test.go` to determine which tags were activated.
+
+```go
+func init() {
+	testingTags["newtag"] = "filename_test.go"
+}
+```
 
 ### Basic test function organization.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,7 +65,8 @@ $ go test -v .
 
         At least one of the following tags should be defined:
 
-           * ALL :       Runs all the tests
+           * ALL :       Runs all the tests (== functional + unit == all feature tests)
+
            * functional: Runs all the tests that use check.v1
            * unit:       Runs unit tests that do not need a live vCD
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -154,21 +154,23 @@ Tests that integrate in the functional suite use the tag `functional`. Using tha
 at once.
 We define as `functional` the tests that need a live vCD to run.
 
-Note that as of today we only have functional tests, but we plan to add more, which can be, for example,
-`unit` tests (will test internal assumptions without using a vCD), or tests that take much time (such as performance,
-endurance, or memory leakage) or require repeated tests over a long period. For this reason, the set of tests that we
-want to run always is the functional suite. For everything else we need to decide whether it's safe or desirable to run
-them together or separately.
+1. The test should always define the `ALL` tag:
 
-The build tag line should also contain the tag `ALL` which will run all the tests, not only the functional suite.
-This includes tests that use a different framework. At the moment, this is useful to run a global compilation test.
+* ALL :       Runs all the tests
+
+2. The test should also always define either the `unit` or `functional` tag:
+
+* functional: Runs all the tests that use check.v1
+* unit:       Runs unit tests that do not need a live vCD
+
+3. Finally, the test should always define the feature tag. For example:
+
+* catalog:    Runs catalog related tests (also `catalog_item`, `media`)
+* disk:       Runs disk related tests
+
+The `ALL` tag includes tests that use a different framework. At the moment, this is useful to run a global compilation test.
 Depending on which additional tests we will implement, we may change the dependency on the `ALL` tag if we detect
 clashes between frameworks.
-
-Finally, each test file needs a tag for the feature we are testing, such as `catalog`, `vapp`, `network`, and so on.
-This allows us to run tests for a single feature without having to use complex regular expressions to match all wanted
-function names. A feature tag can be shared among several files (for example, catalog and catalog item tests both run
-under the `catalog` tag).
 
 If the test file defines a new feature tag (i.e. one that has not been used before) the file should also implement an
 `init` function that sets the tag in the global tag list.
@@ -181,7 +183,7 @@ func init() {
 ```
 
 **VERY IMPORTANT**: if we add a test that runs using a different tag (i.e. it is not included in `functional` tests), we need
-to add such test to the Makefile under `make test`. The general principle is that `make test` runs all tests. If this can't be
+to add such test to the Makefile under `make test`. **The general principle is that `make test` runs all tests**. If this can't be
 achieved by adding the new test to the `functional` tag (perhaps because we foresee framework conflicts), we need to add the
 new test as a separate command.
 For example:

--- a/TESTING.md
+++ b/TESTING.md
@@ -179,6 +179,29 @@ func init() {
 }
 ```
 
+**VERY IMPORTANT**: if we add a test that runs using a different tag (i.e. it is not included in `functional` tests), we need
+to add such test to the Makefile under `make test`. The general principle is that `make test` runs all tests. If this can't be
+achieved by adding the new test to the `functional` tag (perhaps because we foresee framework conflicts), we need to add the
+new test as a separate command.
+For example:
+
+```
+test: fmtcheck
+	@echo "==> Running Tests"
+	cd govcd && \
+    go test -tags "MyNewTag" -timeout=10m -check.vv . && \ 
+	go test -tags "functional" -timeout=60m -check.vv .
+``` 
+
+or we can encapsulate a complex test into a self containing script.
+
+```
+test: fmtcheck
+	@echo "==> Running Tests"
+	./scripts/my_complicated_test.sh
+	cd govcd && go test -tags "functional" -timeout=60m -check.vv .
+``` 
+
 ### Basic test function organization.
 
 Within the testing function, you should perform four actions:

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,7 @@ To run tests with go use these commands:
 
 ```bash
 cd govcd
-go test -check.v .
+go test -tags "gocheck" -check.v .
 ```
 
 If you want to see more details during the test run, use `-check.vv` instead of `-check.v`.
@@ -39,6 +39,55 @@ To run a specific test:
 ```bash
 cd govcd
 go test -check.f Test_SetOvf -check.vv .
+```
+
+The tests can run with several tags that define which components are tested.
+Using the Makefile, you can run one of the following:
+
+```bash
+make testcatalog
+make testnetwork
+make testvapp
+```
+
+For more options, you can run manually in `./govcd`
+When running `go test` without tags, we'll get a list of tags that are available.
+
+```bash
+$ go test -v .
+=== RUN   TestTags
+--- FAIL: TestTags (0.00s)
+    api_test.go:59: # No tags were defined
+    api_test.go:46:
+        # -----------------------------------------------------
+        # Tags are required to run the tests
+        # -----------------------------------------------------
+
+        At least one of the following tags should be defined:
+
+           * ALL :      Runs all the tests
+           * gocheck:   Runs all the tests that use check.v1
+           * gotest:    Runs unit tests that do not need a live vCD
+
+           * catalog:   Runs catalog related tests (also catalog_item, media)
+           * disk:      Runs disk related tests
+           * extension: Runs extension related tests
+           * network:   Runs network and edge gateway related tests
+           * org:       Runs org related tests
+           * query:     Runs query related tests
+           * system:    Runs system related tests
+           * task:      Runs task related tests
+           * vapp:      Runs vapp related tests
+           * vdc:       Runs vdc related tests
+           * vm:        Runs vm related tests
+
+        Examples:
+
+        go test -tags gocheck -check.vv -timeout=45m .
+        go test -tags catalog -check.vv -timeout=45m .
+        go test -tags "query extension" -check.vv -timeout=45m .
+FAIL
+FAIL	github.com/vmware/go-vcloud-director/v2/govcd	0.011s
 ```
 
 To run tests with `concurency` build tag (omitted by default) and Go race detector:

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -23,7 +23,8 @@ func tagsHelp(t *testing.T) {
 
 At least one of the following tags should be defined:
 
-   * ALL :       Runs all the tests
+   * ALL :       Runs all the tests (== functional + unit == all feature tests)
+
    * functional: Runs all the tests that use check.v1
    * unit:       Runs unit tests that do not use check.v1
                  and don't need a live vCD (currently unused, but we plan to)

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -23,26 +23,26 @@ func tagsHelp(t *testing.T) {
 
 At least one of the following tags should be defined:
 
-   * ALL :      Runs all the tests
-   * gocheck:   Runs all the tests that use check.v1
-   * gotest:    Runs unit tests that do not use check.v1
-                and don't need a live vCD (currently unused, but we plan to)
+   * ALL :       Runs all the tests
+   * functional: Runs all the tests that use check.v1
+   * unit:       Runs unit tests that do not use check.v1
+                 and don't need a live vCD (currently unused, but we plan to)
 
-   * catalog:   Runs catalog related tests (also catalog_item, media)
-   * disk:      Runs disk related tests
-   * extension: Runs extension related tests
-   * network:   Runs network and edge gateway related tests
-   * org:       Runs org related tests
-   * query:     Runs query related tests
-   * system:    Runs system related tests
-   * task:      Runs task related tests
-   * vapp:      Runs vapp related tests
-   * vdc:       Runs vdc related tests
-   * vm:        Runs vm related tests
+   * catalog:    Runs catalog related tests (also catalog_item, media)
+   * disk:       Runs disk related tests
+   * extension:  Runs extension related tests
+   * network:    Runs network and edge gateway related tests
+   * org:        Runs org related tests
+   * query:      Runs query related tests
+   * system:     Runs system related tests
+   * task:       Runs task related tests
+   * vapp:       Runs vapp related tests
+   * vdc:        Runs vdc related tests
+   * vm:         Runs vm related tests
 
 Examples:
 
-go test -tags gocheck -check.vv -timeout=45m .
+go test -tags functional -check.vv -timeout=45m .
 go test -tags catalog -check.vv -timeout=15m .
 go test -tags "query extension" -check.vv -timeout=5m .
 `

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -2,6 +2,81 @@
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
+// IMPORTANT: DO NOT ADD build tags to this file
+
 package govcd
 
-import ()
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var testingTags = make(map[string]string)
+
+func tagsHelp(t *testing.T) {
+
+	var helpText string = `
+# -----------------------------------------------------
+# Tags are required to run the tests
+# -----------------------------------------------------
+
+At least one of the following tags should be defined:
+
+   * ALL :      Runs all the tests
+   * gocheck:   Runs all the tests that use check.v1
+   * gotest:    Runs unit tests that do not use check.v1
+                and don't need a live vCD (currently unused, but we plan to)
+
+   * catalog:   Runs catalog related tests (also catalog_item, media)
+   * disk:      Runs disk related tests
+   * extension: Runs extension related tests
+   * network:   Runs network and edge gateway related tests
+   * org:       Runs org related tests
+   * query:     Runs query related tests
+   * system:    Runs system related tests
+   * task:      Runs task related tests
+   * vapp:      Runs vapp related tests
+   * vdc:       Runs vdc related tests
+   * vm:        Runs vm related tests
+
+Examples:
+
+go test -tags gocheck -check.vv -timeout=45m .
+go test -tags catalog -check.vv -timeout=15m .
+go test -tags "query extension" -check.vv -timeout=5m .
+`
+	t.Logf(helpText)
+}
+
+// Tells indirectly if a tag has been set
+// For every tag there is an `init` function that
+// fills an item in `testingTags`
+func isTagSet(tagName string) bool {
+	_, ok := testingTags[tagName]
+	return ok
+}
+
+// For troubleshooting:
+// Shows which tags were set, and in which file.
+func showTags() {
+	if len(testingTags) > 0 {
+		fmt.Println("# Defined tags:")
+	}
+	for k, v := range testingTags {
+		fmt.Printf("# %s (%s)", k, v)
+	}
+}
+
+// Checks whether any tags were defined, and raises an error if not
+func TestTags(t *testing.T) {
+	if len(testingTags) == 0 {
+		t.Logf("# No tags were defined")
+		tagsHelp(t)
+		t.Fail()
+		return
+	}
+	if os.Getenv("SHOW_TAGS") != "" {
+		showTags()
+	}
+}

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -31,7 +31,8 @@ At least one of the following tags should be defined:
    * catalog:    Runs catalog related tests (also catalog_item, media)
    * disk:       Runs disk related tests
    * extension:  Runs extension related tests
-   * network:    Runs network and edge gateway related tests
+   * network:    Runs network related tests
+   * gateway:    Runs edge gateway related tests
    * org:        Runs org related tests
    * query:      Runs query related tests
    * system:     Runs system related tests

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,4 +1,4 @@
-// +build api functional catalog vapp network org query extension task vm vdc system disk ALL
+// +build api functional catalog vapp gateway network org query extension task vm vdc system disk ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
@@ -297,9 +297,13 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		config.VCD.Catalog.Name != "" && config.VCD.Catalog.CatalogItem != "" {
 		vcd.vapp, err = vcd.createTestVapp(TestSetUpSuite)
 		// If no vApp is created, we skip all vApp tests
-		if vcd.vapp == (VApp{}) || err != nil {
-			fmt.Printf("%v", err)
-			vcd.skipVappTests = true
+		if err != nil {
+			fmt.Printf("%v\n", err)
+			panic("Creation failed - Bailing out")
+		}
+		if vcd.vapp == (VApp{}) {
+			fmt.Printf("Creation of vApp %s failed unexpectedly. No error was reported, but vApp is empty\n", TestSetUpSuite)
+			panic("initial vApp is empty - bailing out")
 		}
 	} else {
 		vcd.skipVappTests = true
@@ -683,7 +687,7 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 
 	err = vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error waitinf for created test vApp to have working state: %s", err)
+		return VApp{}, fmt.Errorf("error waiting for created test vApp to have working state: %s", err)
 	}
 
 	return vapp, err

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,4 +1,4 @@
-// +build api gocheck catalog vapp network org query extension task vm vdc system disk ALL
+// +build api functional catalog vapp network org query extension task vm vdc system disk ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -1,4 +1,4 @@
-// +build api gocheck ALL
+// +build api functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -1,3 +1,5 @@
+// +build api gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1,3 +1,5 @@
+// +build catalog gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -406,4 +408,8 @@ func (vcd *TestVCD) Test_CatalogDeleteMediaImage(check *C) {
 		}
 	}
 	check.Assert(entityFound, Equals, false)
+}
+
+func init() {
+	testingTags["catalog"] = "catalog_test.go"
 }

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1,4 +1,4 @@
-// +build catalog gocheck ALL
+// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -1,3 +1,5 @@
+// +build catalog gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -1,4 +1,4 @@
-// +build catalog gocheck ALL
+// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -1,3 +1,5 @@
+// +build disk gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -1,4 +1,4 @@
-// +build disk gocheck ALL
+// +build disk functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,3 +1,5 @@
+// +build network gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,4 +1,4 @@
-// +build network gocheck ALL
+// +build network functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,4 +1,4 @@
-// +build network functional ALL
+// +build gateway functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -1,4 +1,4 @@
-// +build extension gocheck ALL
+// +build extension functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/extension_test.go
+++ b/govcd/extension_test.go
@@ -1,3 +1,5 @@
+// +build extension gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -27,4 +29,8 @@ func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 	expectedType := "application/vnd.vmware.admin.extension.network+xml"
 	check.Assert(externalNetwork.Name, Equals, networkName)
 	check.Assert(externalNetwork.Type, Equals, expectedType)
+}
+
+func init() {
+	testingTags["extension"] = "extension_test.go"
 }

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -1,3 +1,5 @@
+// +build catalog gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -1,4 +1,4 @@
-// +build catalog gocheck ALL
+// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1,4 +1,4 @@
-// +build org gocheck ALL
+// +build org functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1,3 +1,5 @@
+// +build org gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -1,3 +1,5 @@
+// +build network gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -1,4 +1,4 @@
-// +build network gocheck ALL
+// +build network functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -1,3 +1,5 @@
+// +build query gocheck ALL
+
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -1,4 +1,4 @@
-// +build query gocheck ALL
+// +build query functional ALL
 
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,4 +1,4 @@
-// +build system gocheck ALL
+// +build system functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,3 +1,5 @@
+// +build system gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -104,3 +106,7 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 var INVALID_NAME = `*******************************************INVALID
 					****************************************************
 					************************`
+
+func init() {
+	testingTags["system"] = "system_test.go"
+}

--- a/govcd/task_test.go
+++ b/govcd/task_test.go
@@ -1,3 +1,5 @@
+// +build task gocheck ALL
+
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -23,3 +25,7 @@ func (vcd *TestVCD) Test_WaitTaskCompletion(check *C) {
 
 }
 */
+
+func init() {
+	testingTags["task"] = "task_test.go"
+}

--- a/govcd/task_test.go
+++ b/govcd/task_test.go
@@ -1,4 +1,4 @@
-// +build task gocheck ALL
+// +build task functional ALL
 
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,3 +1,5 @@
+// +build vapp gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -24,60 +26,6 @@ func (vcd *TestVCD) TestGetParentVDC(check *C) {
 
 	check.Assert(err, IsNil)
 	check.Assert(vdc.Vdc.Name, Equals, vcd.vdc.Vdc.Name)
-}
-
-func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
-	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error finding network : %v", err)
-	}
-	networks = append(networks, net.OrgVDCNetwork)
-	// Populate Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	if err != nil || cat == (Catalog{}) {
-		return VApp{}, fmt.Errorf("error finding catalog : %v", err)
-	}
-	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error finding catalog item : %v", err)
-	}
-	// Get VAppTemplate
-	vapptemplate, err := catitem.GetVAppTemplate()
-	if err != nil {
-		return VApp{}, fmt.Errorf("error finding vapptemplate : %v", err)
-	}
-	// Get StorageProfileReference
-	storageprofileref, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error finding storage profile: %v", err)
-	}
-	// Compose VApp
-	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, name, "description", true)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
-	}
-	// After a successful creation, the entity is added to the cleanup list.
-	// If something fails after this point, the entity will be removed
-	AddToCleanupList(name, "vapp", "", "createTestVapp")
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
-	}
-	// Get VApp
-	vapp, err := vcd.vdc.FindVAppByName(name)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error getting vapp: %v", err)
-	}
-
-	err = vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
-	if err != nil {
-		return VApp{}, fmt.Errorf("error waitinf for created test vApp to have working state: %s", err)
-	}
-
-	return vapp, err
 }
 
 // Tests Powering On and Powering Off a VApp. Also tests Deletion
@@ -518,4 +466,8 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 		}
 	}
 	check.Assert(isExist, Equals, false)
+}
+
+func init() {
+	testingTags["vapp"] = "vapp_test.go"
 }

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,4 +1,4 @@
-// +build vapp gocheck ALL
+// +build vapp functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -1,4 +1,4 @@
-// +build vapp gocheck ALL
+// +build vapp functional ALL
 
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -1,3 +1,5 @@
+// +build vapp gocheck ALL
+
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,3 +1,5 @@
+// +build vdc gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
@@ -222,4 +224,8 @@ func (vcd *TestVCD) Test_QueryVM(check *C) {
 	check.Assert(err, IsNil)
 
 	check.Assert(vm.VM.Name, Equals, vmName)
+}
+
+func init() {
+	testingTags["vdc"] = "vdc_test.go"
 }

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,4 +1,4 @@
-// +build vdc gocheck ALL
+// +build vdc functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1,3 +1,5 @@
+// +build vm gocheck ALL
+
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
@@ -861,4 +863,8 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	check.Assert(err, IsNil)
 	vmStatus, err = vm.GetStatus()
 	check.Assert(vmStatus, Equals, "POWERED_OFF")
+}
+
+func init() {
+	testingTags["vm"] = "vm_test.go"
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1,4 +1,4 @@
-// +build vm gocheck ALL
+// +build vm functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.


### PR DESCRIPTION
Test files are now all built conditionally using tags.
Running the tests without tags will trigger an error message
with a list of available tags (`cd govcd && go test -v .`).
The tags allow users to run only a subset of the tests, or all of them.
The `Makefile` uses the tags to run the same tests as before (tag `gocheck`),
and a few tags to run tests related to several features (`make
testcatalog`, `make testvapp`, make `testnetwork`).

The split by tags allows also running several sets of tests, one based
on go-check (our current default) and one based on regular Go tests
(which may not require a live vCD).
