### PR TITLE
Remove 'omitempty' struct tag from boolean values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.1 (Jul 29, 2019)
+
+BUG FIXES:
+
+* Remove `omitempty` struct tags from load balancer component boolean fields to allow sending `false` values to API [#222](https://github.com/vmware/go-vcloud-director/pull/222)
+
 ## 2.3.0 (Jul 26, 2019)
 
 * Added edge gateway create/delete functions [#130](https://github.com/vmware/go-vcloud-director/issues/130).

--- a/govcd/lbappprofile_test.go
+++ b/govcd/lbappprofile_test.go
@@ -35,7 +35,10 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 			Method: "sourceip",
 			Expire: 13,
 		},
-		Template: "HTTPS",
+		Template:                      "https",
+		SslPassthrough:                false,
+		InsertXForwardedForHttpHeader: false,
+		ServerSslEnabled:              false,
 	}
 
 	err = deleteLbAppProfileIfExists(edge, lbAppProfileConfig.Name)
@@ -43,6 +46,12 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 	createdLbAppProfile, err := edge.CreateLbAppProfile(lbAppProfileConfig)
 	check.Assert(err, IsNil)
 	check.Assert(createdLbAppProfile.ID, Not(IsNil))
+	check.Assert(createdLbAppProfile.Persistence.Method, Equals, lbAppProfileConfig.Persistence.Method)
+	check.Assert(createdLbAppProfile.Template, Equals, lbAppProfileConfig.Template)
+	check.Assert(createdLbAppProfile.Persistence.Expire, Equals, lbAppProfileConfig.Persistence.Expire)
+	check.Assert(createdLbAppProfile.SslPassthrough, Equals, lbAppProfileConfig.SslPassthrough)
+	check.Assert(createdLbAppProfile.InsertXForwardedForHttpHeader, Equals, lbAppProfileConfig.InsertXForwardedForHttpHeader)
+	check.Assert(createdLbAppProfile.ServerSslEnabled, Equals, lbAppProfileConfig.ServerSslEnabled)
 
 	// We created application profile successfully therefore let's add it to cleanup list
 	parentEntity := vcd.org.Org.Name + "|" + vcd.vdc.Vdc.Name + "|" + vcd.config.VCD.EdgeGateway
@@ -69,6 +78,16 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 	updatedAppProfile, err := edge.UpdateLbAppProfile(lbAppProfileByID)
 	check.Assert(err, IsNil)
 	check.Assert(updatedAppProfile.Persistence.Method, Equals, lbAppProfileByID.Persistence.Method)
