### PR TITLE
Add networkupdate support for `VM`, introduce forced guest customization function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Added method `(*VCDClient) QueryProviderVdcStorageProfiles()` 
 * Added method `(*VCDClient) QueryNetworkPools()` 
 * Added get/add/delete metadata functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
+* Added `UpdateNetworkConnectionSection` for updating VM network configuration [#229](https://github.com/vmware/go-vcloud-director/pull/229)
+* Added `PowerOnAndForceCustomization`, `GetGuestCustomizationStatus`, `BlockWhileGuestCustomizationStatus` [#229](https://github.com/vmware/go-vcloud-director/pull/229)
 
 BUGS FIXED:
 

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -263,12 +263,14 @@ func checkLb(queryUrl string, expectedResponses []string, maxRetryTimeout int) e
 		iterations = maxRetryTimeout / 5
 	}
 
+	httpClient := &http.Client{Timeout: 5}
+
 	fmt.Printf("# Waiting for the virtual server to accept responses (%s interval x %d iterations)"+
 		"\n[_ = timeout, x = connection refused, ?(err) = unknown error, / = no nodes are up yet, "+
 		". = no response from all nodes yet]: ", sleepIntervalDuration.String(), iterations)
 	for i := 1; i <= iterations; i++ {
 		var resp *http.Response
-		resp, err = http.Get(queryUrl)
+		resp, err = httpClient.Get(queryUrl)
 		if err != nil {
 			switch {
 			case strings.Contains(err.Error(), "i/o timeout"):

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -263,7 +263,7 @@ func checkLb(queryUrl string, expectedResponses []string, maxRetryTimeout int) e
 		iterations = maxRetryTimeout / 5
 	}
 
-	httpClient := &http.Client{Timeout: 5}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
 
 	fmt.Printf("# Waiting for the virtual server to accept responses (%s interval x %d iterations)"+
 		"\n[_ = timeout, x = connection refused, ?(err) = unknown error, / = no nodes are up yet, "+

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -248,63 +248,68 @@ func buildLb(edge EdgeGateway, node1Ip, node2Ip string, vcd *TestVCD, check *C) 
 // checkLb queries specified endpoint until it gets all responses in expectedResponses slice
 func checkLb(queryUrl string, expectedResponses []string, maxRetryTimeout int) error {
 	var err error
-	var iterations int
 	if len(expectedResponses) == 0 {
 		return fmt.Errorf("no expected responses specified")
 	}
 
+	retryTimeout := maxRetryTimeout
 	// due to the VMs taking long time to boot it needs to be at least 5 minutes
 	// may be even more in slower environments
-	sleepInterval := 5
-	sleepIntervalDuration := time.Duration(sleepInterval) * time.Second
 	if maxRetryTimeout < 5*60 { // 5 minutes
-		iterations = 60
-	} else {
-		iterations = maxRetryTimeout / 5
+		retryTimeout = 5 * 60 // 5 minutes
 	}
+
+	timeOutAfterInterval := time.Duration(retryTimeout) * time.Second
+	timeoutAfter := time.After(timeOutAfterInterval)
+	tick := time.NewTicker(time.Duration(5) * time.Second)
 
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 
-	fmt.Printf("# Waiting for the virtual server to accept responses (%s interval x %d iterations)"+
+	fmt.Printf("# Waiting for the virtual server to accept responses (timeout after %s)"+
 		"\n[_ = timeout, x = connection refused, ?(err) = unknown error, / = no nodes are up yet, "+
-		". = no response from all nodes yet]: ", sleepIntervalDuration.String(), iterations)
-	for i := 1; i <= iterations; i++ {
-		var resp *http.Response
-		resp, err = httpClient.Get(queryUrl)
-		if err != nil {
-			switch {
-			case strings.Contains(err.Error(), "i/o timeout"):
-				fmt.Printf("_")
-			case strings.Contains(err.Error(), "connect: connection refused"):
-				fmt.Printf("x")
-			case strings.Contains(err.Error(), "connect: network is unreachable"):
-				fmt.Printf("/")
-			default:
-				fmt.Printf("?(%s)", err.Error())
-			}
-		}
+		". = no response from all nodes yet]: ", timeOutAfterInterval.String())
 
-		if err == nil {
-			fmt.Printf(".") // progress bar when waiting for responses from all nodes
-			body, _ := ioutil.ReadAll(resp.Body)
-			// check if the element is in the list
-			for index, value := range expectedResponses {
-				if value == string(body) {
-					expectedResponses = append(expectedResponses[:index], expectedResponses[index+1:]...)
-					if len(expectedResponses) > 0 {
-						fmt.Printf("\n# '%s' responded. Waiting for node(s) '%s': ",
-							value, strings.Join(expectedResponses, ","))
-					} else {
-						fmt.Printf("\n# Last node '%s' responded. Exiting\n", value)
-						return nil
+	for {
+		select {
+		case <-timeoutAfter:
+			return fmt.Errorf("timed out waiting for all nodes to be up: %s", err)
+		case <-tick.C:
+			var resp *http.Response
+			resp, err = httpClient.Get(queryUrl)
+			if err != nil {
+				switch {
+				case strings.Contains(err.Error(), "i/o timeout"):
+					fmt.Printf("_")
+				case strings.Contains(err.Error(), "connect: connection refused"):
+					fmt.Printf("x")
+				case strings.Contains(err.Error(), "connect: network is unreachable"):
+					fmt.Printf("/")
+				default:
+					fmt.Printf("?(%s)", err.Error())
+				}
+			}
+
+			if err == nil {
+				fmt.Printf(".") // progress bar when waiting for responses from all nodes
+				body, _ := ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+				// check if the element is in the list
+				for index, value := range expectedResponses {
+					if value == string(body) {
+						expectedResponses = append(expectedResponses[:index], expectedResponses[index+1:]...)
+						if len(expectedResponses) > 0 {
+							fmt.Printf("\n# '%s' responded. Waiting for node(s) '%s': ",
+								value, strings.Join(expectedResponses, ","))
+						} else {
+							fmt.Printf("\n# Last node '%s' responded. Exiting\n", value)
+							return nil
+						}
 					}
 				}
 			}
 		}
-		time.Sleep(sleepIntervalDuration)
 	}
 
-	return fmt.Errorf("timed out waiting for all nodes to be up: %s", err)
 }
 
 // addFirewallRule adds a firewall rule needed to access virtual server port on edge gateway

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -395,14 +395,14 @@ func (vapp *VApp) GetStatus() (string, error) {
 // of seconds.
 func (vapp *VApp) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds int) error {
 	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
-	tick := time.Tick(200 * time.Millisecond)
+	tick := time.NewTicker(200 * time.Millisecond)
 
 	for {
 		select {
 		case <-timeoutAfter:
 			return fmt.Errorf("timed out waiting for vApp to exit state %s after %d seconds",
 				unwantedStatus, timeOutAfterSeconds)
-		case <-tick:
+		case <-tick.C:
 			currentStatus, err := vapp.GetStatus()
 
 			if err != nil {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -467,7 +467,7 @@ func (vm *VM) Undeploy() (Task, error) {
 
 	// Return the task
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		types.MimeUndeployVappParams, "error undeploy vApp: %s", vu)
+		types.MimeUndeployVappParams, "error undeploy VM: %s", vu)
 }
 
 // Attach or detach an independent disk

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -86,13 +87,35 @@ func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, er
 }
 
 // UpdateNetworkConnectionSection applies network configuration of types.NetworkConnectionSection for the VM
+// Runs synchronously, VM is ready for another operation after this function returns.
 func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSection) error {
 	if vm.VM.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	return vm.client.ExecuteRequestWithoutResponse(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
-		types.MimeNetworkConnectionSection, "error updating network connection: %s", networks)
+	// Retrieve current network configuration so that we are not altering any other internal fields
+	updateNetwork, err := vm.GetNetworkConnectionSection()
+	if err != nil {
+		return fmt.Errorf("cannot read network section for update: %s", err)
+	}
+	updateNetwork.PrimaryNetworkConnectionIndex = networks.PrimaryNetworkConnectionIndex
+	updateNetwork.NetworkConnection = networks.NetworkConnection
+	updateNetwork.Ovf = types.XMLNamespaceOVF
+
+	err = vm.client.ExecuteRequestWithoutResponse(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
+		types.MimeNetworkConnectionSection, "error updating network connection: %s", updateNetwork)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the VM to be in resolved state so that this function is synchronous and VM is ready to handle next task
+	//vm.BlockWhileStatus()
+	err = vm.BlockWhileStatus("UNRESOLVED", vm.client.MaxRetryTimeout)
+	if err != nil {
+		fmt.Errorf("error waiting until VM exists UNRESOLVED state: %s", err)
+	}
+
+	return nil
 }
 
 func (cli *Client) FindVMByHREF(vmHREF string) (VM, error) {
@@ -607,4 +630,29 @@ func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 	errMessage := fmt.Sprintf("error toggling hypervisor nesting feature to %t for VM: %%s", isEnabled)
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
 		"", errMessage, nil)
+}
+
+// BlockWhileStatus blocks until the status of VM exits unwantedStatus.
+// It sleeps 200 milliseconds between iterations and times out after timeOutAfterSeconds
+// of seconds.
+func (vm *VM) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds int) error {
+	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
+	tick := time.Tick(200 * time.Millisecond)
+
+	for {
+		select {
+		case <-timeoutAfter:
+			return fmt.Errorf("timed out waiting for VM to exit state %s after %d seconds",
+				unwantedStatus, timeOutAfterSeconds)
+		case <-tick:
+			currentStatus, err := vm.GetStatus()
+
+			if err != nil {
+				return fmt.Errorf("could not get VM status %s", err)
+			}
+			if currentStatus != unwantedStatus {
+				return nil
+			}
+		}
+	}
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -379,14 +379,14 @@ func (vm *VM) GetGuestCustomizationStatus() (string, error) {
 // It sleeps 3 seconds between iterations and times out after timeOutAfterSeconds of seconds.
 func (vm *VM) BlockWhileGuestCustomizationStatus(unwantedStatus string, timeOutAfterSeconds int) error {
 	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
-	tick := time.Tick(3 * time.Second)
+	tick := time.NewTicker(3 * time.Second)
 
 	for {
 		select {
 		case <-timeoutAfter:
 			return fmt.Errorf("timed out waiting for VM guest customization status to exit state %s after %d seconds",
 				unwantedStatus, timeOutAfterSeconds)
-		case <-tick:
+		case <-tick.C:
 			currentStatus, err := vm.GetGuestCustomizationStatus()
 			if err != nil {
 				return fmt.Errorf("could not get VM customization status %s", err)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -102,17 +102,14 @@ func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSe
 	updateNetwork.NetworkConnection = networks.NetworkConnection
 	updateNetwork.Ovf = types.XMLNamespaceOVF
 
-	err = vm.client.ExecuteRequestWithoutResponse(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
+	task, err := vm.client.ExecuteTaskRequest(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
 		types.MimeNetworkConnectionSection, "error updating network connection: %s", updateNetwork)
 	if err != nil {
 		return err
 	}
-
-	// Wait for the VM to be in resolved state so that this function is synchronous and VM is ready to handle next task
-	//vm.BlockWhileStatus()
-	err = vm.BlockWhileStatus("UNRESOLVED", vm.client.MaxRetryTimeout)
+	err = task.WaitTaskCompletion()
 	if err != nil {
-		fmt.Errorf("error waiting until VM exists UNRESOLVED state: %s", err)
+		return fmt.Errorf("error waiting for task completion after network update for vm %s: %s", vm.VM.Name, err)
 	}
 
 	return nil
@@ -140,15 +137,14 @@ func (vm *VM) PowerOn() (Task, error) {
 
 }
 
-// ForceCustomization forces VM configuration on next power on
-func (vm *VM) ForceCustomization() error {
+// CustomizeAtNextPowerOn forces VM customization on next power on
+func (vm *VM) CustomizeAtNextPowerOn() error {
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/action/customizeAtNextPowerOn"
 
 	return vm.client.ExecuteRequestWithoutResponse(apiEndpoint.String(), http.MethodPost, "",
-		"error powering on VM with forced customization: %s", nil)
+		"error setting forced VM customization for next power on: %s", nil)
 }
-
 
 func (vm *VM) PowerOff() (Task, error) {
 
@@ -343,6 +339,76 @@ func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 
 func (vm *VM) RunCustomizationScript(computername, script string) (Task, error) {
 	return vm.Customize(computername, script, false)
+}
+
+// GetGuestCustomizationSection retrieves
+func (vm *VM) GetGuestCustomizationSection() (*types.GuestCustomizationSection, error) {
+	guestCustomizationSection := &types.GuestCustomizationSection{}
+
+	if vm.VM.HREF == "" {
+		return nil, fmt.Errorf("cannot load guest customization, VM HREF is empty")
+	}
+
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/guestCustomizationSection/", http.MethodGet,
+		types.MimeGuestCustomizationSection, "error retrieving guest customization: %s", nil, guestCustomizationSection)
+
+	return guestCustomizationSection, err
+}
+
+func (vm *VM) GetGuestCustomizationStatus() (*types.GuestCustomizationStatusSection, error) {
+	guestCustomizationStatus := &types.GuestCustomizationStatusSection{}
+
+	if vm.VM.HREF == "" {
+		return nil, fmt.Errorf("cannot load guest customization, VM HREF is empty")
+	}
+
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/guestcustomizationstatus", http.MethodGet,
+		types.MimeGuestCustomizationStatus, "error retrieving guest customization status: %s", nil, guestCustomizationStatus)
+
+	// The request was successful
+	return guestCustomizationStatus, err
+}
+
+//func (vm *VM) UpdateGuestCustomizationSection(*types.GuestCustomizationSection) (*types.GuestCustomizationSection, error) {
+//	guestCustomizationSection := &types.GuestCustomizationSection{}
+//
+//	if vm.VM.HREF == "" {
+//		return nil, fmt.Errorf("cannot load guest customization, VM HREF is empty")
+//	}
+//
+//	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/guestCustomizationSection/", http.MethodGet,
+//		types.MimeGuestCustomizationSection, "error retrieving guest customization: %s", nil, guestCustomizationSection)
+//
+//	// The request was successful
+//	return guestCustomizationSection, err
+//}
+
+
+// BlockWhileGuestCustomizationStatus blocks until the customization status of VM exits unwantedStatus.
+// It sleeps 200 milliseconds between iterations and times out after timeOutAfterSeconds
+// of seconds.
+func (vm *VM) BlockWhileGuestCustomizationStatus(unwantedStatus string, timeOutAfterSeconds int) error {
+	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
+	//tick := time.Tick(200 * time.Millisecond)
+	tick := time.Tick(1 * time.Second)
+
+	for {
+		select {
+		case <-timeoutAfter:
+			return fmt.Errorf("timed out waiting for VM guest customization status to exit state %s after %d seconds",
+				unwantedStatus, timeOutAfterSeconds)
+		case <-tick:
+			currentStatus, err := vm.GetGuestCustomizationStatus()
+			if err != nil {
+				return fmt.Errorf("could not get VM customization status %s", err)
+			}
+			fmt.Println("current status: ", currentStatus.GuestCustStatus)
+			if currentStatus.GuestCustStatus != unwantedStatus {
+				fmt.Println("exiting because of status: ", currentStatus.GuestCustStatus)
+				return nil
+			}
+		}
+	}
 }
 
 func (vm *VM) Customize(computername, script string, changeSid bool) (Task, error) {
@@ -640,29 +706,4 @@ func (vm *VM) ToggleHardwareVirtualization(isEnabled bool) (Task, error) {
 	errMessage := fmt.Sprintf("error toggling hypervisor nesting feature to %t for VM: %%s", isEnabled)
 	return vm.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
 		"", errMessage, nil)
-}
-
-// BlockWhileStatus blocks until the status of VM exits unwantedStatus.
-// It sleeps 200 milliseconds between iterations and times out after timeOutAfterSeconds
-// of seconds.
-func (vm *VM) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds int) error {
-	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
-	tick := time.Tick(200 * time.Millisecond)
-
-	for {
-		select {
-		case <-timeoutAfter:
-			return fmt.Errorf("timed out waiting for VM to exit state %s after %d seconds",
-				unwantedStatus, timeOutAfterSeconds)
-		case <-tick:
-			currentStatus, err := vm.GetStatus()
-
-			if err != nil {
-				return fmt.Errorf("could not get VM status %s", err)
-			}
-			if currentStatus != unwantedStatus {
-				return nil
-			}
-		}
-	}
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -76,7 +76,7 @@ func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, er
 	networkConnectionSection := &types.NetworkConnectionSection{}
 
 	if vm.VM.HREF == "" {
-		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
+		return networkConnectionSection, fmt.Errorf("cannot retrieve network when VM HREF is unset")
 	}
 
 	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/networkConnectionSection/", http.MethodGet,
@@ -90,7 +90,7 @@ func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, er
 // Runs synchronously, VM is ready for another operation after this function returns.
 func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSection) error {
 	if vm.VM.HREF == "" {
-		return fmt.Errorf("cannot refresh, Object is empty")
+		return fmt.Errorf("cannot update network connection when VM HREF is unset")
 	}
 
 	// Retrieve current network configuration so that we are not altering any other internal fields
@@ -361,11 +361,13 @@ func (vm *VM) RunCustomizationScript(computername, script string) (Task, error) 
 	return vm.Customize(computername, script, false)
 }
 
+// GetGuestCustomizationStatus retrieves guest customization status.
+// It can be one of "GC_PENDING", "REBOOT_PENDING", "GC_FAILED", "POST_GC_PENDING", "GC_COMPLETE"
 func (vm *VM) GetGuestCustomizationStatus() (string, error) {
 	guestCustomizationStatus := &types.GuestCustomizationStatusSection{}
 
 	if vm.VM.HREF == "" {
-		return "", fmt.Errorf("cannot load guest customization, VM HREF is empty")
+		return "", fmt.Errorf("cannot retrieve guest customization, VM HREF is empty")
 	}
 
 	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/guestcustomizationstatus", http.MethodGet,

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -139,6 +139,8 @@ func (vm *VM) PowerOn() (Task, error) {
 
 // PowerOnAndForceCustomization is a synchronous function which is equivalent to the functionality
 // one has in UI. It triggers customization which may be useful in some cases (like altering NICs)
+//
+// The VM _must_ be Undeployed for this action to actually work.
 func (vm *VM) PowerOnAndForceCustomization() error {
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
 	apiEndpoint.Path += "/action/deploy"
@@ -424,6 +426,7 @@ func (vm *VM) Customize(computername, script string, changeSid bool) (Task, erro
 		types.MimeGuestCustomizationSection, "error customizing VM: %s", vu)
 }
 
+// Undeploy triggers a VM undeploy and power off action. "Power off" action in UI behaves this way.
 func (vm *VM) Undeploy() (Task, error) {
 
 	vu := &types.UndeployVAppParams{

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -140,6 +140,16 @@ func (vm *VM) PowerOn() (Task, error) {
 
 }
 
+// ForceCustomization forces VM configuration on next power on
+func (vm *VM) ForceCustomization() error {
+	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)
+	apiEndpoint.Path += "/action/customizeAtNextPowerOn"
+
+	return vm.client.ExecuteRequestWithoutResponse(apiEndpoint.String(), http.MethodPost, "",
+		"error powering on VM with forced customization: %s", nil)
+}
+
+
 func (vm *VM) PowerOff() (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -399,7 +399,13 @@ func (vm *VM) GetGuestCustomizationStatus() (string, error) {
 
 // BlockWhileGuestCustomizationStatus blocks until the customization status of VM exits unwantedStatus.
 // It sleeps 3 seconds between iterations and times out after timeOutAfterSeconds of seconds.
+//
+// timeOutAfterSeconds must be more than 4 and less than 2 hours (60s*120)
 func (vm *VM) BlockWhileGuestCustomizationStatus(unwantedStatus string, timeOutAfterSeconds int) error {
+	if timeOutAfterSeconds < 5 || timeOutAfterSeconds > 60*120 {
+		return fmt.Errorf("timeOutAfterSeconds must be in range 4<X<7200")
+	}
+
 	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
 	tick := time.NewTicker(3 * time.Second)
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -85,6 +85,16 @@ func (vm *VM) GetNetworkConnectionSection() (*types.NetworkConnectionSection, er
 	return networkConnectionSection, err
 }
 
+// UpdateNetworkConnectionSection applies network configuration of types.NetworkConnectionSection for the VM
+func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSection) error {
+	if vm.VM.HREF == "" {
+		return fmt.Errorf("cannot refresh, Object is empty")
+	}
+
+	return vm.client.ExecuteRequestWithoutResponse(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
+		types.MimeNetworkConnectionSection, "error updating network connection: %s", networks)
+}
+
 func (cli *Client) FindVMByHREF(vmHREF string) (VM, error) {
 
 	newVm := NewVM(cli)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -827,7 +827,6 @@ func (vcd *TestVCD) Test_GetNetworkConnectionSection(check *C) {
 
 	networkBefore, err := vm.GetNetworkConnectionSection()
 	check.Assert(err, IsNil)
-	//check.Assert(network, IsNil)
 
 	err = vm.UpdateNetworkConnectionSection(networkBefore)
 	check.Assert(err, IsNil)
@@ -871,7 +870,7 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	// 'GC_PENDING' state.
 	custStatus, err := vm.GetGuestCustomizationStatus()
 	check.Assert(err, IsNil)
-	if custStatus == "GC_PENDING" {
+	if custStatus == types.GuestCustStatusPending {
 		vmStatus, err := vm.GetStatus()
 		check.Assert(err, IsNil)
 		// If VM is POWERED OFF - let's power it on before waiting for its status to change
@@ -883,7 +882,7 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 			check.Assert(task.Task.Status, Equals, "success")
 		}
 
-		err = vm.BlockWhileGuestCustomizationStatus("GC_PENDING", 300)
+		err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
 		check.Assert(err, IsNil)
 	}
 
@@ -900,11 +899,11 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	// Ensure that VM has the status set to "GC_PENDING" after forced re-customization
 	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus()
 	check.Assert(err, IsNil)
-	check.Assert(recustomizedVmStatus, Equals, "GC_PENDING")
+	check.Assert(recustomizedVmStatus, Equals, types.GuestCustStatusPending)
 
 	// Wait until the VM exists GC_PENDING status again. At the moment this is the only simple way
 	// to see that the customization really worked as there is no API in vCD to execute remote
 	// commands on guest VMs
-	err = vm.BlockWhileGuestCustomizationStatus("GC_PENDING", 300)
+	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
 	check.Assert(err, IsNil)
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -84,8 +84,8 @@ func (vcd *TestVCD) ensureVappIsSuitableForVMTest(vapp VApp) error {
 		if err != nil {
 			return err
 		}
-		err = task.WaitTaskCompletion()
 		if err != nil {
+			err = task.WaitTaskCompletion()
 			return err
 		}
 	}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -850,7 +850,6 @@ func (vcd *TestVCD) Test_GetNetworkConnectionSection(check *C) {
 // This test relies on longer timeouts in BlockWhileGuestCustomizationStatus because VMs take a lengthy time
 // to boot up and report customization done.
 func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
-
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
@@ -887,20 +886,19 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 		check.Assert(err, IsNil)
 	}
 
-	// VM _must_ be _undeployed_ because PowerOnAndForceCustomization task will never finish (and probably
-	// not triggered) if it is not undeployed.
+	// VM _must_ be _un-deployed_ because PowerOnAndForceCustomization task will never finish (and probably
+	// not triggered) if it is not un-deployed.
 	task, err := vm.Undeploy()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-
 	err = vm.PowerOnAndForceCustomization()
 	check.Assert(err, IsNil)
 
 	// Ensure that VM has the status set to "GC_PENDING" after forced re-customization
-	sa, err := vm.GetGuestCustomizationStatus()
-	check.Assert(sa, Equals, "GC_PENDING")
+	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus()
+	check.Assert(recustomizedVmStatus, Equals, "GC_PENDING")
 
 	// Wait until the VM exists GC_PENDING status again. At the moment this is the only simple way
 	// to see that the customization really worked as there is no API in vCD to execute remote

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -886,12 +886,26 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 		check.Assert(err, IsNil)
 	}
 
-	// VM _must_ be _un-deployed_ because PowerOnAndForceCustomization task will never finish (and probably
-	// not triggered) if it is not un-deployed.
+	// Check that VM is deployed
+	vmIsDeployed, err := vm.IsDeployed()
+	check.Assert(err, IsNil)
+	check.Assert(vmIsDeployed, Equals, true)
+
+	// Try to force operation on deployed VM and expect an error
+	err = vm.PowerOnAndForceCustomization()
+	check.Assert(err, Not(IsNil))
+
+	// VM _must_ be un-deployed because PowerOnAndForceCustomization task will never finish (and
+	// probably not triggered) if it is not un-deployed.
 	task, err := vm.Undeploy()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+
+	// Check that VM is un-deployed
+	vmIsDeployed, err = vm.IsDeployed()
+	check.Assert(err, IsNil)
+	check.Assert(vmIsDeployed, Equals, false)
 
 	err = vm.PowerOnAndForceCustomization()
 	check.Assert(err, IsNil)
@@ -900,6 +914,11 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus()
 	check.Assert(err, IsNil)
 	check.Assert(recustomizedVmStatus, Equals, types.GuestCustStatusPending)
+
+	// Check that VM is deployed
+	vmIsDeployed, err = vm.IsDeployed()
+	check.Assert(err, IsNil)
+	check.Assert(vmIsDeployed, Equals, true)
 
 	// Wait until the VM exists GC_PENDING status again. At the moment this is the only simple way
 	// to see that the customization really worked as there is no API in vCD to execute remote

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -810,3 +810,34 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(vmStatus, Equals, "POWERED_OFF")
 }
+
+func (vcd *TestVCD) Test_GetNetworkConnectionSection(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
+	vapp := vcd.findFirstVapp()
+	vmType, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+
+	vm, err := vcd.client.Client.FindVMByHREF(vmType.HREF)
+	check.Assert(err, IsNil)
+
+	networkBefore, err := vm.GetNetworkConnectionSection()
+	check.Assert(err, IsNil)
+	//check.Assert(network, IsNil)
+
+	err = vm.UpdateNetworkConnectionSection(networkBefore)
+	check.Assert(err, IsNil)
+
+	networkAfter, err := vm.GetNetworkConnectionSection()
+	check.Assert(err, IsNil)
+
+	// Filter out always differing fields and do deep comparison of objects
+	networkBefore.Link = &types.Link{}
+	networkAfter.Link = &types.Link{}
+	check.Assert(networkAfter, DeepEquals, networkBefore)
+
+}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -84,8 +84,8 @@ func (vcd *TestVCD) ensureVappIsSuitableForVMTest(vapp VApp) error {
 		if err != nil {
 			return err
 		}
+		err = task.WaitTaskCompletion()
 		if err != nil {
-			err = task.WaitTaskCompletion()
 			return err
 		}
 	}
@@ -870,6 +870,7 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	// gives any effect therefore we must "wait through" initial guest customization if it is in
 	// 'GC_PENDING' state.
 	custStatus, err := vm.GetGuestCustomizationStatus()
+	check.Assert(err, IsNil)
 	if custStatus == "GC_PENDING" {
 		vmStatus, err := vm.GetStatus()
 		check.Assert(err, IsNil)
@@ -898,6 +899,7 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 
 	// Ensure that VM has the status set to "GC_PENDING" after forced re-customization
 	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus()
+	check.Assert(err, IsNil)
 	check.Assert(recustomizedVmStatus, Equals, "GC_PENDING")
 
 	// Wait until the VM exists GC_PENDING status again. At the moment this is the only simple way

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -161,7 +161,7 @@ const (
 	LbVirtualServerPath = "/loadbalancer/config/virtualservers/"
 )
 
-// Guest customization statues. These are all known possible statuses
+// Guest customization statuses. These are all known possible statuses
 const (
 	GuestCustStatusPending       = "GC_PENDING"
 	GuestCustStatusPostPending   = "POST_GC_PENDING"

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -160,3 +160,12 @@ const (
 	LbAppRulePath       = "/loadbalancer/config/applicationrules/"
 	LbVirtualServerPath = "/loadbalancer/config/virtualservers/"
 )
+
+// Guest customization statues. These are all known possible statuses
+const (
+	GuestCustStatusPending       = "GC_PENDING"
+	GuestCustStatusPostPending   = "POST_GC_PENDING"
+	GuestCustStatusComplete      = "GC_COMPLETE"
+	GuestCustStatusFailed        = "GC_FAILED"
+	GuestCustStatusRebootPending = "REBOOT_PENDING"
+)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -73,6 +73,8 @@ const (
 	MimeRasdItem = "application/vnd.vmware.vcloud.rasdItem+xml"
 	// Mime for guest customization section
 	MimeGuestCustomizationSection = "application/vnd.vmware.vcloud.guestCustomizationSection+xml"
+	// Mime for guest customization status
+	MimeGuestCustomizationStatus = "application/vnd.vmware.vcloud.guestcustomizationstatussection"
 	// Mime for network config section
 	MimeNetworkConfigSection = "application/vnd.vmware.vcloud.networkconfigsection+xml"
 	// Mime for recompose vApp params

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1455,6 +1455,15 @@ type DeployVAppParams struct {
 	ForceCustomization     bool `xml:"forceCustomization,attr,omitempty"`     // Used to specify whether to force customization on deployment, if not set default value is false
 }
 
+// GuestCustomizationStatusSection holds information about guest customization status
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/76f491b4-679c-4e1e-8428-f813d668297a/a2555a1b-22f1-4cca-b481-2a98ab874022/doc/doc/operations/GET-GuestCustStatus.html
+type GuestCustomizationStatusSection struct {
+	XMLName xml.Name `xml:"GuestCustomizationStatusSection"`
+	Xmlns   string   `xml:"xmlns,attr"`
+
+	GuestCustStatus string `xml:"GuestCustStatus"`
+}
+
 // GuestCustomizationSection represents guest customization settings
 // Type: GuestCustomizationSectionType
 // Namespace: http://www.vmware.com/vcloud/v1.5


### PR DESCRIPTION
Ref https://github.com/terraform-providers/terraform-provider-vcd/issues/299, https://github.com/terraform-providers/terraform-provider-vcd/issues/300

This PR introduces a few things:
* Add function for network updates (`vm.UpdateNetworkConnectionSection()`)
* Add forced guest customization related functions

A few general lint fixes:
* Get rid of staticcheck lint error `SA1015: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here` 
* Use http client with timeout in `lb_test.go`