### PR TITLE
Add functions to allow create SNAT and DNAT rules for ext netw on edge gtw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added VDC meta data create/get/delete functions [#203](https://github.com/vmware/go-vcloud-director/pull/203)
 * Added org user create/delete/update functions [#18](https://github.com/vmware/go-vcloud-director/issues/18)
 * Added load balancer application profile [#208](https://github.com/vmware/go-vcloud-director/pull/208)
-* Added edge gateway SNAT/DNAT rules functions which supports org VDC network and external network [#225](https://github.com/terraform-providers/terraform-provider-vcd/issues/225)
+* Added edge gateway SNAT/DNAT rule functions which support org VDC network and external network [#225](https://github.com/terraform-providers/terraform-provider-vcd/issues/225)
 
 ## 2.2.0 (May 15, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added VDC meta data create/get/delete functions [#203](https://github.com/vmware/go-vcloud-director/pull/203)
 * Added org user create/delete/update functions [#18](https://github.com/vmware/go-vcloud-director/issues/18)
 * Added load balancer application profile [#208](https://github.com/vmware/go-vcloud-director/pull/208)
+* Added edge gateway SNAT/DNAT rules functions which supports org VDC network and external network [#225](https://github.com/terraform-providers/terraform-provider-vcd/issues/225)
 
 ## 2.2.0 (May 15, 2019)
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -275,7 +275,7 @@ func (eGW *EdgeGateway) AddDNATRule(networkHref, externalIP, externalPort, inter
 	return eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule, nil
 }
 
-// AddSNATRule creates firewall SNAT rule and return refreshed existing NAT rules array or error
+// AddSNATRule creates SNAT rule and returns refreshed existing NAT rules array or error
 func (eGW *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, description string) ([]*types.NatRule, error) {
 
 	task, err := eGW.AddNATRuleAsync(networkHref, "SNAT", externalIP, "any", internalIP, "any", "any", "", description)
@@ -295,7 +295,7 @@ func (eGW *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, descrip
 	return eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule, nil
 }
 
-// AddNATRuleAsync creates firewall NAT rule and return task or err
+// AddNATRuleAsync creates NAT rule and return task or err
 func (eGW *EdgeGateway) AddNATRuleAsync(networkHref, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType, description string) (Task, error) {
 	if !isValidProtocol(protocol) {
 		return Task{}, fmt.Errorf("provided protocol is not one of TCP, UDP, TCPUDP, ICMP, ANY")

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -272,7 +272,9 @@ func (eGW *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort, 
 
 }
 
-// AddDNATRule creates firewall DNAT rule and return refreshed existing NAT rules array or error
+// AddDNATRule creates DNAT rule and return refreshed existing NAT rules array or error
+// Allows to assign specific network Org VDC or external. Old function AddNATPortMapping and
+// AddNATMapping assigns rule to first external network
 func (eGW *EdgeGateway) AddDNATRule(ruleDetails NatRule) ([]*types.NatRule, error) {
 
 	ruleDetails.natType = "DNAT"
@@ -294,6 +296,8 @@ func (eGW *EdgeGateway) AddDNATRule(ruleDetails NatRule) ([]*types.NatRule, erro
 }
 
 // AddSNATRule creates SNAT rule and returns refreshed existing NAT rules array or error
+// Allows to assign specific network Org VDC or external. Old function AddNATPortMapping and
+// AddNATMapping assigns rule to first external network
 func (eGW *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, description string) ([]*types.NatRule, error) {
 
 	task, err := eGW.AddNATRuleAsync(NatRule{networkHref: networkHref, natType: "SNAT", externalIP: externalIP,
@@ -316,6 +320,8 @@ func (eGW *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, descrip
 }
 
 // AddNATRuleAsync creates NAT rule and return task or err
+// Allows to assign specific network Org VDC or external. Old function AddNATPortMapping and
+// AddNATMapping assigns rule to first external network
 func (eGW *EdgeGateway) AddNATRuleAsync(ruleDetails NatRule) (Task, error) {
 	if !isValidProtocol(ruleDetails.protocol) {
 		return Task{}, fmt.Errorf("provided protocol is not one of TCP, UDP, TCPUDP, ICMP, ANY")

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -145,12 +145,14 @@ func (eGW *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 
 }
 
-// Temporary fix for existing Remove functions - until ID support
+// Temporary fix for existing Remove functions as it doesn't support network interfaces
+// TODO: remove this function when ruleId is available
 func (eGW *EdgeGateway) RemoveNATMappingRule(networkHref, natType, externalIP, internalIP, port string) (Task, error) {
 	return eGW.RemoveNATPortRule(networkHref, natType, externalIP, port, internalIP, port)
 }
 
-// Temporary fix for existing Remove functions - until ID support
+// Temporary fix for existing Remove functions as it doesn't support network interfaces
+// TODO: remove this function when ruleId is available
 func (eGW *EdgeGateway) RemoveNATPortRule(networkHref, natType, externalIP, externalPort, internalIP, internalPort string) (Task, error) {
 	newEdgeConfig := eGW.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 
@@ -198,6 +200,8 @@ func (eGW *EdgeGateway) RemoveNATPortRule(networkHref, natType, externalIP, exte
 
 }
 
+// Temporary fix to support parsing network Id from HREF
+// TODO: remove this function when ruleId is available
 func extractObjectIDfromPath(locationPath string) (string, error) {
 	if locationPath == "" {
 		return "", fmt.Errorf("unable to get ID from empty path")

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -401,7 +401,8 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	description1 := "my Dnat Description 1"
 	description2 := "my Dnatt Description 2"
 
-	natRules, err := edge.AddDNATRule(orgVdcNetwork.OrgVDCNetwork.HREF, vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "", description1)
+	natRules, err := edge.AddDNATRule(NatRule{networkHref: orgVdcNetwork.OrgVDCNetwork.HREF, externalIP: vcd.config.VCD.ExternalIp,
+		externalPort: "1177", internalIP: vcd.config.VCD.InternalIp, internalPort: "77", protocol: "TCP", description: description1})
 	check.Assert(err, IsNil)
 
 	found := false
@@ -433,7 +434,8 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
-	natRules, err = edge.AddDNATRule(externalNetwork.ExternalNetwork.HREF, vcd.config.VCD.ExternalIp, "1188", vcd.config.VCD.InternalIp, "88", "TCP", "", description2)
+	natRules, err = edge.AddDNATRule(NatRule{networkHref: externalNetwork.ExternalNetwork.HREF, externalIP: vcd.config.VCD.ExternalIp,
+		externalPort: "1188", internalIP: vcd.config.VCD.InternalIp, internalPort: "88", protocol: "TCP", description: description2})
 	check.Assert(err, IsNil)
 
 	found = false

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -307,6 +307,8 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
+	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)
+
 	natRules, err := edge.AddSNATRule(orgVdcNetwork.OrgVDCNetwork.HREF, vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, description1)
 	check.Assert(err, IsNil)
 
@@ -324,10 +326,16 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(rule.GatewayNatRule.OriginalIP, Equals, vcd.config.VCD.ExternalIp)
 	check.Assert(rule.Description, Equals, description1)
 
-	task, err := edge.RemoveNATMapping("SNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, "77")
+	task, err := edge.RemoveNATMappingRule(orgVdcNetwork.OrgVDCNetwork.HREF, "SNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, "")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	// verify delete
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
 	natRules, err = edge.AddSNATRule(externalNetwork.ExternalNetwork.HREF, vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, description2)
@@ -346,10 +354,20 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(rule.GatewayNatRule.OriginalIP, Equals, vcd.config.VCD.InternalIp)
 	check.Assert(rule.Description, Equals, description2)
 
-	task, err = edge.RemoveNATMapping("SNAT", vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "77")
+	task, err = edge.RemoveNATMappingRule(externalNetwork.ExternalNetwork.HREF, "SNAT", vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+
+	// verify delete
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
+
 }
 
 func (vcd *TestVCD) Test_AddDNATRule(check *C) {
@@ -378,6 +396,8 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
+	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)
+
 	description1 := "my Dnat Description 1"
 	description2 := "my Dnatt Description 2"
 
@@ -401,10 +421,16 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(rule.GatewayNatRule.Protocol, Equals, "tcp")
 	check.Assert(rule.GatewayNatRule.IcmpSubType, Equals, "")
 
-	task, err := edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77")
+	task, err := edge.RemoveNATPortRule(orgVdcNetwork.OrgVDCNetwork.HREF, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	// verify delete
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
 	natRules, err = edge.AddDNATRule(externalNetwork.ExternalNetwork.HREF, vcd.config.VCD.ExternalIp, "1188", vcd.config.VCD.InternalIp, "88", "TCP", "", description2)
@@ -426,8 +452,14 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(rule.GatewayNatRule.Protocol, Equals, "tcp")
 	check.Assert(rule.GatewayNatRule.IcmpSubType, Equals, "")
 
-	task, err = edge.RemoveNATPortMapping("DNAT", vcd.config.VCD.ExternalIp, "1188", vcd.config.VCD.InternalIp, "88")
+	task, err = edge.RemoveNATPortRule(externalNetwork.ExternalNetwork.HREF, "DNAT", vcd.config.VCD.ExternalIp, "1188", vcd.config.VCD.InternalIp, "88")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	// verify delete
+	err = edge.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 }


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/225

New function added:
AddSNATRule
AddDNATRule
AddNATRuleAsync

These new functions supports NAT rules creation for External netw or Org VDC netw for Edge gtw configuration. Terraform changes also ready.