### PR TITLE
Implement more Get* methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
 * Added methods `AdminOrg.GetAdminVDCByName` and related `GetAdminVDCById`, `GetAdminVDCByNameOrId`
 * Added methods `Catalog.Refresh` and `AdminCatalog.Refresh`
 
+IMPROVEMENTS:
+
+* Move methods for `AdminOrg`, `AdminCatalog`, `AdminVdc` to new files `adminorg.go`,
+ `admincatalog.go`, `adminvdc.go`.
+
 BUGS FIXED:
 
 * Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,25 @@
 ## 2.4.0 (Unreleased)
 
-* Deprecated functions `GetOrgByName(*VCDClient, string) (Org, error)` and `GetAdminOrgByName(*VCDClient, string) (AdminOrg, error)`
-* Deprecated methods `(*AdminOrg)FetchUserByName`, `(*AdminOrg)FetchUserById`, `(*AdminOrg)FetchUserByNameOrId`, `(*AdminOrg)GetRole`.
-* Added method `(*VCDClient) GetOrgByName(string) (*Org, error)`  and related `GetOrgById`, `GetOrgByNameOrId`
-* Added method `(*VCDClient) GetAdminOrgByName(string) (*AdminOrg, error)` and related `GetAdminOrgById`, `GetAdminOrgByNameOrId`
-* Added methods `GetUserByName`, `GetUserById`, `GetUserByNameOrId`, `GetRoleReference`.
-* Added method `(*VCDClient) QueryProviderVdcs()` 
-* Added method `(*VCDClient) QueryProviderVdcStorageProfiles()` 
-* Added method `(*VCDClient) QueryNetworkPools()` 
+* Deprecated functions `GetOrgByName` and `GetAdminOrgByName`
+* Deprecated methods `AdminOrg.FetchUserByName`, `AdminOrg.FetchUserById`, `AdminOrg.FetchUserByNameOrId`, `AdminOrg.GetRole`.
+* Added method `VCDClient.GetOrgByName`  and related `GetOrgById`, `GetOrgByNameOrId`
+* Added method `VCDClient.GetAdminOrgByName` and related `GetAdminOrgById`, `GetAdminOrgByNameOrId`
+* Added methods `AdminOrg.GetUserByName`, `GetUserById`, `GetUserByNameOrId`, `GetRoleReference`.
+* Added method `VCDClient.QueryProviderVdcs` 
+* Added method `VCDClient.QueryProviderVdcStorageProfiles` 
+* Added method `VCDClient.QueryNetworkPools` 
 * Added get/add/delete metadata functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
+* Deprecated methods `AdminOrg.GetAdminVdcByName`, `AdminOrg.GetVdcByName`, `AdminOrg.FindAdminCatalog`, `AdminOrg.FindCatalog`
+* Deprecated methods `Catalog.FindCatalogItem`, `Org.FindCatalog`, `Org.GetVdcByName`
+* Deprecated function `GetExternalNetwork`
+* Added methods `Org.GetCatalogByName` and related `Org.GetCatalogById`, `GetCatalogItemByNameOrId`
+* Added methods `VCDClient.GetExternalNetworkByName` and related `GetExternalNetworkById` and `GetExternalNetworkByNameOrId`
+* Added methods `AdminOrg.GetCatalogByName` and related `Org.GetCatalogById`, `GetCatalogByNameOrId`
+* Added methods `AdminOrg.GetAdminCatalogByName` and related `Org.GetAdminCatalogById`, `GetAdminCatalogByNameOrId`
+* Added methods `Org.GetVDCByName` and related `GetVDCById`, `GetVDCByNameOrId`
+* Added methods `AdminOrg.GetVDCByName` and related `GetVDCById`, `GetVDCByNameOrId`
+* Added methods `AdminOrg.GetAdminVDCByName` and related `GetAdminVDCById`, `GetAdminVDCByNameOrId`
+* Added methods `Catalog.Refresh` and `AdminCatalog.Refresh`
 
 BUGS FIXED:
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -134,7 +134,7 @@ Each entity should have the following methods:
 // ALWAYS
 (parent *Parent) GetEntityByName(name string) (*Entity, error)
 (parent *Parent) GetEntityById(id string) (*Entity, error)
-(parent *Parent) GetEntityByNameOrId(identifier string) (*Entity, error)
+(parent *Parent) getEntityByNameOrId(identifier string) (*Entity, error)
 ```
 
 For example, the parent for `Vdc` is `Org`, the parent for `EdgeGateway` is `Vdc`.

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -134,7 +134,7 @@ Each entity should have the following methods:
 // ALWAYS
 (parent *Parent) GetEntityByName(name string) (*Entity, error)
 (parent *Parent) GetEntityById(id string) (*Entity, error)
-(parent *Parent) getEntityByNameOrId(identifier string) (*Entity, error)
+(parent *Parent) GetEntityByNameOrId(identifier string) (*Entity, error)
 ```
 
 For example, the parent for `Vdc` is `Org`, the parent for `EdgeGateway` is `Vdc`.
@@ -145,6 +145,8 @@ a nil pointer and an error in every other case.
 When the method can establish that the entity was not found because it did not appear in the
 parent's list of entities, the method will return `ErrorEntityNotFound`.
 In no cases we return a nil error when the method fails to find the entity.
+The "ALWAYS" methods can optionally add a Boolean `refresh` argument, signifying that the parent should be refreshed
+prior to attempting a search.
 
 Note: We are in the process of replacing methods that don't adhere to the above principles (for example, return a
 structure instead of a pointer, return a nil error on not-found, etc).

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -36,11 +36,11 @@ func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
 	return catalog.Delete(force, recursive)
 }
 
-//   Updates the Catalog definition from current Catalog struct contents.
-//   Any differences that may be legally applied will be updated.
-//   Returns an error if the call to vCD fails. Update automatically performs
-//   a refresh with the admin catalog it gets back from the rest api
-//   Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Catalog.html
+// Updates the Catalog definition from current Catalog struct contents.
+// Any differences that may be legally applied will be updated.
+// Returns an error if the call to vCD fails. Update automatically performs
+// a refresh with the admin catalog it gets back from the rest api
+// Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Catalog.html
 func (adminCatalog *AdminCatalog) Update() error {
 	reqCatalog := &types.Catalog{
 		Name:        adminCatalog.AdminCatalog.Catalog.Name,

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// AdminCatalog is a admin view of a vCloud Director Catalog
+// To be able to get an AdminCatalog representation, users must have
+// admin credentials to the System org. AdminCatalog is used
+// for creating, updating, and deleting a Catalog.
+// Definition: https://code.vmware.com/apis/220/vcloud#/doc/doc/types/AdminCatalogType.html
+type AdminCatalog struct {
+	AdminCatalog *types.AdminCatalog
+	client       *Client
+}
+
+func NewAdminCatalog(client *Client) *AdminCatalog {
+	return &AdminCatalog{
+		AdminCatalog: new(types.AdminCatalog),
+		client:       client,
+	}
+}
+
+// Deletes the Catalog, returning an error if the vCD call fails.
+// Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
+func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
+	catalog := NewCatalog(adminCatalog.client)
+	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
+	return catalog.Delete(force, recursive)
+}
+
+//   Updates the Catalog definition from current Catalog struct contents.
+//   Any differences that may be legally applied will be updated.
+//   Returns an error if the call to vCD fails. Update automatically performs
+//   a refresh with the admin catalog it gets back from the rest api
+//   Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Catalog.html
+func (adminCatalog *AdminCatalog) Update() error {
+	reqCatalog := &types.Catalog{
+		Name:        adminCatalog.AdminCatalog.Catalog.Name,
+		Description: adminCatalog.AdminCatalog.Description,
+	}
+	vcomp := &types.AdminCatalog{
+		Xmlns:       types.XMLNamespaceVCloud,
+		Catalog:     *reqCatalog,
+		IsPublished: adminCatalog.AdminCatalog.IsPublished,
+	}
+	catalog := &types.AdminCatalog{}
+	_, err := adminCatalog.client.ExecuteRequest(adminCatalog.AdminCatalog.HREF, http.MethodPut,
+		"application/vnd.vmware.admin.catalog+xml", "error updating catalog: %s", vcomp, catalog)
+	adminCatalog.AdminCatalog = catalog
+	return err
+}
+
+// Uploads an ova file to a catalog. This method only uploads bits to vCD spool area.
+// Returns errors if any occur during upload from vCD or upload process. On upload fail client may need to
+// remove vCD catalog item which waits for files to be uploaded. Files from ova are extracted to system
+// temp folder "govcd+random number" and left for inspection on error.
+func (adminCatalog *AdminCatalog) UploadOvf(ovaFileName, itemName, description string, uploadPieceSize int64) (UploadTask, error) {
+	catalog := NewCatalog(adminCatalog.client)
+	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
+	return catalog.UploadOvf(ovaFileName, itemName, description, uploadPieceSize)
+}
+
+func (adminCatalog *AdminCatalog) Refresh() error {
+	if *adminCatalog == (AdminCatalog{}) || adminCatalog.AdminCatalog.HREF == "" {
+		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
+	}
+
+	refreshedCatalog := &types.AdminCatalog{}
+
+	_, err := adminCatalog.client.ExecuteRequest(adminCatalog.AdminCatalog.HREF, http.MethodGet,
+		"", "error refreshing VDC: %s", nil, refreshedCatalog)
+	if err != nil {
+		return err
+	}
+	adminCatalog.AdminCatalog = refreshedCatalog
+
+	return nil
+}

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -1,0 +1,738 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// AdminOrg gives an admin representation of an org.
+// Administrators can delete and update orgs with an admin org object.
+// AdminOrg includes all members of the Org element, and adds several
+// elements that can be viewed and modified only by system administrators.
+// Definition: https://code.vmware.com/apis/220/vcloud#/doc/doc/types/AdminOrgType.html
+type AdminOrg struct {
+	AdminOrg *types.AdminOrg
+	client   *Client
+}
+
+func NewAdminOrg(cli *Client) *AdminOrg {
+	return &AdminOrg{
+		AdminOrg: new(types.AdminOrg),
+		client:   cli,
+	}
+}
+
+// GetAdminVdcByName function uses a valid VDC name and returns a admin VDC object.
+// If no VDC is found, then it returns an empty VDC and no error.
+// Otherwise it returns an empty VDC and an error.
+// Deprecated: Use adminOrg.GetAdminVDCByName
+func (adminOrg *AdminOrg) GetAdminVdcByName(vdcname string) (AdminVdc, error) {
+	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if vdcs.Name == vdcname {
+
+			adminVdc := NewAdminVdc(adminOrg.client)
+
+			_, err := adminOrg.client.ExecuteRequest(vdcs.HREF, http.MethodGet,
+				"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
+
+			return *adminVdc, err
+		}
+	}
+	return AdminVdc{}, nil
+}
+
+// CreateCatalog creates a catalog with given name and description under the
+// the given organization. Returns an AdminCatalog that contains a creation
+// task.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
+func (adminOrg *AdminOrg) CreateCatalog(name, description string) (AdminCatalog, error) {
+	return CreateCatalog(adminOrg.client, adminOrg.AdminOrg.Link, name, description)
+}
+
+// If user specifies valid vdc name then this returns a vdc object.
+// If no vdc is found, then it returns an empty vdc and no error.
+// Otherwise it returns an empty vdc and an error. This function
+// allows users to use an AdminOrg to fetch a vdc as well.
+// Deprecated: Use adminOrg.GetVDCByName instead
+func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
+	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if vdcs.Name == vdcname {
+			splitByAdminHREF := strings.Split(vdcs.HREF, "/api/admin")
+
+			// admin user and normal user will have different urls
+			var vdcHREF string
+			if len(splitByAdminHREF) == 1 {
+				vdcHREF = vdcs.HREF
+			} else {
+				vdcHREF = splitByAdminHREF[0] + "/api" + splitByAdminHREF[1]
+			}
+
+			vdc := NewVdc(adminOrg.client)
+
+			_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
+				"", "error getting vdc: %s", nil, vdc.Vdc)
+
+			return *vdc, err
+		}
+	}
+	return Vdc{}, nil
+}
+
+// CreateVdc creates a VDC with the given params under the given organization.
+// Returns an AdminVdc.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-VdcConfiguration.html
+func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (Task, error) {
+	err := validateVdcConfiguration(vdcConfiguration)
+	if err != nil {
+		return Task{}, err
+	}
+
+	vdcCreateHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
+	if err != nil {
+		return Task{}, fmt.Errorf("error parsing admin org url: %s", err)
+	}
+	vdcCreateHREF.Path += "/vdcsparams"
+
+	adminVdc := NewAdminVdc(adminOrg.client)
+
+	_, err = adminOrg.client.ExecuteRequest(vdcCreateHREF.String(), http.MethodPost,
+		"application/vnd.vmware.admin.createVdcParams+xml", "error retrieving vdc: %s", vdcConfiguration, adminVdc.AdminVdc)
+	if err != nil {
+		return Task{}, err
+	}
+
+	// Return the task
+	task := NewTask(adminOrg.client)
+	task.Task = adminVdc.AdminVdc.Tasks.Task[0]
+	return *task, nil
+}
+
+// Creates the vdc and waits for the asynchronous task to complete.
+func (adminOrg *AdminOrg) CreateVdcWait(vdcDefinition *types.VdcConfiguration) error {
+	task, err := adminOrg.CreateVdc(vdcDefinition)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("couldn't finish creating vdc %#v", err)
+	}
+	return nil
+}
+
+//   Deletes the org, returning an error if the vCD call fails.
+//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
+func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
+	if force && recursive {
+		//undeploys vapps
+		err := adminOrg.undeployAllVApps()
+		if err != nil {
+			return fmt.Errorf("error could not undeploy: %#v", err)
+		}
+		//removes vapps
+		err = adminOrg.removeAllVApps()
+		if err != nil {
+			return fmt.Errorf("error could not remove vapp: %#v", err)
+		}
+		//removes catalogs
+		err = adminOrg.removeCatalogs()
+		if err != nil {
+			return fmt.Errorf("error could not remove all catalogs: %#v", err)
+		}
+		//removes networks
+		err = adminOrg.removeAllOrgNetworks()
+		if err != nil {
+			return fmt.Errorf("error could not remove all networks: %#v", err)
+		}
+		//removes org vdcs
+		err = adminOrg.removeAllOrgVDCs()
+		if err != nil {
+			return fmt.Errorf("error could not remove all vdcs: %#v", err)
+		}
+	}
+	// Disable org
+	err := adminOrg.Disable()
+	if err != nil {
+		return fmt.Errorf("error disabling Org %s: %s", adminOrg.AdminOrg.Name, err)
+	}
+	// Get admin HREF
+	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
+	if err != nil {
+		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
+	}
+	req := adminOrg.client.NewRequest(map[string]string{
+		"force":     strconv.FormatBool(force),
+		"recursive": strconv.FormatBool(recursive),
+	}, http.MethodDelete, *orgHREF, nil)
+	resp, err := checkResp(adminOrg.client.Http.Do(req))
+	if err != nil {
+		return fmt.Errorf("error deleting Org %s: %s", adminOrg.AdminOrg.ID, err)
+	}
+
+	task := NewTask(adminOrg.client)
+	if err = decodeBody(resp, task.Task); err != nil {
+		return fmt.Errorf("error decoding task response: %s", err)
+	}
+	return task.WaitTaskCompletion()
+}
+
+// Disables the org. Returns an error if the call to vCD fails.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-DisableOrg.html
+func (adminOrg *AdminOrg) Disable() error {
+	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
+	if err != nil {
+		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
+	}
+	orgHREF.Path += "/action/disable"
+
+	return adminOrg.client.ExecuteRequestWithoutResponse(orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
+}
+
+//   Updates the Org definition from current org struct contents.
+//   Any differences that may be legally applied will be updated.
+//   Returns an error if the call to vCD fails.
+//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
+func (adminOrg *AdminOrg) Update() (Task, error) {
+	vcomp := &types.AdminOrg{
+		Xmlns:       types.XMLNamespaceVCloud,
+		Name:        adminOrg.AdminOrg.Name,
+		IsEnabled:   adminOrg.AdminOrg.IsEnabled,
+		FullName:    adminOrg.AdminOrg.FullName,
+		Description: adminOrg.AdminOrg.Description,
+		OrgSettings: adminOrg.AdminOrg.OrgSettings,
+	}
+
+	// Same workaround used in Org creation, where OrgGeneralSettings properties
+	// are not set unless UseServerBootSequence is also set
+	if vcomp.OrgSettings.OrgGeneralSettings != nil {
+		vcomp.OrgSettings.OrgGeneralSettings.UseServerBootSequence = true
+	}
+
+	// Return the task
+	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,
+		"application/vnd.vmware.admin.organization+xml", "error updating Org: %s", vcomp)
+}
+
+// Undeploys every vapp within an organization
+func (adminOrg *AdminOrg) undeployAllVApps() error {
+	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		adminVdcHREF, err := url.Parse(vdcs.HREF)
+		if err != nil {
+			return err
+		}
+		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
+		if err != nil {
+			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
+		}
+		err = vdc.undeployAllVdcVApps()
+		if err != nil {
+			return fmt.Errorf("error deleting vapp: %s", err)
+		}
+	}
+	return nil
+}
+
+// Deletes every vapp within an organization
+func (adminOrg *AdminOrg) removeAllVApps() error {
+	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		adminVdcHREF, err := url.Parse(vdcs.HREF)
+		if err != nil {
+			return err
+		}
+		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
+		if err != nil {
+			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
+		}
+		err = vdc.removeAllVdcVApps()
+		if err != nil {
+			return fmt.Errorf("error deleting vapp: %s", err)
+		}
+	}
+	return nil
+}
+
+// Given an adminorg with a valid HREF, the function refetches the adminorg
+// and updates the user's adminorg data. Otherwise if the function fails,
+// it returns an error.  Users should use refresh whenever they have
+// a stale org due to the creation/update/deletion of a resource
+// within the org or the org itself.
+func (adminOrg *AdminOrg) Refresh() error {
+	if *adminOrg == (AdminOrg{}) {
+		return fmt.Errorf("cannot refresh, Object is empty")
+	}
+
+	// Empty struct before a new unmarshal, otherwise we end up with duplicate
+	// elements in slices.
+	unmarshalledAdminOrg := &types.AdminOrg{}
+
+	_, err := adminOrg.client.ExecuteRequest(adminOrg.AdminOrg.HREF, http.MethodGet,
+		"", "error refreshing organization: %s", nil, unmarshalledAdminOrg)
+	if err != nil {
+		return err
+	}
+	adminOrg.AdminOrg = unmarshalledAdminOrg
+
+	return nil
+}
+
+// Gets a vdc within org associated with an admin vdc url
+func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) {
+	// get non admin vdc path
+	vdcURL := adminOrg.client.VCDHREF
+	vdcURL.Path += strings.Split(adminVdcUrl.Path, "/api/admin")[1] //gets id
+
+	vdc := NewVdc(adminOrg.client)
+
+	_, err := adminOrg.client.ExecuteRequest(vdcURL.String(), http.MethodGet,
+		"", "error retrieving vdc: %s", nil, vdc.Vdc)
+
+	return vdc, err
+}
+
+// Removes all vdcs in a org
+func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
+	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
+
+		// Get admin Vdc HREF
+		adminVdcUrl := adminOrg.client.VCDHREF
+		adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/vdc/")[1] + "/action/disable"
+
+		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)
+		_, err := checkResp(adminOrg.client.Http.Do(req))
+		if err != nil {
+			return fmt.Errorf("error disabling vdc: %s", err)
+		}
+		// Get admin vdc HREF for normal deletion
+		adminVdcUrl.Path = strings.Split(adminVdcUrl.Path, "/action/disable")[0]
+		req = adminOrg.client.NewRequest(map[string]string{
+			"recursive": "true",
+			"force":     "true",
+		}, http.MethodDelete, adminVdcUrl, nil)
+		resp, err := checkResp(adminOrg.client.Http.Do(req))
+		if err != nil {
+			return fmt.Errorf("error deleting vdc: %s", err)
+		}
+		task := NewTask(adminOrg.client)
+		if err = decodeBody(resp, task.Task); err != nil {
+			return fmt.Errorf("error decoding task response: %s", err)
+		}
+		if task.Task.Status == "error" {
+			return fmt.Errorf("vdc not properly destroyed")
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("couldn't finish removing vdc %#v", err)
+		}
+
+	}
+
+	return nil
+}
+
+// Removes All networks in the org
+func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
+	for _, networks := range adminOrg.AdminOrg.Networks.Networks {
+		// Get Network HREF
+		networkHREF := adminOrg.client.VCDHREF
+		networkHREF.Path += "/admin/network/" + strings.Split(networks.HREF, "/api/admin/network/")[1] //gets id
+
+		task, err := adminOrg.client.ExecuteTaskRequest(networkHREF.String(), http.MethodDelete,
+			"", "error deleting network: %s", nil)
+		if err != nil {
+			return err
+		}
+
+		if task.Task.Status == "error" {
+			return fmt.Errorf("network not properly destroyed")
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("couldn't finish removing network %#v", err)
+		}
+	}
+	return nil
+}
+
+// Forced removal of all organization catalogs
+func (adminOrg *AdminOrg) removeCatalogs() error {
+	for _, catalogs := range adminOrg.AdminOrg.Catalogs.Catalog {
+		// Get Catalog HREF
+		catalogHREF := adminOrg.client.VCDHREF
+		catalogHREF.Path += "/admin/catalog/" + strings.Split(catalogs.HREF, "/api/admin/catalog/")[1] //gets id
+		req := adminOrg.client.NewRequest(map[string]string{
+			"force":     "true",
+			"recursive": "true",
+		}, http.MethodDelete, catalogHREF, nil)
+		_, err := checkResp(adminOrg.client.Http.Do(req))
+		if err != nil {
+			return fmt.Errorf("error deleting catalog: %s, %s", err, catalogHREF.Path)
+		}
+	}
+	return nil
+
+}
+
+// Given a valid catalog name, FindAdminCatalog returns an AdminCatalog object.
+// If no catalog is found, then returns an empty AdminCatalog and no error.
+// Otherwise it returns an error. Function allows user to use an AdminOrg
+// to also fetch a Catalog. If user does not have proper credentials to
+// perform administrator tasks then function returns an error.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/GET-Catalog-AdminView.html
+// Deprecated: Use adminOrg.GetAdminCatalog instead
+func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, error) {
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		// Get Catalog HREF
+		if catalog.Name == catalogName {
+
+			adminCatalog := NewAdminCatalog(adminOrg.client)
+
+			_, err := adminOrg.client.ExecuteRequest(catalog.HREF, http.MethodGet,
+				"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
+
+			// The request was successful
+			return *adminCatalog, err
+		}
+	}
+	return AdminCatalog{}, nil
+}
+
+// Given a valid catalog name, FindCatalog returns a Catalog object.
+// If no catalog is found, then returns an empty catalog and no error.
+// Otherwise it returns an error. Function allows user to use an AdminOrg
+// to also fetch a Catalog.
+// Deprecated: Use adminOrg.GetCatalogByName instead
+func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		// Get Catalog HREF
+		if catalog.Name == catalogName {
+			catalogURL := adminOrg.client.VCDHREF
+			catalogURL.Path += "/catalog/" + strings.Split(catalog.HREF, "/api/admin/catalog/")[1] //gets id
+
+			cat := NewCatalog(adminOrg.client)
+
+			_, err := adminOrg.client.ExecuteRequest(catalogURL.String(), http.MethodGet,
+				"", "error retrieving catalog: %s", nil, cat.Catalog)
+
+			// The request was successful
+			return *cat, err
+		}
+	}
+	return Catalog{}, nil
+}
+
+// GetCatalogByHref  finds a Catalog by HREF
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetCatalogByHref(catalogHref string) (*Catalog, error) {
+	catalogURL := adminOrg.client.VCDHREF
+	catalogURL.Path += "/catalog/" + strings.Split(catalogHref, "/api/admin/catalog/")[1] //gets id
+
+	cat := NewCatalog(adminOrg.client)
+
+	_, err := adminOrg.client.ExecuteRequest(catalogURL.String(), http.MethodGet,
+		"", "error retrieving catalog: %s", nil, cat.Catalog)
+
+	if err != nil {
+		return nil, err
+	}
+	// The request was successful
+	return cat, nil
+}
+
+// GetCatalogByName  finds a Catalog by Name
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetCatalogByName(catalogName string, refresh bool) (*Catalog, error) {
+
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		if catalog.Name == catalogName {
+			return adminOrg.GetCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// Extracts an UUID from a string, regardless of surrounding text
+// Returns an empty string if no UUID was found
+func extractUuid(input string) string {
+	reGetID := regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)
+	matchListId := reGetID.FindAllStringSubmatch(input, -1)
+	if len(matchListId) > 0 && len(matchListId[0]) > 0 {
+		return matchListId[0][1]
+	}
+	return ""
+}
+
+// equalIds compares two IDs and return true if they are the same
+// The comparison happens by extracting the bare UUID from both the
+// wanted ID and the found one.
+// When the found ID is empty, it used the HREF for such comparison,
+// This function is useful when the reference structure in the parent lookup list
+// may lack the ID (such as in Org.Links, AdminOrg.Catalogs) or has an ID
+// that is only a UUID without prefixes (such as in CatalogItem list)
+//
+// wantedId is the input string to compare
+// foundId is the ID field in the reference record (can be empty)
+// foundHref is the HREF field in the reference record (should never be empty)
+func equalIds(wantedId, foundId, foundHref string) bool {
+
+	wantedUuid := extractUuid(wantedId)
+	foundUuid := ""
+
+	if wantedUuid == "" {
+		return false
+	}
+	if foundId != "" {
+		// In some entities, the ID is a simple UUID without prefix
+		foundUuid = extractUuid(foundId)
+	} else {
+		foundUuid = extractUuid(foundHref)
+	}
+	return foundUuid == wantedUuid
+}
+
+// GetCatalogById finds a Catalog by ID
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetCatalogById(catalogId string, refresh bool) (*Catalog, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		if equalIds(catalogId, catalog.ID, catalog.HREF) {
+			return adminOrg.GetCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetCatalogByNameOrId finds a Catalog by name or ID
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
+	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogByName(name, refresh) }
+	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*Catalog), err
+}
+
+// GetAdminCatalogByHref  finds an AdminCatalog by HREF
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminCatalogByHref(catalogHref string) (*AdminCatalog, error) {
+	adminCatalog := NewAdminCatalog(adminOrg.client)
+
+	_, err := adminOrg.client.ExecuteRequest(catalogHref, http.MethodGet,
+		"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// The request was successful
+	return adminCatalog, nil
+}
+
+// GetCatalogByName finds an AdminCatalog by Name
+// On success, returns a pointer to the AdminCatalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminCatalogByName(catalogName string, refresh bool) (*AdminCatalog, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		// Get Catalog HREF
+		if catalog.Name == catalogName {
+			return adminOrg.GetAdminCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetCatalogById finds an AdminCatalog by ID
+// On success, returns a pointer to the AdminCatalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminCatalogById(catalogId string, refresh bool) (*AdminCatalog, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
+		// Get Catalog HREF
+		if equalIds(catalogId, catalog.ID, catalog.HREF) {
+			return adminOrg.GetAdminCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetAdminCatalogByNameOrId finds an AdminCatalog by name or ID
+// On success, returns a pointer to the AdminCatalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(identifier string, refresh bool) (*AdminCatalog, error) {
+	byName := func(name string, refresh bool) (interface{}, error) {
+		return adminOrg.GetAdminCatalogByName(name, refresh)
+	}
+	byId := func(id string, refresh bool) (interface{}, error) {
+		return adminOrg.GetAdminCatalogById(id, refresh)
+	}
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*AdminCatalog), err
+}
+
+// GetVDCByHref retrieves a VDC using a direct call with the HREF
+func (adminOrg *AdminOrg) GetVDCByHref(vdcHref string) (*Vdc, error) {
+	splitByAdminHREF := strings.Split(vdcHref, "/api/admin")
+
+	// admin user and normal user will have different urls
+	var vdcHREF string
+	if len(splitByAdminHREF) == 1 {
+		vdcHREF = vdcHref
+	} else {
+		vdcHREF = splitByAdminHREF[0] + "/api" + splitByAdminHREF[1]
+	}
+
+	vdc := NewVdc(adminOrg.client)
+
+	_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
+		"", "error getting vdc: %s", nil, vdc.Vdc)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return vdc, nil
+}
+
+// GetVDCByName finds a VDC by Name
+// On success, returns a pointer to the Vdc structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetVDCByName(vdcName string, refresh bool) (*Vdc, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if vdc.Name == vdcName {
+			return adminOrg.GetVDCByHref(vdc.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVDCById finds a VDC by ID
+// On success, returns a pointer to the Vdc structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if equalIds(vdcId, vdc.ID, vdc.HREF) {
+			return adminOrg.GetVDCByHref(vdc.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVDCByNameOrId finds a VDC by name or ID
+// On success, returns a pointer to the VDC structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
+	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(name, refresh) }
+	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*Vdc), err
+}
+
+// GetVDCByHref retrieves a VDC using a direct call with the HREF
+func (adminOrg *AdminOrg) GetAdminVDCByHref(vdcHref string) (*AdminVdc, error) {
+
+	adminVdc := NewAdminVdc(adminOrg.client)
+
+	_, err := adminOrg.client.ExecuteRequest(vdcHref, http.MethodGet,
+		"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
+
+	if err != nil {
+		return nil, err
+	}
+	return adminVdc, nil
+}
+
+// GetAdminVDCByName finds an Admin VDC by Name
+// On success, returns a pointer to the AdminVdc structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminVDCByName(vdcName string, refresh bool) (*AdminVdc, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if vdc.Name == vdcName {
+			return adminOrg.GetAdminVDCByHref(vdc.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetAdminVDCById finds an Admin VDC by ID
+// On success, returns a pointer to the AdminVdc structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminVDCById(vdcId string, refresh bool) (*AdminVdc, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		if equalIds(vdcId, vdc.ID, vdc.HREF) {
+			return adminOrg.GetAdminVDCByHref(vdc.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetAdminVDCByNameOrId finds an Admin VDC by Name Or ID
+// On success, returns a pointer to the AdminVdc structure and a nil error
+// On failure, returns a nil pointer and an error
+func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(identifier string, refresh bool) (*AdminVdc, error) {
+	byName := func(name string, refresh bool) (interface{}, error) {
+		return adminOrg.GetAdminVDCByName(name, refresh)
+	}
+	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*AdminVdc), err
+}

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -532,7 +532,7 @@ func (adminOrg *AdminOrg) GetCatalogById(catalogId string, refresh bool) (*Catal
 func (adminOrg *AdminOrg) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogByName(name, refresh) }
 	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*Catalog), err
 }
 
