### PR TITLE
Add methods to find provider VDC entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0 (Unreleased)
+
+* Added method `(*VCDClient) QueryProviderVdcs()` 
+* Added method `(*VCDClient) QueryProviderVdcStorageProfiles()` 
+* Added method `(*VCDClient) QueryNetworkPools()` 
+
 ## 2.3.1 (Jul 29, 2019)
 
 BUG FIXES:

--- a/TESTING.md
+++ b/TESTING.md
@@ -316,7 +316,7 @@ While running tests, the following environment variables can be used:
 * `GOVCD_CONFIG=/path/file`: sets an alternative configuration file for the tests.
    e.g.:  `GOVCD_CONFIG=/some/path/govcd_test_config.yaml go test -tags functional -timeout 0 .`
 * `GOVCD_DEBUG=1`: enable debug output on screen.
-* `TEST_VERBOSE=1`: shows execution details in unit tests.
+* `GOVCD_TEST_VERBOSE=1`: shows execution details in some tests.
 * `GOVCD_SKIP_VAPP_CREATION=1`: will not create the initial vApp. All tests that
    depend on a vApp availability will be skipped.
 * `GOVCD_TASK_MONITOR=show|log|simple_show|simple|log`: sets a task monitor function when running `task.WaitCompletion`

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -14,6 +14,8 @@ import (
 
 var testingTags = make(map[string]string)
 
+var testVerbose bool = os.Getenv("GOVCD_TEST_VERBOSE") != ""
+
 func tagsHelp(t *testing.T) {
 
 	var helpText string = `

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -15,6 +15,7 @@ import (
 var testingTags = make(map[string]string)
 
 var testVerbose bool = os.Getenv("GOVCD_TEST_VERBOSE") != ""
+
 // longer than the 128 characters so nothing can be named this
 var INVALID_NAME = `*******************************************INVALID
 					****************************************************

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -464,6 +464,7 @@ func getExtension(client *Client) (*types.Extension, error) {
 }
 
 // QueryProviderVdcStorageProfileByName finds a provider VDC storage profile by name
+// Deprecated: use vcdClient.QueryProviderVdcStorageProfileByName instead
 func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
@@ -477,6 +478,7 @@ func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*ty
 }
 
 // QueryNetworkPoolByName finds a network pool by name
+// Deprecated: use vcdClient.QueryNetworkPoolByName instead
 func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResultNetworkPoolRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "networkPool",
@@ -489,7 +491,8 @@ func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 	return results.Results.NetworkPoolRecord, nil
 }
 
-// QueryNetworkPoolByName finds a provider VDC by name
+// QueryProviderVdcByName finds a provider VDC by name
+// Deprecated: use vcdClient.QueryProviderVdcByName instead
 func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",
@@ -500,6 +503,94 @@ func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 	}
 
 	return results.Results.VMWProviderVdcRecord, nil