+
+	// Update boolean value fields
+	lbAppProfileByID.SslPassthrough = true
+	lbAppProfileByID.InsertXForwardedForHttpHeader = true
+	lbAppProfileByID.ServerSslEnabled = true
+	updatedAppProfile, err = edge.UpdateLbAppProfile(lbAppProfileByID)
+	check.Assert(err, IsNil)
+	check.Assert(updatedAppProfile.SslPassthrough, Equals, lbAppProfileByID.SslPassthrough)
+	check.Assert(updatedAppProfile.InsertXForwardedForHttpHeader, Equals, lbAppProfileByID.InsertXForwardedForHttpHeader)
+	check.Assert(updatedAppProfile.ServerSslEnabled, Equals, lbAppProfileByID.ServerSslEnabled)
 
 	// Verify that updated application profile and its configuration are identical
 	check.Assert(updatedAppProfile, DeepEquals, lbAppProfileByID)

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -52,9 +52,10 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 
 	// Configure creation object including reference to service monitor
 	lbPoolConfig := &types.LbPool{
-		Name:      TestLbServerPool,
-		Algorithm: "round-robin",
-		MonitorId: lbMonitor.ID,
+		Name:        TestLbServerPool,
+		Transparent: false,
+		Algorithm:   "round-robin",
+		MonitorId:   lbMonitor.ID,
 		Members: types.LbPoolMembers{
 			types.LbPoolMember{
 				Name:      "Server_one",
@@ -78,6 +79,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 	createdLbPool, err := edge.CreateLbServerPool(lbPoolConfig)
 	check.Assert(err, IsNil)
 	check.Assert(createdLbPool.ID, Not(IsNil))
+	check.Assert(createdLbPool.Transparent, Equals, lbPoolConfig.Transparent)
 	check.Assert(createdLbPool.MonitorId, Equals, lbMonitor.ID)
 	check.Assert(len(createdLbPool.Members), Equals, 2)
 	check.Assert(createdLbPool.Members[0].Condition, Equals, "enabled")
@@ -114,6 +116,12 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 	updatedLBPool, err := edge.UpdateLbServerPool(lbPoolByID)
 	check.Assert(err, IsNil)
 	check.Assert(updatedLBPool.Algorithm, Equals, lbPoolByID.Algorithm)
+
+	// Update boolean value fields
+	lbPoolByID.Transparent = true
+	updatedLBPool, err = edge.UpdateLbServerPool(lbPoolByID)
+	check.Assert(err, IsNil)
+	check.Assert(updatedLBPool.Transparent, Equals, lbPoolByID.Transparent)
 
 	// Verify that updated pool and it's configuration are identical
 	check.Assert(updatedLBPool, DeepEquals, lbPoolByID)

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -47,8 +47,8 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	lbVirtualServerConfig := &types.LbVirtualServer{
 		Name:                 TestLbVirtualServer,
 		IpAddress:            vcd.config.VCD.ExternalIp, // Load balancer virtual server serves on Edge gw IP
-		Enabled:              true,
-		AccelerationEnabled:  true,
+		Enabled:              false,
+		AccelerationEnabled:  false,
 		Protocol:             "http",
 		Port:                 8888,
 		ConnectionLimit:      5,
@@ -106,6 +106,14 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	updatedLBPool, err := edge.UpdateLbVirtualServer(lbVirtualServerById)
 	check.Assert(err, IsNil)
 	check.Assert(updatedLBPool.Port, Equals, lbVirtualServerById.Port)
+
+	// Update boolean value fields
+	lbVirtualServerById.Enabled = true
+	lbVirtualServerById.AccelerationEnabled = true
+	updatedLBPool, err = edge.UpdateLbVirtualServer(lbVirtualServerById)
+	check.Assert(err, IsNil)
+	check.Assert(updatedLBPool.Enabled, Equals, lbVirtualServerById.Enabled)
+	check.Assert(updatedLBPool.AccelerationEnabled, Equals, lbVirtualServerById.AccelerationEnabled)
 
 	// Verify that updated pool and its configuration are identical
 	check.Assert(updatedLBPool, DeepEquals, lbVirtualServerById)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1714,7 +1714,7 @@ type LbPool struct {
 	Description         string        `xml:"description,omitempty"`
 	Algorithm           string        `xml:"algorithm"`
 	AlgorithmParameters string        `xml:"algorithmParameters,omitempty"`
-	Transparent         bool          `xml:"transparent,omitempty"`
+	Transparent         bool          `xml:"transparent"`
 	MonitorId           string        `xml:"monitorId,omitempty"`
 	Members             LbPoolMembers `xml:"member,omitempty"`
 }
@@ -1743,12 +1743,12 @@ type LbAppProfile struct {
 	XMLName                       xml.Name                  `xml:"applicationProfile"`
 	ID                            string                    `xml:"applicationProfileId,omitempty"`
 	Name                          string                    `xml:"name,omitempty"`
-	SslPassthrough                bool                      `xml:"sslPassthrough,omitempty"`
+	SslPassthrough                bool                      `xml:"sslPassthrough"`
 	Template                      string                    `xml:"template,omitempty"`
 	HttpRedirect                  *LbAppProfileHttpRedirect `xml:"httpRedirect,omitempty"`
 	Persistence                   *LbAppProfilePersistence  `xml:"persistence,omitempty"`
-	InsertXForwardedForHttpHeader bool                      `xml:"insertXForwardedFor,omitempty"`
-	ServerSslEnabled              bool                      `xml:"serverSslEnabled,omitempty"`
+	InsertXForwardedForHttpHeader bool                      `xml:"insertXForwardedFor"`
+	ServerSslEnabled              bool                      `xml:"serverSslEnabled"`
 }
 
 type LbAppProfiles []LbAppProfile
@@ -1788,11 +1788,11 @@ type LbVirtualServer struct {
 	ID                   string   `xml:"virtualServerId,omitempty"`
 	Name                 string   `xml:"name,omitempty"`
 	Description          string   `xml:"description,omitempty"`
-	Enabled              bool     `xml:"enabled,omitempty"`
+	Enabled              bool     `xml:"enabled"`
 	IpAddress            string   `xml:"ipAddress"`
 	Protocol             string   `xml:"protocol"`
 	Port                 int      `xml:"port"`
-	AccelerationEnabled  bool     `xml:"accelerationEnabled,omitempty"`
+	AccelerationEnabled  bool     `xml:"accelerationEnabled"`
 	ConnectionLimit      int      `xml:"connectionLimit,omitempty"`
 	ConnectionRateLimit  int      `xml:"connectionRateLimit,omitempty"`
 	ApplicationProfileId string   `xml:"applicationProfileId,omitempty"`


### PR DESCRIPTION
Boolean values are not sent if they have `omitempty` tag. This causes some functionality problems (as some boolean fields are not properly set).

This PR removes `omitempty` struct tags from all `bool` fields in load balancers and adds extra tests.