### PR TITLE
Fix Issue #204 "Can't create disks > 2GiB"

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -106,8 +106,8 @@ type TestConfig struct {
 		ExternalNetworkPortGroupType string `yaml:"externalNetworkPortGroupType,omitempty"`
 		VimServer                    string `yaml:"vimServer,omitempty"`
 		Disk                         struct {
-			Size          int `yaml:"size,omitempty"`
-			SizeForUpdate int `yaml:"sizeForUpdate,omitempty"`
+			Size          int64 `yaml:"size,omitempty"`
+			SizeForUpdate int64 `yaml:"sizeForUpdate,omitempty"`
 		}
 	} `yaml:"vcd"`
 	Logging struct {

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -44,7 +44,7 @@ func NewDiskRecord(cli *Client) *DiskRecord {
 
 // While theoretically we can use smaller amounts, there is an issue when updating
 // disks with size < 1MB
-const MinimumDiskSize int = 1048576 // = 1Mb
+const MinimumDiskSize int64 = 1048576 // = 1Mb
 
 // Create an independent disk in VDC
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 102 - 103,

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2303,7 +2303,7 @@ type Disk struct {
 	OperationKey    string           `xml:"operationKey,attr,omitempty"`
 	Name            string           `xml:"name,attr"`
 	Status          int              `xml:"status,attr,omitempty"`
-	Size            int              `xml:"size,attr"`
+	Size            int64            `xml:"size,attr"`
 	Iops            *int             `xml:"iops,attr,omitempty"`
 	BusType         string           `xml:"busType,attr,omitempty"`
 	BusSubType      string           `xml:"busSubType,attr,omitempty"`


### PR DESCRIPTION
Change type of size field in definition and usage

As reported in Issue #204, the `Size` field should have been an `int64`, not `int`.

Signed-off-by: Giuseppe Maxia <gmaxia@vmware.com>