+}
+
+// QueryNetworkPoolByName finds a network pool by name
+func (vcdClient *VCDClient) QueryNetworkPoolByName(name string) (*types.QueryResultNetworkPoolRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "networkPool",
+		"filter": fmt.Sprintf("(name==%s)", name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, networkPool := range results.Results.NetworkPoolRecord {
+		if networkPool.Name == name {
+			return networkPool, nil
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// QueryProviderVdcByName finds a provider VDC by name
+func (vcdClient *VCDClient) QueryProviderVdcByName(name string) (*types.QueryResultVMWProviderVdcRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "providerVdc",
+		"filter": fmt.Sprintf("(name==%s)", name),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, providerVdc := range results.Results.VMWProviderVdcRecord {
+		if providerVdc.Name == name {
+			return providerVdc, nil
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// QueryProviderVdcStorageProfileByName finds a provider VDC storage profile by name
+func (vcdClient *VCDClient) QueryProviderVdcStorageProfileByName(name string) (*types.QueryResultProviderVdcStorageProfileRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "providerVdcStorageProfile",
+		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, storageProfile := range results.Results.ProviderVdcStorageProfileRecord {
+		if storageProfile.Name == name {
+			return storageProfile, nil
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// QueryProviderVdcs gets the list of available provider VDCs
+func (vcdClient *VCDClient) QueryProviderVdcs() ([]*types.QueryResultVMWProviderVdcRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type": "providerVdc",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results.Results.VMWProviderVdcRecord, nil
+}
+
+// QueryNetworkPools gets the list of network pools
+func (vcdClient *VCDClient) QueryNetworkPools() ([]*types.QueryResultNetworkPoolRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type": "networkPool",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results.Results.NetworkPoolRecord, nil
+}
+
+// QueryProviderVdcStorageProfiles gets the list of provider VDC storage profiles
+func (vcdClient *VCDClient) QueryProviderVdcStorageProfiles() ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+		"type": "providerVdcStorageProfile",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results.Results.ProviderVdcStorageProfileRecord, nil
 }
 
 // GetNetworkPoolByHREF functions fetches an network pool using VDC client and network pool href

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -464,7 +464,6 @@ func getExtension(client *Client) (*types.Extension, error) {
 }
 
 // QueryProviderVdcStorageProfileByName finds a provider VDC storage profile by name
-// Deprecated: use vcdClient.QueryProviderVdcStorageProfileByName instead
 func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
@@ -478,7 +477,6 @@ func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*ty
 }
 
 // QueryNetworkPoolByName finds a network pool by name
-// Deprecated: use vcdClient.QueryNetworkPoolByName instead
 func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResultNetworkPoolRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "networkPool",
@@ -492,7 +490,6 @@ func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 }
 
 // QueryProviderVdcByName finds a provider VDC by name
-// Deprecated: use vcdClient.QueryProviderVdcByName instead
 func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",
@@ -503,58 +500,6 @@ func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 	}
 
 	return results.Results.VMWProviderVdcRecord, nil
-}
-
-// QueryNetworkPoolByName finds a network pool by name
-func (vcdClient *VCDClient) QueryNetworkPoolByName(name string) (*types.QueryResultNetworkPoolRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
-		"type":   "networkPool",
-		"filter": fmt.Sprintf("(name==%s)", name),
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, networkPool := range results.Results.NetworkPoolRecord {
-		if networkPool.Name == name {
-			return networkPool, nil
-		}
-	}
-	return nil, ErrorEntityNotFound
-}
-
-// QueryProviderVdcByName finds a provider VDC by name
-func (vcdClient *VCDClient) QueryProviderVdcByName(name string) (*types.QueryResultVMWProviderVdcRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
-		"type":   "providerVdc",
-		"filter": fmt.Sprintf("(name==%s)", name),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, providerVdc := range results.Results.VMWProviderVdcRecord {
-		if providerVdc.Name == name {
-			return providerVdc, nil
-		}
-	}
-	return nil, ErrorEntityNotFound
-}
-
-// QueryProviderVdcStorageProfileByName finds a provider VDC storage profile by name
-func (vcdClient *VCDClient) QueryProviderVdcStorageProfileByName(name string) (*types.QueryResultProviderVdcStorageProfileRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
-		"type":   "providerVdcStorageProfile",
-		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, storageProfile := range results.Results.ProviderVdcStorageProfileRecord {
-		if storageProfile.Name == name {
-			return storageProfile, nil
-		}
-	}
-	return nil, ErrorEntityNotFound
 }
 
 // QueryProviderVdcs gets the list of available provider VDCs

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -243,6 +243,7 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 	}
 	providerVdcs, err := vcd.client.QueryProviderVdcs()
 	check.Assert(err, IsNil)
+	check.Assert(len(providerVdcName) > 0, Equals, true)
 
 	providerFound := false
 	for _, providerVdc := range providerVdcs {
@@ -257,9 +258,6 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 			fmt.Printf("\t enabled %v\n", providerVdc.IsEnabled)
 			fmt.Println("")
 		}
-		newPvdc, err := vcd.client.QueryProviderVdcByName(providerVdc.Name)
-		check.Assert(err, IsNil)
-		check.Assert(newPvdc.Name, Equals, providerVdc.Name)
 	}
 	check.Assert(providerFound, Equals, true)
 
@@ -268,6 +266,7 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 	}
 	netPools, err := vcd.client.QueryNetworkPools()
 	check.Assert(err, IsNil)
+	check.Assert(len(netPools) > 0, Equals, true)
 	networkPoolFound := false
 	for _, networkPool := range netPools {
 		if networkPoolName == networkPool.Name {
@@ -279,9 +278,6 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 			fmt.Printf("\t type %v\n", networkPool.NetworkPoolType)
 			fmt.Println("")
 		}
-		newNetworkPool, err := vcd.client.QueryNetworkPoolByName(networkPool.Name)
-		check.Assert(err, IsNil)
-		check.Assert(newNetworkPool.Name, Equals, networkPool.Name)
 	}
 	check.Assert(networkPoolFound, Equals, true)
 
@@ -290,6 +286,7 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 	}
 	storageProfiles, err := vcd.client.QueryProviderVdcStorageProfiles()
 	check.Assert(err, IsNil)
+	check.Assert(len(storageProfiles) > 0, Equals, true)
 	storageProfileFound := false
 	for _, sp := range storageProfiles {
 		if storageProfileName == sp.Name {
@@ -304,9 +301,6 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 			fmt.Printf("\t used        %12d\n", sp.StorageUsedMB)
 			fmt.Println("")
 		}
-		newStorageProfile, err := vcd.client.QueryProviderVdcStorageProfileByName(sp.Name)
-		check.Assert(err, IsNil)
-		check.Assert(newStorageProfile.Name, Equals, sp.Name)
 	}
 	check.Assert(storageProfileFound, Equals, true)
 

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -8,7 +8,6 @@ package govcd
 
 import (
 	"fmt"
-	"os"
 
 	. "gopkg.in/check.v1"
 
@@ -245,7 +244,6 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 	providerVdcs, err := vcd.client.QueryProviderVdcs()
 	check.Assert(err, IsNil)
 
-	testVerbose := os.Getenv("TEST_VERBOSE") != ""
 	providerFound := false
 	for _, providerVdc := range providerVdcs {
 		if providerVdcName == providerVdc.Name {

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -8,7 +8,6 @@
 package govcd
 
 import (
-	"os"
 	"testing"
 )
 
@@ -105,7 +104,7 @@ func Test_BareID(t *testing.T) {
 			t.Fail()
 		}
 		if bareId == it.expected {
-			if os.Getenv("TEST_VERBOSE") != "" {
+			if testVerbose {
 				t.Logf("ID '%s': found '%s' as expected", it.rawId, it.expected)
 			}
 		} else {
@@ -120,7 +119,7 @@ func Test_BareID(t *testing.T) {
 			t.Fail()
 		}
 		if bareId == it.expected {
-			if os.Getenv("TEST_VERBOSE") != "" {
+			if testVerbose {
 				t.Logf("ID '%s': found '%s' as expected", it.rawId, it.expected)
 			}
 		} else {

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -214,7 +214,7 @@ func Test_GetUuidFromHref(t *testing.T) {
 			t.Fail()
 		}
 		if bareId == it.expected {
-			if os.Getenv("TEST_VERBOSE") != "" {
+			if testVerbose {
 				t.Logf("ID '%s': found '%s' as expected", it.rawHref, it.expected)
 			}
 		} else {
@@ -229,7 +229,7 @@ func Test_GetUuidFromHref(t *testing.T) {
 			t.Fail()
 		}
 		if bareId == it.expected {
-			if os.Getenv("TEST_VERBOSE") != "" {
+			if testVerbose {
 				t.Logf("ID '%s': found '%s' as expected", it.rawHref, it.expected)
 			}
 		} else {


### PR DESCRIPTION
Add method VCDClient.QueryProviderVdcs
Add method VCDClient.QueryNetworkPools
Add method VCDClient.QueryProviderVdcStorageProfiles

The main reason for these additions is to improve the configuration file generation, and allow us to create them using just the credentials, while the provider VDC is retrieved from the server.