### PR TITLE
Fix org user

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -73,11 +73,14 @@ $ go test -v .
            * catalog:    Runs catalog related tests (also catalog_item, media)
            * disk:       Runs disk related tests
            * extnetwork: Runs external network related tests
-           * network:    Runs network and edge gateway related tests
+           * lb:       	 Runs load balancer related tests
+           * network:    Runs network related tests
+           * gateway:    Runs edge gateway related tests
            * org:        Runs org related tests
            * query:      Runs query related tests
            * system:     Runs system related tests
            * task:       Runs task related tests
+           * user:       Runs user related tests
            * vapp:       Runs vapp related tests
            * vdc:        Runs vdc related tests
            * vm:         Runs vm related tests

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -31,12 +31,14 @@ At least one of the following tags should be defined:
    * catalog:    Runs catalog related tests (also catalog_item, media)
    * disk:       Runs disk related tests
    * extnetwork: Runs external network related tests
+   * lb:       	 Runs load balancer related tests
    * network:    Runs network related tests
    * gateway:    Runs edge gateway related tests
    * org:        Runs org related tests
    * query:      Runs query related tests
    * system:     Runs system related tests
    * task:       Runs task related tests
+   * user:       Runs user related tests
    * vapp:       Runs vapp related tests
    * vdc:        Runs vdc related tests
    * vm:         Runs vm related tests

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -35,6 +35,7 @@ type OrgUserConfiguration struct {
 	Description     string // Optional
 	EmailAddress    string // Optional
 	Telephone       string // Optional
+	IM              string // Optional
 }
 
 const (
@@ -273,6 +274,7 @@ func (adminOrg *AdminOrg) CreateUserSimple(userData OrgUserConfiguration) (*OrgU
 		FullName:        userData.FullName,
 		EmailAddress:    userData.EmailAddress,
 		Description:     userData.Description,
+		IM:              userData.IM,
 		Role:            &types.Reference{HREF: role.HREF},
 	}
 


### PR DESCRIPTION
This is a leftover from the Org User PR from last week.
There was a missing field in the simpler configuration structure, which prevented us from using it in Terraform.

I have also added missing tags to the documentation (`api_test.go` and `TESTING.md`)