### PR TITLE
Change Vdc.Status to return Int

### DIFF
--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -367,7 +367,7 @@ type Vdc struct {
 	ID           string `xml:"id,attr,omitempty"`
 	OperationKey string `xml:"operationKey,attr,omitempty"`
 	Name         string `xml:"name,attr"`
-	Status       int `xml:"status,attr,omitempty"`
+	Status       int    `xml:"status,attr,omitempty"`
 
 	AllocationModel    string                `xml:"AllocationModel"`
 	AvailableNetworks  []*AvailableNetworks  `xml:"AvailableNetworks,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -367,7 +367,7 @@ type Vdc struct {
 	ID           string `xml:"id,attr,omitempty"`
 	OperationKey string `xml:"operationKey,attr,omitempty"`
 	Name         string `xml:"name,attr"`
-	Status       string `xml:"status,attr,omitempty"`
+	Status       int `xml:"status,attr,omitempty"`
 
 	AllocationModel    string                `xml:"AllocationModel"`
 	AvailableNetworks  []*AvailableNetworks  `xml:"AvailableNetworks,omitempty"`


### PR DESCRIPTION
Returning the Vdc.Status as a string breaks the usage of the `types.VDCStatuses[]` map as the value returned is of `type string` and not `type int` as the map is defined here https://github.com/vmware/go-vcloud-director/blob/master/types/v56/types.go#37. Currently something like this is required to use the `types.VDCStatues[]` map:

```
i, err := strconv.Atoi(vdc.Vdc.Status)
if err != nil {
	return err
}
log.Info(types.VDCStatuses[i])    // Returns the mapped value       
```

This change would give `Vdc.Status` the same behavior as `Vapp.Status` when using either of their corresponding maps and allow for this to work:

```
log.Info(types.VDCStatuses[vdc.Vdc.Status])
```

## IMPORTANT

To help us process your pull request efficiently, please follow the 
guidelines shown below. 

## A Pull Request should be associated with an Issue

We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
and potentially we'll be able to point development in a particular direction.

We accept PRs without associated issues provided the change is sufficiently evident 
from the commit message. If you have typos or simple bug fixes go for it.

## Description

Related issue: (`<URL or #NUMBER of your Issue>`)

- (Required) Short description of changes in the PR subject

- (Required) Detailed description of changes include tests and
  documentation. If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name
