### PR TITLE
Add handling of timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ IMPROVEMENTS:
 
 * Move methods for `AdminOrg`, `AdminCatalog`, `AdminVdc` to new files `adminorg.go`,
  `admincatalog.go`, `adminvdc.go`.
+* Added default value for http timeout(600s) which is configurable
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ IMPROVEMENTS:
 
 * Move methods for `AdminOrg`, `AdminCatalog`, `AdminVdc` to new files `adminorg.go`,
  `admincatalog.go`, `adminvdc.go`.
-* Added default value for http timeout(600s) which is configurable
+* Added default value for HTTP timeout (600s) which is configurable
 
 BUGS FIXED:
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -88,7 +88,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 
 // NewVCDClient initializes VMware vCloud Director client with reasonable defaults.
 // It accepts functions of type VCDClientOption for adjusting defaults.
-func NewVCDClient(vcdEndpoint url.URL, insecure bool, timeout int, options ...VCDClientOption) *VCDClient {
+func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	// Setting defaults
 	vcdClient := &VCDClient{
 		Client: Client{
@@ -102,7 +102,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, timeout int, options ...VC
 					Proxy:               http.ProxyFromEnvironment,
 					TLSHandshakeTimeout: 120 * time.Second,
 				},
-				Timeout: time.Duration(timeout) * time.Second,
+				Timeout: 600 * time.Second,
 			},
 			MaxRetryTimeout: 60, // Default timeout in seconds for Client
 		},
@@ -165,6 +165,14 @@ func WithMaxRetryTimeout(timeoutSeconds int) VCDClientOption {
 func WithAPIVersion(version string) VCDClientOption {
 	return func(vcdClient *VCDClient) error {
 		vcdClient.Client.APIVersion = version
+		return nil
+	}
+}
+
+// WithTimeout allows to override default http timeout
+func WithHttpTimeout(timeout int64) VCDClientOption {
+	return func(vcdClient *VCDClient) error {
+		vcdClient.Client.Http.Timeout = time.Duration(timeout) * time.Second
 		return nil
 	}
 }

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -100,11 +100,11 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 						InsecureSkipVerify: insecure,
 					},
 					Proxy:               http.ProxyFromEnvironment,
-					TLSHandshakeTimeout: 120 * time.Second,
+					TLSHandshakeTimeout: 120 * time.Second, // Default timeout for TSL hand shake
 				},
-				Timeout: 600 * time.Second,
+				Timeout: 600 * time.Second, // Default value for http request+response timeout
 			},
-			MaxRetryTimeout: 60, // Default timeout in seconds for Client
+			MaxRetryTimeout: 60, // Default timeout in seconds for retries calls in functions
 		},
 	}
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -169,7 +169,7 @@ func WithAPIVersion(version string) VCDClientOption {
 	}
 }
 
