### PR TITLE
Fix storage profile query

### DIFF
--- a/govcd/system.go
+++ b/govcd/system.go
@@ -237,7 +237,7 @@ func getExtension(client *Client) (*types.Extension, error) {
 func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
-		"filter": fmt.Sprintf("(name==%s)", name),
+		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
 	})
 	if err != nil {
 		return nil, err

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -102,6 +102,13 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 	doesOrgExist(check, vcd)
 }
 
+func (vcd *TestVCD) Test_FindBadlyNamedStorageProfile(check *C) {
+	reNotFound := `can't find any VDC Storage_profiles`
+	_, err := vcd.vdc.FindStorageProfileReference("name with spaces")
+	check.Assert(err, NotNil)
+	check.Assert(err.Error(), Matches, reNotFound)
+}
+
 // longer than the 128 characters so nothing can be named this
 var INVALID_NAME = `*******************************************INVALID
 					****************************************************


### PR DESCRIPTION
Change fixes spacing issue in request:
```2019/05/15 12:45:29 GET https://bos1-vcd-sp-static-200-43.eng.vmware.com/api/query?&type=providerVdcStorageProfile&filter=(name==b b)```
->
```2019/05/15 12:45:29 GET https://bos1-vcd-sp-static-200-43.eng.vmware.com/api/query?&type=providerVdcStorageProfile&filter=(name==b+b)```

Without escaping name with space we getting nasty error.