### PR TITLE
Add autorization header for transfer files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ BREAKING CHANGES:
 
 IMPROVEMENTS:
 * Refactored code by introducing helper function to handle API calls. New functions ExecuteRequest, ExecuteTaskRequest, ExecuteRequestWithoutResponse
+* Add authorization request header for media file and catalog item upload
 
 ## 2.1.0 (March 21, 2019)
 


### PR DESCRIPTION
Fix for https://github.com/terraform-providers/terraform-provider-vcd/issues/227

Due to custom implementation, transfer files functionality wasn't assigning  authorization request header. vCD doesn't require that and works, but for users who are behind proxy/firewalls which filter out request without authorization request header upload isn't working. This fix reuse are common request building function, logging and request handling.