### PR TITLE
Fix unhandled errors and improve style

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -72,8 +72,7 @@ func (cli *Client) NewRequestWitNotEncodedParams(params map[string]string, notEn
 		payload := ""
 		if req.ContentLength > 0 {
 			// We try to convert body to a *bytes.Buffer
-			var ibody interface{}
-			ibody = body
+			var ibody interface{} = body
 			bbody, ok := ibody.(*bytes.Buffer)
 			// If the inner object is a bytes.Buffer, we get a safe copy of the data.
 			// If it is really just an io.Reader, we don't, as the copy would empty the reader

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -60,7 +60,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 		missing_items = append(missing_items, "org")
 	}
 	if len(missing_items) > 0 {
-		return fmt.Errorf("Authorization is not possible because of these missing items: %v", missing_items)
+		return fmt.Errorf("authorization is not possible because of these missing items: %v", missing_items)
 	}
 	// No point in checking for errors here
 	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodPost, vcdCli.sessionHREF, nil)

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -418,7 +418,7 @@ func queryVappTemplate(client *Client, vappTemplateUrl *url.URL, newItemName str
 	for _, task := range vappTemplateParsed.Tasks.Task {
 		if "error" == task.Status && newItemName == task.Owner.Name {
 			util.Logger.Printf("[Error] %#v", task.Error)
-			return vappTemplateParsed, fmt.Errorf("Error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
+			return vappTemplateParsed, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 		}
 	}
 

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -48,6 +48,7 @@ func (vcd *TestVCD) Test_UpdateCatalog(check *C) {
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
 	catalog, err := org.FindAdminCatalog(TestUpdateCatalog)
+	check.Assert(err, IsNil)
 	if catalog != (AdminCatalog{}) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
@@ -75,6 +76,7 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
 	adminCatalog, err := org.FindAdminCatalog(TestDeleteCatalog)
+	check.Assert(err, IsNil)
 	if adminCatalog != (AdminCatalog{}) {
 		err = adminCatalog.Delete(true, true)
 		check.Assert(err, IsNil)
@@ -130,6 +132,7 @@ func (vcd *TestVCD) Test_UploadOvf_progress_works(check *C) {
 	AddToCleanupList(itemName, "catalogItem", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_UploadOvf")
 
 	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -164,6 +167,7 @@ func (vcd *TestVCD) Test_UploadOvf_ShowUploadProgress_works(check *C) {
 	check.Assert(string(result), Matches, ".*Upload progress 100.00%")
 
 	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -237,6 +241,7 @@ func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName s
 	AddToCleanupList(itemName, "catalogItem", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_UploadOvf")
 
 	catalog, err = org.FindCatalog(catalogName)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -288,6 +293,7 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage(check *C) {
 
 	//verifyMediaImageUploaded(vcd.vdc.client, check, TestUploadMedia)
 	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, TestCatalogUploadMedia)
 }
 
@@ -313,6 +319,7 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_progress_works(check *C) {
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadCatalogMediaImage")
 
 	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -345,6 +352,7 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_ShowUploadProgress_works(check 
 
 	check.Assert(string(result), Matches, ".*Upload progress 100.00%")
 	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -49,6 +49,7 @@ func (vcd *TestVCD) Test_Delete(check *C) {
 	check.Assert(err, IsNil)
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
 
 	// add catalogItem
 	uploadTask, err := catalog.UploadOvf(vcd.config.OVA.OVAPath, TestDeleteCatalogItem, "upload from delete catalog item test", 1024)

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -115,6 +115,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	}
 
 	updateTask, err := disk.Update(newDiskInfo)
+	check.Assert(err, IsNil)
 	err = updateTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
@@ -233,6 +234,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	}
 
 	updateTask, err := disk.Update(newDiskInfo)
+	check.Assert(err, IsNil)
 	err = updateTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -196,6 +196,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 
 	// Configures VPN service
 	task, err := edge.AddIpsecVPN(ipsecVPNConfig)
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
@@ -214,6 +215,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 
 	// Removes VPN service
 	task, err = edge.RemoveIpsecVPN()
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -156,7 +156,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 		for _, task := range mediaForUpload.Tasks.Task {
 			if "error" == task.Status && mediaName == mediaForUpload.Name {
 				util.Logger.Printf("[Error] issue with creating media %#v", task.Error)
-				return nil, fmt.Errorf("Error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
+				return nil, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 			}
 		}
 	}
@@ -212,7 +212,7 @@ func queryMedia(client *Client, mediaUrl string, newItemName string) (*types.Med
 	for _, task := range mediaParsed.Tasks.Task {
 		if "error" == task.Status && newItemName == task.Owner.Name {
 			util.Logger.Printf("[Error] %#v", task.Error)
-			return mediaParsed, fmt.Errorf("Error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
+			return mediaParsed, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 		}
 	}
 

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -396,11 +396,11 @@ func (adminOrg *AdminOrg) undeployAllVApps() error {
 		}
 		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
 		if err != nil {
-			return fmt.Errorf("Error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
+			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
 		}
 		err = vdc.undeployAllVdcVApps()
 		if err != nil {
-			return fmt.Errorf("Error deleting vapp: %s", err)
+			return fmt.Errorf("error deleting vapp: %s", err)
 		}
 	}
 	return nil
@@ -415,11 +415,11 @@ func (adminOrg *AdminOrg) removeAllVApps() error {
 		}
 		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
 		if err != nil {
-			return fmt.Errorf("Error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
+			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
 		}
 		err = vdc.removeAllVdcVApps()
 		if err != nil {
-			return fmt.Errorf("Error deleting vapp: %s", err)
+			return fmt.Errorf("error deleting vapp: %s", err)
 		}
 	}
 	return nil
@@ -471,7 +471,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 		}
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("Couldn't finish removing vdc %#v", err)
+			return fmt.Errorf("couldn't finish removing vdc %#v", err)
 		}
 
 	}

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -21,9 +21,9 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	adminOrg, err := GetAdminOrgByName(vcd.client, TestRefreshOrg)
+	adminOrg, _ := GetAdminOrgByName(vcd.client, TestRefreshOrg)
 	if adminOrg != (AdminOrg{}) {
-		err = adminOrg.Delete(true, true)
+		err := adminOrg.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
 	task, err := CreateOrg(vcd.client, TestRefreshOrg, TestRefreshOrg, TestRefreshOrg, &types.OrgSettings{
@@ -70,9 +70,9 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	org, err := GetAdminOrgByName(vcd.client, TestDeleteOrg)
+	org, _ := GetAdminOrgByName(vcd.client, TestDeleteOrg)
 	if org != (AdminOrg{}) {
-		err = org.Delete(true, true)
+		err := org.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
 	task, err := CreateOrg(vcd.client, TestDeleteOrg, TestDeleteOrg, TestDeleteOrg, &types.OrgSettings{}, true)
@@ -101,9 +101,9 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	org, err := GetAdminOrgByName(vcd.client, TestUpdateOrg)
+	org, _ := GetAdminOrgByName(vcd.client, TestUpdateOrg)
 	if org != (AdminOrg{}) {
-		err = org.Delete(true, true)
+		err := org.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
 	task, err := CreateOrg(vcd.client, TestUpdateOrg, TestUpdateOrg, TestUpdateOrg, &types.OrgSettings{
@@ -374,9 +374,9 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 	org, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
-	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
-	catalog, err := org.FindAdminCatalog(TestCreateCatalog)
+	check.Assert(org, Not(Equals), AdminOrg{})
+	catalog, _ := org.FindAdminCatalog(TestCreateCatalog)
 	if catalog != (AdminCatalog{}) {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -25,6 +25,8 @@ type OrgVDCNetwork struct {
 	client        *Client
 }
 
+var reErrorBusy2 = regexp.MustCompile("is busy, cannot proceed with the operation.$")
+
 // NewOrgVDCNetwork creates an org vdc network client
 func NewOrgVDCNetwork(cli *Client) *OrgVDCNetwork {
 	return &OrgVDCNetwork{
@@ -66,7 +68,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 		req := orgVdcNet.client.NewRequest(map[string]string{}, http.MethodDelete, *apiEndpoint, nil)
 		resp, err = checkResp(orgVdcNet.client.Http.Do(req))
 		if err != nil {
-			if match, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); match {
+			if reErrorBusy2.MatchString(err.Error()) {
 				time.Sleep(3 * time.Second)
 				continue
 			}
@@ -148,7 +150,7 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 				req.Header.Add("Content-Type", av.Type)
 				resp, err = checkResp(vdc.client.Http.Do(req))
 				if err != nil {
-					if match, _ := regexp.MatchString("is busy, cannot proceed with the operation.$", err.Error()); match {
+					if reErrorBusy2.MatchString(err.Error()) {
 						time.Sleep(3 * time.Second)
 						continue
 					}

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -56,9 +56,9 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	org, err := GetAdminOrgByName(vcd.client, TestCreateOrg)
+	org, _ := GetAdminOrgByName(vcd.client, TestCreateOrg)
 	if org != (AdminOrg{}) {
-		err = org.Delete(true, true)
+		err := org.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
 	settings := &types.OrgSettings{

--- a/govcd/upload.go
+++ b/govcd/upload.go
@@ -148,7 +148,7 @@ func uploadPartFile(client *Client, part []byte, partDataSize int64, uDetails up
 
 	response, err := checkResp(client.Http.Do(request))
 	if err != nil {
-		return fmt.Errorf("File upload failed. Err: %s \n", err)
+		return fmt.Errorf("file upload failed. Err: %s", err)
 	}
 	response.Body.Close()
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -70,7 +70,7 @@ func (vapp *VApp) getParentVDC() (Vdc, error) {
 			return *vdc, nil
 		}
 	}
-	return Vdc{}, fmt.Errorf("Could not find a parent Vdc")
+	return Vdc{}, fmt.Errorf("could not find a parent Vdc")
 }
 
 func (vapp *VApp) Refresh() error {
@@ -211,7 +211,7 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 			task.Task = taskItem
 			err := task.WaitTaskCompletion()
 			if err != nil {
-				return fmt.Errorf("Error performing task: %#v", err)
+				return fmt.Errorf("error performing task: %#v", err)
 			}
 		}
 	}
@@ -643,6 +643,9 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 	}
 
 	networksection, err := vapp.GetNetworkConnectionSection()
+	if err != nil {
+		return Task{}, err
+	}
 
 	for index, network := range networks {
 		// Determine what type of address is requested for the vApp

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -100,8 +100,7 @@ func (vcd *TestVCD) Test_SetOvf(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	var test map[string]string
-	test = make(map[string]string)
+	var test = make(map[string]string)
 	test["guestinfo.hostname"] = "testhostname"
 	task, err := vcd.vapp.SetOvf(test)
 
@@ -177,6 +176,7 @@ func (vcd *TestVCD) Test_ChangeCPUcount(check *C) {
 	task, err := vcd.vapp.ChangeCPUCount(1)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
@@ -205,6 +205,7 @@ func (vcd *TestVCD) Test_ChangeCPUCountWithCore(check *C) {
 	task, err := vcd.vapp.ChangeCPUCountWithCore(cpuCount, &cores)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	err = vcd.vapp.Refresh()
@@ -226,6 +227,7 @@ func (vcd *TestVCD) Test_ChangeCPUCountWithCore(check *C) {
 	task, err = vcd.vapp.ChangeCPUCountWithCore(currentCpus, &currentCores)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
@@ -238,6 +240,7 @@ func (vcd *TestVCD) Test_ChangeMemorySize(check *C) {
 
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
@@ -269,6 +272,7 @@ func (vcd *TestVCD) Test_ChangeVMName(check *C) {
 	task, err := vcd.vapp.ChangeVMName("My-vm")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
@@ -565,6 +569,7 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 		task, err := vapp.AddRAWNetworkConfig(orgvdcnetworks)
 		check.Assert(err, IsNil)
 		err = task.WaitTaskCompletion()
+		check.Assert(err, IsNil)
 		check.Assert(task.Task.Status, Equals, "success")
 
 		desiredNetConfig.NetworkConnection = append(desiredNetConfig.NetworkConnection,
@@ -621,5 +626,4 @@ func verifyNetworkConnectionSection(check *C, actual, desired *types.NetworkConn
 			check.Assert(actualNic.IPAddress, Not(Equals), "")
 		}
 	}
-	return
 }

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -67,13 +67,19 @@ func (vdc *Vdc) undeployAllVdcVApps() error {
 				}
 				vapp, err := vdc.getVdcVAppbyHREF(vappHREF)
 				if err != nil {
-					return fmt.Errorf("Error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
+					return fmt.Errorf("error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
 				}
 				task, err := vapp.Undeploy()
+				if err != nil {
+					return err
+				}
 				if task == (Task{}) {
 					continue
 				}
 				err = task.WaitTaskCompletion()
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -214,7 +220,6 @@ func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error
 				return types.Reference{HREF: sp.HREF, Name: sp.Name}, nil
 			}
 		}
-		return types.Reference{}, fmt.Errorf("can't find VDC Storage_profile: %s", name)
 	}
 	return types.Reference{}, fmt.Errorf("can't find any VDC Storage_profiles")
 }
@@ -293,6 +298,9 @@ func (vdc *Vdc) ComposeRawVApp(name string) error {
 
 	task, err := vdc.client.ExecuteTaskRequest(vdcHref.String(), http.MethodPost,
 		types.MimeComposeVappParams, "error instantiating a new vApp:: %s", vcomp)
+	if err != nil {
+		return fmt.Errorf("error executing task request: %#v", err)
+	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -163,6 +163,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	check.Check(vapp_status, Equals, "POWERED_OFF")
 	// Deleting VApp
 	task, err = vapp.Delete()
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	if err != nil {
 		panic(err)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -640,14 +640,12 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 
 // check resource subtype for specific value which means media is injected
 func isMediaInjected(items []*types.VirtualHardwareItem) bool {
-	isFound := false
 	for _, hardwareItem := range items {
 		if hardwareItem.ResourceSubType == types.VMsCDResourceSubType {
-			isFound = true
-			break
+			return true
 		}
 	}
-	return isFound
+	return false
 }
 
 // Test Insert or Eject Media for VM
@@ -752,6 +750,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	check.Assert(0, Not(Equals), currentCores)
 
 	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
+	check.Assert(err, IsNil)
 
 	cores := 2
 	cpuCount := 4
@@ -759,6 +758,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	task, err := vm.ChangeCPUCountWithCore(cpuCount, &cores)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	err = vm.Refresh()
@@ -780,6 +780,7 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	task, err = vm.ChangeCPUCountWithCore(currentCpus, &currentCores)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
@@ -794,11 +795,13 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	check.Assert(nestingStatus, Equals, false)
 
 	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
+	check.Assert(err, IsNil)
 
 	// PowerOn
 	task, err := vm.PowerOn()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Try to change the setting on powered on VM to fail
@@ -809,12 +812,14 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	task, err = vm.PowerOff()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Perform steps on powered off VM
 	task, err = vm.ToggleHardwareVirtualization(true)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	err = vm.Refresh()
@@ -824,6 +829,7 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	task, err = vm.ToggleHardwareVirtualization(false)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	err = vm.Refresh()
@@ -842,29 +848,35 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 
 	// Ensure VM is not powered on
 	vmStatus, err := vm.GetStatus()
+	check.Assert(err, IsNil)
 	if vmStatus != "POWERED_OFF" {
 		task, err := vm.PowerOff()
 		check.Assert(err, IsNil)
 		err = task.WaitTaskCompletion()
+		check.Assert(err, IsNil)
 		check.Assert(task.Task.Status, Equals, "success")
 	}
 
 	task, err := vm.PowerOn()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 	err = vm.Refresh()
 	check.Assert(err, IsNil)
 	vmStatus, err = vm.GetStatus()
+	check.Assert(err, IsNil)
 	check.Assert(vmStatus, Equals, "POWERED_ON")
 
 	// Power off again
 	task, err = vm.PowerOff()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 	err = vm.Refresh()
 	check.Assert(err, IsNil)
 	vmStatus, err = vm.GetStatus()
+	check.Assert(err, IsNil)
 	check.Assert(vmStatus, Equals, "POWERED_OFF")
 }


### PR DESCRIPTION
Fix missing error handling in many test files
Fix style issues with error handling (such as message starting with uppercase or ending with newline or punctuation).

Most of these issues were found by running staticcheck, and some by code inspection following a test failure.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>