@@ -601,7 +601,7 @@ func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(identifier string, refresh b
 	byId := func(id string, refresh bool) (interface{}, error) {
 		return adminOrg.GetAdminCatalogById(id, refresh)
 	}
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*AdminCatalog), err
 }
 
@@ -671,7 +671,7 @@ func (adminOrg *AdminOrg) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
 func (adminOrg *AdminOrg) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(name, refresh) }
 	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*Vdc), err
 }
 
@@ -733,6 +733,6 @@ func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(identifier string, refresh bool)
 		return adminOrg.GetAdminVDCByName(name, refresh)
 	}
 	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*AdminVdc), err
 }

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -39,12 +39,9 @@ func NewAdminOrg(cli *Client) *AdminOrg {
 func (adminOrg *AdminOrg) GetAdminVdcByName(vdcname string) (AdminVdc, error) {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if vdcs.Name == vdcname {
-
 			adminVdc := NewAdminVdc(adminOrg.client)
-
 			_, err := adminOrg.client.ExecuteRequest(vdcs.HREF, http.MethodGet,
 				"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
-
 			return *adminVdc, err
 		}
 	}
@@ -393,12 +390,9 @@ func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, er
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
 		if catalog.Name == catalogName {
-
 			adminCatalog := NewAdminCatalog(adminOrg.client)
-
 			_, err := adminOrg.client.ExecuteRequest(catalog.HREF, http.MethodGet,
 				"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
-
 			// The request was successful
 			return *adminCatalog, err
 		}
@@ -530,9 +524,12 @@ func (adminOrg *AdminOrg) GetCatalogById(catalogId string, refresh bool) (*Catal
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
 func (adminOrg *AdminOrg) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogByName(name, refresh) }
-	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*Catalog), err
 }
 
@@ -595,13 +592,16 @@ func (adminOrg *AdminOrg) GetAdminCatalogById(catalogId string, refresh bool) (*
 // On success, returns a pointer to the AdminCatalog structure and a nil error
 // On failure, returns a nil pointer and an error
 func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(identifier string, refresh bool) (*AdminCatalog, error) {
-	byName := func(name string, refresh bool) (interface{}, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
 		return adminOrg.GetAdminCatalogByName(name, refresh)
 	}
-	byId := func(id string, refresh bool) (interface{}, error) {
+	getById := func(id string, refresh bool) (interface{}, error) {
 		return adminOrg.GetAdminCatalogById(id, refresh)
 	}
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*AdminCatalog), err
 }
 
@@ -669,9 +669,12 @@ func (adminOrg *AdminOrg) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
 // On success, returns a pointer to the VDC structure and a nil error
 // On failure, returns a nil pointer and an error
 func (adminOrg *AdminOrg) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(name, refresh) }
-	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*Vdc), err
 }
 
@@ -729,10 +732,13 @@ func (adminOrg *AdminOrg) GetAdminVDCById(vdcId string, refresh bool) (*AdminVdc
 // On success, returns a pointer to the AdminVdc structure and a nil error
 // On failure, returns a nil pointer and an error
 func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(identifier string, refresh bool) (*AdminVdc, error) {
-	byName := func(name string, refresh bool) (interface{}, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
 		return adminOrg.GetAdminVDCByName(name, refresh)
 	}
-	byId := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*AdminVdc), err
 }