-// WithTimeout allows to override default http timeout
+// WithHttpTimeout allows to override default http timeout
 func WithHttpTimeout(timeout int64) VCDClientOption {
 	return func(vcdClient *VCDClient) error {
 		vcdClient.Client.Http.Timeout = time.Duration(timeout) * time.Second

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -88,7 +88,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 
 // NewVCDClient initializes VMware vCloud Director client with reasonable defaults.
 // It accepts functions of type VCDClientOption for adjusting defaults.
-func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
+func NewVCDClient(vcdEndpoint url.URL, insecure bool, timeout int, options ...VCDClientOption) *VCDClient {
 	// Setting defaults
 	vcdClient := &VCDClient{
 		Client: Client{
@@ -102,6 +102,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 					Proxy:               http.ProxyFromEnvironment,
 					TLSHandshakeTimeout: 120 * time.Second,
 				},
+				Timeout: time.Duration(timeout) * time.Second,
 			},
 			MaxRetryTimeout: 60, // Default timeout in seconds for Client
 		},

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -88,6 +88,7 @@ type TestConfig struct {
 		Url             string `yaml:"url"`
 		SysOrg          string `yaml:"sysOrg"`
 		MaxRetryTimeout int    `yaml:"maxRetryTimeout,omitempty"`
+		HttpTimeout     int64  `yaml:"httpTimeout,omitempty"`
 	}
 	VCD struct {
 		Org         string `yaml:"org"`
@@ -351,7 +352,11 @@ func GetTestVCDFromYaml(testConfig TestConfig, options ...VCDClientOption) (*VCD
 		options = append(options, WithMaxRetryTimeout(testConfig.Provider.MaxRetryTimeout))
 	}
 
-	return NewVCDClient(*configUrl, true, 600, options...), nil
+	if testConfig.Provider.HttpTimeout != 0 {
+		options = append(options, WithHttpTimeout(testConfig.Provider.HttpTimeout))
+	}
+
+	return NewVCDClient(*configUrl, true, options...), nil
 }
 
 // Necessary to enable the suite tests with TestVCD

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -351,7 +351,7 @@ func GetTestVCDFromYaml(testConfig TestConfig, options ...VCDClientOption) (*VCD
 		options = append(options, WithMaxRetryTimeout(testConfig.Provider.MaxRetryTimeout))
 	}
 
-	return NewVCDClient(*configUrl, true, options...), nil
+	return NewVCDClient(*configUrl, true, 600, options...), nil
 }
 
 // Necessary to enable the suite tests with TestVCD

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -22,7 +22,6 @@
 			"name": "mycat",
 			"//": "One item in the catalog. It will be used to compose test vApps. Some tests",
 			"//": "rely on it being Photon OS. It is is not Photon OS - the tests will be skipped",
-
 			"catalogItem": "myitem",
 			"description": "my cat for loading",
 			"catalogItemDescription": "my item to create vapps"

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -7,7 +7,8 @@
 		"sysOrg": "System",
 		"//": "(Optional) In some cases the vCloud Director SDK must wait. It can be",
 		"//": "customized using the below var. If it is not set SDK assumes a default value.",
-		"maxRetryTimeout": 60
+		"maxRetryTimeout": 60,
+    "httpTimeout" : 600
 	},
 	"vcd": {
 		"org": "myorg",
@@ -21,7 +22,7 @@
 			"name": "mycat",
 			"//": "One item in the catalog. It will be used to compose test vApps. Some tests",
 			"//": "rely on it being Photon OS. It is is not Photon OS - the tests will be skipped",
-			
+
 			"catalogItem": "myitem",
 			"description": "my cat for loading",
 			"catalogItemDescription": "my item to create vapps"

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -22,6 +22,9 @@ provider:
     # where vCloud director may take time to respond and retry mechanism is needed.
     # This must be >0 to avoid instant timeout errors. If omitted - default value is set.
     # maxRetryTimeout: 60
+    # (Optional) httpTimeout specifies a time limit (in seconds) for waiting http response.
+    # If omitted - default value is set.
+    # httpTimeout: 600
 vcd:
     # Name of the organization (mandatory)
     org: myorg

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -22,6 +22,7 @@ provider:
     # where vCloud director may take time to respond and retry mechanism is needed.
     # This must be >0 to avoid instant timeout errors. If omitted - default value is set.
     # maxRetryTimeout: 60
+    #
     # (Optional) httpTimeout specifies a time limit (in seconds) for waiting http response.
     # If omitted - default value is set.
     # httpTimeout: 600

--- a/samples/discover.go
+++ b/samples/discover.go
@@ -121,7 +121,7 @@ func (c *Config) Client() (*govcd.VCDClient, error) {
 		return nil, fmt.Errorf("Unable to pass url: %s", err)
 	}
 
-	vcdclient := govcd.NewVCDClient(*u, c.Insecure, 600)
+	vcdclient := govcd.NewVCDClient(*u, c.Insecure)
 	err = vcdclient.Authenticate(c.User, c.Password, c.Org)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to authenticate: %s", err)

--- a/samples/discover.go
+++ b/samples/discover.go
@@ -121,7 +121,7 @@ func (c *Config) Client() (*govcd.VCDClient, error) {
 		return nil, fmt.Errorf("Unable to pass url: %s", err)
 	}
 
-	vcdclient := govcd.NewVCDClient(*u, c.Insecure)
+	vcdclient := govcd.NewVCDClient(*u, c.Insecure, 600)
 	err = vcdclient.Authenticate(c.User, c.Password, c.Org)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to authenticate: %s", err)


### PR DESCRIPTION
When network/env isn't stable sometime response are lost. Standard http go behaviour is wait for it for unlimited time. We saw that from time to time in cassini when using terraform tests that terraform hang ups.

Solutions is introduce configurable timeout when create client. This allows to avoid hang ups and throw time out errors.

Verified with local env - hangups doesn't happen.
Verified with cassini evn - hangups happen and timeout throws error.