### PR TITLE
Edge gateway creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.2.0 (Unreleased)
+## 2.3.0 (Unreleased)
+
+* Added edge gateway create/delete functions [#130](https://github.com/vmware/go-vcloud-director/issues/130).
+
+## 2.2.0 (May 2, 2019)
 
 FEATURES:
 
@@ -8,7 +12,6 @@ FEATURES:
 using VCDClient.APIVCDMaxVersionIs(string) and VCDClient.APIClientVersionIs(string).
 * Added ability to override currently used vCD API version WithAPIVersion(string) [#174](https://github.com/vmware/go-vcloud-director/pull/174).
 * Added ability to enable nested hypervisor option for VM with VM.ToggleNestedHypervisor(bool) [#219](https://github.com/terraform-providers/terraform-provider-vcd/issues/219).
-* Added edge gateway create/delete functions [#130](https://github.com/vmware/go-vcloud-director/issues/130).
 
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ FEATURES:
 using VCDClient.APIVCDMaxVersionIs(string) and VCDClient.APIClientVersionIs(string).
 * Added ability to override currently used vCD API version WithAPIVersion(string) [#174](https://github.com/vmware/go-vcloud-director/pull/174).
 * Added ability to enable nested hypervisor option for VM with VM.ToggleNestedHypervisor(bool) [#219](https://github.com/terraform-providers/terraform-provider-vcd/issues/219).
-* Added edge gateway create/delete functions
+* Added edge gateway create/delete functions [#130](https://github.com/vmware/go-vcloud-director/issues/130).
 
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Added edge gateway create/delete functions [#130](https://github.com/vmware/go-vcloud-director/issues/130).
 
-## 2.2.0 (May 2, 2019)
+## 2.2.0 (May 15, 2019)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 using VCDClient.APIVCDMaxVersionIs(string) and VCDClient.APIClientVersionIs(string).
 * Added ability to override currently used vCD API version WithAPIVersion(string) [#174](https://github.com/vmware/go-vcloud-director/pull/174).
 * Added ability to enable nested hypervisor option for VM with VM.ToggleNestedHypervisor(bool) [#219](https://github.com/terraform-providers/terraform-provider-vcd/issues/219).
+* Added edge gateway create/delete functions
 
 
 BREAKING CHANGES:

--- a/TESTING.md
+++ b/TESTING.md
@@ -306,6 +306,22 @@ func (vcd *TestVCD) Test_ComposeVApp(check *checks.C) {
 }
 ```
 
+# Environment variables
+
+While running tests, the following environment variables can be used:
+
+* `GOVCD_CONFIG=/path/file`: sets an alternative configuration file for the tests.
+   e.g.:  `GOVCD_CONFIG=/some/path/govcd_test_config.yaml go test -tags functional -timeout 0 .`
+* `GOVCD_DEBUG=1`: enable debug output on screen.
+* `TEST_VERBOSE=1`: shows execution details in unit tests.
+* `GOVCD_SKIP_VAPP_CREATION=1`: will not create the initial vApp. All tests that
+   depend on a vApp availability will be skipped.
+* `GOVCD_TASK_MONITOR=show|log|simple_show|simple|log`: sets a task monitor function when running `task.WaitCompletion`
+    * `show` : displays full task details on screen
+    * `log` : writes full task details in the log
+    * `simple_show` : displays a summary line for the task on screen
+    * `simple_log` : writes a summary line for the task in the log
+
 # Final Words
 Be careful about using our tests as these tests run on a real vcd. If you don't have 1 gb of ram and 2 vcpus available then you should not be running tests that deploy your vm/change memory and cpu. However everything created will be removed at the end of testing.
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -300,8 +300,17 @@ func executeRequest(pathURL, requestType, contentType string, payload interface{
 
 func isMessageWithPlaceHolder(message string) bool {
 	err := fmt.Errorf(message, "test error")
-	if strings.Contains(err.Error(), "%!(EXTRA") {
-		return false
+	return !strings.Contains(err.Error(), "%!(EXTRA")
+}
+
+// combinedTaskErrorMessage is a general purpose function
+// that returns the contents of the operation error and, if found, the error
+// returned by the associated task
+func combinedTaskErrorMessage(task *types.Task, err error) string {
+	extendedError := err.Error()
+	if task.Error != nil {
+		extendedError = fmt.Sprintf("operation error: %s - task error: [%d - %s] %s",
+			err, task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 	}
-	return true
+	return extendedError
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -465,12 +465,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			vcd.infoCleanup("removeLeftoverEntries: [INFO] edge gateway '%s' not found\n", entity.Name)
 			return
 		}
-		task, err := edge.Delete(true, true)
-		if err != nil {
-			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
-			return
-		}
-		err = task.WaitTaskCompletion()
+		err = edge.Delete(true, true)
 		if err != nil {
 			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
 			return

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -478,24 +478,6 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
 		return
 	case "network":
-		/*
-			orgName, vdcName := splitParent(entity.Parent, "|")
-			if orgName == "" || vdcName == "" {
-				vcd.infoCleanup(splitParentNotFound, entity.Parent)
-				return
-			}
-			org, err := GetAdminOrgByName(vcd.client, orgName)
-			if org == (AdminOrg{}) || err != nil {
-				vcd.infoCleanup(notFoundMsg, "org", orgName)
-				return
-			}
-			vdc, err := org.GetVdcByName(vdcName)
-			if vdc == (Vdc{}) || err != nil {
-				vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
-				return
-			}
-		*/
-
 		_, vdc, err := vcd.getAdminOrgAndVdcFromCleanupEntity(entity)
 		if err != nil {
 			vcd.infoCleanup("%s", err)
@@ -525,23 +507,6 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			vcd.infoCleanup("removeLeftoverEntries: [ERROR] No VDC and ORG provided for media '%s'\n", entity.Name)
 			return
 		}
-		/*
-			orgName, vdcName := splitParent(entity.Parent, "|")
-			if orgName == "" || vdcName == "" {
-				vcd.infoCleanup(splitParentNotFound, entity.Parent)
-				return
-			}
-			org, err := GetAdminOrgByName(vcd.client, orgName)
-			if org == (AdminOrg{}) || err != nil {
-				vcd.infoCleanup(notFoundMsg, "org", orgName)
-				return
-			}
-			vdc, err := org.GetVdcByName(vdcName)
-			if vdc == (Vdc{}) || err != nil {
-				vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
-				return
-			}
-		*/
 		_, vdc, err := vcd.getAdminOrgAndVdcFromCleanupEntity(entity)
 		if err != nil {
 			vcd.infoCleanup("%s", err)

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -338,15 +338,35 @@ func splitParent(parent string, separator string) (first, second string) {
 	return
 }
 
+var splitParentNotFound string = "removeLeftoverEntries: [ERROR] missing parent info (%s). The parent fields must be defined with a separator '|'\n"
+var notFoundMsg string = "removeLeftoverEntries: [INFO] No action for %s '%s'\n"
+
+func (vcd *TestVCD) getAdminOrgAndVdcFromCleanupEntity(entity CleanupEntity) (org AdminOrg, vdc Vdc, err error) {
+	orgName, vdcName := splitParent(entity.Parent, "|")
+	if orgName == "" || vdcName == "" {
+		vcd.infoCleanup(splitParentNotFound, entity.Parent)
+		return AdminOrg{}, Vdc{}, fmt.Errorf("can't find parents names")
+	}
+	org, err = GetAdminOrgByName(vcd.client, orgName)
+	if org == (AdminOrg{}) || err != nil {
+		vcd.infoCleanup(notFoundMsg, "org", orgName)
+		return AdminOrg{}, Vdc{}, fmt.Errorf("can't find org")
+	}
+	vdc, err = org.GetVdcByName(vdcName)
+	if vdc == (Vdc{}) || err != nil {
+		vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
+		return AdminOrg{}, Vdc{}, fmt.Errorf("can't find vdc")
+	}
+	return org, vdc, nil
+}
+
 // Removes leftover entities that may still exist after failed tests
 // or the ones that were explicitly created for several tests and
 // were relying on this procedure to clean up at the end.
 func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 	var introMsg string = "removeLeftoverEntries: [INFO] Attempting cleanup of %s '%s' instantiated by %s\n"
-	var notFoundMsg string = "removeLeftoverEntries: [INFO] No action for %s '%s'\n"
 	var removedMsg string = "removeLeftoverEntries: [INFO] Removed %s '%s' created by %s\n"
 	var notDeletedMsg string = "removeLeftoverEntries: [ERROR] Error deleting %s '%s': %s\n"
-	var splitParentNotFound string = "removeLeftopverEntries: [ERROR] missing parent info (%s). The parent fields must be defined with a separator '|'\n"
 	// NOTE: this is a cleanup function that should continue even if errors are found.
 	// For this reason, the [ERROR] messages won't be followed by a program termination
 	vcd.infoCleanup(introMsg, entity.EntityType, entity.Name, entity.CreatedBy)
@@ -436,23 +456,49 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		}
 		return
 	case "edgegateway":
-		//TODO: find an easy way of undoing edge GW customization
+		_, vdc, err := vcd.getAdminOrgAndVdcFromCleanupEntity(entity)
+		if err != nil {
+			return
+		}
+		edge, err := vdc.FindEdgeGateway(entity.Name)
+		if err != nil {
+			vcd.infoCleanup("removeLeftoverEntries: [INFO] edge gateway '%s' not found\n", entity.Name)
+			return
+		}
+		task, err := edge.Delete(true, true)
+		if err != nil {
+			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
+			return
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
+			return
+		}
+		vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
 		return
 	case "network":
-		orgName, vdcName := splitParent(entity.Parent, "|")
-		if orgName == "" || vdcName == "" {
-			vcd.infoCleanup(splitParentNotFound, entity.Parent)
-			return
-		}
-		org, err := GetAdminOrgByName(vcd.client, orgName)
-		if org == (AdminOrg{}) || err != nil {
-			vcd.infoCleanup(notFoundMsg, "org", orgName)
-			return
-		}
-		vdc, err := org.GetVdcByName(vdcName)
-		if vdc == (Vdc{}) || err != nil {
-			vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
-			return
+		/*
+			orgName, vdcName := splitParent(entity.Parent, "|")
+			if orgName == "" || vdcName == "" {
+				vcd.infoCleanup(splitParentNotFound, entity.Parent)
+				return
+			}
+			org, err := GetAdminOrgByName(vcd.client, orgName)
+			if org == (AdminOrg{}) || err != nil {
+				vcd.infoCleanup(notFoundMsg, "org", orgName)
+				return
+			}
+			vdc, err := org.GetVdcByName(vdcName)
+			if vdc == (Vdc{}) || err != nil {
+				vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
+				return
+			}
+		*/
+
+		_, vdc, err := vcd.getAdminOrgAndVdcFromCleanupEntity(entity)
+		if err != nil {
+			vcd.infoCleanup("%s", err)
 		}
 		err = RemoveOrgVdcNetworkIfExists(vdc, entity.Name)
 		if err == nil {
@@ -479,20 +525,26 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			vcd.infoCleanup("removeLeftoverEntries: [ERROR] No VDC and ORG provided for media '%s'\n", entity.Name)
 			return
 		}
-		orgName, vdcName := splitParent(entity.Parent, "|")
-		if orgName == "" || vdcName == "" {
-			vcd.infoCleanup(splitParentNotFound, entity.Parent)
-			return
-		}
-		org, err := GetAdminOrgByName(vcd.client, orgName)
-		if org == (AdminOrg{}) || err != nil {
-			vcd.infoCleanup(notFoundMsg, "org", orgName)
-			return
-		}
-		vdc, err := org.GetVdcByName(vdcName)
-		if vdc == (Vdc{}) || err != nil {
-			vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
-			return
+		/*
+			orgName, vdcName := splitParent(entity.Parent, "|")
+			if orgName == "" || vdcName == "" {
+				vcd.infoCleanup(splitParentNotFound, entity.Parent)
+				return
+			}
+			org, err := GetAdminOrgByName(vcd.client, orgName)
+			if org == (AdminOrg{}) || err != nil {
+				vcd.infoCleanup(notFoundMsg, "org", orgName)
+				return
+			}
+			vdc, err := org.GetVdcByName(vdcName)
+			if vdc == (Vdc{}) || err != nil {
+				vcd.infoCleanup(notFoundMsg, "vdc", vdcName)
+				return
+			}
+		*/
+		_, vdc, err := vcd.getAdminOrgAndVdcFromCleanupEntity(entity)
+		if err != nil {
+			vcd.infoCleanup("%s", err)
 		}
 		err = RemoveMediaImageIfExists(vdc, entity.Name)
 		if err == nil {

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -66,28 +66,27 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 func (catalog *Catalog) Delete(force, recursive bool) error {
 
 	adminCatalogHREF := catalog.client.VCDHREF
-	adminCatalogHREF.Path += "/admin/catalog/" + getEntityNumericId(catalog.Catalog.ID)
+	catalogID, err := getBareEntityId(catalog.Catalog.ID)
+	if err != nil {
+		return err
+	}
+	if catalogID == "" {
+		return fmt.Errorf("empty ID returned for catalog ID %s", catalog.Catalog.ID)
+	}
+	adminCatalogHREF.Path += "/admin/catalog/" + catalogID
 
 	req := catalog.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
 	}, http.MethodDelete, adminCatalogHREF, nil)
 
-	_, err := checkResp(catalog.client.Http.Do(req))
+	_, err = checkResp(catalog.client.Http.Do(req))
 
 	if err != nil {
 		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.ID, err)
 	}
 
 	return nil
-}
-
-// slice only numeric part from ID:"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0"
-func getEntityNumericId(catalogId string) string {
-	if catalogId != "" && (len(catalogId) > 19) {
-		return catalogId[19:]
-	}
-	return ""
 }
 
 // Deletes the Catalog, returning an error if the vCD call fails.

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -66,7 +66,7 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 func (catalog *Catalog) Delete(force, recursive bool) error {
 
 	adminCatalogHREF := catalog.client.VCDHREF
-	catalogID, err := getBareEntityId(catalog.Catalog.ID)
+	catalogID, err := getBareEntityUuid(catalog.Catalog.ID)
 	if err != nil {
 		return err
 	}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -648,7 +648,7 @@ func (egw *EdgeGateway) DeleteAsync(force bool, recursive bool) (Task, error) {
 	util.Logger.Printf("[TRACE] EdgeGateway.Delete - deleting edge gateway with force: %t, recursive: %t", force, recursive)
 
 	if egw.EdgeGateway.HREF == "" {
-		return Task{}, fmt.Errorf("cannot delete, Object is empty")
+		return Task{}, fmt.Errorf("cannot delete, HREF is missing")
 	}
 
 	egwUrl, err := url.ParseRequestURI(egw.EdgeGateway.HREF)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -642,7 +642,7 @@ func (eGW *EdgeGateway) RemoveIpsecVPN() (Task, error) {
 	return eGW.AddIpsecVPN(ipsecVPNConfig)
 }
 
-// Deletes the edge gateway, returning a task and an error if the vCD call fails.
+// Deletes the edge gateway, returning a task and an error with the operation result.
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/DELETE-EdgeGateway.html
 func (egw *EdgeGateway) DeleteAsync(force bool, recursive bool) (Task, error) {
 	util.Logger.Printf("[TRACE] EdgeGateway.Delete - deleting edge gateway with force: %t, recursive: %t", force, recursive)
@@ -671,7 +671,7 @@ func (egw *EdgeGateway) DeleteAsync(force bool, recursive bool) (Task, error) {
 	return *task, err
 }
 
-// Deletes the edge gateway, returning an error if the vCD call fails.
+// Deletes the edge gateway, returning an error with the operation result.
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/DELETE-EdgeGateway.html
 func (egw *EdgeGateway) Delete(force bool, recursive bool) error {
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -24,6 +24,7 @@ type EdgeGateway struct {
 	client      *Client
 }
 
+// Simplified structure used to list networks connected to an edge gateway
 type SimpleNetworkIdentifier struct {
 	Name          string
 	InterfaceType string
@@ -641,9 +642,9 @@ func (eGW *EdgeGateway) RemoveIpsecVPN() (Task, error) {
 	return eGW.AddIpsecVPN(ipsecVPNConfig)
 }
 
-// Deletes the edge gateway, returning an error if the vCD call fails.
+// Deletes the edge gateway, returning a task and an error if the vCD call fails.
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/DELETE-EdgeGateway.html
-func (egw *EdgeGateway) Delete(force bool, recursive bool) (Task, error) {
+func (egw *EdgeGateway) DeleteTask(force bool, recursive bool) (Task, error) {
 	util.Logger.Printf("[TRACE] EdgeGateway.Delete - deleting edge gateway with force: %t, recursive: %t", force, recursive)
 
 	if egw.EdgeGateway.HREF == "" {
@@ -667,14 +668,58 @@ func (egw *EdgeGateway) Delete(force bool, recursive bool) (Task, error) {
 	if err = decodeBody(resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding task response: %s", err)
 	}
-	if task.Task.Status == "error" {
-		return Task{}, fmt.Errorf("edge gateway not properly destroyed")
-	}
-	return *task, nil
+	return *task, err
 }
 
-// Returns the list of networks associated with an edge gateway
-func (egw *EdgeGateway) Networks() ([]SimpleNetworkIdentifier, error) {
+// Deletes the edge gateway, returning an error if the vCD call fails.
+// https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/DELETE-EdgeGateway.html
+func (egw *EdgeGateway) Delete(force bool, recursive bool) error {
+
+	task, err := egw.DeleteTask(force, recursive)
+	if err != nil {
+		return err
+	}
+	/*
+		util.Logger.Printf("[TRACE] EdgeGateway.Delete - deleting edge gateway with force: %t, recursive: %t", force, recursive)
+
+		if egw.EdgeGateway.HREF == "" {
+			return  fmt.Errorf("cannot delete, Object is empty")
+		}
+
+		egwUrl, err := url.ParseRequestURI(egw.EdgeGateway.HREF)
+		if err != nil {
+			return  fmt.Errorf("error parsing edge gateway url: %s", err)
+		}
+
+		req := egw.client.NewRequest(map[string]string{
+			"force":     strconv.FormatBool(force),
+			"recursive": strconv.FormatBool(recursive),
+		}, http.MethodDelete, *egwUrl, nil)
+		resp, err := checkResp(egw.client.Http.Do(req))
+		if err != nil {
+			return  fmt.Errorf("error deleting edge gateway: %s", err)
+		}
+		task := NewTask(egw.client)
+		if err = decodeBody(resp, task.Task); err != nil {
+			return  fmt.Errorf("error decoding task response: %s", err)
+		}
+	*/
+	if task.Task.Status == "error" {
+		return fmt.Errorf(combinedTaskErrorMessage(task.Task, fmt.Errorf("edge gateway not properly destroyed")))
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf(combinedTaskErrorMessage(task.Task, err))
+	}
+
+	return nil
+}
+
+// GetNetworks returns the list of networks associated with an edge gateway
+// In the return structure, an interfaceType of "uplink" indicates an external network,
+// while "internal" is for Org VDC routed networks
+func (egw *EdgeGateway) GetNetworks() ([]SimpleNetworkIdentifier, error) {
 	var networks []SimpleNetworkIdentifier
 	err := egw.Refresh()
 	if err != nil {

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -24,6 +24,11 @@ type EdgeGateway struct {
 	client      *Client
 }
 
+type SimpleNetworkIdentifier struct {
+	Name          string
+	InterfaceType string
+}
+
 var reErrorBusy = regexp.MustCompile(`is busy completing an operation.$`)
 
 func NewEdgeGateway(cli *Client) *EdgeGateway {
@@ -666,4 +671,22 @@ func (egw *EdgeGateway) Delete(force bool, recursive bool) (Task, error) {
 		return Task{}, fmt.Errorf("edge gateway not properly destroyed")
 	}
 	return *task, nil
+}
+
+// Returns the list of networks associated with an edge gateway
+func (egw *EdgeGateway) Networks() ([]SimpleNetworkIdentifier, error) {
+	var networks []SimpleNetworkIdentifier
+	err := egw.Refresh()
+	if err != nil {
+		return networks, err
+	}
+	for _, net := range egw.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
+		netIdentifier := SimpleNetworkIdentifier{
+			Name:          net.Name,
+			InterfaceType: net.InterfaceType,
+		}
+		networks = append(networks, netIdentifier)
+	}
+
+	return networks, nil
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -209,7 +209,10 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	newConf := edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 	newConfState := newConf.GatewayIpsecVpnService.IsEnabled
 	newConfTunnel := newConf.GatewayIpsecVpnService.Tunnel
-	newConfEndpoint := newConf.GatewayIpsecVpnService.Endpoint
+
+	// TODO: assumption about not nil endpoints doesn't hold for all vCD versions and configurations
+	// Needs research
+	//newConfEndpoint := newConf.GatewayIpsecVpnService.Endpoint
 	check.Assert(newConfState, Equals, true)
 	check.Assert(newConfTunnel, NotNil)
 	// check.Assert(newConfEndpoint, NotNil)
@@ -228,7 +231,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	afterDeletionConf := edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 	newConfState = afterDeletionConf.GatewayIpsecVpnService.IsEnabled
 	newConfTunnel = afterDeletionConf.GatewayIpsecVpnService.Tunnel
-	newConfEndpoint = afterDeletionConf.GatewayIpsecVpnService.Endpoint
+	newConfEndpoint := afterDeletionConf.GatewayIpsecVpnService.Endpoint
 	check.Assert(newConfState, Equals, false)
 	check.Assert(newConfTunnel, IsNil)
 	check.Assert(newConfEndpoint, IsNil)
@@ -256,7 +259,7 @@ func (vcd *TestVCD) TestEdgeGateway_Networks(check *C) {
 	}
 
 	var networkList []SimpleNetworkIdentifier
-	networkList, err = edge.Networks()
+	networkList, err = edge.GetNetworks()
 	check.Assert(err, IsNil)
 	foundExternalNetwork := false
 	foundNetwork := false

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -211,7 +211,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	newConfEndpoint := newConf.GatewayIpsecVpnService.Endpoint
 	check.Assert(newConfState, Equals, true)
 	check.Assert(newConfTunnel, NotNil)
-	check.Assert(newConfEndpoint, NotNil)
+	// check.Assert(newConfEndpoint, NotNil)
 
 	// Removes VPN service
 	task, err = edge.RemoveIpsecVPN()

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -237,9 +237,9 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	check.Assert(newConfEndpoint, IsNil)
 }
 
-func (vcd *TestVCD) TestEdgeGateway_Networks(check *C) {
+func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip("Skipping test because no edgegatway given")
+		check.Skip("Skipping test because no edge gatway given")
 	}
 	if vcd.config.VCD.ExternalNetwork == "" {
 		check.Skip("Skipping test because no external network given")

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -125,6 +125,7 @@ func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
 	}
 
 	check.Assert(err, IsNil)
+	AddToCleanupList(externalNetwork.Name, "externalNetwork", "", "Test_ExternalNetworkDelete")
 	check.Assert(task.Task, Not(Equals), types.Task{})
 
 	err = task.WaitTaskCompletion()
@@ -134,14 +135,11 @@ func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
 	check.Assert(err, IsNil)
 
 	err = createdExternalNetwork.DeleteWait()
-	if err != nil {
-		AddToCleanupList(externalNetwork.Name, "externalNetwork", "", "Test_ExternalNetworkDelete")
-	}
 	check.Assert(err, IsNil)
 
-	// check through existing catalogItems
+	// check through existing external networks
 	_, err = GetExternalNetwork(vcd.client, externalNetwork.Name)
-	check.Assert(err, IsNil)
+	check.Assert(err, NotNil)
 }
 
 // Retrieves an external network and checks that its contents are filled as expected
@@ -174,6 +172,7 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(task.Task, Not(Equals), types.Task{})
 
+	AddToCleanupList(externalNetwork.Name, "externalNetwork", "", "Test_CreateExternalNetwork")
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
@@ -196,9 +195,6 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	check.Assert(newExternalNetwork.ExternalNetwork.Configuration.FenceMode, Equals, "isolated")
 
 	err = newExternalNetwork.DeleteWait()
-	if err != nil {
-		AddToCleanupList(externalNetwork.Name, "externalNetwork", "", "Test_CreateExternalNetwork")
-	}
 	check.Assert(err, IsNil)
 }
 

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -152,12 +152,12 @@ func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 	if networkName == "" {
 		check.Skip("No external network provided")
 	}
-	externalNetwork, err := GetExternalNetworkByName(vcd.client, networkName)
+	externalNetwork, err := GetExternalNetwork(vcd.client, networkName)
 	check.Assert(err, IsNil)
-	LogExternalNetwork(*externalNetwork)
-	check.Assert(externalNetwork.HREF, Not(Equals), "")
-	check.Assert(externalNetwork.Name, Equals, networkName)
-	check.Assert(externalNetwork.Type, Equals, types.MimeExtensionNetwork)
+	LogExternalNetwork(*externalNetwork.ExternalNetwork)
+	check.Assert(externalNetwork.ExternalNetwork.HREF, Not(Equals), "")
+	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, networkName)
+	check.Assert(externalNetwork.ExternalNetwork.Type, Equals, types.MimeExternalNetwork)
 }
 
 func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -8,9 +8,11 @@ package govcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	. "gopkg.in/check.v1"
 	"net/url"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // Retrieves an external network and checks that its contents are filled as expected
@@ -26,49 +28,52 @@ func (vcd *TestVCD) Test_ExternalNetworkGetByName(check *C) {
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 }
 
-// Tests System function Delete by creating external network and
-// deleting it after.
-func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
+// Helper function that creates an external network to be used in other tests
+func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix string) (skippingReason string, externalNetwork *types.ExternalNetwork, task Task, err error) {
+
 	if vcd.skipAdminTests {
-		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+		return fmt.Sprintf(TestRequiresSysAdminPrivileges, testName), externalNetwork, Task{}, nil
 	}
 
 	if vcd.config.VCD.ExternalNetwork == "" {
-		check.Skip("Test_ExternalNetworkDelete: External network isn't configured. Test can't proceed")
+		return fmt.Sprintf("%s: External network isn't configured. Test can't proceed", testName), externalNetwork, Task{}, nil
 	}
 
 	if vcd.config.VCD.VimServer == "" {
-		check.Skip("Test_ExternalNetworkDelete: Vim server isn't configured. Test can't proceed")
+		return fmt.Sprintf("%s: Vim server isn't configured. Test can't proceed", testName), externalNetwork, Task{}, nil
 	}
 
 	if vcd.config.VCD.ExternalNetworkPortGroup == "" {
-		check.Skip("Test_ExternalNetworkDelete: Port group isn't configured. Test can't proceed")
+		return fmt.Sprintf("%s: Port group isn't configured. Test can't proceed", testName), externalNetwork, Task{}, nil
 	}
 
 	if vcd.config.VCD.ExternalNetworkPortGroupType == "" {
-		check.Skip("Test_ExternalNetworkDelete: Port group type isn't configured. Test can't proceed")
+		return fmt.Sprintf("%s: Port group type isn't configured. Test can't proceed", testName), externalNetwork, Task{}, nil
 	}
 
 	virtualCenters, err := QueryVirtualCenters(vcd.client, fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer))
-	check.Assert(err, IsNil)
+	if err != nil {
+		return "", externalNetwork, Task{}, err
+	}
 	if len(virtualCenters) == 0 {
-		check.Skip(fmt.Sprintf("No vSphere server found with name '%s'", vcd.config.VCD.VimServer))
+		return fmt.Sprintf("No vSphere server found with name '%s'", vcd.config.VCD.VimServer), externalNetwork, Task{}, nil
 	}
 	vimServerHref := virtualCenters[0].HREF
 
 	// Resolve port group info
 	portGroups, err := QueryPortGroups(vcd.client, fmt.Sprintf("(name==%s;portgroupType==%s)", url.QueryEscape(vcd.config.VCD.ExternalNetworkPortGroup), vcd.config.VCD.ExternalNetworkPortGroupType))
-	check.Assert(err, IsNil)
+	if err != nil {
+		return "", externalNetwork, Task{}, err
+	}
 	if len(portGroups) == 0 {
-		check.Skip(fmt.Sprintf("No port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup))
+		return fmt.Sprintf("No port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup), externalNetwork, Task{}, nil
 	}
 	if len(portGroups) > 1 {
-		check.Skip(fmt.Sprintf("More than one port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup))
+		return fmt.Sprintf("More than one port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup), externalNetwork, Task{}, nil
 	}
 
-	externalNetwork := &types.ExternalNetwork{
-		Name:        TestDeleteExternalNetwork,
+	externalNetwork = &types.ExternalNetwork{
+		Name:        networkName,
 		Description: "Test Create External Network",
 		Xmlns:       types.XMLNamespaceExtension,
 		XmlnsVCloud: types.XMLNamespaceVCloud,
@@ -76,10 +81,11 @@ func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
 			Xmlns: types.XMLNamespaceVCloud,
 			IPScopes: &types.IPScopes{
 				IPScope: []*types.IPScope{&types.IPScope{
-					Gateway: "192.168.201.1",
-					Netmask: "255.255.255.0",
-					DNS1:    "192.168.202.253",
-					DNS2:    "192.168.202.254",
+					Gateway:   "192.168.201.1",
+					Netmask:   "255.255.255.0",
+					DNS1:      "192.168.202.253",
+					DNS2:      "192.168.202.254",
+					DNSSuffix: dnsSuffix,
 					IPRanges: &types.IPRanges{
 						IPRange: []*types.IPRange{
 							&types.IPRange{
@@ -104,7 +110,20 @@ func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
 			},
 		},
 	}
-	task, err := CreateExternalNetwork(vcd.client, externalNetwork)
+	task, err = CreateExternalNetwork(vcd.client, externalNetwork)
+	return skippingReason, externalNetwork, task, err
+}
+
+// Tests System function Delete by creating external network and
+// deleting it after.
+func (vcd *TestVCD) Test_ExternalNetworkDelete(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	skippingReason, externalNetwork, task, err := vcd.testCreateExternalNetwork(check.TestName(), TestDeleteExternalNetwork, "")
+	if skippingReason != "" {
+		check.Skip(skippingReason)
+	}
+
 	check.Assert(err, IsNil)
 	check.Assert(task.Task, Not(Equals), types.Task{})
 
@@ -145,82 +164,13 @@ func (vcd *TestVCD) Test_GetExternalNetwork(check *C) {
 
 func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-	if vcd.skipAdminTests {
-		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+
+	dnsSuffix := "some.net"
+	skippingReason, externalNetwork, task, err := vcd.testCreateExternalNetwork(check.TestName(), TestCreateExternalNetwork, dnsSuffix)
+	if skippingReason != "" {
+		check.Skip(skippingReason)
 	}
 
-	if vcd.config.VCD.ExternalNetwork == "" {
-		check.Skip("Test_CreateExternalNetwork: External network isn't configured. Test can't proceed")
-	}
-
-	if vcd.config.VCD.VimServer == "" {
-		check.Skip("Test_CreateExternalNetwork: Vim server isn't configured. Test can't proceed")
-	}
-
-	if vcd.config.VCD.ExternalNetworkPortGroup == "" {
-		check.Skip("Test_CreateExternalNetwork: Port group isn't configured. Test can't proceed")
-	}
-
-	if vcd.config.VCD.ExternalNetworkPortGroupType == "" {
-		check.Skip("Test_CreateExternalNetwork: Port group type isn't configured. Test can't proceed")
-	}
-
-	virtualCenters, err := QueryVirtualCenters(vcd.client, fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer))
-	check.Assert(err, IsNil)
-	if len(virtualCenters) == 0 {
-		check.Skip(fmt.Sprintf("No vSphere server found with name '%s'", vcd.config.VCD.VimServer))
-	}
-	vimServerHref := virtualCenters[0].HREF
-
-	// Resolve port group info
-	portGroups, err := QueryPortGroups(vcd.client, fmt.Sprintf("(name==%s;portgroupType==%s)", url.QueryEscape(vcd.config.VCD.ExternalNetworkPortGroup), vcd.config.VCD.ExternalNetworkPortGroupType))
-	check.Assert(err, IsNil)
-	if len(portGroups) == 0 {
-		check.Skip(fmt.Sprintf("No port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup))
-	}
-	if len(portGroups) > 1 {
-		check.Skip(fmt.Sprintf("More then one found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup))
-	}
-
-	externalNetwork := &types.ExternalNetwork{
-		Name:        TestCreateExternalNetwork,
-		Description: "Test Create External Network",
-		Xmlns:       types.XMLNamespaceExtension,
-		XmlnsVCloud: types.XMLNamespaceVCloud,
-		Configuration: &types.NetworkConfiguration{
-			Xmlns: types.XMLNamespaceVCloud,
-			IPScopes: &types.IPScopes{
-				IPScope: []*types.IPScope{&types.IPScope{
-					Gateway:   "192.168.201.1",
-					Netmask:   "255.255.255.0",
-					DNS1:      "192.168.202.253",
-					DNS2:      "192.168.202.254",
-					DNSSuffix: "some.net",
-					IPRanges: &types.IPRanges{
-						IPRange: []*types.IPRange{
-							&types.IPRange{
-								StartAddress: "192.168.201.3",
-								EndAddress:   "192.168.201.250",
-							},
-						},
-					},
-				},
-				}},
-			FenceMode: "isolated",
-		},
-		VimPortGroupRefs: &types.VimObjectRefs{
-			VimObjectRef: []*types.VimObjectRef{
-				&types.VimObjectRef{
-					VimServerRef: &types.Reference{
-						HREF: vimServerHref,
-					},
-					MoRef:         portGroups[0].MoRef,
-					VimObjectType: vcd.config.VCD.ExternalNetworkPortGroupType,
-				},
-			},
-		},
-	}
-	task, err := CreateExternalNetwork(vcd.client, externalNetwork)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task, Not(Equals), types.Task{})
 
@@ -236,7 +186,7 @@ func (vcd *TestVCD) Test_CreateExternalNetwork(check *C) {
 	check.Assert(ipScope[0].Netmask, Equals, "255.255.255.0")
 	check.Assert(ipScope[0].DNS1, Equals, "192.168.202.253")
 	check.Assert(ipScope[0].DNS2, Equals, "192.168.202.254")
-	check.Assert(ipScope[0].DNSSuffix, Equals, "some.net")
+	check.Assert(ipScope[0].DNSSuffix, Equals, dnsSuffix)
 
 	check.Assert(len(ipScope[0].IPRanges.IPRange), Equals, 1)
 	ipRange := ipScope[0].IPRanges.IPRange[0]

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -144,12 +144,14 @@ func prettyTask(task *types.Task) string {
 }
 
 // Returns an Edge Gateway service configuration structure as JSON
-func prettyEdgeGatewayServiceConfiguration(conf *types.EdgeGatewayServiceConfiguration) string {
-	byteBuf, err := json.MarshalIndent(conf, " ", " ")
+//func prettyEdgeGatewayServiceConfiguration(conf types.EdgeGatewayServiceConfiguration) string {
+func prettyEdgeGateway(egw types.EdgeGateway) string {
+	result := ""
+	byteBuf, err := json.MarshalIndent(egw, " ", " ")
 	if err == nil {
-		return fmt.Sprintf("%s\n", string(byteBuf))
+		result += fmt.Sprintf("%s\n", string(byteBuf))
 	}
-	return ""
+	return result
 }
 
 func LogNetwork(conf types.OrgVDCNetwork) {
@@ -244,10 +246,22 @@ func outTask(destination string, task *types.Task, howManyTimes int, elapsed tim
 	out(destination, "-------------------------------\n")
 }
 
+func simpleOutTask(destination string, task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	if task == nil {
+		out(destination, "Task is null\n")
+		return
+	}
+	out(destination, "%s (%s) - elapsed: [%s:%d] - progress: %d%%\n", task.OperationName, task.Status, elapsed.Round(1*time.Second), howManyTimes, task.Progress)
+}
+
 func LogTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
 	outTask("log", task, howManyTimes, elapsed, first, last)
 }
 
 func ShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
 	outTask("screen", task, howManyTimes, elapsed, first, last)
+}
+
+func SimpleShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	simpleOutTask("screen", task, howManyTimes, elapsed, first, last)
 }

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -117,7 +117,7 @@ func prettyDisk(disk types.Disk) string {
 }
 
 // Returns an External Network structure as JSON
-func prettyExternalNetwork(network types.ExternalNetworkReference) string {
+func prettyExternalNetwork(network types.ExternalNetwork) string {
 	byteBuf, err := json.MarshalIndent(network, " ", " ")
 	if err == nil {
 		return fmt.Sprintf("%s\n", string(byteBuf))
@@ -162,11 +162,11 @@ func ShowNetwork(conf types.OrgVDCNetwork) {
 	out("screen", prettyNetworkConf(conf))
 }
 
-func LogExternalNetwork(network types.ExternalNetworkReference) {
+func LogExternalNetwork(network types.ExternalNetwork) {
 	out("log", prettyExternalNetwork(network))
 }
 
-func ShowExternalNetwork(network types.ExternalNetworkReference) {
+func ShowExternalNetwork(network types.ExternalNetwork) {
 	out("screen", prettyExternalNetwork(network))
 }
 

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -265,3 +265,7 @@ func ShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, 
 func SimpleShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
 	simpleOutTask("screen", task, howManyTimes, elapsed, first, last)
 }
+
+func SimpleLogTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	simpleOutTask("log", task, howManyTimes, elapsed, first, last)
+}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -16,12 +16,12 @@ import (
 
 // Simple structure to pass Edge Gateway creation parameters.
 type EdgeGatewayCreation struct {
-	externalNetworks     []string
-	orgName              string
-	vdcName              string
-	egwName              string
-	description          string
-	backingConfiguration string
+	ExternalNetworks     []string
+	OrgName              string
+	VdcName              string
+	EgwName              string
+	Description          string
+	BackingConfiguration string
 }
 
 // List of allowed values for GatewayBackingConfig.
@@ -85,34 +85,34 @@ func getBareEntityId(entityId string) (string, error) {
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/POST-CreateEdgeGateway.html
 func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, error) {
 
-	adminOrg, err := GetAdminOrgByName(vcdClient, egwc.orgName)
+	adminOrg, err := GetAdminOrgByName(vcdClient, egwc.OrgName)
 	if err != nil {
 		return Task{}, err
 	}
-	vdc, err := adminOrg.GetVdcByName(egwc.vdcName)
+	vdc, err := adminOrg.GetVdcByName(egwc.VdcName)
 	if err != nil {
 		return Task{}, err
 	}
 
 	backingAllowed := false
 	for _, allowed := range EGWAllowedBackingConfig {
-		if allowed == egwc.backingConfiguration {
+		if allowed == egwc.BackingConfiguration {
 			backingAllowed = true
 		}
 	}
 	if !backingAllowed {
 		return Task{},
 			fmt.Errorf("backing configuration value '%s' not accepted. Allowed values: %v ",
-				egwc.backingConfiguration, EGWAllowedBackingConfig)
+				egwc.BackingConfiguration, EGWAllowedBackingConfig)
 	}
 
 	// This is the main configuration structure
 	egwConfiguration := &types.EdgeGateway{
 		Xmlns:       types.XMLNamespaceVCloud,
-		Name:        egwc.egwName,
-		Description: egwc.description,
+		Name:        egwc.EgwName,
+		Description: egwc.Description,
 		Configuration: &types.GatewayConfiguration{
-			GatewayBackingConfig: egwc.backingConfiguration,
+			GatewayBackingConfig: egwc.BackingConfiguration,
 			GatewayInterfaces: &types.GatewayInterfaces{
 				GatewayInterface: []*types.GatewayInterface{},
 			},
@@ -120,12 +120,12 @@ func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, er
 		},
 	}
 
-	if len(egwc.externalNetworks) == 0 {
+	if len(egwc.ExternalNetworks) == 0 {
 		return Task{}, fmt.Errorf("no external networks provided. At least one is needed")
 	}
 
 	// Add external networks inside the configuration structure
-	for _, extNetName := range egwc.externalNetworks {
+	for _, extNetName := range egwc.ExternalNetworks {
 		extNet, err := GetExternalNetworkByName(vcdClient, extNetName)
 		if err != nil {
 			return Task{}, err
@@ -149,10 +149,10 @@ func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, er
 
 	ID, err := getBareEntityId(vdc.Vdc.ID)
 	if err != nil {
-		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s: %s", egwc.vdcName, err)
+		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s: %s", egwc.VdcName, err)
 	}
 	if ID == "" {
-		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s - empty ID returned", egwc.vdcName)
+		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s - empty ID returned", egwc.VdcName)
 	}
 	egwCreateHREF.Path += fmt.Sprintf("/admin/vdc/%s/edgeGateways", ID)
 
@@ -181,7 +181,7 @@ func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, er
 			return deployTask, nil
 		}
 	}
-	return Task{}, fmt.Errorf("no deployment task found for edge gateway %s - The edge gateway might have been created, but not deployed properly", egwc.egwName)
+	return Task{}, fmt.Errorf("no deployment task found for edge gateway %s - The edge gateway might have been created, but not deployed properly", egwc.EgwName)
 }
 
 // If user specifies a valid organization name, then this returns a

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -375,8 +375,8 @@ func QueryPortGroups(vcdCli *VCDClient, filter string) ([]*types.PortGroupRecord
 	return results.Results.PortGroupRecord, nil
 }
 
-// GetExternalNetwork returns an ExternalNetwork object if user the network name matches an existing one.
-// If no valid external network is found, it returns an empty ExternalNetwork and an error
+// GetExternalNetwork returns an ExternalNetwork reference if user the network name matches an existing one.
+// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
 func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
 
 	if !vcdClient.Client.IsSysAdmin {

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -186,14 +186,14 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 
 	egwCreateHREF := vcdClient.Client.VCDHREF
 
-	ID, err := getBareEntityUuid(vdc.Vdc.ID)
+	vdcId, err := getBareEntityUuid(vdc.Vdc.ID)
 	if err != nil {
 		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s: %s", vdcName, err)
 	}
-	if ID == "" {
+	if vdcId == "" {
 		return Task{}, fmt.Errorf("error retrieving ID from Vdc %s - empty ID returned", vdcName)
 	}
-	egwCreateHREF.Path += fmt.Sprintf("/admin/vdc/%s/edgeGateways", ID)
+	egwCreateHREF.Path += fmt.Sprintf("/admin/vdc/%s/edgeGateways", vdcId)
 
 	// The first task is the creation task. It is quick, and does only create the vCD entity,
 	// but not yet deploy the underlying VM

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -223,6 +223,9 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 	return Task{}, fmt.Errorf("no deployment task found for edge gateway %s - The edge gateway might have been created, but not deployed properly", egwName)
 }
 
+// Private convenience function used by CreateAndConfigureEdgeGateway and CreateEdgeGateway to
+// process the task and return the object that was created.
+// It should not be invoked directly.
 func createEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfiguration *types.EdgeGateway) (EdgeGateway, error) {
 	var task Task
 	var err error

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -125,9 +125,9 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
 	orgName := vcd.config.VCD.Org
 	vdcName := vcd.config.VCD.Vdc
 	egc := EdgeGatewayCreation{
-		externalNetworks: []string{TestCreateExternalNetwork},
-		orgName:          orgName,
-		vdcName:          vdcName,
+		ExternalNetworks: []string{TestCreateExternalNetwork},
+		OrgName:          orgName,
+		VdcName:          vdcName,
 	}
 
 	// A full test takes approx 3m:30s with both "compact" and "full"
@@ -135,21 +135,21 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
 	// To reduce testing time, comment the previous line and uncomment the next one
 	// testingRange := []string{"compact"}
 	for _, backingConf := range testingRange {
-		egc.backingConfiguration = backingConf
-		egc.egwName = newEgwName + "_" + backingConf
-		egc.description = egc.egwName
+		egc.BackingConfiguration = backingConf
+		egc.EgwName = newEgwName + "_" + backingConf
+		egc.Description = egc.EgwName
 		task, err := CreateEdgeGateway(vcd.client, egc)
 		check.Assert(task, NotNil)
 		check.Assert(err, IsNil)
 
-		AddToCleanupList(egc.egwName, "edgegateway", orgName+"|"+vdcName, "Test_CreateDeleteEdgeGateway")
+		AddToCleanupList(egc.EgwName, "edgegateway", orgName+"|"+vdcName, "Test_CreateDeleteEdgeGateway")
 		err = task.WaitInspectTaskCompletion(SimpleShowTask, 10*time.Second)
 		check.Assert(err, IsNil)
 
-		edge, err := vcd.vdc.FindEdgeGateway(egc.egwName)
+		edge, err := vcd.vdc.FindEdgeGateway(egc.EgwName)
 		check.Assert(err, IsNil)
 
-		check.Assert(edge.EdgeGateway.Name, Equals, egc.egwName)
+		check.Assert(edge.EdgeGateway.Name, Equals, egc.EgwName)
 		// Edge gateway status:
 		//  0 : being created
 		//  1 : ready
@@ -164,7 +164,7 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
 		check.Assert(err, IsNil)
 
 		// Once deleted, look for the edge gateway again. It should return an error
-		edge, err = vcd.vdc.FindEdgeGateway(egc.egwName)
+		edge, err = vcd.vdc.FindEdgeGateway(egc.EgwName)
 		check.Assert(err, NotNil)
 		check.Assert(edge, Equals, EdgeGateway{})
 	}

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -1,0 +1,131 @@
+// +build unit ALL
+
+/*
+* Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+* Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"os"
+	"testing"
+)
+
+// Tests reliability of getBareEntityId, which returns a bare UUID from an
+// entity ID field
+func Test_BareID(t *testing.T) {
+
+	type idTest struct {
+		rawId    string
+		expected string
+	}
+
+	idTestList := []idTest{
+		{
+			"urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			"97384890-180c-4563-b9b7-0dc50a2430b0",
+		},
+		{
+			"urn:vcloud:org:deadbeef-0000-0000-0000-000000000000",
+			"deadbeef-0000-0000-0000-000000000000",
+		},
+		{
+			"urn:vcloud:task:11111111-0000-0000-0000-000000000000",
+			"11111111-0000-0000-0000-000000000000",
+		},
+		{
+			"urn:vcloud:task:aaaaaaaa-bbbb-ccc0-dddd-eeeeeeeeeeee",
+			"aaaaaaaa-bbbb-ccc0-dddd-eeeeeeeeeeee",
+		},
+		{
+			"urn:vcloud:vdc:72fefde7-4fed-45b8-a774-79b72c870325",
+			"72fefde7-4fed-45b8-a774-79b72c870325",
+		},
+		{
+			"urn:composite-name:vdc:72fefde7-4fed-45b8-a774-79b72c870325",
+			"72fefde7-4fed-45b8-a774-79b72c870325",
+		},
+		{
+			"urn:underscored_name:vdc:72fefde7-4fed-45b8-a774-79b72c870325",
+			"72fefde7-4fed-45b8-a774-79b72c870325",
+		},
+		{
+			"urn:mixed_name-with-dashes:double-string:72fefde7-4fed-45b8-a774-79b72c870325",
+			"72fefde7-4fed-45b8-a774-79b72c870325",
+		},
+	}
+	idTestExpectedToFailList := []idTest{
+		{
+			"missing:one:digit:12345678-1234-1234-1234-12345678901",
+			"",
+		},
+		{
+			"missing:one:digit:1234567-1234-1234-1234-123456789012",
+			"",
+		},
+		{
+			"missing:one:digit:12345678-123-1234-1234-123456789012",
+			"",
+		},
+		{
+			"too:many:digits:123456789-1234-1234-1234-123456789012",
+			"",
+		},
+		{
+			"too:many:digits:12345678-12345-1234-1234-123456789012",
+			"",
+		},
+		{
+			"too:many:digits:12345678-1234-1234-1234-1234567890123",
+			"",
+		},
+		{
+			"unexpected:letters:in_ID:abcdefgh-1234-1234-1234-123456789012",
+			"",
+		},
+		{
+			"unexpected:letters:in_ID:abcdef00-x234-w234-1234-123456789012",
+			"",
+		},
+		{
+			"unexpected:letters:in,prefix:12345678-1234-1234-1234-123456789012",
+			"",
+		},
+		{
+			"unexpected:letters:in/prefix:12345678-1234-1234-1234-123456789012",
+			"",
+		},
+	}
+
+	for _, it := range idTestList {
+		bareId, err := getBareEntityId(it.rawId)
+		if err != nil {
+			t.Logf("error extracting bare ID: %s", err)
+			t.Fail()
+		}
+		if bareId == it.expected {
+			if os.Getenv("TEST_VERBOSE") != "" {
+				t.Logf("ID '%s': found '%s' as expected", it.rawId, it.expected)
+			}
+		} else {
+			t.Logf("error getting bare ID: expected '%s' but found '%s'", it.expected, bareId)
+			t.Fail()
+		}
+	}
+	for _, it := range idTestExpectedToFailList {
+		bareId, err := getBareEntityId(it.rawId)
+		if err == nil {
+			t.Logf("unexpected success with raw ID %s", it.rawId)
+			t.Fail()
+		}
+		if bareId == it.expected {
+			if os.Getenv("TEST_VERBOSE") != "" {
+				t.Logf("ID '%s': found '%s' as expected", it.rawId, it.expected)
+			}
+		} else {
+			t.Logf("error getting bare ID: expected '%s' but found '%s'", it.expected, bareId)
+			t.Fail()
+		}
+	}
+}

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-// Tests reliability of getBareEntityId, which returns a bare UUID from an
+// Tests reliability of getBareEntityUuid, which returns a bare UUID from an
 // entity ID field
 func Test_BareID(t *testing.T) {
 
@@ -99,7 +99,7 @@ func Test_BareID(t *testing.T) {
 	}
 
 	for _, it := range idTestList {
-		bareId, err := getBareEntityId(it.rawId)
+		bareId, err := getBareEntityUuid(it.rawId)
 		if err != nil {
 			t.Logf("error extracting bare ID: %s", err)
 			t.Fail()
@@ -114,7 +114,7 @@ func Test_BareID(t *testing.T) {
 		}
 	}
 	for _, it := range idTestExpectedToFailList {
-		bareId, err := getBareEntityId(it.rawId)
+		bareId, err := getBareEntityUuid(it.rawId)
 		if err == nil {
 			t.Logf("unexpected success with raw ID %s", it.rawId)
 			t.Fail()

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -93,6 +93,7 @@ func (task *Task) WaitInspectTaskCompletion(inspectionFunc InspectionFunc, delay
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
+	taskMonitor := os.Getenv("GOVCD_TASK_MONITOR")
 	howManyTimesRefreshed := 0
 	startTime := time.Now()
 	for {
@@ -127,18 +128,19 @@ func (task *Task) WaitInspectTaskCompletion(inspectionFunc InspectionFunc, delay
 			return nil
 		}
 
+		// If the environment variable "GOVCD_TASK_MONITOR" is set, its value
+		// will be used to choose among pre-defined InspectionFunc
 		if inspectionFunc == nil {
-			taskMonitor := os.Getenv("GOVCD_TASK_MONITOR")
 			if taskMonitor != "" {
 				switch taskMonitor {
 				case "log":
-					inspectionFunc = LogTask
+					inspectionFunc = LogTask // writes full task details to the log
 				case "show":
-					inspectionFunc = ShowTask
+					inspectionFunc = ShowTask // writes full task details to the screen
 				case "simple_log":
-					inspectionFunc = SimpleLogTask
+					inspectionFunc = SimpleLogTask // writes a summary line for the task to the log
 				case "simple_show":
-					inspectionFunc = SimpleShowTask
+					inspectionFunc = SimpleShowTask // writes a summary line for the task to the screen
 				}
 			}
 		}

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -126,6 +127,21 @@ func (task *Task) WaitInspectTaskCompletion(inspectionFunc InspectionFunc, delay
 			return nil
 		}
 
+		if inspectionFunc == nil {
+			taskMonitor := os.Getenv("GOVCD_TASK_MONITOR")
+			if taskMonitor != "" {
+				switch taskMonitor {
+				case "log":
+					inspectionFunc = LogTask
+				case "show":
+					inspectionFunc = ShowTask
+				case "simple_log":
+					inspectionFunc = SimpleLogTask
+				case "simple_show":
+					inspectionFunc = SimpleShowTask
+				}
+			}
+		}
 		if inspectionFunc != nil {
 			inspectionFunc(task.Task,
 				howManyTimesRefreshed,

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1514,6 +1514,7 @@ type GatewayConfiguration struct {
 	EdgeGatewayServiceConfiguration *GatewayFeatures   `xml:"EdgeGatewayServiceConfiguration,omitempty"` // Represents Gateway Features.
 	HaEnabled                       bool               `xml:"HaEnabled,omitempty"`                       // True if this gateway is highly available. (Requires two vShield edge VMs.)
 	AdvancedNetworkingEnabled       bool               `xml:"AdvancedNetworkingEnabled,omitempty"`       // True if the gateway uses advanced networking
+	DistributedRoutingEnabled       bool               `xml:"DistributedRoutingEnabled,omitempty"`       // True if gateway is attached to a Distributed Logical Router
 	UseDefaultRouteForDNSRelay      bool               `xml:"UseDefaultRouteForDnsRelay,omitempty"`      // True if the default gateway on the external network selected for default route should be used as the DNS relay.
 }
 

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1513,6 +1513,7 @@ type GatewayConfiguration struct {
 	GatewayInterfaces               *GatewayInterfaces `xml:"GatewayInterfaces"`                         // List of Gateway interfaces.
 	EdgeGatewayServiceConfiguration *GatewayFeatures   `xml:"EdgeGatewayServiceConfiguration,omitempty"` // Represents Gateway Features.
 	HaEnabled                       bool               `xml:"HaEnabled,omitempty"`                       // True if this gateway is highly available. (Requires two vShield edge VMs.)
+	AdvancedNetworkingEnabled       bool               `xml:"AdvancedNetworkingEnabled,omitempty"`       // True if the gateway uses advanced networking
 	UseDefaultRouteForDNSRelay      bool               `xml:"UseDefaultRouteForDnsRelay,omitempty"`      // True if the default gateway on the external network selected for default route should be used as the DNS relay.
 }
 

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1486,6 +1486,7 @@ type InstantiateVAppTemplateParams struct {
 // Since: 5.1
 type EdgeGateway struct {
 	// Attributes
+	Xmlns        string `xml:"xmlns,attr,omitempty"`
 	HREF         string `xml:"href,attr,omitempty"`         // The URI of the entity.
 	Type         string `xml:"type,attr,omitempty"`         // The MIME type of the entity.
 	ID           string `xml:"id,attr,omitempty"`           // The entity identifier, expressed in URN format. The value of this attribute uniquely identifies the entity, persists for the life of the entity, and is never reused


### PR DESCRIPTION
Implements Issue #130:

Add functions `CreateEdgeGateway()` and `(egw *EdgeGateway) Delete()`.

1. To create an edge gateway, we need to pass at least 7 parameters, possibly more. My current choice is to pass a simplified structure containing only the necessary parameters, and deal with other customisations in a different function. Another possibility would be passing the API customisation structure to the creation. We do this (for legacy reasons) for networks but I am not sure whether we want to burden client applications with such complexity. I could expose two functions: one that use the current parameters and one that uses the full customisation. TBD. 
2. A strange thing happens on creation, because the task returned by vCD creates the edge gateway entity but does not deploy the VM that is used for that. Another task starts immediately after. For this reason, the first task is refreshed right in the creation function, and the second task gets returned.
3. When creating edge gateways, the GUI mentions Compact, Large, Xlarge, and Quad Large. In the API, I only find something that mentions compact, and it's the "GatewayBackingConfig", which only accepts "compact" and "full". Probably the two things are not related. 
4. Testing edge gateways is a unique challenge, because in Cassini servers we can only set an usable edge gateway when we set the first one. This is because the first external network has already taken the only port group of type "NETWORK" that was available. For this reason, I did some refactoring to the external network testing, to be able to create external networks outside their current tests. I was able to remove duplicated code while keeping the functionality intact.
5. Another change that was necessary is a little refactoring of the function that use the catalog ID. The current one used a slice to get the ID, but this only works when the prefix has a fixed length. When the entity name changes, the prefix is different, and the slice method cannot be used. So I implemented it using a regular expression, and I added a unit test to make sure it works in most cases.