--- a/govcd/adminorg_unit_test.go
+++ b/govcd/adminorg_unit_test.go
@@ -2,7 +2,6 @@
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
-* Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/adminorg_unit_test.go
+++ b/govcd/adminorg_unit_test.go
@@ -1,0 +1,120 @@
+// +build unit ALL
+
+/*
+* Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+* Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"testing"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// Tests that equalIds returns the expected result whether the target reference
+// contains or not an ID
+func Test_equalIds(t *testing.T) {
+
+	type testData struct {
+		wanted    string
+		reference types.Reference
+		expected  bool
+	}
+	var testItems = []testData{
+		{
+			// Regular case: all values are set in the reference
+			wanted: "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			reference: types.Reference{
+				Name: "all_values",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b0",
+				ID:   "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			},
+			expected: true,
+		},
+		{
+			// Catalog Item case: The ID is a simple UUID
+			wanted: "urn:vcloud:catalogitem:97384890-180c-4563-b9b7-0dc50a2430b0",
+			reference: types.Reference{
+				Name: "all_values",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b0",
+				ID:   "97384890-180c-4563-b9b7-0dc50a2430b0",
+			},
+			expected: true,
+		},
+		{
+			// Regular case: all values are set in the reference but wanted is empty
+			wanted: "",
+			reference: types.Reference{
+				Name: "all_values",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b0",
+				ID:   "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			},
+			expected: false,
+		},
+		{
+			// wanted and ID are different
+			wanted: "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			reference: types.Reference{
+				Name: "not_matching",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b0",
+				ID:   "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b1",
+			},
+			expected: false,
+		},
+		{
+			// Missing ID, the match happens with the HREF (as in VDC)
+			wanted: "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			reference: types.Reference{
+				Name: "no_id",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b0",
+				ID:   "",
+			},
+			expected: true,
+		},
+		{
+			// Missing ID, the UUID in the HREF is different from the one in wanted, will fail
+			wanted: "urn:vcloud:catalog:97384890-180c-4563-b9b7-0dc50a2430b0",
+			reference: types.Reference{
+				Name: "no_id_no_matching",
+				HREF: "https://vcd.somecompany.org/api/entity/97384890-180c-4563-b9b7-0dc50a2430b1",
+				ID:   "",
+			},
+			expected: false,
+		},
+		{
+			// all bogus values. Matches by ID
+			wanted: "urn:vcloud:catalog:deadbeef-0000-0000-0000-000000000000",
+			reference: types.Reference{
+				Name: "all_dummy_values",
+				HREF: "https://vcd.somecompany.org/api/entity/deadbeef-0000-0000-0000-000000000000",
+				ID:   "urn:vcloud:catalog:deadbeef-0000-0000-0000-000000000000",
+			},
+			expected: true,
+		},
+		{
+			// Missing both ID and HREF, will fail
+			wanted: "urn:vcloud:catalog:deadbeef-0000-0000-0000-000000000000",
+			reference: types.Reference{
+				Name: "missing_ids",
+				HREF: "",
+				ID:   "",
+			},
+			expected: false,
+		},
+	}
+	for _, item := range testItems {
+		result := equalIds(item.wanted, item.reference.ID, item.reference.HREF)
+		if result == item.expected {
+			if testVerbose {
+				t.Logf("Test:     %s\nExpected: %v\nwanted:   '%s'\nID:       '%s'\nHREF:     '%s'",
+					item.reference.Name, item.expected, item.wanted, item.reference.ID, item.reference.HREF)
+			}
+		} else {
+			t.Logf("Test:     %s\nExpected: %v\nwanted:   '%s'\nID:       '%s'\nHREF:     '%s'",
+				item.reference.Name, item.expected, item.wanted, item.reference.ID, item.reference.HREF)
+			t.Fail()
+		}
+	}
+}

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type AdminVdc struct {
+	AdminVdc *types.AdminVdc
+	client   *Client
+}
+
+func NewAdminVdc(cli *Client) *AdminVdc {
+	return &AdminVdc{
+		AdminVdc: new(types.AdminVdc),
+		client:   cli,
+	}
+}
+
+// Given an adminVdc with a valid HREF, the function refresh the adminVdc
+// and updates the adminVdc data. Returns an error on failure
+// Users should use refresh whenever they suspect
+// a stale VDC due to the creation/update/deletion of a resource
+// within the the VDC itself.
+func (adminVdc *AdminVdc) Refresh() error {
+	if *adminVdc == (AdminVdc{}) || adminVdc.AdminVdc.HREF == "" {
+		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
+	}
+
+	// Empty struct before a new unmarshal, otherwise we end up with duplicate
+	// elements in slices.
+	unmarshalledAdminVdc := &types.AdminVdc{}
+
+	_, err := adminVdc.client.ExecuteRequest(adminVdc.AdminVdc.HREF, http.MethodGet,
+		"", "error refreshing VDC: %s", nil, unmarshalledAdminVdc)
+	if err != nil {
+		return err
+	}
+	adminVdc.AdminVdc = unmarshalledAdminVdc
+
+	return nil
+}
+
+// UpdateAsync updates VDC from current VDC struct contents.
+// Any differences that may be legally applied will be updated.
+// Returns an error if the call to vCD fails.
+// API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
+func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
+
+	adminVdc.AdminVdc.Xmlns = types.XMLNamespaceVCloud
+
+	// Return the task
+	return adminVdc.client.ExecuteTaskRequest(adminVdc.AdminVdc.HREF, http.MethodPut,
+		types.MimeAdminVDC, "error updating VDC: %s", adminVdc.AdminVdc)
+}
+
+// Update function updates an Admin VDC from current VDC struct contents.
+// Any differences that may be legally applied will be updated.
+// Returns an empty AdminVdc struct and error if the call to vCD fails.
+// API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
+func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
+	task, err := adminVdc.UpdateAsync()
+	if err != nil {
+		return AdminVdc{}, err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return AdminVdc{}, err
+	}
+
+	err = adminVdc.Refresh()
+	if err != nil {
+		return AdminVdc{}, err
+	}
+
+	return *adminVdc, nil
+}

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -28,20 +28,6 @@ const (
 	defaultPieceSize int64 = 1024 * 1024
 )
 
-type CatalogOperations interface {
-	FindCatalogItem(catalogItem string) (CatalogItem, error)
-}
-
-// AdminCatalog is a admin view of a vCloud Director Catalog
-// To be able to get an AdminCatalog representation, users must have
-// admin credentials to the System org. AdminCatalog is used
-// for creating, updating, and deleting a Catalog.
-// Definition: https://code.vmware.com/apis/220/vcloud#/doc/doc/types/AdminCatalogType.html
-type AdminCatalog struct {
-	AdminCatalog *types.AdminCatalog
-	client       *Client
-}
-
 type Catalog struct {
 	Catalog *types.Catalog
 	client  *Client
@@ -51,13 +37,6 @@ func NewCatalog(client *Client) *Catalog {
 	return &Catalog{
 		Catalog: new(types.Catalog),
 		client:  client,
-	}
-}
-
-func NewAdminCatalog(client *Client) *AdminCatalog {
-	return &AdminCatalog{
-		AdminCatalog: new(types.AdminCatalog),
-		client:       client,
 	}
 }
 
@@ -89,36 +68,6 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 	return nil
 }
 
-// Deletes the Catalog, returning an error if the vCD call fails.
-// Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
-func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
-	catalog := NewCatalog(adminCatalog.client)
-	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.Delete(force, recursive)
-}
-
-//   Updates the Catalog definition from current Catalog struct contents.
-//   Any differences that may be legally applied will be updated.
-//   Returns an error if the call to vCD fails. Update automatically performs
-//   a refresh with the admin catalog it gets back from the rest api
-//   Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Catalog.html
-func (adminCatalog *AdminCatalog) Update() error {
-	reqCatalog := &types.Catalog{
-		Name:        adminCatalog.AdminCatalog.Catalog.Name,
-		Description: adminCatalog.AdminCatalog.Description,
-	}
-	vcomp := &types.AdminCatalog{
-		Xmlns:       types.XMLNamespaceVCloud,
-		Catalog:     *reqCatalog,
-		IsPublished: adminCatalog.AdminCatalog.IsPublished,
-	}
-	catalog := &types.AdminCatalog{}
-	_, err := adminCatalog.client.ExecuteRequest(adminCatalog.AdminCatalog.HREF, http.MethodPut,
-		"application/vnd.vmware.admin.catalog+xml", "error updating catalog: %s", vcomp, catalog)
-	adminCatalog.AdminCatalog = catalog
-	return err
-}
-
 // Envelope is a ovf description root element. File contains information for vmdk files.
 // Namespace: http://schemas.dmtf.org/ovf/envelope/1
 // Description: Envelope is a ovf description root element. File contains information for vmdk files..
@@ -135,6 +84,7 @@ type Envelope struct {
 // then the function returns a CatalogItem. If the item does not
 // exist, then it returns an empty CatalogItem. If the call fails
 // at any point, it returns an error.
+// Deprecated: use GetCatalogItemByName instead
 func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error) {
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
@@ -150,16 +100,6 @@ func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error)
 	}
 
 	return CatalogItem{}, nil
-}
-
-// Uploads an ova file to a catalog. This method only uploads bits to vCD spool area.
-// Returns errors if any occur during upload from vCD or upload process. On upload fail client may need to
-// remove vCD catalog item which waits for files to be uploaded. Files from ova are extracted to system
-// temp folder "govcd+random number" and left for inspection on error.
-func (adminCatalog *AdminCatalog) UploadOvf(ovaFileName, itemName, description string, uploadPieceSize int64) (UploadTask, error) {
-	catalog := NewCatalog(adminCatalog.client)
-	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.UploadOvf(ovaFileName, itemName, description, uploadPieceSize)
 }
 
 // Uploads an ova file to a catalog. This method only uploads bits to vCD spool area.
@@ -415,7 +355,7 @@ func queryVappTemplate(client *Client, vappTemplateUrl *url.URL, newItemName str
 	}
 
 	for _, task := range vappTemplateParsed.Tasks.Task {
-		if "error" == task.Status && newItemName == task.Owner.Name {
+		if task.Status == "error" && newItemName == task.Owner.Name {
 			util.Logger.Printf("[Error] %#v", task.Error)
 			return vappTemplateParsed, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 		}
@@ -717,4 +657,87 @@ func (cat *Catalog) UploadMediaImage(mediaName, mediaDescription, filePath strin
 	}
 
 	return executeUpload(cat.client, createdMedia, mediaFilePath, mediaName, fileSize, uploadPieceSize)
+}
+
+// Refresh gets a fresh copy of the catalog from vCD
+func (cat *Catalog) Refresh() error {
+	if cat == nil || *cat == (Catalog{}) || cat.Catalog.HREF == "" {
+		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
+	}
+
+	refreshedCatalog := &types.Catalog{}
+
+	_, err := cat.client.ExecuteRequest(cat.Catalog.HREF, http.MethodGet,
+		"", "error refreshing VDC: %s", nil, refreshedCatalog)
+	if err != nil {
+		return err
+	}
+	cat.Catalog = refreshedCatalog
+
+	return nil
+}
+
+// GetCatalogItemByHref finds a CatalogItem by HREF
+// On success, returns a pointer to the CatalogItem structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *Catalog) GetCatalogItemByHref(catalogItemHref string) (*CatalogItem, error) {
+
+	catItem := NewCatalogItem(cat.client)
+
+	_, err := cat.client.ExecuteRequest(catalogItemHref, http.MethodGet,
+		"", "error retrieving catalog: %s", nil, catItem.CatalogItem)
+	if err != nil {
+		return nil, err
+	}
+	return catItem, nil
+}
+
+// GetCatalogItemByName finds a CatalogItem by Name
+// On success, returns a pointer to the CatalogItem structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *Catalog) GetCatalogItemByName(catalogItemName string, refresh bool) (*CatalogItem, error) {
+	if refresh {
+		err := cat.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, catalogItems := range cat.Catalog.CatalogItems {
+		for _, catalogItem := range catalogItems.CatalogItem {
+			if catalogItem.Name == catalogItemName && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
+				return cat.GetCatalogItemByHref(catalogItem.HREF)
+			}
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetCatalogItemById finds a Catalog Item by ID
+// On success, returns a pointer to the CatalogItem structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*CatalogItem, error) {
+	if refresh {
+		err := cat.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, catalogItems := range cat.Catalog.CatalogItems {
+		for _, catalogItem := range catalogItems.CatalogItem {
+			if equalIds(catalogItemId, catalogItem.ID, catalogItem.HREF) && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
+				return cat.GetCatalogItemByHref(catalogItem.HREF)
+			}
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetCatalogItemByNameOrId finds a Catalog Item by Name or ID
+// On success, returns a pointer to the CatalogItem structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *Catalog) GetCatalogItemByNameOrId(identifier string, refresh bool) (*CatalogItem, error) {
+	byName := func(name string, refresh bool) (interface{}, error) { return cat.GetCatalogItemByName(name, refresh) }
+	byId := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*CatalogItem), err
 }

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -738,6 +738,6 @@ func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*Cat
 func (cat *Catalog) GetCatalogItemByNameOrId(identifier string, refresh bool) (*CatalogItem, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return cat.GetCatalogItemByName(name, refresh) }
 	byId := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*CatalogItem), err
 }

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -736,8 +736,11 @@ func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*Cat
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error
 func (cat *Catalog) GetCatalogItemByNameOrId(identifier string, refresh bool) (*CatalogItem, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return cat.GetCatalogItemByName(name, refresh) }
-	byId := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return cat.GetCatalogItemByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*CatalogItem), err
 }

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -16,29 +16,64 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+// Tests catalog refresh
+func (vcd *TestVCD) Test_CatalogRefresh(check *C) {
+	catalogName := vcd.config.VCD.Catalog.Name
+	if catalogName == "" {
+		check.Skip("Test_CatalogRefresh: Catalog name not given.")
+		return
+	}
+	cat, err := vcd.org.GetCatalogByName(catalogName, false)
+	if err != nil {
+		check.Skip("Test_CatalogRefresh: Catalog not found.")
+		return
+	}
+	catalogId := cat.Catalog.ID
+	numItems := len(cat.Catalog.CatalogItems)
+	dateCreated := cat.Catalog.DateCreated
+	check.Assert(cat, NotNil)
+	check.Assert(cat.Catalog.Name, Equals, catalogName)
+
+	// Pollute the catalog structure
+	cat.Catalog.Name = INVALID_NAME
+	cat.Catalog.ID = invalidEntityId
+	cat.Catalog.CatalogItems = nil
+	cat.Catalog.DateCreated = ""
+
+	// Get the catalog again from vCD
+	err = cat.Refresh()
+	check.Assert(err, IsNil)
+	check.Assert(cat, NotNil)
+	check.Assert(cat.Catalog.Name, Equals, catalogName)
+	check.Assert(cat.Catalog.DateCreated, Equals, dateCreated)
+	check.Assert(len(cat.Catalog.CatalogItems), Equals, numItems)
+	check.Assert(cat.Catalog.ID, Equals, catalogId)
+}
+
 func (vcd *TestVCD) Test_FindCatalogItem(check *C) {
 	// Fetch Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_FindCatalogItem: Catalog not found. Test can't proceed")
+		return
 	}
 
 	// Find Catalog Item
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_FindCatalogItem: Catalog Item not given. Test can't proceed")
 	}
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catalogItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
-	check.Assert(catitem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
+	check.Assert(catalogItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 	// If given a description in config file then it checks if the descriptions match
 	// Otherwise it skips the assert
 	if vcd.config.VCD.Catalog.CatalogItemDescription != "" {
-		check.Assert(catitem.CatalogItem.Description, Equals, vcd.config.VCD.Catalog.CatalogItemDescription)
+		check.Assert(catalogItem.CatalogItem.Description, Equals, vcd.config.VCD.Catalog.CatalogItemDescription)
 	}
-	// Test non-existant catalog item
-	catitem, err = cat.FindCatalogItem("INVALID")
-	check.Assert(catitem, Equals, CatalogItem{})
-	check.Assert(err, IsNil)
+	// Test non-existent catalog item
+	catalogItem, err = cat.GetCatalogItemByName("INVALID", false)
+	check.Assert(err, NotNil)
+	check.Assert(catalogItem, IsNil)
 }
 
 // Creates a Catalog, updates the description, and checks the changes against the
@@ -47,9 +82,8 @@ func (vcd *TestVCD) Test_UpdateCatalog(check *C) {
 	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	catalog, err := org.FindAdminCatalog(TestUpdateCatalog)
-	check.Assert(err, IsNil)
-	if catalog != (AdminCatalog{}) {
+	catalog, _ := org.GetAdminCatalogByName(TestUpdateCatalog, false)
+	if catalog != nil {
 		err = catalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
@@ -75,13 +109,12 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	adminCatalog, err := org.FindAdminCatalog(TestDeleteCatalog)
-	check.Assert(err, IsNil)
-	if adminCatalog != (AdminCatalog{}) {
-		err = adminCatalog.Delete(true, true)
+	oldCatalog, _ := org.GetAdminCatalogByName(TestDeleteCatalog, false)
+	if oldCatalog != nil {
+		err = oldCatalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err = org.CreateCatalog(TestDeleteCatalog, TestDeleteCatalog)
+	adminCatalog, err := org.CreateCatalog(TestDeleteCatalog, TestDeleteCatalog)
 	check.Assert(err, IsNil)
 	// After a successful creation, the entity is added to the cleanup list.
 	// If something fails after this point, the entity will be removed
@@ -89,10 +122,9 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestDeleteCatalog)
 	err = adminCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
-	catalog, err := org.FindCatalog(TestDeleteCatalog)
-	check.Assert(err, IsNil)
-	check.Assert(catalog, Equals, Catalog{})
-
+	catalog, err := org.GetAdminCatalogByName(TestDeleteCatalog, true)
+	check.Assert(err, NotNil)
+	check.Assert(catalog, IsNil)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -131,7 +163,7 @@ func (vcd *TestVCD) Test_UploadOvf_progress_works(check *C) {
 
 	AddToCleanupList(itemName, "catalogItem", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_UploadOvf")
 
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
@@ -166,8 +198,9 @@ func (vcd *TestVCD) Test_UploadOvf_ShowUploadProgress_works(check *C) {
 
 	check.Assert(string(result), Matches, ".*Upload progress 100.00%")
 
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -240,12 +273,12 @@ func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName s
 
 	AddToCleanupList(itemName, "catalogItem", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_UploadOvf")
 
-	catalog, err = org.FindCatalog(catalogName)
+	catalog, err = org.GetCatalogByName(catalogName, false)
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
-func verifyCatalogItemUploaded(check *C, catalog Catalog, itemName string) {
+func verifyCatalogItemUploaded(check *C, catalog *Catalog, itemName string) {
 	entityFound := false
 	for _, catalogItems := range catalog.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
@@ -257,11 +290,11 @@ func verifyCatalogItemUploaded(check *C, catalog Catalog, itemName string) {
 	check.Assert(entityFound, Equals, true)
 }
 
-func findCatalog(vcd *TestVCD, check *C, catalogName string) (Catalog, AdminOrg) {
+func findCatalog(vcd *TestVCD, check *C, catalogName string) (*Catalog, *AdminOrg) {
 	org := getOrg(vcd, check)
-	catalog, err := org.FindCatalog(catalogName)
+	catalog, err := org.GetCatalogByName(catalogName, false)
 	check.Assert(err, IsNil)
-	return catalog, *org
+	return catalog, org
 }
 
 func getOrg(vcd *TestVCD, check *C) *AdminOrg {
@@ -292,8 +325,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage(check *C) {
 	AddToCleanupList(TestCatalogUploadMedia, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadCatalogMediaImage")
 
 	//verifyMediaImageUploaded(vcd.vdc.client, check, TestUploadMedia)
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, TestCatalogUploadMedia)
 }
 
@@ -318,8 +352,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_progress_works(check *C) {
 
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadCatalogMediaImage")
 
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -351,8 +386,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_ShowUploadProgress_works(check 
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadCatalogMediaImage")
 
 	check.Assert(string(result), Matches, ".*Upload progress 100.00%")
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
@@ -372,6 +408,7 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_error_withSameItem(check *C) {
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadCatalogMediaImage")
 
 	_, err2 := vcd.vdc.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	check.Assert(err2, NotNil)
 	check.Assert(err2.Error(), Matches, ".*already exists. Upload with different name.*")
 }
 
@@ -405,8 +442,9 @@ func (vcd *TestVCD) Test_CatalogDeleteMediaImage(check *C) {
 
 	//addition check
 	// check through existing catalogItems
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 	entityFound := false
 	for _, catalogItems := range catalog.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
@@ -420,4 +458,43 @@ func (vcd *TestVCD) Test_CatalogDeleteMediaImage(check *C) {
 
 func init() {
 	testingTags["catalog"] = "catalog_test.go"
+}
+
+// Tests CatalogItem retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_CatalogGetItem(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_CatalogGetItem: Org name not given.")
+		return
+	}
+	if vcd.config.VCD.Catalog.Name == "" {
+		check.Skip("Test_CatalogGetItem: Catalog name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+		return catalog.GetCatalogItemByName(name, refresh)
+	}
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return catalog.GetCatalogItemById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+		return catalog.GetCatalogItemByNameOrId(id, refresh)
+	}
+
+	var def = GetterTestDefinition{
+		parentType:       "Catalog",
+		parentName:       vcd.config.VCD.Catalog.Name,
+		entityType:       "CatalogItem",
+		entityName:       vcd.config.VCD.Catalog.CatalogItem,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -479,22 +479,22 @@ func (vcd *TestVCD) Test_CatalogGetItem(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return catalog.GetCatalogItemByName(name, refresh)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return catalog.GetCatalogItemById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) { return catalog.GetCatalogItemById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return catalog.GetCatalogItemByNameOrId(id, refresh)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "Catalog",
-		parentName:       vcd.config.VCD.Catalog.Name,
-		entityType:       "CatalogItem",
-		entityName:       vcd.config.VCD.Catalog.CatalogItem,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "Catalog",
+		parentName:    vcd.config.VCD.Catalog.Name,
+		entityType:    "CatalogItem",
+		entityName:    vcd.config.VCD.Catalog.CatalogItem,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -15,16 +15,18 @@ import (
 func (vcd *TestVCD) Test_GetVAppTemplate(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
+		return
 	}
+	check.Assert(cat, NotNil)
 
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
 	}
 
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catitem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 
 	// Get VAppTemplate
@@ -48,8 +50,9 @@ func (vcd *TestVCD) Test_Delete(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 
 	// add catalogItem
 	uploadTask, err := catalog.UploadOvf(vcd.config.OVA.OVAPath, TestDeleteCatalogItem, "upload from delete catalog item test", 1024)
@@ -57,16 +60,16 @@ func (vcd *TestVCD) Test_Delete(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
-	catalogItem, err := catalog.FindCatalogItem(TestDeleteCatalogItem)
+	catalogItem, err := catalog.GetCatalogItemByName(TestDeleteCatalogItem, false)
 	check.Assert(err, IsNil)
 
 	err = catalogItem.Delete()
 	check.Assert(err, IsNil)
 
 	// check through existing catalogItems
-	catalog, err = org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	entityFound := false
 	for _, catalogItems := range catalog.Catalog.CatalogItems {

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -309,8 +309,9 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := GetExternalNetwork(vcd.client, vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
+	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
 	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)
@@ -376,8 +377,9 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := GetExternalNetwork(vcd.client, vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
+	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
 	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)
@@ -455,8 +457,9 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := GetExternalNetwork(vcd.client, vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
+	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
 	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)

--- a/govcd/entity.go
+++ b/govcd/entity.go
@@ -7,33 +7,33 @@ package govcd
 type genericGetter func(string, bool) (interface{}, error)
 
 // getEntityByNameOrId finds a generic entity by Name Or ID
-// On success, returns a pointer to the AdminVdc structure and a nil error
+// On success, returns an empty interface representing a pointer to the structure and a nil error
 // On failure, returns a nil pointer and an error
 // Example usage:
 //
 // func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
-// 	byName := func(name string, refresh bool) (interface{}, error) {
+// 	getByName := func(name string, refresh bool) (interface{}, error) {
 // 		return org.GetCatalogByName(name, refresh)
 // 	}
-// 	byId := func(id string, refresh bool) (interface{}, error) {
+// 	getById := func(id string, refresh bool) (interface{}, error) {
 // 	  return org.GetCatalogById(id, refresh)
 // 	}
-// 	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+// 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 // 	return entity.(*Catalog), err
 // }
-func getEntityByNameOrId(byName, byId genericGetter, identifier string, refresh bool) (interface{}, error) {
+func getEntityByNameOrId(getByName, getById genericGetter, identifier string, refresh bool) (interface{}, error) {
 
 	var byNameErr, byIdErr error
 	var entity interface{}
 
-	entity, byIdErr = byId(identifier, refresh)
+	entity, byIdErr = getById(identifier, refresh)
 	if byIdErr == nil {
 		// Found by ID
 		return entity, nil
 	}
 	if IsNotFound(byIdErr) {
 		// Not found by ID, try by name
-		entity, byNameErr = byName(identifier, false)
+		entity, byNameErr = getByName(identifier, false)
 		return entity, byNameErr
 	} else {
 		// On any other error, we return it

--- a/govcd/entity.go
+++ b/govcd/entity.go
@@ -19,6 +19,9 @@ type genericGetter func(string, bool) (interface{}, error)
 // 	  return org.GetCatalogById(id, refresh)
 // 	}
 // 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+//  if entity != nil {
+//    return nil, err
+//  }
 // 	return entity.(*Catalog), err
 // }
 func getEntityByNameOrId(getByName, getById genericGetter, identifier string, refresh bool) (interface{}, error) {

--- a/govcd/entity.go
+++ b/govcd/entity.go
@@ -6,7 +6,7 @@ package govcd
 
 type genericGetter func(string, bool) (interface{}, error)
 
-// GetEntityByNameOrId finds a generic entity by Name Or ID
+// getEntityByNameOrId finds a generic entity by Name Or ID
 // On success, returns a pointer to the AdminVdc structure and a nil error
 // On failure, returns a nil pointer and an error
 // Example usage:
@@ -18,10 +18,10 @@ type genericGetter func(string, bool) (interface{}, error)
 // 	byId := func(id string, refresh bool) (interface{}, error) {
 // 	  return org.GetCatalogById(id, refresh)
 // 	}
-// 	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+// 	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 // 	return entity.(*Catalog), err
 // }
-func GetEntityByNameOrId(byName, byId genericGetter, identifier string, refresh bool) (interface{}, error) {
+func getEntityByNameOrId(byName, byId genericGetter, identifier string, refresh bool) (interface{}, error) {
 
 	var byNameErr, byIdErr error
 	var entity interface{}

--- a/govcd/entity.go
+++ b/govcd/entity.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+type genericGetter func(string, bool) (interface{}, error)
+
+// GetEntityByNameOrId finds a generic entity by Name Or ID
+// On success, returns a pointer to the AdminVdc structure and a nil error
+// On failure, returns a nil pointer and an error
+// Example usage:
+//
+// func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
+// 	byName := func(name string, refresh bool) (interface{}, error) {
+// 		return org.GetCatalogByName(name, refresh)
+// 	}
+// 	byId := func(id string, refresh bool) (interface{}, error) {
+// 	  return org.GetCatalogById(id, refresh)
+// 	}
+// 	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+// 	return entity.(*Catalog), err
+// }
+func GetEntityByNameOrId(byName, byId genericGetter, identifier string, refresh bool) (interface{}, error) {
+
+	var byNameErr, byIdErr error
+	var entity interface{}
+
+	entity, byIdErr = byId(identifier, refresh)
+	if byIdErr == nil {
+		// Found by ID
+		return entity, nil
+	}
+	if IsNotFound(byIdErr) {
+		// Not found by ID, try by name
+		entity, byNameErr = byName(identifier, false)
+		return entity, byNameErr
+	} else {
+		// On any other error, we return it
+		return nil, byIdErr
+	}
+}

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -62,7 +62,7 @@ func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
 // Semi-generic tests that check the complete set of Get methods for an entity
 // GetEntityByName
 // GetEntityById
-// GetEntityByNameOrId (using name or Id)
+// getEntityByNameOrId (using name or Id)
 // Get invalid name or ID
 // To use this function, the entity must satisfy the interface GenericEntity
 // and within the caller it must define the getter functions

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -14,24 +14,24 @@ import (
 )
 
 // An interface used to test the result of Get* methods
-type GenericEntity interface {
+type genericEntity interface {
 	name() string // returns the entity name
 	id() string   // returns the entity ID
 }
 
 // Defines a generic getter to test all Get* methods
-type GetterTestDefinition struct {
-	parentName       string                                    // Name of the parent entity
-	parentType       string                                    // Type of the parent entity
-	entityType       string                                    // Type of the entity to retrieve (Must match the type name)
-	entityName       string                                    // Name of the entity to retrieve
-	getterPrefix     string                                    // Base name for getter functions
-	getterByName     func(string, bool) (GenericEntity, error) // A function that retrieves the entity by name
-	getterById       func(string, bool) (GenericEntity, error) // A function that retrieves the entity by ID
-	getterByNameOrId func(string, bool) (GenericEntity, error) // A function that retrieves the entity by name or ID
+type getterTestDefinition struct {
+	parentName    string                                    // Name of the parent entity
+	parentType    string                                    // Type of the parent entity
+	entityType    string                                    // Type of the entity to retrieve (Must match the type name)
+	entityName    string                                    // Name of the entity to retrieve
+	getterPrefix  string                                    // Base name for getter functions
+	getByName     func(string, bool) (genericEntity, error) // A function that retrieves the entity by name
+	getById       func(string, bool) (genericEntity, error) // A function that retrieves the entity by ID
+	getByNameOrId func(string, bool) (genericEntity, error) // A function that retrieves the entity by name or ID
 }
 
-// Satisfy interface GenericEntity
+// Satisfy interface genericEntity
 func (adminCat *AdminCatalog) name() string { return adminCat.AdminCatalog.Name }
 func (adminCat *AdminCatalog) id() string   { return adminCat.AdminCatalog.ID }
 
@@ -64,7 +64,7 @@ func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
 // GetEntityById
 // getEntityByNameOrId (using name or Id)
 // Get invalid name or ID
-// To use this function, the entity must satisfy the interface GenericEntity
+// To use this function, the entity must satisfy the interface genericEntity
 // and within the caller it must define the getter functions
 //
 // Example usage:
@@ -78,23 +78,23 @@ func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
 //	check.Assert(err, IsNil)
 //	check.Assert(org, NotNil)
 //
-//	byName := func(name string, refresh bool) (GenericEntity, error) { return org.GetVDCByName(name, refresh) }
-//	byId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCById(id, refresh) }
-//	byNameOrId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+//	getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(name, refresh) }
+//	getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(id, refresh) }
+//	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
 //
-//	var def = GetterTestDefinition{
+//	var def = getterTestDefinition{
 //		parentType:       "Org",
 //		parentName:       vcd.config.VCD.Org,
 //		entityType:       "Vdc",
 //		getterPrefix:     "VDC",
 //		entityName:       vcd.config.VCD.Vdc,
-//		getterByName:     byName,
-//		getterById:       byId,
-//		getterByNameOrId: byNameOrId,
+//		getByName:        getByName,
+//		getById:          getById,
+//		getByNameOrId:    getByNameOrId,
 //	}
 //	vcd.testFinderGetGenericEntity(def, check)
 // }
-func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *C) {
+func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *C) {
 	entityName := def.entityName
 	if entityName == "" {
 		check.Skip(fmt.Sprintf("testFinderGetGenericEntity: %s name not given.", def.entityType))
@@ -116,8 +116,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByName\n", def.parentType, def.getterPrefix)
 	}
-	ge, err := def.getterByName(entityName, false)
-	entity1 := ge.(GenericEntity)
+	ge, err := def.getByName(entityName, false)
+	entity1 := ge.(genericEntity)
 	if err != nil {
 		check.Skip(fmt.Sprintf("testFinderGetGenericEntity: %s %s not found.", def.entityType, def.entityName))
 		return
@@ -138,8 +138,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sById\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterById(entityId, false)
-	entity2 := ge.(GenericEntity)
+	ge, err = def.getById(entityId, false)
+	entity2 := ge.(genericEntity)
 	check.Assert(err, IsNil)
 	check.Assert(entity2, NotNil)
 	check.Assert(entity2.name(), Equals, entityName)
@@ -150,8 +150,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByNameOrId\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterByNameOrId(entityId, false)
-	entity3 := ge.(GenericEntity)
+	ge, err = def.getByNameOrId(entityId, false)
+	entity3 := ge.(genericEntity)
 	check.Assert(err, IsNil)
 	check.Assert(entity3, NotNil)
 	check.Assert(entity3.name(), Equals, entityName)
@@ -162,8 +162,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByNameOrId\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterByNameOrId(entityName, false)
-	entity4 := ge.(GenericEntity)
+	ge, err = def.getByNameOrId(entityName, false)
+	entity4 := ge.(genericEntity)
 	check.Assert(err, IsNil)
 	check.Assert(entity4, NotNil)
 	check.Assert(entity4.name(), Equals, entityName)
@@ -174,8 +174,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByName (invalid name)\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterByName(INVALID_NAME, false)
-	entity5 := ge.(GenericEntity)
+	ge, err = def.getByName(INVALID_NAME, false)
+	entity5 := ge.(genericEntity)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity5, IsNil)
@@ -184,8 +184,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByNameOrId (invalid name)\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterByNameOrId(INVALID_NAME, false)
-	entity6 := ge.(GenericEntity)
+	ge, err = def.getByNameOrId(INVALID_NAME, false)
+	entity6 := ge.(genericEntity)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity6, IsNil)
@@ -194,8 +194,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sById (invalid ID)\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterById(invalidEntityId, false)
-	entity7 := ge.(GenericEntity)
+	ge, err = def.getById(invalidEntityId, false)
+	entity7 := ge.(genericEntity)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity7, IsNil)
@@ -204,8 +204,8 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *
 	if testVerbose {
 		fmt.Printf("#Testing %s.Get%sByNameOrId (invalid ID)\n", def.parentType, def.getterPrefix)
 	}
-	ge, err = def.getterByNameOrId(invalidEntityId, false)
-	entity8 := ge.(GenericEntity)
+	ge, err = def.getByNameOrId(invalidEntityId, false)
+	entity8 := ge.(genericEntity)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity8, IsNil)

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -66,6 +66,34 @@ func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
 // Get invalid name or ID
 // To use this function, the entity must satisfy the interface GenericEntity
 // and within the caller it must define the getter functions
+//
+// Example usage:
+//
+// func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
+//	if vcd.config.VCD.Org == "" {
+//		check.Skip("Test_OrgGetVdc: Org name not given.")
+//		return
+//	}
+//	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+//	check.Assert(err, IsNil)
+//	check.Assert(org, NotNil)
+//
+//	byName := func(name string, refresh bool) (GenericEntity, error) { return org.GetVDCByName(name, refresh) }
+//	byId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCById(id, refresh) }
+//	byNameOrId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+//
+//	var def = GetterTestDefinition{
+//		parentType:       "Org",
+//		parentName:       vcd.config.VCD.Org,
+//		entityType:       "Vdc",
+//		getterPrefix:     "VDC",
+//		entityName:       vcd.config.VCD.Vdc,
+//		getterByName:     byName,
+//		getterById:       byId,
+//		getterByNameOrId: byNameOrId,
+//	}
+//	vcd.testFinderGetGenericEntity(def, check)
+// }
 func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *C) {
 	entityName := def.entityName
 	if entityName == "" {

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -1,0 +1,184 @@
+// +build api functional catalog org extnetwork vm vdc system user ALL
+
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"reflect"
+
+	. "gopkg.in/check.v1"
+)
+
+// An interface used to test the result of Get* methods
+type GenericEntity interface {
+	name() string // returns the entity name
+	id() string   // returns the entity ID
+}
+
+// Defines a generic getter to test all Get* methods
+type GetterTestDefinition struct {
+	parentName       string                                    // Name of the parent entity
+	parentType       string                                    // Type of the parent entity
+	entityType       string                                    // Type of the entity to retrieve (Must match the type name)
+	entityName       string                                    // Name of the entity to retrieve
+	getterPrefix     string                                    // Base name for getter functions
+	getterByName     func(string, bool) (GenericEntity, error) // A function that retrieves the entity by name
+	getterById       func(string, bool) (GenericEntity, error) // A function that retrieves the entity by ID
+	getterByNameOrId func(string, bool) (GenericEntity, error) // A function that retrieves the entity by name or ID
+}
+
+// Satisfy interface GenericEntity
+func (adminCat *AdminCatalog) name() string { return adminCat.AdminCatalog.Name }
+func (adminCat *AdminCatalog) id() string   { return adminCat.AdminCatalog.ID }
+
+func (adminOrg *AdminOrg) name() string { return adminOrg.AdminOrg.Name }
+func (adminOrg *AdminOrg) id() string   { return adminOrg.AdminOrg.ID }
+
+func (vdc *AdminVdc) name() string { return vdc.AdminVdc.Name }
+func (vdc *AdminVdc) id() string   { return vdc.AdminVdc.ID }
+
+func (cat *Catalog) name() string { return cat.Catalog.Name }
+func (cat *Catalog) id() string   { return cat.Catalog.ID }
+
+func (catItem *CatalogItem) name() string { return catItem.CatalogItem.Name }
+func (catItem *CatalogItem) id() string   { return catItem.CatalogItem.ID }
+
+func (extNet *ExternalNetwork) name() string { return extNet.ExternalNetwork.Name }
+func (extNet *ExternalNetwork) id() string   { return extNet.ExternalNetwork.ID }
+
+func (org *Org) name() string { return org.Org.Name }
+func (org *Org) id() string   { return org.Org.ID }
+
+func (orgUser *OrgUser) name() string { return orgUser.User.Name }
+func (orgUser *OrgUser) id() string   { return orgUser.User.ID }
+
+func (vdc *Vdc) name() string { return vdc.Vdc.Name }
+func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
+
+// Semi-generic tests that check the complete set of Get methods for an entity
+// GetEntityByName
+// GetEntityById
+// GetEntityByNameOrId (using name or Id)
+// Get invalid name or ID
+// To use this function, the entity must satisfy the interface GenericEntity
+// and within the caller it must define the getter functions
+func (vcd *TestVCD) testFinderGetGenericEntity(def GetterTestDefinition, check *C) {
+	entityName := def.entityName
+	if entityName == "" {
+		check.Skip(fmt.Sprintf("testFinderGetGenericEntity: %s name not given.", def.entityType))
+		return
+	}
+
+	if def.getterPrefix == "" {
+		def.getterPrefix = def.entityType
+	}
+	if def.parentType == "" {
+		check.Skip("Field parentType was not filled.")
+	}
+	if testVerbose {
+		fmt.Printf("testFinderGetGenericEntity: %s %s getting %s \n", def.parentType, def.parentName, def.entityType)
+	}
+
+	// 1. Get the entity by name
+
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByName\n", def.parentType, def.getterPrefix)
+	}
+	ge, err := def.getterByName(entityName, false)
+	entity1 := ge.(GenericEntity)
+	if err != nil {
+		check.Skip(fmt.Sprintf("testFinderGetGenericEntity: %s %s not found.", def.entityType, def.entityName))
+		return
+	}
+
+	wantedType := fmt.Sprintf("*govcd.%s", def.entityType)
+	if testVerbose {
+		fmt.Printf("# Detected entity type %s\n", reflect.TypeOf(entity1))
+	}
+
+	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity1)), Equals, wantedType)
+
+	check.Assert(entity1, NotNil)
+	check.Assert(entity1.name(), Equals, entityName)
+	entityId := entity1.id()
+
+	// 2. Get the entity by ID
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sById\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterById(entityId, false)
+	entity2 := ge.(GenericEntity)
+	check.Assert(err, IsNil)
+	check.Assert(entity2, NotNil)
+	check.Assert(entity2.name(), Equals, entityName)
+	check.Assert(entity2.id(), Equals, entityId)
+	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity2)), Equals, wantedType)
+
+	// 3. Get the entity by Name or ID, using a known ID
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByNameOrId\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterByNameOrId(entityId, false)
+	entity3 := ge.(GenericEntity)
+	check.Assert(err, IsNil)
+	check.Assert(entity3, NotNil)
+	check.Assert(entity3.name(), Equals, entityName)
+	check.Assert(entity3.id(), Equals, entityId)
+	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity3)), Equals, wantedType)
+
+	// 4. Get the entity by Name or ID, using the entity name
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByNameOrId\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterByNameOrId(entityName, false)
+	entity4 := ge.(GenericEntity)
+	check.Assert(err, IsNil)
+	check.Assert(entity4, NotNil)
+	check.Assert(entity4.name(), Equals, entityName)
+	check.Assert(entity4.id(), Equals, entityId)
+	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity4)), Equals, wantedType)
+
+	// 5. Attempting a search by name with an invalid name
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByName (invalid name)\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterByName(INVALID_NAME, false)
+	entity5 := ge.(GenericEntity)
+	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
+	check.Assert(entity5, IsNil)
+
+	// 6. Attempting a search by name or ID with an invalid name
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByNameOrId (invalid name)\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterByNameOrId(INVALID_NAME, false)
+	entity6 := ge.(GenericEntity)
+	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
+	check.Assert(entity6, IsNil)
+
+	// 7. Attempting a search by ID with an invalid ID
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sById (invalid ID)\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterById(invalidEntityId, false)
+	entity7 := ge.(GenericEntity)
+	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
+	check.Assert(entity7, IsNil)
+
+	// 8. Attempting a search by name or ID with an invalid ID
+	if testVerbose {
+		fmt.Printf("#Testing %s.Get%sByNameOrId (invalid ID)\n", def.parentType, def.getterPrefix)
+	}
+	ge, err = def.getterByNameOrId(invalidEntityId, false)
+	entity8 := ge.(GenericEntity)
+	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
+	check.Assert(entity8, IsNil)
+}

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -209,22 +209,22 @@ func init() {
 // Tests ExternalNetwork retrieval by name, by ID, and by a combination of name and ID
 func (vcd *TestVCD) Test_SystemGetExternalNetwork(check *C) {
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return vcd.client.GetExternalNetworkByName(name)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetExternalNetworkById(id) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.client.GetExternalNetworkById(id) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return vcd.client.GetExternalNetworkByNameOrId(id)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "VDCClient",
-		parentName:       "System",
-		entityType:       "ExternalNetwork",
-		entityName:       vcd.config.VCD.ExternalNetwork,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "VDCClient",
+		parentName:    "System",
+		entityType:    "ExternalNetwork",
+		entityName:    vcd.config.VCD.ExternalNetwork,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_UploadMediaImage(check *C) {
 
 	AddToCleanupList(TestUploadMedia, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
 
-	verifyMediaImageUploaded(&vcd.vdc, check, TestUploadMedia)
+	verifyMediaImageUploaded(vcd.vdc, check, TestUploadMedia)
 }
 
 func skipWhenMediaPathMissing(vcd *TestVCD, check *C) {
@@ -59,7 +59,7 @@ func (vcd *TestVCD) Test_UploadMediaImage_progress_works(check *C) {
 
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
 
-	verifyMediaImageUploaded(&vcd.vdc, check, itemName)
+	verifyMediaImageUploaded(vcd.vdc, check, itemName)
 }
 
 // Tests System function UploadMediaImage by checking UploadTask.ShowUploadProgress writes values of progress to stdin.
@@ -88,7 +88,7 @@ func (vcd *TestVCD) Test_UploadMediaImage_ShowUploadProgress_works(check *C) {
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
 
 	check.Assert(string(result), Matches, ".*Upload progress 100.00%")
-	verifyMediaImageUploaded(&vcd.vdc, check, itemName)
+	verifyMediaImageUploaded(vcd.vdc, check, itemName)
 }
 
 // Tests System function UploadMediaImage by creating media item and expecting specific error
@@ -105,6 +105,7 @@ func (vcd *TestVCD) Test_UploadMediaImage_error_withSameItem(check *C) {
 	AddToCleanupList(itemName, "mediaImage", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_UploadMediaImage")
 
 	_, err2 := vcd.vdc.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	check.Assert(err2, NotNil)
 	check.Assert(err2.Error(), Matches, ".*already exists. Upload with different name.*")
 }
 
@@ -147,7 +148,7 @@ func (vcd *TestVCD) Test_FindMediaAsCatalogItem(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -186,16 +186,17 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog not found. Test can't proceed")
+		return
 	}
 
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
@@ -225,16 +226,17 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 
 func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog not found. Test can't proceed")
+		return
 	}
 
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
@@ -282,7 +284,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaItem(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
@@ -330,7 +332,7 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaItem(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	check.Assert(catalog.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -119,6 +119,20 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 	return *catalog, err
 }
 
+// CreateCatalog creates a catalog with given name and description under
+// the given organization. Returns an Catalog that contains a creation
+// task.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
+func (org *Org) CreateCatalog(name, description string) (Catalog, error) {
+	catalog := NewCatalog(org.client)
+	adminCatalog, err := CreateCatalog(org.client, org.Org.Link, name, description)
+	if err != nil {
+		return Catalog{}, err
+	}
+	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
+	return *catalog, nil
+}
+
 func validateVdcConfiguration(vdcDefinition *types.VdcConfiguration) error {
 	if vdcDefinition.Xmlns == "" {
 		return errors.New("VdcConfiguration missing required field: Xmlns")

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -236,9 +236,12 @@ func (org *Org) GetCatalogById(catalogId string, refresh bool) (*Catalog, error)
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
 func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return org.GetCatalogByName(name, refresh) }
-	byId := func(id string, refresh bool) (interface{}, error) { return org.GetCatalogById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return org.GetCatalogByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return org.GetCatalogById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*Catalog), err
 }
 
@@ -296,8 +299,11 @@ func (org *Org) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
 // On success, returns a pointer to the VDC structure and a nil error
 // On failure, returns a nil pointer and an error
 func (org *Org) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return org.GetVDCByName(name, refresh) }
-	byId := func(id string, refresh bool) (interface{}, error) { return org.GetVDCById(id, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return org.GetVDCByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return org.GetVDCById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*Vdc), err
 }

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -8,20 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
-
-// Interface for methods in common for Org and AdminOrg
-type OrgOperations interface {
-	FindCatalog(catalog string) (Catalog, error)
-	GetVdcByName(vdcname string) (Vdc, error)
-	Refresh() error
-}
 
 type Org struct {
 	Org    *types.Org
@@ -63,6 +53,7 @@ func (org *Org) Refresh() error {
 // Given a valid catalog name, FindCatalog returns a Catalog object.
 // If no catalog is found, then returns an empty catalog and no error.
 // Otherwise it returns an error.
+// Deprecated: use org.GetCatalogByName instead
 func (org *Org) FindCatalog(catalogName string) (Catalog, error) {
 
 	for _, link := range org.Org.Link {
@@ -83,6 +74,7 @@ func (org *Org) FindCatalog(catalogName string) (Catalog, error) {
 // If user specifies valid vdc name then this returns a vdc object.
 // If no vdc is found, then it returns an empty vdc and no error.
 // Otherwise it returns an empty vdc and an error.
+// Deprecated: use org.GetVDCByName instead
 func (org *Org) GetVdcByName(vdcname string) (Vdc, error) {
 	for _, link := range org.Org.Link {
 		if link.Name == vdcname {
@@ -95,147 +87,6 @@ func (org *Org) GetVdcByName(vdcname string) (Vdc, error) {
 		}
 	}
 	return Vdc{}, nil
-}
-
-// Given an adminVdc with a valid HREF, the function refresh the adminVdc
-// and updates the adminVdc data. Returns an error on failure
-// Users should use refresh whenever they suspect
-// a stale VDC due to the creation/update/deletion of a resource
-// within the the VDC itself.
-func (adminVdc *AdminVdc) Refresh() error {
-	if *adminVdc == (AdminVdc{}) || adminVdc.AdminVdc.HREF == "" {
-		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
-	}
-
-	// Empty struct before a new unmarshal, otherwise we end up with duplicate
-	// elements in slices.
-	unmarshalledAdminVdc := &types.AdminVdc{}
-
-	_, err := adminVdc.client.ExecuteRequest(adminVdc.AdminVdc.HREF, http.MethodGet,
-		"", "error refreshing VDC: %s", nil, unmarshalledAdminVdc)
-	if err != nil {
-		return err
-	}
-	adminVdc.AdminVdc = unmarshalledAdminVdc
-
-	return nil
-}
-
-// GetAdminVdcByName function uses a valid VDC name and returns a admin VDC object.
-// If no VDC is found, then it returns an empty VDC and no error.
-// Otherwise it returns an empty VDC and an error.
-func (adminOrg *AdminOrg) GetAdminVdcByName(vdcname string) (AdminVdc, error) {
-	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
-		if vdcs.Name == vdcname {
-
-			adminVdc := NewAdminVdc(adminOrg.client)
-
-			_, err := adminOrg.client.ExecuteRequest(vdcs.HREF, http.MethodGet,
-				"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
-
-			return *adminVdc, err
-		}
-	}
-	return AdminVdc{}, nil
-}
-
-// UpdateAsync updates VDC from current VDC struct contents.
-// Any differences that may be legally applied will be updated.
-// Returns an error if the call to vCD fails.
-// API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
-func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
-
-	adminVdc.AdminVdc.Xmlns = types.XMLNamespaceVCloud
-
-	// Return the task
-	return adminVdc.client.ExecuteTaskRequest(adminVdc.AdminVdc.HREF, http.MethodPut,
-		types.MimeAdminVDC, "error updating VDC: %s", adminVdc.AdminVdc)
-}
-
-// Update function updates an Admin VDC from current VDC struct contents.
-// Any differences that may be legally applied will be updated.
-// Returns an empty AdminVdc struct and error if the call to vCD fails.
-// API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
-func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
-	task, err := adminVdc.UpdateAsync()
-	if err != nil {
-		return AdminVdc{}, err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return AdminVdc{}, err
-	}
-
-	err = adminVdc.Refresh()
-	if err != nil {
-		return AdminVdc{}, err
-	}
-
-	return *adminVdc, nil
-}
-
-// AdminOrg gives an admin representation of an org.
-// Administrators can delete and update orgs with an admin org object.
-// AdminOrg includes all members of the Org element, and adds several
-// elements that can be viewed and modified only by system administrators.
-// Definition: https://code.vmware.com/apis/220/vcloud#/doc/doc/types/AdminOrgType.html
-type AdminOrg struct {
-	AdminOrg *types.AdminOrg
-	client   *Client
-}
-
-func NewAdminOrg(cli *Client) *AdminOrg {
-	return &AdminOrg{
-		AdminOrg: new(types.AdminOrg),
-		client:   cli,
-	}
-}
-
-// Given an adminorg with a valid HREF, the function refetches the adminorg
-// and updates the user's adminorg data. Otherwise if the function fails,
-// it returns an error.  Users should use refresh whenever they have
-// a stale org due to the creation/update/deletion of a resource
-// within the org or the org itself.
-func (adminOrg *AdminOrg) Refresh() error {
-	if *adminOrg == (AdminOrg{}) {
-		return fmt.Errorf("cannot refresh, Object is empty")
-	}
-
-	// Empty struct before a new unmarshal, otherwise we end up with duplicate
-	// elements in slices.
-	unmarshalledAdminOrg := &types.AdminOrg{}
-
-	_, err := adminOrg.client.ExecuteRequest(adminOrg.AdminOrg.HREF, http.MethodGet,
-		"", "error refreshing organization: %s", nil, unmarshalledAdminOrg)
-	if err != nil {
-		return err
-	}
-	adminOrg.AdminOrg = unmarshalledAdminOrg
-
-	return nil
-}
-
-// CreateCatalog creates a catalog with given name and description under the
-// the given organization. Returns an AdminCatalog that contains a creation
-// task.
-// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
-func (adminOrg *AdminOrg) CreateCatalog(name, description string) (AdminCatalog, error) {
-	return CreateCatalog(adminOrg.client, adminOrg.AdminOrg.Link, name, description)
-}
-
-// CreateCatalog creates a catalog with given name and description under the
-// the given organization. Returns an Catalog that contains a creation
-// task.
-// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
-func (org *Org) CreateCatalog(name, description string) (Catalog, error) {
-	catalog := NewCatalog(org.client)
-	adminCatalog, err := CreateCatalog(org.client, org.Org.Link, name, description)
-	if err != nil {
-		return Catalog{}, err
-	}
-	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return *catalog, nil
 }
 
 func CreateCatalog(client *Client, links types.LinkList, Name, Description string) (AdminCatalog, error) {
@@ -266,34 +117,6 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 		"application/vnd.vmware.admin.catalog+xml", "error creating catalog: %s", vcomp, catalog.AdminCatalog)
 
 	return *catalog, err
-}
-
-// If user specifies valid vdc name then this returns a vdc object.
-// If no vdc is found, then it returns an empty vdc and no error.
-// Otherwise it returns an empty vdc and an error. This function
-// allows users to use an AdminOrg to fetch a vdc as well.
-func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
-	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
-		if vdcs.Name == vdcname {
-			splitByAdminHREF := strings.Split(vdcs.HREF, "/api/admin")
-
-			// admin user and normal user will have different urls
-			var vdcHREF string
-			if len(splitByAdminHREF) == 1 {
-				vdcHREF = vdcs.HREF
-			} else {
-				vdcHREF = splitByAdminHREF[0] + "/api" + splitByAdminHREF[1]
-			}
-
-			vdc := NewVdc(adminOrg.client)
-
-			_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
-				"", "error getting vdc: %s", nil, vdc.Vdc)
-
-			return *vdc, err
-		}
-	}
-	return Vdc{}, nil
 }
 
 func validateVdcConfiguration(vdcDefinition *types.VdcConfiguration) error {
@@ -342,321 +165,125 @@ func validateVdcConfiguration(vdcDefinition *types.VdcConfiguration) error {
 	return nil
 }
 
-// CreateVdc creates a VDC with the given params under the given organization.
-// Returns an AdminVdc.
-// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-VdcConfiguration.html
-func (org *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (Task, error) {
-	err := validateVdcConfiguration(vdcConfiguration)
+// GetCatalogByHref  finds a Catalog by HREF
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetCatalogByHref(catalogHref string) (*Catalog, error) {
+	cat := NewCatalog(org.client)
+
+	_, err := org.client.ExecuteRequest(catalogHref, http.MethodGet,
+		"", "error retrieving catalog: %s", nil, cat.Catalog)
 	if err != nil {
-		return Task{}, err
+		return nil, err
 	}
-
-	vdcCreateHREF, err := url.ParseRequestURI(org.AdminOrg.HREF)
-	if err != nil {
-		return Task{}, fmt.Errorf("error parsing admin org url: %s", err)
-	}
-	vdcCreateHREF.Path += "/vdcsparams"
-
-	adminVdc := NewAdminVdc(org.client)
-
-	_, err = org.client.ExecuteRequest(vdcCreateHREF.String(), http.MethodPost,
-		"application/vnd.vmware.admin.createVdcParams+xml", "error retrieving vdc: %s", vdcConfiguration, adminVdc.AdminVdc)
-	if err != nil {
-		return Task{}, err
-	}
-
-	// Return the task
-	task := NewTask(org.client)
-	task.Task = adminVdc.AdminVdc.Tasks.Task[0]
-	return *task, nil
+	// The request was successful
+	return cat, nil
 }
 
-// Creates the vdc and waits for the asynchronous task to complete.
-func (org *AdminOrg) CreateVdcWait(vdcDefinition *types.VdcConfiguration) error {
-	task, err := org.CreateVdc(vdcDefinition)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return fmt.Errorf("couldn't finish creating vdc %#v", err)
-	}
-	return nil
-}
-
-//   Deletes the org, returning an error if the vCD call fails.
-//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
-func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
-	if force && recursive {
-		//undeploys vapps
-		err := adminOrg.undeployAllVApps()
+// GetCatalogByName  finds a Catalog by Name
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetCatalogByName(catalogName string, refresh bool) (*Catalog, error) {
+	if refresh {
+		err := org.Refresh()
 		if err != nil {
-			return fmt.Errorf("error could not undeploy: %#v", err)
-		}
-		//removes vapps
-		err = adminOrg.removeAllVApps()
-		if err != nil {
-			return fmt.Errorf("error could not remove vapp: %#v", err)
-		}
-		//removes catalogs
-		err = adminOrg.removeCatalogs()
-		if err != nil {
-			return fmt.Errorf("error could not remove all catalogs: %#v", err)
-		}
-		//removes networks
-		err = adminOrg.removeAllOrgNetworks()
-		if err != nil {
-			return fmt.Errorf("error could not remove all networks: %#v", err)
-		}
-		//removes org vdcs
-		err = adminOrg.removeAllOrgVDCs()
-		if err != nil {
-			return fmt.Errorf("error could not remove all vdcs: %#v", err)
+			return nil, err
 		}
 	}
-	// Disable org
-	err := adminOrg.Disable()
-	if err != nil {
-		return fmt.Errorf("error disabling Org %s: %s", adminOrg.AdminOrg.Name, err)
-	}
-	// Get admin HREF
-	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
-	if err != nil {
-		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
-	}
-	req := adminOrg.client.NewRequest(map[string]string{
-		"force":     strconv.FormatBool(force),
-		"recursive": strconv.FormatBool(recursive),
-	}, http.MethodDelete, *orgHREF, nil)
-	resp, err := checkResp(adminOrg.client.Http.Do(req))
-	if err != nil {
-		return fmt.Errorf("error deleting Org %s: %s", adminOrg.AdminOrg.ID, err)
-	}
-
-	task := NewTask(adminOrg.client)
-	if err = decodeBody(resp, task.Task); err != nil {
-		return fmt.Errorf("error decoding task response: %s", err)
-	}
-	return task.WaitTaskCompletion()
-}
-
-// Disables the org. Returns an error if the call to vCD fails.
-// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-DisableOrg.html
-func (adminOrg *AdminOrg) Disable() error {
-	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
-	if err != nil {
-		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
-	}
-	orgHREF.Path += "/action/disable"
-
-	return adminOrg.client.ExecuteRequestWithoutResponse(orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
-}
-
-//   Updates the Org definition from current org struct contents.
-//   Any differences that may be legally applied will be updated.
-//   Returns an error if the call to vCD fails.
-//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
-func (adminOrg *AdminOrg) Update() (Task, error) {
-	vcomp := &types.AdminOrg{
-		Xmlns:       types.XMLNamespaceVCloud,
-		Name:        adminOrg.AdminOrg.Name,
-		IsEnabled:   adminOrg.AdminOrg.IsEnabled,
-		FullName:    adminOrg.AdminOrg.FullName,
-		Description: adminOrg.AdminOrg.Description,
-		OrgSettings: adminOrg.AdminOrg.OrgSettings,
-	}
-
-	/**/
-	// Same workaround used in Org creation, where OrgGeneralSettings properties
-	// are not set unless UseServerBootSequence is also set
-	if vcomp.OrgSettings.OrgGeneralSettings != nil {
-		vcomp.OrgSettings.OrgGeneralSettings.UseServerBootSequence = true
-	}
-
-	/**/
-
-	// Return the task
-	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,
-		"application/vnd.vmware.admin.organization+xml", "error updating Org: %s", vcomp)
-}
-
-// Undeploys every vapp within an organization
-func (adminOrg *AdminOrg) undeployAllVApps() error {
-	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
-		adminVdcHREF, err := url.Parse(vdcs.HREF)
-		if err != nil {
-			return err
-		}
-		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
-		if err != nil {
-			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
-		}
-		err = vdc.undeployAllVdcVApps()
-		if err != nil {
-			return fmt.Errorf("error deleting vapp: %s", err)
-		}
-	}
-	return nil
-}
-
-// Deletes every vapp within an organization
-func (adminOrg *AdminOrg) removeAllVApps() error {
-	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
-		adminVdcHREF, err := url.Parse(vdcs.HREF)
-		if err != nil {
-			return err
-		}
-		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
-		if err != nil {
-			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
-		}
-		err = vdc.removeAllVdcVApps()
-		if err != nil {
-			return fmt.Errorf("error deleting vapp: %s", err)
-		}
-	}
-	return nil
-}
-
-// Gets a vdc within org associated with an admin vdc url
-func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) {
-	// get non admin vdc path
-	vdcURL := adminOrg.client.VCDHREF
-	vdcURL.Path += strings.Split(adminVdcUrl.Path, "/api/admin")[1] //gets id
-
-	vdc := NewVdc(adminOrg.client)
-
-	_, err := adminOrg.client.ExecuteRequest(vdcURL.String(), http.MethodGet,
-		"", "error retrieving vdc: %s", nil, vdc.Vdc)
-
-	return vdc, err
-}
-
-// Removes all vdcs in a org
-func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
-	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
-
-		// Get admin Vdc HREF
-		adminVdcUrl := adminOrg.client.VCDHREF
-		adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/vdc/")[1] + "/action/disable"
-
-		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)
-		_, err := checkResp(adminOrg.client.Http.Do(req))
-		if err != nil {
-			return fmt.Errorf("error disabling vdc: %s", err)
-		}
-		// Get admin vdc HREF for normal deletion
-		adminVdcUrl.Path = strings.Split(adminVdcUrl.Path, "/action/disable")[0]
-		req = adminOrg.client.NewRequest(map[string]string{
-			"recursive": "true",
-			"force":     "true",
-		}, http.MethodDelete, adminVdcUrl, nil)
-		resp, err := checkResp(adminOrg.client.Http.Do(req))
-		if err != nil {
-			return fmt.Errorf("error deleting vdc: %s", err)
-		}
-		task := NewTask(adminOrg.client)
-		if err = decodeBody(resp, task.Task); err != nil {
-			return fmt.Errorf("error decoding task response: %s", err)
-		}
-		if task.Task.Status == "error" {
-			return fmt.Errorf("vdc not properly destroyed")
-		}
-		err = task.WaitTaskCompletion()
-		if err != nil {
-			return fmt.Errorf("couldn't finish removing vdc %#v", err)
-		}
-
-	}
-
-	return nil
-}
-
-// Removes All networks in the org
-func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
-	for _, networks := range adminOrg.AdminOrg.Networks.Networks {
-		// Get Network HREF
-		networkHREF := adminOrg.client.VCDHREF
-		networkHREF.Path += "/admin/network/" + strings.Split(networks.HREF, "/api/admin/network/")[1] //gets id
-
-		task, err := adminOrg.client.ExecuteTaskRequest(networkHREF.String(), http.MethodDelete,
-			"", "error deleting network: %s", nil)
-		if err != nil {
-			return err
-		}
-
-		if task.Task.Status == "error" {
-			return fmt.Errorf("network not properly destroyed")
-		}
-		err = task.WaitTaskCompletion()
-		if err != nil {
-			return fmt.Errorf("couldn't finish removing network %#v", err)
-		}
-	}
-	return nil
-}
-
-// Forced removal of all organization catalogs
-func (adminOrg *AdminOrg) removeCatalogs() error {
-	for _, catalogs := range adminOrg.AdminOrg.Catalogs.Catalog {
+	for _, catalog := range org.Org.Link {
 		// Get Catalog HREF
-		catalogHREF := adminOrg.client.VCDHREF
-		catalogHREF.Path += "/admin/catalog/" + strings.Split(catalogs.HREF, "/api/admin/catalog/")[1] //gets id
-		req := adminOrg.client.NewRequest(map[string]string{
-			"force":     "true",
-			"recursive": "true",
-		}, http.MethodDelete, catalogHREF, nil)
-		_, err := checkResp(adminOrg.client.Http.Do(req))
+		if catalog.Name == catalogName && catalog.Type == types.MimeCatalog {
+			return org.GetCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetCatalogById finds a Catalog by ID
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetCatalogById(catalogId string, refresh bool) (*Catalog, error) {
+	if refresh {
+		err := org.Refresh()
 		if err != nil {
-			return fmt.Errorf("error deleting catalog: %s, %s", err, catalogHREF.Path)
+			return nil, err
 		}
 	}
-	return nil
-
+	for _, catalog := range org.Org.Link {
+		// Get Catalog HREF
+		if equalIds(catalogId, catalog.ID, catalog.HREF) {
+			return org.GetCatalogByHref(catalog.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
 }
 
-// Given a valid catalog name, FindCatalog returns an AdminCatalog object.
-// If no catalog is found, then returns an empty AdminCatalog and no error.
-// Otherwise it returns an error. Function allows user to use an AdminOrg
-// to also fetch a Catalog. If user does not have proper credentials to
-// perform administrator tasks then function returns an error.
-// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/GET-Catalog-AdminView.html
-func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, error) {
-	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
-		// Get Catalog HREF
-		if catalog.Name == catalogName {
-
-			adminCatalog := NewAdminCatalog(adminOrg.client)
-
-			_, err := adminOrg.client.ExecuteRequest(catalog.HREF, http.MethodGet,
-				"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
-
-			// The request was successful
-			return *adminCatalog, err
-		}
-	}
-	return AdminCatalog{}, nil
+// GetCatalogByNameOrId finds a Catalog by name or ID
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
+	byName := func(name string, refresh bool) (interface{}, error) { return org.GetCatalogByName(name, refresh) }
+	byId := func(id string, refresh bool) (interface{}, error) { return org.GetCatalogById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*Catalog), err
 }
 
-// Given a valid catalog name, FindCatalog returns a Catalog object.
-// If no catalog is found, then returns an empty catalog and no error.
-// Otherwise it returns an error. Function allows user to use an AdminOrg
-// to also fetch a Catalog.
-func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
-	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
-		// Get Catalog HREF
-		if catalog.Name == catalogName {
-			catalogURL := adminOrg.client.VCDHREF
-			catalogURL.Path += "/catalog/" + strings.Split(catalog.HREF, "/api/admin/catalog/")[1] //gets id
+// GetVDCByHref finds a VDC by HREF
+// On success, returns a pointer to the VDC structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetVDCByHref(vdcHref string) (*Vdc, error) {
+	vdc := NewVdc(org.client)
+	_, err := org.client.ExecuteRequest(vdcHref, http.MethodGet,
+		"", "error retrieving VDC: %s", nil, vdc.Vdc)
+	if err != nil {
+		return nil, err
+	}
+	// The request was successful
+	return vdc, nil
+}
 
-			cat := NewCatalog(adminOrg.client)
-
-			_, err := adminOrg.client.ExecuteRequest(catalogURL.String(), http.MethodGet,
-				"", "error retrieving catalog: %s", nil, cat.Catalog)
-
-			// The request was successful
-			return *cat, err
+// GetVDCByName finds a VDC by Name
+// On success, returns a pointer to the VDC structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetVDCByName(vdcName string, refresh bool) (*Vdc, error) {
+	if refresh {
+		err := org.Refresh()
+		if err != nil {
+			return nil, err
 		}
 	}
-	return Catalog{}, nil
+	for _, link := range org.Org.Link {
+		if link.Name == vdcName && link.Type == types.MimeVDC {
+			return org.GetVDCByHref(link.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVDCById finds a VDC by ID
+// On success, returns a pointer to the VDC structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
+	if refresh {
+		err := org.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, link := range org.Org.Link {
+		if equalIds(vdcId, link.ID, link.HREF) {
+			return org.GetVDCByHref(link.HREF)
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVDCByNameOrId finds a VDC by name or ID
+// On success, returns a pointer to the VDC structure and a nil error
+// On failure, returns a nil pointer and an error
+func (org *Org) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
+	byName := func(name string, refresh bool) (interface{}, error) { return org.GetVDCByName(name, refresh) }
+	byId := func(id string, refresh bool) (interface{}, error) { return org.GetVDCById(id, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*Vdc), err
 }

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -224,7 +224,7 @@ func (org *Org) GetCatalogById(catalogId string, refresh bool) (*Catalog, error)
 func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return org.GetCatalogByName(name, refresh) }
 	byId := func(id string, refresh bool) (interface{}, error) { return org.GetCatalogById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*Catalog), err
 }
 
@@ -284,6 +284,6 @@ func (org *Org) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
 func (org *Org) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return org.GetVDCByName(name, refresh) }
 	byId := func(id string, refresh bool) (interface{}, error) { return org.GetVDCById(id, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*Vdc), err
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -11,8 +11,9 @@ import (
 	"math"
 	"time"
 
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // Tests Refresh for Org by updating the org and then asserting if the
@@ -196,14 +197,14 @@ func doesOrgExist(check *C, vcd *TestVCD) {
 // that doesn't exist. Asserts an error if the function finds it or
 // if the error is not nil.
 func (vcd *TestVCD) Test_GetVdcByName(check *C) {
-	vdc, err := vcd.org.GetVdcByName(vcd.config.VCD.Vdc)
-	check.Assert(vdc, Not(Equals), Vdc{})
+	vdc, err := vcd.org.GetVDCByName(vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
 	check.Assert(vdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	vdc, err = vcd.org.GetVdcByName(INVALID_NAME)
-	check.Assert(vdc, Equals, Vdc{})
-	check.Assert(err, IsNil)
+	vdc, err = vcd.org.GetVDCByName(INVALID_NAME, false)
+	check.Assert(err, NotNil)
+	check.Assert(vdc, IsNil)
 }
 
 // Tests org function Admin version of GetVDCByName with the vdc
@@ -218,14 +219,14 @@ func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	vdc, err := adminOrg.GetVdcByName(vcd.config.VCD.Vdc)
-	check.Assert(vdc, Not(Equals), Vdc{})
+	vdc, err := adminOrg.GetVDCByName(vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
 	check.Assert(vdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	vdc, err = adminOrg.GetVdcByName(INVALID_NAME)
-	check.Assert(vdc, Equals, Vdc{})
-	check.Assert(err, IsNil)
+	vdc, err = adminOrg.GetVDCByName(INVALID_NAME, false)
+	check.Assert(vdc, IsNil)
+	check.Assert(err, NotNil)
 }
 
 // Tests org function GetVDCByName with the vdc specified
@@ -322,16 +323,15 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 			UsesFastProvisioning: true,
 		}
 
-		vdc, err := adminOrg.GetVdcByName(vdcConfiguration.Name)
-		check.Assert(err, IsNil)
-		if vdc != (Vdc{}) {
+		vdc, _ := adminOrg.GetVDCByName(vdcConfiguration.Name, false)
+		if vdc != nil {
 			err = vdc.DeleteWait(true, true)
 			check.Assert(err, IsNil)
 		}
 
 		task, err := adminOrg.CreateVdc(vdcConfiguration)
-		check.Assert(task, Equals, Task{})
 		check.Assert(err, Not(IsNil))
+		check.Assert(task, Equals, Task{})
 		check.Assert(err.Error(), Equals, "VdcConfiguration missing required field: ComputeCapacity[0].Memory.Units")
 		vdcConfiguration.ComputeCapacity[0].Memory.Units = "MB"
 
@@ -340,13 +340,9 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 
 		AddToCleanupList(vdcConfiguration.Name, "vdc", vcd.org.Org.Name, "Test_CreateVdc")
 
-		// Refresh so the new VDC shows up in the org's list
-		err = adminOrg.Refresh()
+		vdc, err = adminOrg.GetVDCByName(vdcConfiguration.Name, true)
 		check.Assert(err, IsNil)
-
-		vdc, err = adminOrg.GetVdcByName(vdcConfiguration.Name)
-		check.Assert(err, IsNil)
-		check.Assert(vdc, Not(Equals), Vdc{})
+		check.Assert(vdc, NotNil)
 		check.Assert(vdc.Vdc.Name, Equals, vdcConfiguration.Name)
 		check.Assert(vdc.Vdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 		check.Assert(vdc.Vdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
@@ -354,11 +350,9 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 		err = vdc.DeleteWait(true, true)
 		check.Assert(err, IsNil)
 
-		err = adminOrg.Refresh()
-		check.Assert(err, IsNil)
-		vdc, err = adminOrg.GetVdcByName(vdcConfiguration.Name)
-		check.Assert(err, IsNil)
-		check.Assert(vdc, Equals, Vdc{})
+		vdc, err = adminOrg.GetVDCByName(vdcConfiguration.Name, true)
+		check.Assert(err, NotNil)
+		check.Assert(vdc, IsNil)
 	}
 }
 
@@ -369,18 +363,18 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_FindCatalog(check *C) {
 	// Find Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	check.Assert(cat, Not(Equals), Catalog{})
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(cat, NotNil)
 	check.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
 	// checks if user gave a catalog description in config file
 	if vcd.config.VCD.Catalog.Description != "" {
 		check.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
 	// Check Invalid Catalog
-	cat, err = vcd.org.FindCatalog(INVALID_NAME)
-	check.Assert(cat, Equals, Catalog{})
-	check.Assert(err, IsNil)
+	cat, err = vcd.org.GetCatalogByName(INVALID_NAME, false)
+	check.Assert(err, NotNil)
+	check.Assert(cat, IsNil)
 }
 
 // Tests Admin version of FindCatalog with Catalog in config file. Asserts an
@@ -397,7 +391,7 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 	// Find Catalog
-	cat, err := adminOrg.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := adminOrg.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(cat, Not(Equals), Catalog{})
 	check.Assert(err, IsNil)
 	check.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
@@ -406,9 +400,9 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 		check.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
 	// Check Invalid Catalog
-	cat, err = adminOrg.FindCatalog(INVALID_NAME)
-	check.Assert(cat, Equals, Catalog{})
-	check.Assert(err, IsNil)
+	cat, err = adminOrg.GetCatalogByName(INVALID_NAME, false)
+	check.Assert(err, NotNil)
+	check.Assert(cat, IsNil)
 }
 
 // Tests CreateCatalog by creating a catalog named CatalogCreationTest and
@@ -418,29 +412,29 @@ func (vcd *TestVCD) Test_CreateCatalog(check *C) {
 	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	catalog, _ := org.FindAdminCatalog(TestCreateCatalog)
-	if catalog != (AdminCatalog{}) {
-		err = catalog.Delete(true, true)
+	oldAdminCatalog, _ := org.GetAdminCatalogByName(TestCreateCatalog, false)
+	if oldAdminCatalog != nil {
+		err = oldAdminCatalog.Delete(true, true)
 		check.Assert(err, IsNil)
 	}
-	catalog, err = org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
+	adminCatalog, err := org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
 	check.Assert(err, IsNil)
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
-	check.Assert(catalog.AdminCatalog.Name, Equals, TestCreateCatalog)
-	check.Assert(catalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestCreateCatalog)
+	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
-	task.Task = catalog.AdminCatalog.Tasks.Task[0]
+	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	org, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyCatalog, err := org.FindAdminCatalog(TestCreateCatalog)
-	check.Assert(copyCatalog, Not(Equals), AdminCatalog{})
+	copyAdminCatalog, err := org.GetAdminCatalogByName(TestCreateCatalog, true)
 	check.Assert(err, IsNil)
-	check.Assert(catalog.AdminCatalog.Name, Equals, copyCatalog.AdminCatalog.Name)
-	check.Assert(catalog.AdminCatalog.Description, Equals, copyCatalog.AdminCatalog.Description)
-	check.Assert(catalog.AdminCatalog.IsPublished, Equals, false)
-	err = catalog.Delete(true, true)
+	check.Assert(copyAdminCatalog, NotNil)
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, copyAdminCatalog.AdminCatalog.Name)
+	check.Assert(adminCatalog.AdminCatalog.Description, Equals, copyAdminCatalog.AdminCatalog.Description)
+	check.Assert(adminCatalog.AdminCatalog.IsPublished, Equals, false)
+	err = adminCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
 }
 
@@ -454,12 +448,13 @@ func (vcd *TestVCD) Test_GetAdminCatalog(check *C) {
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	// Find Catalog
-	cat, err := adminOrg.FindAdminCatalog(vcd.config.VCD.Catalog.Name)
+	adminCatalog, err := adminOrg.GetAdminCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
-	check.Assert(cat.AdminCatalog.Name, Equals, vcd.config.VCD.Catalog.Name)
+	check.Assert(adminCatalog, NotNil)
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, vcd.config.VCD.Catalog.Name)
 	// checks if user gave a catalog description in config file
 	if vcd.config.VCD.Catalog.Description != "" {
-		check.Assert(cat.AdminCatalog.Description, Equals, vcd.config.VCD.Catalog.Description)
+		check.Assert(adminCatalog.AdminCatalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
 }
 
@@ -468,15 +463,16 @@ func (vcd *TestVCD) Test_GetAdminCatalog(check *C) {
 func (vcd *TestVCD) Test_RefreshVdc(check *C) {
 
 	adminOrg, vdcConfiguration, err := setupVDc(vcd, check)
+	check.Assert(err, IsNil)
 
 	// Refresh so the new VDC shows up in the org's list
 	err = adminOrg.Refresh()
 	check.Assert(err, IsNil)
 
-	adminVdc, err := adminOrg.GetAdminVdcByName(vdcConfiguration.Name)
+	adminVdc, err := adminOrg.GetAdminVDCByName(vdcConfiguration.Name, false)
 
 	check.Assert(err, IsNil)
-	check.Assert(adminVdc, Not(Equals), Vdc{})
+	check.Assert(adminVdc, NotNil)
 	check.Assert(adminVdc.AdminVdc.Name, Equals, vdcConfiguration.Name)
 	check.Assert(adminVdc.AdminVdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 	check.Assert(adminVdc.AdminVdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
@@ -573,9 +569,8 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 		IsThinProvision:      true,
 		UsesFastProvisioning: true,
 	}
-	vdc, err := adminOrg.GetVdcByName(vdcConfiguration.Name)
-	check.Assert(err, IsNil)
-	if vdc != (Vdc{}) {
+	vdc, _ := adminOrg.GetVDCByName(vdcConfiguration.Name, false)
+	if vdc != nil {
 		err = vdc.DeleteWait(true, true)
 		check.Assert(err, IsNil)
 	}
@@ -589,15 +584,16 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 // variable is updated.
 func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	adminOrg, vdcConfiguration, err := setupVDc(vcd, check)
+	check.Assert(err, IsNil)
 
 	// Refresh so the new VDC shows up in the org's list
 	err = adminOrg.Refresh()
 	check.Assert(err, IsNil)
 
-	adminVdc, err := adminOrg.GetAdminVdcByName(vdcConfiguration.Name)
+	adminVdc, err := adminOrg.GetAdminVDCByName(vdcConfiguration.Name, false)
 
 	check.Assert(err, IsNil)
-	check.Assert(adminVdc, Not(Equals), Vdc{})
+	check.Assert(adminVdc, NotNil)
 	check.Assert(adminVdc.AdminVdc.Name, Equals, vdcConfiguration.Name)
 	check.Assert(adminVdc.AdminVdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 	check.Assert(adminVdc.AdminVdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
@@ -663,12 +659,194 @@ func (vcd *TestVCD) Test_GetAdminVdcByName(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	adminVdc, err := adminOrg.GetAdminVdcByName(vcd.config.VCD.Vdc)
-	check.Assert(adminVdc, Not(Equals), AdminVdc{})
+	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
+	check.Assert(adminVdc, NotNil)
 	check.Assert(adminVdc.AdminVdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	adminVdc, err = adminOrg.GetAdminVdcByName(INVALID_NAME)
-	check.Assert(adminVdc, Equals, AdminVdc{})
+	adminVdc, err = adminOrg.GetAdminVDCByName(INVALID_NAME, false)
+	check.Assert(err, NotNil)
+	check.Assert(adminVdc, IsNil)
+}
+
+// Tests catalog retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_OrgGetCatalog(check *C) {
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+		return vcd.org.GetCatalogByName(name, refresh)
+	}
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.org.GetCatalogById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+		return vcd.org.GetCatalogByNameOrId(id, refresh)
+	}
+
+	var def = GetterTestDefinition{
+		parentType:       "Org",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "Catalog",
+		entityName:       vcd.config.VCD.Catalog.Name,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+
+	vcd.testFinderGetGenericEntity(def, check)
+}
+
+// Tests admin catalog retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_AdminOrgGetAdminCatalog(check *C) {
+	catalogName := vcd.config.VCD.Catalog.Name
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_AdminOrgGetAdminCatalog: Org name not given.")
+		return
+	}
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetAdminCatalogByName(name, refresh)
+	}
+	getterById := func(id string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetAdminCatalogById(id, refresh)
+	}
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetAdminCatalogByNameOrId(id, refresh)
+	}
+
+	var def = GetterTestDefinition{
+		parentType:       "AdminOrg",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "AdminCatalog",
+		entityName:       catalogName,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+
+	vcd.testFinderGetGenericEntity(def, check)
+
+}
+
+// Tests catalog retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_AdminOrgGetCatalog(check *C) {
+	catalogName := vcd.config.VCD.Catalog.Name
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_AdminOrgGetCatalog: Org name not given.")
+		return
+	}
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetCatalogByName(name, refresh)
+	}
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetCatalogById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetCatalogByNameOrId(id, refresh)
+	}
+
+	var def = GetterTestDefinition{
+		parentType:       "AdminOrg",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "Catalog",
+		entityName:       catalogName,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+
+	vcd.testFinderGetGenericEntity(def, check)
+
+}
+
+// Tests VDC retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_AdminOrgGetVdc(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_AdminOrgGetVdc: Org name not given.")
+		return
+	}
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCByName(name, refresh) }
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCByNameOrId(id, refresh) }
+
+	var def = GetterTestDefinition{
+		parentType:       "AdminOrg",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "Vdc",
+		getterPrefix:     "VDC",
+		entityName:       vcd.config.VCD.Vdc,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
+}
+
+// Tests VDC retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_AdminOrgGetAdminVdc(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_AdminOrgGetAdminVdc: Org name not given.")
+		return
+	}
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetAdminVDCByName(name, refresh)
+	}
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+		return adminOrg.GetAdminVDCByNameOrId(id, refresh)
+	}
+
+	var def = GetterTestDefinition{
+		parentType:       "AdminOrg",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "AdminVdc",
+		getterPrefix:     "AdminVDC",
+		entityName:       vcd.config.VCD.Vdc,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
+}
+
+// Tests VDC retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_OrgGetVdc: Org name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	getterByName := func(name string, refresh bool) (GenericEntity, error) { return org.GetVDCByName(name, refresh) }
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCById(id, refresh) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+
+	var def = GetterTestDefinition{
+		parentType:       "Org",
+		parentName:       vcd.config.VCD.Org,
+		entityType:       "Vdc",
+		getterPrefix:     "VDC",
+		entityName:       vcd.config.VCD.Vdc,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -705,22 +705,22 @@ func (vcd *TestVCD) Test_GetAdminVdcByName(check *C) {
 // Tests catalog retrieval by name, by ID, and by a combination of name and ID
 func (vcd *TestVCD) Test_OrgGetCatalog(check *C) {
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return vcd.org.GetCatalogByName(name, refresh)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.org.GetCatalogById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.org.GetCatalogById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return vcd.org.GetCatalogByNameOrId(id, refresh)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "Org",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "Catalog",
-		entityName:       vcd.config.VCD.Catalog.Name,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "Org",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "Catalog",
+		entityName:    vcd.config.VCD.Catalog.Name,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 
 	vcd.testFinderGetGenericEntity(def, check)
@@ -738,24 +738,24 @@ func (vcd *TestVCD) Test_AdminOrgGetAdminCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetAdminCatalogByName(name, refresh)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetAdminCatalogById(id, refresh)
 	}
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetAdminCatalogByNameOrId(id, refresh)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "AdminOrg",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "AdminCatalog",
-		entityName:       catalogName,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "AdminOrg",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "AdminCatalog",
+		entityName:    catalogName,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 
 	vcd.testFinderGetGenericEntity(def, check)
@@ -774,22 +774,22 @@ func (vcd *TestVCD) Test_AdminOrgGetCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetCatalogByName(name, refresh)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetCatalogById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetCatalogById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetCatalogByNameOrId(id, refresh)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "AdminOrg",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "Catalog",
-		entityName:       catalogName,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "AdminOrg",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "Catalog",
+		entityName:    catalogName,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 
 	vcd.testFinderGetGenericEntity(def, check)
@@ -807,19 +807,19 @@ func (vcd *TestVCD) Test_AdminOrgGetVdc(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCByName(name, refresh) }
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetVDCByNameOrId(id, refresh) }
+	getByName := func(name string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCByName(name, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCByNameOrId(id, refresh) }
 
-	var def = GetterTestDefinition{
-		parentType:       "AdminOrg",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "Vdc",
-		getterPrefix:     "VDC",
-		entityName:       vcd.config.VCD.Vdc,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "AdminOrg",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "Vdc",
+		getterPrefix:  "VDC",
+		entityName:    vcd.config.VCD.Vdc,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }
@@ -835,23 +835,23 @@ func (vcd *TestVCD) Test_AdminOrgGetAdminVdc(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) {
+	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetAdminVDCByName(name, refresh)
 	}
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return adminOrg.GetAdminVDCById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) {
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
 		return adminOrg.GetAdminVDCByNameOrId(id, refresh)
 	}
 
-	var def = GetterTestDefinition{
-		parentType:       "AdminOrg",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "AdminVdc",
-		getterPrefix:     "AdminVDC",
-		entityName:       vcd.config.VCD.Vdc,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "AdminOrg",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "AdminVdc",
+		getterPrefix:  "AdminVDC",
+		entityName:    vcd.config.VCD.Vdc,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }
@@ -867,19 +867,19 @@ func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) { return org.GetVDCByName(name, refresh) }
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCById(id, refresh) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+	getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(name, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
 
-	var def = GetterTestDefinition{
-		parentType:       "Org",
-		parentName:       vcd.config.VCD.Org,
-		entityType:       "Vdc",
-		getterPrefix:     "VDC",
-		entityName:       vcd.config.VCD.Vdc,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "Org",
+		parentName:    vcd.config.VCD.Org,
+		entityType:    "Vdc",
+		getterPrefix:  "VDC",
+		entityName:    vcd.config.VCD.Vdc,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -44,7 +44,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkEGW(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkEGW
 
-	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	err := RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)
 	if err != nil {
 		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
 	}
@@ -106,7 +106,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkIso
 
-	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	err := RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)
 	if err != nil {
 		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
 	}
@@ -164,7 +164,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	err := RemoveOrgVdcNetworkIfExists(vcd.vdc, networkName)
+	err := RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)
 	if err != nil {
 		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -556,27 +556,12 @@ func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork,
 // GetExternalNetworkByNameOrId returns an ExternalNetwork reference if either the network name or ID matches an existing one.
 // If no valid external network is found, it returns an empty ExternalNetwork reference and an error
 func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*ExternalNetwork, error) {
-	/*
-		var byNameErr, byIdErr error
-		var externalNetwork *ExternalNetwork
-
-		externalNetwork, byIdErr = vcdClient.GetExternalNetworkById(identifier)
-		if byIdErr == nil {
-			// Found by ID
-			return externalNetwork, nil
-		}
-		if IsNotFound(byIdErr) {
-			// Not found by ID, try by name
-			externalNetwork, byNameErr = vcdClient.GetExternalNetworkByName(identifier)
-			return externalNetwork, byNameErr
-		} else {
-			// On any other error, we return it
-			return nil, byIdErr
-		}
-	*/
-	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
-	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
+	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*ExternalNetwork), err
 }
 
@@ -772,28 +757,12 @@ func (vcdClient *VCDClient) GetOrgById(orgId string) (*Org, error) {
 // On success, returns a pointer to the Org structure and a nil error
 // On failure, returns a nil pointer and an error
 func (vcdClient *VCDClient) GetOrgByNameOrId(identifier string) (*Org, error) {
-	/*
-		var byNameErr, byIdErr error
-		var org *Org
-		org, byIdErr = vcdClient.GetOrgById(identifier)
-		if byIdErr == nil {
-			// Found by ID
-			return org, nil
-		}
-		if IsNotFound(byIdErr) {
-			// Not found by ID, try by name
-			org, byNameErr = vcdClient.GetOrgByName(identifier)
-			return org, byNameErr
-		} else {
-			// On any other error, we return it
-			return nil, byIdErr
-		}
-
-	*/
-
-	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(name) }
-	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(id) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
+	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(name) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(id) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*Org), err
 }
 
@@ -845,27 +814,11 @@ func (vcdClient *VCDClient) GetAdminOrgById(orgId string) (*AdminOrg, error) {
 // On success, returns a pointer to the Admin Org structure and a nil error
 // On failure, returns a nil pointer and an error
 func (vcdClient *VCDClient) GetAdminOrgByNameOrId(identifier string) (*AdminOrg, error) {
-	/*
-		var byNameErr, byIdErr error
-		var adminOrg *AdminOrg
-
-		adminOrg, byIdErr = vcdClient.GetAdminOrgById(identifier)
-		if byIdErr == nil {
-			// Found by ID
-			return adminOrg, nil
-		}
-		if IsNotFound(byIdErr) {
-			// Not found by ID, try by name
-			adminOrg, byNameErr = vcdClient.GetAdminOrgByName(identifier)
-			return adminOrg, byNameErr
-		} else {
-			// On any other error, we return it
-			return nil, byIdErr
-		}
-	*/
-
-	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(name) }
-	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(id) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
+	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(name) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(id) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*AdminOrg), err
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -576,7 +576,7 @@ func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*Ex
 	*/
 	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
 	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
 	return entity.(*ExternalNetwork), err
 }
 
@@ -793,7 +793,7 @@ func (vcdClient *VCDClient) GetOrgByNameOrId(identifier string) (*Org, error) {
 
 	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(name) }
 	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(id) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
 	return entity.(*Org), err
 }
 
@@ -866,6 +866,6 @@ func (vcdClient *VCDClient) GetAdminOrgByNameOrId(identifier string) (*AdminOrg,
 
 	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(name) }
 	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(id) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, false)
 	return entity.(*AdminOrg), err
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -693,7 +693,7 @@ func GetNetworkPoolByHREF(client *VCDClient, href string) (*types.VMWNetworkPool
 	networkPool := &types.VMWNetworkPool{}
 
 	_, err := client.Client.ExecuteRequest(href, http.MethodGet,
-		"", "error fetching network ppol: %s", nil, networkPool)
+		"", "error fetching network pool: %s", nil, networkPool)
 
 	// Return the disk
 	return networkPool, err

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -155,7 +155,7 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 	}
 	// Add external networks inside the configuration structure
 	for _, extNetName := range egwc.ExternalNetworks {
-		extNet, err := GetExternalNetwork(vcdClient, extNetName)
+		extNet, err := vcdClient.GetExternalNetworkByName(extNetName)
 		if err != nil {
 			return Task{}, err
 		}
@@ -206,7 +206,7 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 	if err != nil {
 		return Task{}, err
 	}
-	vdc, err := adminOrg.GetVdcByName(vdcName)
+	vdc, err := adminOrg.GetVDCByName(vdcName, false)
 	if err != nil {
 		return Task{}, err
 	}
@@ -275,7 +275,7 @@ func createEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfig
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	vdc, err := org.GetVdcByName(egwc.VdcName)
+	vdc, err := org.GetVDCByName(egwc.VdcName, false)
 	if err != nil {
 		return EdgeGateway{}, err
 	}
@@ -437,6 +437,7 @@ func QueryPortGroups(vcdCli *VCDClient, filter string) ([]*types.PortGroupRecord
 
 // GetExternalNetwork returns an ExternalNetwork reference if user the network name matches an existing one.
 // If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+// Deprecated: use vcdClient.GetExternalNetworkByName instead
 func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
@@ -474,6 +475,109 @@ func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetw
 	}
 	return externalNetwork, fmt.Errorf("could not find external network named %s", networkName)
 
+}
+
+// GetExternalNetworks returns a list of available external networks
+func (vcdClient *VCDClient) GetExternalNetworks() (*types.ExternalNetworkReferences, error) {
+
+	if !vcdClient.Client.IsSysAdmin {
+		return nil, fmt.Errorf("functionality requires system administrator privileges")
+	}
+
+	extNetworkHREF, err := getExternalNetworkHref(&vcdClient.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	extNetworkRefs := &types.ExternalNetworkReferences{}
+	_, err = vcdClient.Client.ExecuteRequest(extNetworkHREF, http.MethodGet,
+		types.MimeNetworkConnectionSection, "error retrieving external networks: %s", nil, extNetworkRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return extNetworkRefs, nil
+}
+
+// GetExternalNetworkByName returns an ExternalNetwork reference if the network name matches an existing one.
+// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*ExternalNetwork, error) {
+
+	extNetworkRefs, err := vcdClient.GetExternalNetworks()
+
+	if err != nil {
+		return nil, err
+	}
+
+	externalNetwork := NewExternalNetwork(&vcdClient.Client)
+
+	for _, netRef := range extNetworkRefs.ExternalNetworkReference {
+		if netRef.Name == networkName {
+			externalNetwork.ExternalNetwork.HREF = netRef.HREF
+			err = externalNetwork.Refresh()
+			if err != nil {
+				return nil, err
+			}
+			return externalNetwork, nil
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetExternalNetworkById returns an ExternalNetwork reference if the network ID matches an existing one.
+// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork, error) {
+
+	extNetworkRefs, err := vcdClient.GetExternalNetworks()
+
+	if err != nil {
+		return nil, err
+	}
+
+	externalNetwork := NewExternalNetwork(&vcdClient.Client)
+
+	for _, netRef := range extNetworkRefs.ExternalNetworkReference {
+		// ExternalNetworkReference items don't have ID
+		// We compare using the UUID from HREF
+		if equalIds(id, "", netRef.HREF) {
+			externalNetwork.ExternalNetwork.HREF = netRef.HREF
+			err = externalNetwork.Refresh()
+			if err != nil {
+				return nil, err
+			}
+			return externalNetwork, nil
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetExternalNetworkByNameOrId returns an ExternalNetwork reference if either the network name or ID matches an existing one.
+// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*ExternalNetwork, error) {
+	/*
+		var byNameErr, byIdErr error
+		var externalNetwork *ExternalNetwork
+
+		externalNetwork, byIdErr = vcdClient.GetExternalNetworkById(identifier)
+		if byIdErr == nil {
+			// Found by ID
+			return externalNetwork, nil
+		}
+		if IsNotFound(byIdErr) {
+			// Not found by ID, try by name
+			externalNetwork, byNameErr = vcdClient.GetExternalNetworkByName(identifier)
+			return externalNetwork, byNameErr
+		} else {
+			// On any other error, we return it
+			return nil, byIdErr
+		}
+	*/
+	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
+	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	return entity.(*ExternalNetwork), err
 }
 
 // CreateExternalNetwork allows create external network and returns Task or error.
@@ -668,21 +772,29 @@ func (vcdClient *VCDClient) GetOrgById(orgId string) (*Org, error) {
 // On success, returns a pointer to the Org structure and a nil error
 // On failure, returns a nil pointer and an error
 func (vcdClient *VCDClient) GetOrgByNameOrId(identifier string) (*Org, error) {
-	var byNameErr, byIdErr error
-	var org *Org
-	org, byIdErr = vcdClient.GetOrgById(identifier)
-	if byIdErr == nil {
-		// Found by ID
-		return org, nil
-	}
-	if IsNotFound(byIdErr) {
-		// Not found by ID, try by name
-		org, byNameErr = vcdClient.GetOrgByName(identifier)
-		return org, byNameErr
-	} else {
-		// On any other error, we return it
-		return nil, byIdErr
-	}
+	/*
+		var byNameErr, byIdErr error
+		var org *Org
+		org, byIdErr = vcdClient.GetOrgById(identifier)
+		if byIdErr == nil {
+			// Found by ID
+			return org, nil
+		}
+		if IsNotFound(byIdErr) {
+			// Not found by ID, try by name
+			org, byNameErr = vcdClient.GetOrgByName(identifier)
+			return org, byNameErr
+		} else {
+			// On any other error, we return it
+			return nil, byIdErr
+		}
+
+	*/
+
+	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(name) }
+	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(id) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	return entity.(*Org), err
 }
 
 // GetAdminOrgByName finds an Admin Organization by name
@@ -733,20 +845,27 @@ func (vcdClient *VCDClient) GetAdminOrgById(orgId string) (*AdminOrg, error) {
 // On success, returns a pointer to the Admin Org structure and a nil error
 // On failure, returns a nil pointer and an error
 func (vcdClient *VCDClient) GetAdminOrgByNameOrId(identifier string) (*AdminOrg, error) {
-	var byNameErr, byIdErr error
-	var adminOrg *AdminOrg
+	/*
+		var byNameErr, byIdErr error
+		var adminOrg *AdminOrg
 
-	adminOrg, byIdErr = vcdClient.GetAdminOrgById(identifier)
-	if byIdErr == nil {
-		// Found by ID
-		return adminOrg, nil
-	}
-	if IsNotFound(byIdErr) {
-		// Not found by ID, try by name
-		adminOrg, byNameErr = vcdClient.GetAdminOrgByName(identifier)
-		return adminOrg, byNameErr
-	} else {
-		// On any other error, we return it
-		return nil, byIdErr
-	}
+		adminOrg, byIdErr = vcdClient.GetAdminOrgById(identifier)
+		if byIdErr == nil {
+			// Found by ID
+			return adminOrg, nil
+		}
+		if IsNotFound(byIdErr) {
+			// Not found by ID, try by name
+			adminOrg, byNameErr = vcdClient.GetAdminOrgByName(identifier)
+			return adminOrg, byNameErr
+		} else {
+			// On any other error, we return it
+			return nil, byIdErr
+		}
+	*/
+
+	byName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(name) }
+	byId := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(id) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, false)
+	return entity.(*AdminOrg), err
 }

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -23,18 +23,18 @@ func (vcd *TestVCD) Test_SystemGetOrg(check *C) {
 		return
 	}
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgByName(name) }
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgById(id) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgByNameOrId(id) }
+	getByName := func(name string, refresh bool) (genericEntity, error) { return vcd.client.GetOrgByName(name) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.client.GetOrgById(id) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return vcd.client.GetOrgByNameOrId(id) }
 
-	var def = GetterTestDefinition{
-		parentType:       "VCDClient",
-		parentName:       "System",
-		entityType:       "Org",
-		entityName:       vcd.config.VCD.Org,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "VCDClient",
+		parentName:    "System",
+		entityType:    "Org",
+		entityName:    vcd.config.VCD.Org,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }
@@ -47,18 +47,18 @@ func (vcd *TestVCD) Test_SystemGetAdminOrg(check *C) {
 		return
 	}
 
-	getterByName := func(name string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgByName(name) }
-	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgById(id) }
-	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgByNameOrId(id) }
+	getByName := func(name string, refresh bool) (genericEntity, error) { return vcd.client.GetAdminOrgByName(name) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.client.GetAdminOrgById(id) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return vcd.client.GetAdminOrgByNameOrId(id) }
 
-	var def = GetterTestDefinition{
-		parentType:       "VCDClient",
-		parentName:       "System",
-		entityType:       "AdminOrg",
-		entityName:       vcd.config.VCD.Org,
-		getterByName:     getterByName,
-		getterById:       getterById,
-		getterByNameOrId: getterByNameOrId,
+	var def = getterTestDefinition{
+		parentType:    "VCDClient",
+		parentName:    "System",
+		entityType:    "AdminOrg",
+		entityName:    vcd.config.VCD.Org,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -15,116 +15,52 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// Tests System methods vcd.GetOrg* by checking if the org object
-// returned has the same name as the one provided in the config file.
-// Asserts an error if the names don't match or if the function returned
-// an error. Also tests an org that doesn't exist. Asserts an error
-// if the function finds it or if the error is nil.
-// Repeats the same operations fot GetOrgById, GetOrgByNameOrId, GetOrg
-func (vcd *TestVCD) Test_GetOrgByNameOrId(check *C) {
+// Tests Org retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_SystemGetOrg(check *C) {
 
-	// Test Get by name
-	orgName := vcd.config.VCD.Org
-	org1, err1 := vcd.client.GetOrgByName(orgName)
-	check.Assert(org1, NotNil)
-	check.Assert(err1, IsNil)
-	check.Assert(org1.Org.Name, Equals, orgName)
-	orgId := org1.Org.ID
-	// Tests Org that doesn't exist
-	org1, err1 = vcd.client.GetOrgByName(INVALID_NAME)
-	check.Assert(org1, IsNil)
-	// When we explicitly search for a non existing item, we expect the error to be not nil
-	check.Assert(err1, NotNil)
-	check.Assert(IsNotFound(err1), Equals, true)
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_SystemGetOrg: Org name not given.")
+		return
+	}
 
-	// Test Get by ID
-	org2, err2 := vcd.client.GetOrgById(orgId)
-	check.Assert(org2, NotNil)
-	check.Assert(err2, IsNil)
-	check.Assert(org2.Org.Name, Equals, orgName)
-	check.Assert(org2.Org.ID, Equals, orgId)
-	org2, err2 = vcd.client.GetOrgById(invalidEntityId)
-	check.Assert(org2, IsNil)
-	check.Assert(err2, NotNil)
-	check.Assert(IsNotFound(err2), Equals, true)
+	getterByName := func(name string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgByName(name) }
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgById(id) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetOrgByNameOrId(id) }
 
-	// Test Get by name or ID using the ID
-	org3, err3 := vcd.client.GetOrgByNameOrId(orgId)
-	check.Assert(org3, NotNil)
-	check.Assert(err3, IsNil)
-	check.Assert(org3.Org.Name, Equals, orgName)
-	check.Assert(org3.Org.ID, Equals, orgId)
-	org3, err3 = vcd.client.GetOrgByNameOrId(invalidEntityId)
-	check.Assert(org3, IsNil)
-	check.Assert(err3, NotNil)
-	check.Assert(IsNotFound(err3), Equals, true)
-
-	// Test Get by name or ID using the name
-	org4, err4 := vcd.client.GetOrgByNameOrId(orgName)
-	check.Assert(org4, NotNil)
-	check.Assert(err4, IsNil)
-	check.Assert(org4.Org.Name, Equals, orgName)
-	check.Assert(org4.Org.ID, Equals, orgId)
-	org4, err4 = vcd.client.GetOrgByNameOrId(INVALID_NAME)
-	check.Assert(org4, IsNil)
-	check.Assert(err4, NotNil)
-	check.Assert(IsNotFound(err4), Equals, true)
+	var def = GetterTestDefinition{
+		parentType:       "VCDClient",
+		parentName:       "System",
+		entityType:       "Org",
+		entityName:       vcd.config.VCD.Org,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }
 
-// Tests System methods vcd.GetAdminOrg* by checking if the adminOrg object
-// returned has the same name as the one provided in the config file.
-// Asserts an error if the names don't match or if the function returned
-// an error. Also tests an admin org that doesn't exist. Asserts an error
-// if the function finds it or if the error is nil.
-// Repeats the same operations fot GetAdminOrgById, GetAdminOrgByNameOrId, GetAdminOrg
-func (vcd *TestVCD) Test_GetAdminOrgByNameOrId(check *C) {
+// Tests AdminOrg retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_SystemGetAdminOrg(check *C) {
 
-	// Test Get by name
-	adminOrgName := vcd.config.VCD.Org
-	adminOrg1, err1 := vcd.client.GetAdminOrgByName(adminOrgName)
-	check.Assert(adminOrg1, NotNil)
-	check.Assert(err1, IsNil)
-	check.Assert(adminOrg1.AdminOrg.Name, Equals, adminOrgName)
-	orgId := adminOrg1.AdminOrg.ID
-	// Tests Org that doesn't exist
-	adminOrg1, err1 = vcd.client.GetAdminOrgByName(INVALID_NAME)
-	check.Assert(adminOrg1, IsNil)
-	// When we explicitly search for a non existing item, we expect the error to be not nil
-	check.Assert(err1, NotNil)
-	check.Assert(IsNotFound(err1), Equals, true)
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_SystemGetAdminOrg: Org name not given.")
+		return
+	}
 
-	// Test Get by ID
-	adminOrg2, err2 := vcd.client.GetAdminOrgById(orgId)
-	check.Assert(adminOrg2, NotNil)
-	check.Assert(err2, IsNil)
-	check.Assert(adminOrg2.AdminOrg.Name, Equals, adminOrgName)
-	check.Assert(adminOrg2.AdminOrg.ID, Equals, orgId)
-	adminOrg2, err2 = vcd.client.GetAdminOrgById(invalidEntityId)
-	check.Assert(adminOrg2, IsNil)
-	check.Assert(err2, NotNil)
-	check.Assert(IsNotFound(err2), Equals, true)
+	getterByName := func(name string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgByName(name) }
+	getterById := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgById(id) }
+	getterByNameOrId := func(id string, refresh bool) (GenericEntity, error) { return vcd.client.GetAdminOrgByNameOrId(id) }
 
-	// Test Get by name or ID using the ID
-	adminOrg3, err3 := vcd.client.GetAdminOrgByNameOrId(orgId)
-	check.Assert(adminOrg3, NotNil)
-	check.Assert(err3, IsNil)
-	check.Assert(adminOrg3.AdminOrg.Name, Equals, adminOrgName)
-	check.Assert(adminOrg3.AdminOrg.ID, Equals, orgId)
-	adminOrg3, err3 = vcd.client.GetAdminOrgByNameOrId(invalidEntityId)
-	check.Assert(adminOrg3, IsNil)
-	check.Assert(err3, NotNil)
-	check.Assert(IsNotFound(err3), Equals, true)
-
-	// Test Get by name or ID using the name
-	adminOrg4, err4 := vcd.client.GetAdminOrgByNameOrId(adminOrgName)
-	check.Assert(adminOrg4, NotNil)
-	check.Assert(err4, IsNil)
-	check.Assert(adminOrg4.AdminOrg.Name, Equals, adminOrgName)
-	check.Assert(adminOrg4.AdminOrg.ID, Equals, orgId)
-	adminOrg4, err4 = vcd.client.GetAdminOrgByNameOrId(INVALID_NAME)
-	check.Assert(adminOrg4, IsNil)
-	check.Assert(err4, NotNil)
-	check.Assert(IsNotFound(err4), Equals, true)
+	var def = GetterTestDefinition{
+		parentType:       "VCDClient",
+		parentName:       "System",
+		entityType:       "AdminOrg",
+		entityName:       vcd.config.VCD.Org,
+		getterByName:     getterByName,
+		getterById:       getterById,
+		getterByNameOrId: getterByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }
 
 // Tests the creation of an org with general settings,
@@ -307,9 +243,9 @@ func (vcd *TestVCD) Test_GetNetworkPoolByHREF(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	adminVdc, err := adminOrg.GetAdminVdcByName(vcd.config.VCD.Vdc)
-	check.Assert(adminVdc, Not(Equals), AdminVdc{})
+	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
+	check.Assert(adminVdc, NotNil)
 
 	// Get network pool by href
 	foundNetworkPool, err := GetNetworkPoolByHREF(vcd.client, adminVdc.AdminVdc.NetworkPoolReference.HREF)

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -2,7 +2,6 @@
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
-* Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -161,21 +161,10 @@ func (adminOrg *AdminOrg) GetUserById(id string, refresh bool) (*OrgUser, error)
 // If it is false, it will search within the data already in memory (useful when
 // looping through the users and we know that no changes have occurred in the meantime)
 func (adminOrg *AdminOrg) GetUserByNameOrId(identifier string, refresh bool) (*OrgUser, error) {
-	var byNameErr, byIdErr error
-	// First look by ID
-	orgUser, byIdErr := adminOrg.GetUserByName(identifier, true)
-	if byIdErr == nil {
-		// found by ID
-		return orgUser, nil
-	}
-	// If not found by ID, look by name
-	if IsNotFound(byIdErr) {
-		orgUser, byNameErr = adminOrg.GetUserById(identifier, false)
-		return orgUser, byNameErr
-	} else {
-		// On any other error, we return it
-		return nil, byIdErr
-	}
+	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserByName(name, refresh) }
+	byId := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserById(name, refresh) }
+	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	return entity.(*OrgUser), err
 }
 
 // GetRole finds a role within the organization

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -163,7 +163,7 @@ func (adminOrg *AdminOrg) GetUserById(id string, refresh bool) (*OrgUser, error)
 func (adminOrg *AdminOrg) GetUserByNameOrId(identifier string, refresh bool) (*OrgUser, error) {
 	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserByName(name, refresh) }
 	byId := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserById(name, refresh) }
-	entity, err := GetEntityByNameOrId(byName, byId, identifier, refresh)
+	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
 	return entity.(*OrgUser), err
 }
 

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -161,9 +161,12 @@ func (adminOrg *AdminOrg) GetUserById(id string, refresh bool) (*OrgUser, error)
 // If it is false, it will search within the data already in memory (useful when
 // looping through the users and we know that no changes have occurred in the meantime)
 func (adminOrg *AdminOrg) GetUserByNameOrId(identifier string, refresh bool) (*OrgUser, error) {
-	byName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserByName(name, refresh) }
-	byId := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserById(name, refresh) }
-	entity, err := getEntityByNameOrId(byName, byId, identifier, refresh)
+	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserByName(name, refresh) }
+	getById := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetUserById(name, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+	if entity == nil {
+		return nil, err
+	}
 	return entity.(*OrgUser), err
 }
 

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -441,13 +441,14 @@ func (vcd *TestVCD) Test_AddNewVMNilNIC(check *C) {
 	}
 
 	// Populate Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	check.Assert((Catalog{}), Not(Equals), cat)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(cat, NotNil)
 
 	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catitem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
