### PR TITLE
Add metadata functionality for vAppTemplate and media image/item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0 (To be decided, 2019)
+
+* Added get/add/delete functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
+
 ## 2.3.1 (Jul 29, 2019)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.0 (To be decided, 2019)
 
-* Added get/add/delete functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
+* Added get/add/delete metadata functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -337,3 +337,20 @@ func FindMediaAsCatalogItem(org *Org, catalogName, mediaName string) (CatalogIte
 	}
 	return media, nil
 }
+
+// Refresh refreshes the media item information by href
+func (mediaItem *MediaItem) Refresh() error {
+
+	if mediaItem.MediaItem == nil {
+		return fmt.Errorf("cannot refresh, Object is empty")
+	}
+
+	url := mediaItem.MediaItem.HREF
+
+	mediaItem.MediaItem = &types.MediaRecordType{}
+
+	_, err := mediaItem.client.ExecuteRequest(url, http.MethodGet,
+		"", "error retrieving media item: %s", nil, mediaItem.MediaItem)
+
+	return err
+}

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -346,6 +346,9 @@ func (mediaItem *MediaItem) Refresh() error {
 	}
 
 	url := mediaItem.MediaItem.HREF
+	if url == "nil" {
+		return fmt.Errorf("cannot refresh, HREF is empty")
+	}
 
 	mediaItem.MediaItem = &types.MediaRecordType{}
 

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -21,13 +21,13 @@ import (
 
 type MediaItem struct {
 	MediaItem *types.MediaRecordType
-	client    *Client
+	vdc       *Vdc
 }
 
-func NewMediaItem(cli *Client) *MediaItem {
+func NewMediaItem(vdc *Vdc) *MediaItem {
 	return &MediaItem{
 		MediaItem: new(types.MediaRecordType),
-		client:    cli,
+		vdc:       vdc,
 	}
 }
 
@@ -313,7 +313,7 @@ func (mediaItem *MediaItem) Delete() (Task, error) {
 	util.Logger.Printf("[TRACE] Deleting media item: %#v", mediaItem.MediaItem.Name)
 
 	// Return the task
-	return mediaItem.client.ExecuteTaskRequest(mediaItem.MediaItem.HREF, http.MethodDelete,
+	return mediaItem.vdc.client.ExecuteTaskRequest(mediaItem.MediaItem.HREF, http.MethodDelete,
 		"", "error deleting Media item: %s", nil)
 }
 
@@ -345,15 +345,12 @@ func (mediaItem *MediaItem) Refresh() error {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	url := mediaItem.MediaItem.HREF
-	if url == "nil" {
-		return fmt.Errorf("cannot refresh, HREF is empty")
+	if mediaItem.MediaItem.Name == "nil" {
+		return fmt.Errorf("cannot refresh, Name is empty")
 	}
 
-	mediaItem.MediaItem = &types.MediaRecordType{}
-
-	_, err := mediaItem.client.ExecuteRequest(url, http.MethodGet,
-		"", "error retrieving media item: %s", nil, mediaItem.MediaItem)
+	latestMediaItem, err := mediaItem.vdc.FindMediaImage(mediaItem.MediaItem.Name)
+	*mediaItem = latestMediaItem
 
 	return err
 }

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -170,10 +170,11 @@ func (vcd *TestVCD) Test_FindMediaAsCatalogItem(check *C) {
 // Tests System function Refresh
 func (vcd *TestVCD) Test_RefreshMediaImage(check *C) {
 	skipWhenMediaPathMissing(vcd, check)
-	itemName := TestUploadMedia + "6"
+	itemName := "TestRefreshMedia"
 
 	uploadTask, err := vcd.vdc.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
+	check.Assert(uploadTask, NotNil)
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
@@ -181,6 +182,7 @@ func (vcd *TestVCD) Test_RefreshMediaImage(check *C) {
 
 	mediaItem, err := vcd.vdc.FindMediaImage(itemName)
 	check.Assert(err, IsNil)
+	check.Assert(mediaItem, NotNil)
 	check.Assert(mediaItem, Not(Equals), MediaItem{})
 
 	oldMediaItem := mediaItem

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -166,3 +166,25 @@ func (vcd *TestVCD) Test_FindMediaAsCatalogItem(check *C) {
 	check.Assert(catalogItem.CatalogItem.Name, Equals, itemName)
 
 }
+
+// Tests System function Refresh
+func (vcd *TestVCD) Test_RefreshMediaImage(check *C) {
+	skipWhenMediaPathMissing(vcd, check)
+	itemName := TestUploadMedia + "6"
+
+	uploadTask, err := vcd.vdc.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	check.Assert(err, IsNil)
+	err = uploadTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
+
+	mediaItem, err := vcd.vdc.FindMediaImage(itemName)
+	check.Assert(err, IsNil)
+	check.Assert(mediaItem, Not(Equals), MediaItem{})
+
+	oldMediaItem := mediaItem
+	mediaItem.Refresh()
+
+	check.Assert(oldMediaItem.MediaItem, Equals, mediaItem.MediaItem)
+}

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -188,5 +188,8 @@ func (vcd *TestVCD) Test_RefreshMediaImage(check *C) {
 	oldMediaItem := mediaItem
 	mediaItem.Refresh()
 
-	check.Assert(oldMediaItem.MediaItem, Equals, mediaItem.MediaItem)
+	check.Assert(mediaItem, NotNil)
+	check.Assert(oldMediaItem.MediaItem.ID, Equals, mediaItem.MediaItem.ID)
+	check.Assert(oldMediaItem.MediaItem.Name, Equals, mediaItem.MediaItem.Name)
+	check.Assert(oldMediaItem.MediaItem.HREF, Equals, mediaItem.MediaItem.HREF)
 }

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -203,7 +203,7 @@ func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(key string) (Task, error) 
 // GetMetadata() function calls private function getMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which returns a *types.Metadata struct for provided media item input.
 func (mediaItem *MediaItem) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(mediaItem.client, mediaItem.MediaItem.HREF)
+	return getMetadata(mediaItem.vdc.client, mediaItem.MediaItem.HREF)
 }
 
 // AddMetadata() function adds metadata key/value pair provided as input.
@@ -228,7 +228,7 @@ func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, e
 // AddMetadataAsync() function calls private function addMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which adds metadata key/value pair provided as input.
 func (mediaItem *MediaItem) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(mediaItem.client, key, value, mediaItem.MediaItem.HREF)
+	return addMetadata(mediaItem.vdc.client, key, value, mediaItem.MediaItem.HREF)
 }
 
 // DeleteMetadata() function calls deletes metadata depending on key provided as input from media item.
@@ -248,5 +248,5 @@ func (mediaItem *MediaItem) DeleteMetadata(key string) error {
 // DeleteMetadataAsync() function calls private function deleteMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which deletes metadata depending on key provided as input from media item.
 func (mediaItem *MediaItem) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(mediaItem.client, key, mediaItem.MediaItem.HREF)
+	return deleteMetadata(mediaItem.vdc.client, key, mediaItem.MediaItem.HREF)
 }

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -25,7 +25,7 @@ func (vm *VM) DeleteMetadata(key string) (Task, error) {
 }
 
 // AddMetadata() function calls private function addMetadata() with vm.client and vm.VM.HREF
-// which adds metadata key, value pair provided as input to VM.
+// which adds metadata key/value pair provided as input to VM.
 func (vm *VM) AddMetadata(key string, value string) (Task, error) {
 	return addMetadata(vm.client, key, value, vm.VM.HREF)
 }
@@ -55,7 +55,7 @@ func (vdc *Vdc) DeleteMetadata(key string) (Vdc, error) {
 	return *vdc, nil
 }
 
-// AddMetadata() function adds metadata key, value pair provided as input to VDC.
+// AddMetadata() function adds metadata key/value pair provided as input to VDC.
 func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
 	task, err := addMetadata(vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
 	if err != nil {
@@ -75,7 +75,7 @@ func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
 	return *vdc, nil
 }
 
-// AddMetadata() function adds metadata key, value pair provided as input to VDC.
+// AddMetadata() function adds metadata key/value pair provided as input to VDC.
 // and returns task
 func (vdc *Vdc) AddMetadataAsync(key string, value string) (Task, error) {
 	return addMetadata(vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
@@ -124,7 +124,7 @@ func deleteMetadata(client *Client, key string, requestUri string) (Task, error)
 }
 
 // AddMetadata() function calls private function addMetadata() with vapp.client and vapp.VApp.HREF
-// which adds metadata key, value pair provided as input
+// which adds metadata key/value pair provided as input
 func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
 	return addMetadata(vapp.client, key, value, vapp.VApp.HREF)
 }
@@ -155,7 +155,7 @@ func (vAppTemplate *VAppTemplate) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
 }
 
-// AddMetadata() function adds metadata key, value pair provided as input and returned update VAppTemplate
+// AddMetadata() function adds metadata key/value pair provided as input and returned update VAppTemplate
 func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTemplate, error) {
 	task, err := vAppTemplate.AddMetadataAsync(key, value)
 	if err != nil {
@@ -174,8 +174,8 @@ func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTe
 	return vAppTemplate, nil
 }
 
-// AddMetadata() function calls private function addMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
-// which adds metadata key, value pair provided as input.
+// AddMetadataAsync() function calls private function addMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
+// which adds metadata key/value pair provided as input.
 func (vAppTemplate *VAppTemplate) AddMetadataAsync(key string, value string) (Task, error) {
 	return addMetadata(vAppTemplate.client, key, value, vAppTemplate.VAppTemplate.HREF)
 }
@@ -194,7 +194,7 @@ func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
 	return nil
 }
 
-// DeleteMetadata() function calls private function deleteMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
+// DeleteMetadataAsync() function calls private function deleteMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
 // which deletes metadata depending on key provided as input from catalog item.
 func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
@@ -206,7 +206,7 @@ func (mediaItem *MediaItem) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(mediaItem.client, mediaItem.MediaItem.HREF)
 }
 
-// AddMetadata() function adds metadata key, value pair provided as input.
+// AddMetadata() function adds metadata key/value pair provided as input.
 func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, error) {
 	task, err := mediaItem.AddMetadataAsync(key, value)
 	if err != nil {
@@ -214,19 +214,19 @@ func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, e
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return nil, fmt.Errorf("error completing add metadata for media item task: %#v", err)
+		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
 	}
 
 	err = mediaItem.Refresh()
 	if err != nil {
-		return nil, fmt.Errorf("error refreshing media item: %#v", err)
+		return nil, fmt.Errorf("error refreshing media item: %s", err)
 	}
 
 	return mediaItem, nil
 }
 
-// AddMetadata() function calls private function addMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
-// which adds metadata key, value pair provided as input.
+// AddMetadataAsync() function calls private function addMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
+// which adds metadata key/value pair provided as input.
 func (mediaItem *MediaItem) AddMetadataAsync(key string, value string) (Task, error) {
 	return addMetadata(mediaItem.client, key, value, mediaItem.MediaItem.HREF)
 }
@@ -239,13 +239,13 @@ func (mediaItem *MediaItem) DeleteMetadata(key string) error {
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error completing delete metadata for media item task: %#v", err)
+		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
 	}
 
 	return nil
 }
 
-// DeleteMetadata() function calls private function deleteMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
+// DeleteMetadataAsync() function calls private function deleteMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which deletes metadata depending on key provided as input from media item.
 func (mediaItem *MediaItem) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(mediaItem.client, key, mediaItem.MediaItem.HREF)

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"fmt"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"net/http"
 	"net/url"
@@ -123,7 +124,7 @@ func deleteMetadata(client *Client, key string, requestUri string) (Task, error)
 }
 
 // AddMetadata() function calls private function addMetadata() with vapp.client and vapp.VApp.HREF
