### PR TITLE
Fix for external network serialization and deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 BUGS FIXED:
 
 * Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property
-* Fif bug in External network creation and get when description wasn't populated.
+* Fix bug in External network creation and get when description wasn't populated.
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 BUGS FIXED:
 
 * Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property
+* Fif bug in External network creation and get when description wasn't populated.
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -51,15 +51,9 @@ func (externalNetwork ExternalNetwork) Refresh() error {
 	return err
 }
 
-func validateExternalNetwork(externalNetwork *types.ExternalNetworkCreate) error {
+func validateExternalNetwork(externalNetwork *types.ExternalNetwork) error {
 	if externalNetwork.Name == "" {
 		return errors.New("external Network missing required field: Name")
-	}
-	if externalNetwork.XmlnsVmext == "" {
-		return errors.New("external Network missing required field: XmlnsVmext")
-	}
-	if externalNetwork.XmlnsVcloud == "" {
-		return errors.New("external Network missing required field: XmlnsVcloud")
 	}
 	return nil
 }

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -51,12 +51,15 @@ func (externalNetwork ExternalNetwork) Refresh() error {
 	return err
 }
 
-func validateExternalNetwork(externalNetwork *types.ExternalNetwork) error {
+func validateExternalNetwork(externalNetwork *types.ExternalNetworkCreate) error {
 	if externalNetwork.Name == "" {
 		return errors.New("external Network missing required field: Name")
 	}
-	if externalNetwork.Xmlns == "" {
-		return errors.New("external Network missing required field: Xmlns")
+	if externalNetwork.XmlnsVmext == "" {
+		return errors.New("external Network missing required field: XmlnsVmext")
+	}
+	if externalNetwork.XmlnsVcload == "" {
+		return errors.New("external Network missing required field: XmlnsVcload")
 	}
 	return nil
 }

--- a/govcd/externalnetwork.go
+++ b/govcd/externalnetwork.go
@@ -58,8 +58,8 @@ func validateExternalNetwork(externalNetwork *types.ExternalNetworkCreate) error
 	if externalNetwork.XmlnsVmext == "" {
 		return errors.New("external Network missing required field: XmlnsVmext")
 	}
-	if externalNetwork.XmlnsVcload == "" {
-		return errors.New("external Network missing required field: XmlnsVcload")
+	if externalNetwork.XmlnsVcloud == "" {
+		return errors.New("external Network missing required field: XmlnsVcloud")
 	}
 	return nil
 }

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -29,7 +29,7 @@ func (vcd *TestVCD) Test_ExternalNetworkGetByName(check *C) {
 }
 
 // Helper function that creates an external network to be used in other tests
-func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix string) (skippingReason string, externalNetwork *types.ExternalNetworkCreate, task Task, err error) {
+func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix string) (skippingReason string, externalNetwork *types.ExternalNetwork, task Task, err error) {
 
 	if vcd.skipAdminTests {
 		return fmt.Sprintf(TestRequiresSysAdminPrivileges, testName), externalNetwork, Task{}, nil
@@ -72,12 +72,9 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 		return fmt.Sprintf("More than one port group found with name '%s'", vcd.config.VCD.ExternalNetworkPortGroup), externalNetwork, Task{}, nil
 	}
 
-	externalNetwork = &types.ExternalNetworkCreate{
+	externalNetwork = &types.ExternalNetwork{
 		Name:        networkName,
 		Description: "Test Create External Network",
-		XmlnsVmext:  types.XMLNamespaceExtension,
-		XmlnsVcloud: types.XMLNamespaceVCloud,
-		Type:        types.MimeExternalNetwork,
 		Configuration: &types.NetworkConfiguration{
 			Xmlns: types.XMLNamespaceVCloud,
 			IPScopes: &types.IPScopes{
@@ -99,9 +96,9 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 				}},
 			FenceMode: "isolated",
 		},
-		VimPortGroupRefs: &types.VimObjectRefsCreate{
-			VimObjectRef: []*types.VimObjectRefCreate{
-				&types.VimObjectRefCreate{
+		VimPortGroupRefs: &types.VimObjectRefs{
+			VimObjectRef: []*types.VimObjectRef{
+				&types.VimObjectRef{
 					VimServerRef: &types.Reference{
 						HREF: vimServerHref,
 					},

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -76,7 +76,7 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 		Name:        networkName,
 		Description: "Test Create External Network",
 		XmlnsVmext:  types.XMLNamespaceExtension,
-		XmlnsVcload: types.XMLNamespaceVCloud,
+		XmlnsVcloud: types.XMLNamespaceVCloud,
 		Type:        types.MimeExternalNetwork,
 		Configuration: &types.NetworkConfiguration{
 			Xmlns: types.XMLNamespaceVCloud,

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -534,6 +534,7 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.Exte
 		VCloudExtension  *types.VCloudExtension      `xml:"VCloudExtension,omitempty"`
 	}
 
+	// Specific struct is used as two different name spaces needed for vCD API and return struct has diff name spaces
 	externalNetwork := &externalNetworkCreate{}
 	externalNetwork.HREF = externalNetworkData.HREF
 	externalNetwork.Description = externalNetworkData.Description

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -479,15 +479,46 @@ func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetw
 // CreateExternalNetwork allows create external network and returns Task or error.
 // types.ExternalNetwork struct is general and used for various types of networks. But for external network
 // fence mode is always isolated, isInherited is false, parentNetwork is empty.
-func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.ExternalNetworkCreate) (Task, error) {
+func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.ExternalNetwork) (Task, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
 		return Task{}, fmt.Errorf("functionality requires system administrator privileges")
 	}
 
-	err := validateExternalNetwork(externalNetwork)
+	err := validateExternalNetwork(externalNetworkData)
 	if err != nil {
 		return Task{}, err
+	}
+
+	externalNetwork := &types.ExternalNetworkCreate{}
+	externalNetwork.HREF = externalNetworkData.HREF
+	externalNetwork.Description = externalNetworkData.Description
+	externalNetwork.Name = externalNetworkData.Name
+	externalNetwork.Type = externalNetworkData.Type
+	externalNetwork.ID = externalNetworkData.ID
+	externalNetwork.OperationKey = externalNetworkData.OperationKey
+	externalNetwork.Link = externalNetworkData.Link
+	externalNetwork.Configuration = externalNetworkData.Configuration
+	externalNetwork.VCloudExtension = externalNetworkData.VCloudExtension
+	externalNetwork.XmlnsVmext = types.XMLNamespaceExtension
+	externalNetwork.XmlnsVcloud = types.XMLNamespaceVCloud
+	externalNetwork.Type = types.MimeExternalNetwork
+	if externalNetworkData.VimPortGroupRefs != nil {
+		externalNetwork.VimPortGroupRefs = &types.VimObjectRefsCreate{}
+		for _, vimObjRef := range externalNetworkData.VimPortGroupRefs.VimObjectRef {
+			externalNetwork.VimPortGroupRefs.VimObjectRef = append(externalNetwork.VimPortGroupRefs.VimObjectRef, &types.VimObjectRefCreate{
+				VimServerRef:  vimObjRef.VimServerRef,
+				MoRef:         vimObjRef.MoRef,
+				VimObjectType: vimObjRef.VimObjectType,
+			})
+		}
+	}
+	if externalNetworkData.VimPortGroupRef != nil {
+		externalNetwork.VimPortGroupRef = &types.VimObjectRefCreate{
+			VimServerRef:  externalNetworkData.VimPortGroupRef.VimServerRef,
+			MoRef:         externalNetworkData.VimPortGroupRef.MoRef,
+			VimObjectType: externalNetworkData.VimPortGroupRef.VimObjectType,
+		}
 	}
 
 	externalNetHREF := vcdClient.Client.VCDHREF

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -479,7 +479,7 @@ func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetw
 // CreateExternalNetwork allows create external network and returns Task or error.
 // types.ExternalNetwork struct is general and used for various types of networks. But for external network
 // fence mode is always isolated, isInherited is false, parentNetwork is empty.
-func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.ExternalNetwork) (Task, error) {
+func CreateExternalNetwork(vcdClient *VCDClient, externalNetwork *types.ExternalNetworkCreate) (Task, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
 		return Task{}, fmt.Errorf("functionality requires system administrator privileges")

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -31,49 +31,6 @@ type EdgeGatewayCreation struct {
 	DistributedRoutingEnabled  bool     // If advanced networking enabled, also enable distributed routing
 }
 
-// Type: VimObjectRefType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
-// Description: Represents the Managed Object Reference (MoRef) and the type of a vSphere object.
-// Since: 0.9
-type vimObjectRefCreate struct {
-	VimServerRef  *types.Reference `xml:"vmext:VimServerRef"`
-	MoRef         string           `xml:"vmext:MoRef"`
-	VimObjectType string           `xml:"vmext:VimObjectType"`
-}
-
-// Type: VimObjectRefsType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
-// Description: List of VimObjectRef elements.
-// Since: 0.9
-type vimObjectRefsCreate struct {
-	VimObjectRef []*vimObjectRefCreate `xml:"vmext:VimObjectRef"`
-}
-
-// Type: VMWExternalNetworkType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
-// Description: External network type.
-// Since: 1.0
-type externalNetworkCreate struct {
-	XMLName          xml.Name                    `xml:"vmext:VMWExternalNetwork"`
-	XmlnsVmext       string                      `xml:"xmlns:vmext,attr,omitempty"`
-	XmlnsVcloud      string                      `xml:"xmlns:vcloud,attr,omitempty"`
-	HREF             string                      `xml:"href,attr,omitempty"`
-	Type             string                      `xml:"type,attr,omitempty"`
-	ID               string                      `xml:"id,attr,omitempty"`
-	OperationKey     string                      `xml:"operationKey,attr,omitempty"`
-	Name             string                      `xml:"name,attr"`
-	Link             []*types.Link               `xml:"Link,omitempty"`
-	Description      string                      `xml:"vcloud:Description,omitempty"`
-	Tasks            *types.TasksInProgress      `xml:"Tasks,omitempty"`
-	Configuration    *types.NetworkConfiguration `xml:"vcloud:Configuration,omitempty"`
-	VimPortGroupRef  *vimObjectRefCreate         `xml:"VimPortGroupRef,omitempty"`
-	VimPortGroupRefs *vimObjectRefsCreate        `xml:"vmext:VimPortGroupRefs,omitempty"`
-	VCloudExtension  *types.VCloudExtension      `xml:"VCloudExtension,omitempty"`
-}
-
 // Creates an Admin Organization based on settings, description, and org name.
 // The Organization created will have these settings specified in the
 // settings parameter. The settings variable is defined in types.go.
@@ -532,6 +489,49 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.Exte
 	err := validateExternalNetwork(externalNetworkData)
 	if err != nil {
 		return Task{}, err
+	}
+
+	// Type: VimObjectRefType
+	// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+	// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+	// Description: Represents the Managed Object Reference (MoRef) and the type of a vSphere object.
+	// Since: 0.9
+	type vimObjectRefCreate struct {
+		VimServerRef  *types.Reference `xml:"vmext:VimServerRef"`
+		MoRef         string           `xml:"vmext:MoRef"`
+		VimObjectType string           `xml:"vmext:VimObjectType"`
+	}
+
+	// Type: VimObjectRefsType
+	// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+	// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+	// Description: List of VimObjectRef elements.
+	// Since: 0.9
+	type vimObjectRefsCreate struct {
+		VimObjectRef []*vimObjectRefCreate `xml:"vmext:VimObjectRef"`
+	}
+
+	// Type: VMWExternalNetworkType
+	// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+	// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
+	// Description: External network type.
+	// Since: 1.0
+	type externalNetworkCreate struct {
+		XMLName          xml.Name                    `xml:"vmext:VMWExternalNetwork"`
+		XmlnsVmext       string                      `xml:"xmlns:vmext,attr,omitempty"`
+		XmlnsVcloud      string                      `xml:"xmlns:vcloud,attr,omitempty"`
+		HREF             string                      `xml:"href,attr,omitempty"`
+		Type             string                      `xml:"type,attr,omitempty"`
+		ID               string                      `xml:"id,attr,omitempty"`
+		OperationKey     string                      `xml:"operationKey,attr,omitempty"`
+		Name             string                      `xml:"name,attr"`
+		Link             []*types.Link               `xml:"Link,omitempty"`
+		Description      string                      `xml:"vcloud:Description,omitempty"`
+		Tasks            *types.TasksInProgress      `xml:"Tasks,omitempty"`
+		Configuration    *types.NetworkConfiguration `xml:"vcloud:Configuration,omitempty"`
+		VimPortGroupRef  *vimObjectRefCreate         `xml:"VimPortGroupRef,omitempty"`
+		VimPortGroupRefs *vimObjectRefsCreate        `xml:"vmext:VimPortGroupRefs,omitempty"`
+		VCloudExtension  *types.VCloudExtension      `xml:"VCloudExtension,omitempty"`
 	}
 
 	externalNetwork := &externalNetworkCreate{}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2355,6 +2355,7 @@ type ExternalNetworkCreate struct {
 	Description      string                `xml:"vcloud:Description,omitempty"`
 	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`
 	Configuration    *NetworkConfiguration `xml:"vcloud:Configuration,omitempty"`
+	VimPortGroupRef  *VimObjectRefCreate   `xml:"VimPortGroupRef,omitempty"`
 	VimPortGroupRefs *VimObjectRefsCreate  `xml:"vmext:VimPortGroupRefs,omitempty"`
 	VCloudExtension  *VCloudExtension      `xml:"VCloudExtension,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2345,7 +2345,7 @@ type VimObjectRefsCreate struct {
 type ExternalNetworkCreate struct {
 	XMLName          xml.Name              `xml:"vmext:VMWExternalNetwork"`
 	XmlnsVmext       string                `xml:"xmlns:vmext,attr,omitempty"`
-	XmlnsVcload      string                `xml:"xmlns:vcloud,attr,omitempty"`
+	XmlnsVcloud      string                `xml:"xmlns:vcloud,attr,omitempty"`
 	HREF             string                `xml:"href,attr,omitempty"`
 	Type             string                `xml:"type,attr,omitempty"`
 	ID               string                `xml:"id,attr,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -322,7 +322,7 @@ type InstantiationParams struct {
 // Since: 5.1
 type OrgVDCNetwork struct {
 	XMLName       xml.Name              `xml:"OrgVdcNetwork"`
-	Xmlns         string                `xml:"xmlns,attr,imitempty"`
+	Xmlns         string                `xml:"xmlns,attr,omitempty"`
 	HREF          string                `xml:"href,attr,omitempty"`
 	Type          string                `xml:"type,attr,omitempty"`
 	ID            string                `xml:"id,attr,omitempty"`
@@ -2308,6 +2308,17 @@ type VimObjectRef struct {
 	VimObjectType string     `xml:"VimObjectType"`
 }
 
+// Type: VimObjectRefType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+// Description: Represents the Managed Object Reference (MoRef) and the type of a vSphere object.
+// Since: 0.9
+type VimObjectRefCreate struct {
+	VimServerRef  *Reference `xml:"vmext:VimServerRef"`
+	MoRef         string     `xml:"vmext:MoRef"`
+	VimObjectType string     `xml:"vmext:VimObjectType"`
+}
+
 // Type: VimObjectRefsType
 // Namespace: http://www.vmware.com/vcloud/extension/v1.5
 // https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
@@ -2317,6 +2328,37 @@ type VimObjectRefs struct {
 	VimObjectRef []*VimObjectRef `xml:"VimObjectRef"`
 }
 
+// Type: VimObjectRefsType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
+// Description: List of VimObjectRef elements.
+// Since: 0.9
+type VimObjectRefsCreate struct {
+	VimObjectRef []*VimObjectRefCreate `xml:"vmext:VimObjectRef"`
+}
+
+// Type: VMWExternalNetworkType
+// Namespace: http://www.vmware.com/vcloud/extension/v1.5
+// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
+// Description: External network type.
+// Since: 1.0
+type ExternalNetworkCreate struct {
+	XMLName          xml.Name              `xml:"vmext:VMWExternalNetwork"`
+	XmlnsVmext       string                `xml:"xmlns:vmext,attr,omitempty"`
+	XmlnsVcload      string                `xml:"xmlns:vcloud,attr,omitempty"`
+	HREF             string                `xml:"href,attr,omitempty"`
+	Type             string                `xml:"type,attr,omitempty"`
+	ID               string                `xml:"id,attr,omitempty"`
+	OperationKey     string                `xml:"operationKey,attr,omitempty"`
+	Name             string                `xml:"name,attr"`
+	Link             []*Link               `xml:"Link,omitempty"`
+	Description      string                `xml:"vcloud:Description,omitempty"`
+	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`
+	Configuration    *NetworkConfiguration `xml:"vcloud:Configuration,omitempty"`
+	VimPortGroupRefs *VimObjectRefsCreate  `xml:"vmext:VimPortGroupRefs,omitempty"`
+	VCloudExtension  *VCloudExtension      `xml:"VCloudExtension,omitempty"`
+}
+
 // Type: VMWExternalNetworkType
 // Namespace: http://www.vmware.com/vcloud/extension/v1.5
 // https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
@@ -2324,18 +2366,17 @@ type VimObjectRefs struct {
 // Since: 1.0
 type ExternalNetwork struct {
 	XMLName          xml.Name              `xml:"VMWExternalNetwork"`
-	Xmlns            string                `xml:"xmlns,attr,omitempty"`
-	XmlnsVCloud      string                `xml:"xmlns:vcloud,attr,omitempty"`
 	HREF             string                `xml:"href,attr,omitempty"`
 	Type             string                `xml:"type,attr,omitempty"`
 	ID               string                `xml:"id,attr,omitempty"`
 	OperationKey     string                `xml:"operationKey,attr,omitempty"`
 	Name             string                `xml:"name,attr"`
-	Description      string                `xml:"vcloud:Description,omitempty"`
-	Configuration    *NetworkConfiguration `xml:"Configuration,omitempty"`
 	Link             []*Link               `xml:"Link,omitempty"`
-	VimPortGroupRefs *VimObjectRefs        `xml:"VimPortGroupRefs,omitempty"`
+	Description      string                `xml:"Description,omitempty"`
 	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`
+	Configuration    *NetworkConfiguration `xml:"Configuration,omitempty"`
+	VimPortGroupRef  *VimObjectRef         `xml:"VimPortGroupRef,omitempty"`
+	VimPortGroupRefs *VimObjectRefs        `xml:"VimPortGroupRefs,omitempty"`
 	VCloudExtension  *VCloudExtension      `xml:"VCloudExtension,omitempty"`
 }
 

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2308,17 +2308,6 @@ type VimObjectRef struct {
 	VimObjectType string     `xml:"VimObjectType"`
 }
 
-// Type: VimObjectRefType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
-// Description: Represents the Managed Object Reference (MoRef) and the type of a vSphere object.
-// Since: 0.9
-type VimObjectRefCreate struct {
-	VimServerRef  *Reference `xml:"vmext:VimServerRef"`
-	MoRef         string     `xml:"vmext:MoRef"`
-	VimObjectType string     `xml:"vmext:VimObjectType"`
-}
-
 // Type: VimObjectRefsType
 // Namespace: http://www.vmware.com/vcloud/extension/v1.5
 // https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
@@ -2326,38 +2315,6 @@ type VimObjectRefCreate struct {
 // Since: 0.9
 type VimObjectRefs struct {
 	VimObjectRef []*VimObjectRef `xml:"VimObjectRef"`
-}
-
-// Type: VimObjectRefsType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VimObjectRefsType.html
-// Description: List of VimObjectRef elements.
-// Since: 0.9
-type VimObjectRefsCreate struct {
-	VimObjectRef []*VimObjectRefCreate `xml:"vmext:VimObjectRef"`
-}
-
-// Type: VMWExternalNetworkType
-// Namespace: http://www.vmware.com/vcloud/extension/v1.5
-// https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/types/VMWExternalNetworkType.html
-// Description: External network type.
-// Since: 1.0
-type ExternalNetworkCreate struct {
-	XMLName          xml.Name              `xml:"vmext:VMWExternalNetwork"`
-	XmlnsVmext       string                `xml:"xmlns:vmext,attr,omitempty"`
-	XmlnsVcloud      string                `xml:"xmlns:vcloud,attr,omitempty"`
-	HREF             string                `xml:"href,attr,omitempty"`
-	Type             string                `xml:"type,attr,omitempty"`
-	ID               string                `xml:"id,attr,omitempty"`
-	OperationKey     string                `xml:"operationKey,attr,omitempty"`
-	Name             string                `xml:"name,attr"`
-	Link             []*Link               `xml:"Link,omitempty"`
-	Description      string                `xml:"vcloud:Description,omitempty"`
-	Tasks            *TasksInProgress      `xml:"Tasks,omitempty"`
-	Configuration    *NetworkConfiguration `xml:"vcloud:Configuration,omitempty"`
-	VimPortGroupRef  *VimObjectRefCreate   `xml:"VimPortGroupRef,omitempty"`
-	VimPortGroupRefs *VimObjectRefsCreate  `xml:"vmext:VimPortGroupRefs,omitempty"`
-	VCloudExtension  *VCloudExtension      `xml:"VCloudExtension,omitempty"`
 }
 
 // Type: VMWExternalNetworkType


### PR DESCRIPTION
Changes to fix issue where external network description wasn't read. Issue noticed by Giuseppe.

Create needs to use two namespaces and `go` don't work with them, so namespaces are hardcoded. Read functionality needs seperate struct as API returns different look of xml from create in regards of namespaces(prefix)