### PR TITLE
Parse error of &types.NSXError{} for Load balancer Delete methods

### DIFF
--- a/govcd/lbappprofile.go
+++ b/govcd/lbappprofile.go
@@ -154,8 +154,13 @@ func (egw *EdgeGateway) DeleteLbAppProfile(lbAppProfileConfig *types.LbAppProfil
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
 
-	return egw.client.ExecuteRequestWithoutResponse(httpPath, http.MethodDelete, "application/xml",
-		"unable to delete application profile: %s", nil)
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to delete application profile: %s", nil, &types.NSXError{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteLbAppProfileById wraps DeleteLbAppProfile and requires only ID for deletion

--- a/govcd/lbapprule.go
+++ b/govcd/lbapprule.go
@@ -154,8 +154,13 @@ func (egw *EdgeGateway) DeleteLbAppRule(lbAppRuleConfig *types.LbAppRule) error 
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
 
-	return egw.client.ExecuteRequestWithoutResponse(httpPath, http.MethodDelete, "application/xml",
-		"unable to delete application rule: %s", nil)
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to delete application rule: %s", nil, &types.NSXError{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteLBAppRuleById wraps DeleteLbAppRule and requires only ID for deletion

--- a/govcd/lbserverpool.go
+++ b/govcd/lbserverpool.go
@@ -152,8 +152,14 @@ func (egw *EdgeGateway) DeleteLbServerPool(lbPoolConfig *types.LbPool) error {
 	if err != nil {
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
-	return egw.client.ExecuteRequestWithoutResponse(httpPath, http.MethodDelete, types.AnyXMLMime,
-		"unable to delete Server Pool: %s", nil)
+
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to delete server pool: %s", nil, &types.NSXError{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteLbServerPoolById wraps DeleteLbServerPool and requires only ID for deletion

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -92,7 +92,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 
 	// Try to delete used service monitor and expect it to fail with nice error
 	err = edge.DeleteLbServiceMonitor(lbMon)
-	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	check.Assert(err, ErrorMatches, `.*Fail to delete objectId .*\S+.* for it is used by .*`)
 
 	// Lookup by both name and ID and compare that these are equal values
 	lbPoolByID, err := edge.getLbServerPool(&types.LbPool{ID: createdLbPool.ID})

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -90,6 +90,10 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 	// We created server pool successfully therefore let's add it to cleanup list
 	AddToCleanupList(TestLbServerPool, "lbServerPool", parentEntity, check.TestName())
 
+	// Try to delete used service monitor and expect it to fail with nice error
+	err = edge.DeleteLbServiceMonitor(lbMon)
+	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+
 	// Lookup by both name and ID and compare that these are equal values
 	lbPoolByID, err := edge.getLbServerPool(&types.LbPool{ID: createdLbPool.ID})
 	check.Assert(err, IsNil)

--- a/govcd/lbservicemonitor.go
+++ b/govcd/lbservicemonitor.go
@@ -153,8 +153,14 @@ func (egw *EdgeGateway) DeleteLbServiceMonitor(lbMonitorConfig *types.LbMonitor)
 	if err != nil {
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
-	return egw.client.ExecuteRequestWithoutResponse(httpPath, http.MethodDelete, types.AnyXMLMime,
-		"unable to delete Service Monitor: %s", nil)
+
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to delete service monitor: %s", nil, &types.NSXError{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteLbServiceMonitorById wraps DeleteLbServiceMonitor and requires only ID for deletion

--- a/govcd/lbvirtualserver.go
+++ b/govcd/lbvirtualserver.go
@@ -156,8 +156,14 @@ func (egw *EdgeGateway) DeleteLbVirtualServer(lbVirtualServerConfig *types.LbVir
 	if err != nil {
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
-	return egw.client.ExecuteRequestWithoutResponse(httpPath, http.MethodDelete, types.AnyXMLMime,
-		"unable to delete load balancer virtual server: %s", nil)
+
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to delete load balancer virtual server: %s", nil, &types.NSXError{})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // DeleteLbVirtualServerById wraps DeleteLbVirtualServer and requires only ID for deletion

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -40,7 +40,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 		check.Skip("Skipping test because the edge gateway does not have advanced networking enabled")
 	}
 
-	_, serverPoolId, appProfileId, appRuleId := buildTestLBVirtualServerPrereqs("1.1.1.1", "2.2.2.2",
+	serviceMonitorId, serverPoolId, appProfileId, appRuleId := buildTestLBVirtualServerPrereqs("1.1.1.1", "2.2.2.2",
 		TestLbVirtualServer, check, vcd, edge)
 
 	// Configure creation object including reference to service monitor
@@ -72,6 +72,16 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	check.Assert(createdLbVirtualServer.AccelerationEnabled, Equals, lbVirtualServerConfig.AccelerationEnabled)
 	check.Assert(createdLbVirtualServer.ApplicationRuleIds, DeepEquals, lbVirtualServerConfig.ApplicationRuleIds)
 	check.Assert(createdLbVirtualServer.DefaultPoolId, Equals, lbVirtualServerConfig.DefaultPoolId)
+
+	// Try to delete child components and expect a a well parsed NSX error
+	err = edge.DeleteLbServiceMonitorById(serviceMonitorId)
+	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	err = edge.DeleteLbServerPoolById(serverPoolId)
+	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	err = edge.DeleteLbAppProfileById(appProfileId)
+	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	err = edge.DeleteLbAppRuleById(appRuleId)
+	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
 
 	// We created virtual server successfully therefore let's prepend it to cleanup list so that it
 	// is deleted before the child components

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -73,15 +73,15 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	check.Assert(createdLbVirtualServer.ApplicationRuleIds, DeepEquals, lbVirtualServerConfig.ApplicationRuleIds)
 	check.Assert(createdLbVirtualServer.DefaultPoolId, Equals, lbVirtualServerConfig.DefaultPoolId)
 
-	// Try to delete child components and expect a a well parsed NSX error
+	// Try to delete child components and expect a well parsed NSX error
 	err = edge.DeleteLbServiceMonitorById(serviceMonitorId)
-	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	check.Assert(err, ErrorMatches, `.*Fail to delete objectId .*\S+.* for it is used by .*`)
 	err = edge.DeleteLbServerPoolById(serverPoolId)
-	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	check.Assert(err, ErrorMatches, `.*Fail to delete objectId .*\S+.* for it is used by .*`)
 	err = edge.DeleteLbAppProfileById(appProfileId)
-	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	check.Assert(err, ErrorMatches, `.*Fail to delete objectId .*\S+.* for it is used by .*`)
 	err = edge.DeleteLbAppRuleById(appRuleId)
-	check.Assert(err, ErrorMatches, ".*Fail to delete objectId .* for it is used by .*")
+	check.Assert(err, ErrorMatches, `.*Fail to delete objectId .*\S+.* for it is used by .*`)
 
 	// We created virtual server successfully therefore let's prepend it to cleanup list so that it
 	// is deleted before the child components


### PR DESCRIPTION
At the moment load balancer components do not parse NSX error (&types.NSXError{}) if the Delete method fails. This does not give proper information to user without it.

Currently the provider gives such error:
```
vcd_lb_service_monitor.monitor: Destroying... [id=monitor-42]

Error: error deleting load balancer service monitor: unable to delete Service Monitor: API Error: 0:
```
After this PR it would be:
```
vcd_lb_service_monitor.monitor: Destroying... [id=monitor-42]

Error: error deleting load balancer service monitor: unable to delete service monitor: vShield Edge [LoadBalancer] Fail to delete objectId monitor-42 for it is used by pool-29 (API error: 14570)
```