### PR TITLE
Fix org update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * Added method `(*VCDClient) QueryNetworkPools()` 
 * Added get/add/delete metadata functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
 
+BUGS FIXED:
+
+* Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property
+
 ## 2.3.1 (Jul 29, 2019)
 
 BUG FIXES:

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -470,10 +470,10 @@ func (adminOrg *AdminOrg) Update() (Task, error) {
 	// Same workaround used in Org creation, where OrgGeneralSettings properties
 	// are not set unless UseServerBootSequence is also set
 	if vcomp.OrgSettings.OrgGeneralSettings != nil {
-			vcomp.OrgSettings.OrgGeneralSettings.UseServerBootSequence = true
+		vcomp.OrgSettings.OrgGeneralSettings.UseServerBootSequence = true
 	}
 
-	 /**/
+	/**/
 
 	// Return the task
 	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -466,6 +466,15 @@ func (adminOrg *AdminOrg) Update() (Task, error) {
 		OrgSettings: adminOrg.AdminOrg.OrgSettings,
 	}
 
+	/**/
+	// Same workaround used in Org creation, where OrgGeneralSettings properties
+	// are not set unless UseServerBootSequence is also set
+	if vcomp.OrgSettings.OrgGeneralSettings != nil {
+			vcomp.OrgSettings.OrgGeneralSettings.UseServerBootSequence = true
+	}
+
+	 /**/
+
 	// Return the task
 	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,
 		"application/vnd.vmware.admin.organization+xml", "error updating Org: %s", vcomp)


### PR DESCRIPTION
    Fix bug in Org Update

    Org Update has the same problem of Org Create, where CanPublishCatalogs
    was not handled correctly if the surrounding structure was empty.
    Also add a test to check various combinations of bool updating