+	check.Assert(catitem, NotNil)
 
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()
@@ -486,13 +487,14 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	}
 
 	// Populate Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	check.Assert((Catalog{}), Not(Equals), cat)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
+	check.Assert(cat, NotNil)
 
 	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catitem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
+	check.Assert(catitem, NotNil)
 
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -17,16 +17,18 @@ import (
 func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
+		return
 	}
+	check.Assert(cat, NotNil)
 
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -30,19 +30,6 @@ func NewVdc(cli *Client) *Vdc {
 	}
 }
 
-type AdminVdc struct {
-	AdminVdc *types.AdminVdc
-	client   *Client
-	VApp     *types.VApp
-}
-
-func NewAdminVdc(cli *Client) *AdminVdc {
-	return &AdminVdc{
-		AdminVdc: new(types.AdminVdc),
-		client:   cli,
-	}
-}
-
 // Gets a vapp with a specific url vappHREF
 func (vdc *Vdc) getVdcVAppbyHREF(vappHREF *url.URL) (*VApp, error) {
 	vapp := NewVApp(vdc.client)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -119,15 +119,17 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
 	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	check.Assert(err, IsNil)
 	networks = append(networks, net.OrgVDCNetwork)
 	check.Assert(err, IsNil)
 	// Populate Catalog
-	cat, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
-	check.Assert(cat, Not(Equals), (Catalog{}))
+	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(cat, NotNil)
 	// Populate Catalog Item
-	catitem, err := cat.FindCatalogItem(vcd.config.VCD.Catalog.CatalogItem)
+	catitem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
+	check.Assert(catitem, NotNil)
 	// Get VAppTemplate
 	vapptemplate, err := catitem.GetVAppTemplate()
 	check.Assert(err, IsNil)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -38,7 +38,7 @@ func (vcd *TestVCD) findFirstVapp() VApp {
 		fmt.Println(err)
 		return VApp{}
 	}
-	vdc, err := org.GetVdcByName(config.VCD.Vdc)
+	vdc, err := org.GetVDCByName(config.VCD.Vdc, false)
 	if err != nil {
 		fmt.Println(err)
 		return VApp{}
@@ -439,6 +439,9 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 // Test Insert or Eject Media for VM
 func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	itemName := "TestHandleInsertOrEjectMedia"
 
 	// Find VApp
@@ -458,8 +461,9 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
@@ -498,6 +502,9 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 // Test Insert or Eject Media for VM
 func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	itemName := "TestInsertOrEjectMedia"
 
 	// Find VApp
@@ -517,8 +524,9 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
@@ -580,6 +588,9 @@ func isMediaInjected(items []*types.VirtualHardwareItem) bool {
 
 // Test Insert or Eject Media for VM
 func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 
 	itemName := "TestAnswerVmQuestion"
 
@@ -600,8 +611,9 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.FindCatalog(vcd.config.VCD.Catalog.Name)
+	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
 
 	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
@@ -715,6 +727,9 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 }
 
 func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	vapp := vcd.findFirstVapp()
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
@@ -768,6 +783,9 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 }
 
 func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 	vapp := vcd.findFirstVapp()
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {

--- a/govcd/vm_unit_test.go
+++ b/govcd/vm_unit_test.go
@@ -2,7 +2,6 @@
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
-* Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd

--- a/samples/discover.go
+++ b/samples/discover.go
@@ -152,7 +152,7 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	vdc, err := org.GetVdcByName(config.VDC)
+	vdc, err := org.GetVDCByName(config.VDC, false)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -181,7 +181,7 @@ func main() {
 
 	if catalog_name != "" {
 		fmt.Printf("\ncatalog items\n")
-		cat, err := org.FindCatalog(catalog_name)
+		cat, err := org.GetCatalogByName(catalog_name, false)
 		if err != nil {
 			fmt.Printf("Error retrieving catalog %s\n%s\n", catalog_name, err)
 			os.Exit(1)


### PR DESCRIPTION
* New Get methods for Catalog, AdminCatalog, Vdc, AdminVdc, CatalogItem,
  ExternalNetwork
* Deprecate corresponding functions/methods
* Replace usage of deprecated functions with new methods
* Add entity.go and entity_test.go for semi-generic operations with Get*
  functions
* Move methods for AdminOrg, AdminCatalog, AdminVdc to new files adminorg.go,
  admincatalog.go, adminvdc.go