-// which adds metadata key, value pair provided as input.
+// which adds metadata key, value pair provided as input
 func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
 	return addMetadata(vapp.client, key, value, vapp.VApp.HREF)
 }
@@ -146,4 +147,106 @@ func addMetadata(client *Client, key string, value string, requestUri string) (T
 	// Return the task
 	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
 		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
+}
+
+// GetMetadata() function calls private function getMetadata() with catalogItem.client and catalogItem.CatalogItem.HREF
+// which returns a *types.Metadata struct for provided catalog item input.
+func (vAppTemplate *VAppTemplate) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
+}
+
+// AddMetadata() function adds metadata key, value pair provided as input and returned update VAppTemplate
+func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTemplate, error) {
+	task, err := vAppTemplate.AddMetadataAsync(key, value)
+	if err != nil {
+		return nil, err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error completing add metadata for vApp template task: %#v", err)
+	}
+
+	err = vAppTemplate.Refresh()
+	if err != nil {
+		return nil, fmt.Errorf("error refreshing vApp template: %#v", err)
+	}
+
+	return vAppTemplate, nil
+}
+
+// AddMetadata() function calls private function addMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
+// which adds metadata key, value pair provided as input.
+func (vAppTemplate *VAppTemplate) AddMetadataAsync(key string, value string) (Task, error) {
+	return addMetadata(vAppTemplate.client, key, value, vAppTemplate.VAppTemplate.HREF)
+}
+
+// DeleteMetadata() function calls deletes metadata depending on key provided as input from media item.
+func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
+	task, err := vAppTemplate.DeleteMetadataAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error completing delete metadata for vApp template task: %#v", err)
+	}
+
+	return nil
+}
+
+// DeleteMetadata() function calls private function deleteMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
+// which deletes metadata depending on key provided as input from catalog item.
+func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(key string) (Task, error) {
+	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
+}
+
+// GetMetadata() function calls private function getMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
+// which returns a *types.Metadata struct for provided media item input.
+func (mediaItem *MediaItem) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(mediaItem.client, mediaItem.MediaItem.HREF)
+}
+
+// AddMetadata() function adds metadata key, value pair provided as input.
+func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, error) {
+	task, err := mediaItem.AddMetadataAsync(key, value)
+	if err != nil {
+		return nil, err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error completing add metadata for media item task: %#v", err)
+	}
+
+	err = mediaItem.Refresh()
+	if err != nil {
+		return nil, fmt.Errorf("error refreshing media item: %#v", err)
+	}
+
+	return mediaItem, nil
+}
+
+// AddMetadata() function calls private function addMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
+// which adds metadata key, value pair provided as input.
+func (mediaItem *MediaItem) AddMetadataAsync(key string, value string) (Task, error) {
+	return addMetadata(mediaItem.client, key, value, mediaItem.MediaItem.HREF)
+}
+
+// DeleteMetadata() function calls deletes metadata depending on key provided as input from media item.
+func (mediaItem *MediaItem) DeleteMetadata(key string) error {
+	task, err := mediaItem.DeleteMetadataAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error completing delete metadata for media item task: %#v", err)
+	}
+
+	return nil
+}
+
+// DeleteMetadata() function calls private function deleteMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
+// which deletes metadata depending on key provided as input from media item.
+func (mediaItem *MediaItem) DeleteMetadataAsync(key string) (Task, error) {
+	return deleteMetadata(mediaItem.client, key, mediaItem.MediaItem.HREF)
 }

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -281,8 +281,8 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaItem(check *C) {
 	itemName := "TestDeleteMediaMetaData"
 
 	org, err := GetAdminOrgByName(vcd.client, vcd.org.Org.Name)
-	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
+	check.Assert(org, Not(Equals), AdminOrg{})
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -197,9 +197,13 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 
 	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
+	check.Assert(catItem, NotNil)
+	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	vAppTemplate, err := catItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
+	check.Assert(vAppTemplate, NotNil)
+	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Add metadata
 	_, err = vAppTemplate.AddMetadata("key2", "value2")
@@ -211,6 +215,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 
 	metadata, err := vAppTemplate.GetMetadata()
 	check.Assert(err, IsNil)
+	check.Assert(metadata, NotNil)
 	for _, k := range metadata.MetadataEntry {
 		if k.Key == "key2" {
 			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
@@ -231,13 +236,19 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 
 	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
+	check.Assert(catItem, NotNil)
+	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	vAppTemplate, err := catItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
+	check.Assert(vAppTemplate, NotNil)
+	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Check how much metaData exist
 	metadata, err := vAppTemplate.GetMetadata()
 	check.Assert(err, IsNil)
+	check.Assert(metadata, NotNil)
+	check.Assert(metadata.MetadataEntry, NotNil)
 	existingMetaDataCount := len(metadata.MetadataEntry)
 
 	// Add metadata
@@ -247,6 +258,8 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	// Check if metadata was added correctly
 	metadata, err = vAppTemplate.GetMetadata()
 	check.Assert(err, IsNil)
+	check.Assert(metadata, NotNil)
+	check.Assert(metadata.MetadataEntry, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, existingMetaDataCount+1)
 	var foundEntry *types.MetadataEntry
 	for _, entry := range metadata.MetadataEntry {
@@ -273,19 +286,22 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaItem(check *C) {
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
+	check.Assert(uploadTask, NotNil)
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_DeleteMetadataOnMediaItem")
 
 	err = vcd.org.Refresh()
 	check.Assert(err, IsNil)
 
 	mediaItem, err := vcd.vdc.FindMediaImage(itemName)
 	check.Assert(err, IsNil)
+	check.Assert(mediaItem, NotNil)
 	check.Assert(mediaItem, Not(Equals), MediaItem{})
 	check.Assert(mediaItem.MediaItem.Name, Equals, itemName)
 
@@ -299,6 +315,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaItem(check *C) {
 
 	metadata, err := mediaItem.GetMetadata()
 	check.Assert(err, IsNil)
+	check.Assert(metadata, NotNil)
 	for _, k := range metadata.MetadataEntry {
 		if k.Key == "key2" {
 			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
@@ -317,19 +334,23 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaItem(check *C) {
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
+	check.Assert(catalog.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
+	check.Assert(uploadTask, NotNil)
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
+	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_AddMetadataOnMediaItem")
 
 	err = vcd.org.Refresh()
 	check.Assert(err, IsNil)
 
 	mediaItem, err := vcd.vdc.FindMediaImage(itemName)
 	check.Assert(err, IsNil)
+	check.Assert(mediaItem, NotNil)
 	check.Assert(mediaItem, Not(Equals), MediaItem{})
 	check.Assert(mediaItem.MediaItem.Name, Equals, itemName)
 
@@ -340,6 +361,7 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaItem(check *C) {
 	// Check if metadata was added correctly
 	metadata, err := mediaItem.GetMetadata()
 	check.Assert(err, IsNil)
+	check.Assert(metadata, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -280,7 +280,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaItem(check *C) {
 
 	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	check.Assert(org, Not(Equals), AdminOrg{})
+	check.Assert(org, NotNil)
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)
@@ -327,8 +327,8 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaItem(check *C) {
 	itemName := "TestAddMediaMetaData"
 
 	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
-	check.Assert(org, Not(Equals), AdminOrg{})
 	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
 
 	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -248,7 +248,6 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	metadata, err := vAppTemplate.GetMetadata()
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
-	check.Assert(metadata.MetadataEntry, NotNil)
 	existingMetaDataCount := len(metadata.MetadataEntry)
 
 	// Add metadata
@@ -259,7 +258,6 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	metadata, err = vAppTemplate.GetMetadata()
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
-	check.Assert(metadata.MetadataEntry, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, existingMetaDataCount+1)
 	var foundEntry *types.MetadataEntry
 	for _, entry := range metadata.MetadataEntry {

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -58,6 +58,9 @@ func (vAppTemplate *VAppTemplate) Refresh() error {
 	}
 
 	url := vAppTemplate.VAppTemplate.HREF
+	if url == "nil" {
+		return fmt.Errorf("cannot refresh, HREF is empty")
+	}
 
 	vAppTemplate.VAppTemplate = &types.VAppTemplate{}
 

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -49,3 +49,20 @@ func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateP
 	}
 	return nil
 }
+
+// Refresh refreshes the vApp template item information by href
+func (vAppTemplate *VAppTemplate) Refresh() error {
+
+	if vAppTemplate.VAppTemplate == nil {
+		return fmt.Errorf("cannot refresh, Object is empty")
+	}
+
+	url := vAppTemplate.VAppTemplate.HREF
+
+	vAppTemplate.VAppTemplate = &types.VAppTemplate{}
+
+	_, err := vAppTemplate.client.ExecuteRequest(url, http.MethodGet,
+		"", "error retrieving vApp template item: %s", nil, vAppTemplate.VAppTemplate)
+
+	return err
+}

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -6,4 +6,36 @@
 
 package govcd
 
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
 // TODO: Write test for InstantiateVAppTemplate
+
+func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
+
+	fmt.Printf("Running: %s\n", check.TestName())
+	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	if err != nil {
+		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
+	}
+
+	if vcd.config.VCD.Catalog.CatalogItem == "" {
+		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
+	}
+
+	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	check.Assert(err, IsNil)
+
+	// Get VAppTemplate
+	vAppTemplate, err := catItem.GetVAppTemplate()
+	check.Assert(err, IsNil)
+	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
+
+	oldVAppTemplate := vAppTemplate
+
+	err = vAppTemplate.Refresh()
+	check.Assert(oldVAppTemplate.VAppTemplate, Equals, vAppTemplate.VAppTemplate)
+}

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -41,5 +41,7 @@ func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
 
 	err = vAppTemplate.Refresh()
 	check.Assert(err, IsNil)
-	check.Assert(oldVAppTemplate.VAppTemplate, Equals, vAppTemplate.VAppTemplate)
+	check.Assert(oldVAppTemplate.VAppTemplate.ID, Equals, vAppTemplate.VAppTemplate.ID)
+	check.Assert(oldVAppTemplate.VAppTemplate.Name, Equals, vAppTemplate.VAppTemplate.Name)
+	check.Assert(oldVAppTemplate.VAppTemplate.HREF, Equals, vAppTemplate.VAppTemplate.HREF)
 }

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -28,14 +28,18 @@ func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
 
 	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
 	check.Assert(err, IsNil)
+	check.Assert(catItem, NotNil)
+	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Get VAppTemplate
 	vAppTemplate, err := catItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
+	check.Assert(vAppTemplate, NotNil)
 	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	oldVAppTemplate := vAppTemplate
 
 	err = vAppTemplate.Refresh()
+	check.Assert(err, IsNil)
 	check.Assert(oldVAppTemplate.VAppTemplate, Equals, vAppTemplate.VAppTemplate)
 }

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -562,7 +562,7 @@ func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
 		return MediaItem{}, err
 	}
 
-	newMediaItem := NewMediaItem(vdc.client)
+	newMediaItem := NewMediaItem(vdc)
 
 	if len(mediaResults) == 1 {
 		newMediaItem.MediaItem = mediaResults[0]


### PR DESCRIPTION
Ref:https://github.com/terraform-providers/terraform-provider-vcd/issues/285
Added new CRUD metadata functions for vApp template and media image.
Also new refresh functions for vApp template and media image.

This new functions will be used in terraform to provide resources metadata capabilities.