### PR TITLE
Fix for removing shared catalogs when removing org.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ BUGS FIXED:
 
 * Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property
 * Fix bug in External network creation and get when description wasn't populated.
+* Fix bug in Org delete where would delete other organization shared catalogs.
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ BUGS FIXED:
 
 * Fix bug in AdminOrg.Update, where OrgGeneralSettings would not update correctly if it contained only one property
 * Fix bug in External network creation and get when description wasn't populated.
-* Fix bug in Org delete where would delete other organization shared catalogs.
+* Fix bug in Org Delete, which would remove catalogs shared from other organizations.
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -389,7 +389,7 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 // isCatalogFromSameOrg checks if catalog is in same Org. Shared catalogs form other Org are showed as normal one
 // in some API responses.
 func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) {
-	foundCatalogs, err := adminOrg.FinAdminCatalogByName(catalogName, adminOrg.AdminOrg.Name)
+	foundCatalogs, err := adminOrg.FindCatalogRecordTypes(catalogName)
 	if err != nil {
 		return false, err
 	}
@@ -401,17 +401,17 @@ func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) 
 }
 
 // FinCatalogByName uses catalog name and Org name to return CatalogRecordType information.
-func (adminOrg *AdminOrg) FinAdminCatalogByName(name, orgName string) ([]*types.CatalogRecordType, error) {
-	util.Logger.Printf("[DEBUG] FinAdminCatalogByName with name: %s and org name: %s", name, orgName)
+func (adminOrg *AdminOrg) FindCatalogRecordTypes(name string) ([]*types.CatalogRecordType, error) {
+	util.Logger.Printf("[DEBUG] FindCatalogRecordTypes with name: %s and org name: %s", name, adminOrg.AdminOrg.Name)
 	results, err := adminOrg.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "adminCatalog",
-		"filter": fmt.Sprintf("(name==%s;orgName==%s)", url.QueryEscape(name), url.QueryEscape(orgName)),
+		"filter": fmt.Sprintf("(name==%s;orgName==%s)", url.QueryEscape(name), url.QueryEscape(adminOrg.AdminOrg.Name)),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	util.Logger.Printf("[DEBUG] FinAdminCatalogByName returned with : %#v and error: %s", results.Results.CatalogRecord, err)
+	util.Logger.Printf("[DEBUG] FindCatalogRecordTypes returned with : %#v and error: %s", results.Results.CatalogRecord, err)
 	return results.Results.CatalogRecord, nil
 }
 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -365,7 +365,7 @@ func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
 	return nil
 }
 
-// Forced removal of all organization catalogs
+// removeCatalogs force removal of all organization catalogs
 func (adminOrg *AdminOrg) removeCatalogs() error {
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		isCatalogFromSameOrg, err := isCatalogFromSameOrg(adminOrg, catalog.Name)
@@ -404,7 +404,7 @@ func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) 
 	return false, nil
 }
 
-// FinCatalogByName uses catalog name and Org name to return AdminCatalogRecord information.
+// FindAdminCatalogRecords uses catalog name to return AdminCatalogRecord information.
 func (adminOrg *AdminOrg) FindAdminCatalogRecords(name string) ([]*types.AdminCatalogRecord, error) {
 	util.Logger.Printf("[DEBUG] FindAdminCatalogRecords with name: %s and org name: %s", name, adminOrg.AdminOrg.Name)
 	results, err := adminOrg.client.QueryWithNotEncodedParams(nil, map[string]string{

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -390,7 +390,7 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 
 }
 
-// isCatalogFromSameOrg checks if catalog is in same Org. Shared catalogs form other Org are showed as normal one
+// isCatalogFromSameOrg checks if catalog is in same Org. Shared catalogs from other Org are showed as normal one
 // in some API responses.
 func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) {
 	foundCatalogs, err := adminOrg.FindAdminCatalogRecords(catalogName)

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -302,11 +302,11 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 
 		adminVdcUrl := adminOrg.client.VCDHREF
-		splitVcdId := strings.Split(vdcs.HREF, "/api/vdc/")
-		if len(splitVcdId) == 1 {
+		splitVdcId := strings.Split(vdcs.HREF, "/api/vdc/")
+		if len(splitVdcId) == 1 {
 			adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/admin/vdc/")[1] + "/action/disable"
 		} else {
-			adminVdcUrl.Path += "/admin/vdc/" + splitVcdId[1] + "/action/disable"
+			adminVdcUrl.Path += "/admin/vdc/" + splitVdcId[1] + "/action/disable"
 		}
 
 		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -301,9 +301,13 @@ func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) 
 func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 
-		// Get admin Vdc HREF
 		adminVdcUrl := adminOrg.client.VCDHREF
-		adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/vdc/")[1] + "/action/disable"
+		splitVcdId := strings.Split(vdcs.HREF, "/api/vdc/")
+		if len(splitVcdId) == 1 {
+			adminVdcUrl.Path += "/admin/vdc/" + strings.Split(vdcs.HREF, "/api/admin/vdc/")[1] + "/action/disable"
+		} else {
+			adminVdcUrl.Path += "/admin/vdc/" + splitVcdId[1] + "/action/disable"
+		}
 
 		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)
 		_, err := checkResp(adminOrg.client.Http.Do(req))

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -389,7 +389,7 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 // isCatalogFromSameOrg checks if catalog is in same Org. Shared catalogs form other Org are showed as normal one
 // in some API responses.
 func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) {
-	foundCatalogs, err := adminOrg.FindCatalogRecordTypes(catalogName)
+	foundCatalogs, err := adminOrg.FindAdminCatalogRecords(catalogName)
 	if err != nil {
 		return false, err
 	}
@@ -400,9 +400,9 @@ func isCatalogFromSameOrg(adminOrg *AdminOrg, catalogName string) (bool, error) 
 	return false, nil
 }
 
-// FinCatalogByName uses catalog name and Org name to return CatalogRecordType information.
-func (adminOrg *AdminOrg) FindCatalogRecordTypes(name string) ([]*types.CatalogRecordType, error) {
-	util.Logger.Printf("[DEBUG] FindCatalogRecordTypes with name: %s and org name: %s", name, adminOrg.AdminOrg.Name)
+// FinCatalogByName uses catalog name and Org name to return AdminCatalogRecord information.
+func (adminOrg *AdminOrg) FindAdminCatalogRecords(name string) ([]*types.AdminCatalogRecord, error) {
+	util.Logger.Printf("[DEBUG] FindAdminCatalogRecords with name: %s and org name: %s", name, adminOrg.AdminOrg.Name)
 	results, err := adminOrg.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "adminCatalog",
 		"filter": fmt.Sprintf("(name==%s;orgName==%s)", url.QueryEscape(name), url.QueryEscape(adminOrg.AdminOrg.Name)),
@@ -411,8 +411,8 @@ func (adminOrg *AdminOrg) FindCatalogRecordTypes(name string) ([]*types.CatalogR
 		return nil, err
 	}
 
-	util.Logger.Printf("[DEBUG] FindCatalogRecordTypes returned with : %#v and error: %s", results.Results.CatalogRecord, err)
-	return results.Results.CatalogRecord, nil
+	util.Logger.Printf("[DEBUG] FindAdminCatalogRecords returned with : %#v and error: %s", results.Results.AdminCatalogRecord, err)
+	return results.Results.AdminCatalogRecord, nil
 }
 
 // Given a valid catalog name, FindAdminCatalog returns an AdminCatalog object.

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Creates a Catalog and then verify that finds it
-func (vcd *TestVCD) Test_Client_FinAdminCatalogByName(check *C) {
+func (vcd *TestVCD) Test_FindCatalogRecordTypes(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
@@ -29,7 +29,7 @@ func (vcd *TestVCD) Test_Client_FinAdminCatalogByName(check *C) {
 	err = adminOrg.Refresh()
 	check.Assert(err, IsNil)
 
-	findRecords, err := adminOrg.FinAdminCatalogByName(catalogName, adminOrg.AdminOrg.Name)
+	findRecords, err := adminOrg.FindCatalogRecordTypes(catalogName)
 	check.Assert(err, IsNil)
 	check.Assert(findRecords, NotNil)
 	check.Assert(len(findRecords), Equals, 1)

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -29,7 +29,7 @@ func (vcd *TestVCD) Test_FindCatalogRecordTypes(check *C) {
 	err = adminOrg.Refresh()
 	check.Assert(err, IsNil)
 
-	findRecords, err := adminOrg.FindCatalogRecordTypes(catalogName)
+	findRecords, err := adminOrg.FindAdminCatalogRecords(catalogName)
 	check.Assert(err, IsNil)
 	check.Assert(findRecords, NotNil)
 	check.Assert(len(findRecords), Equals, 1)

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -1,0 +1,38 @@
+// +build org functional ALL
+
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+package govcd
+
+import (
+	"fmt"
+	. "gopkg.in/check.v1"
+)
+
+// Creates a Catalog and then verify that finds it
+func (vcd *TestVCD) Test_Client_FinAdminCatalogByName(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+	catalogName := "catalogForQuery"
+	adminCatalog, err := adminOrg.CreateCatalog(catalogName, "catalogForQueryDescription")
+	check.Assert(err, IsNil)
+	AddToCleanupList(catalogName, "catalog", vcd.config.VCD.Org, check.TestName())
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, catalogName)
+
+	// just imitate wait
+	err = adminOrg.Refresh()
+	check.Assert(err, IsNil)
+
+	findRecords, err := adminOrg.FinAdminCatalogByName(catalogName, adminOrg.AdminOrg.Name)
+	check.Assert(err, IsNil)
+	check.Assert(findRecords, NotNil)
+	check.Assert(len(findRecords), Equals, 1)
+	check.Assert(findRecords[0].Name, Equals, catalogName)
+	check.Assert(findRecords[0].OrgName, Equals, adminOrg.AdminOrg.Name)
+}

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Creates a Catalog and then verify that finds it
-func (vcd *TestVCD) Test_FindCatalogRecordTypes(check *C) {
+func (vcd *TestVCD) Test_FindAdminCatalogRecords(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -31,6 +31,15 @@ func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 	return getResult(&vcdCli.Client, req)
 }
 
+func (vdc *Vdc) Query(params map[string]string) (Results, error) {
+	queryUrl := vdc.client.VCDHREF
+	queryUrl.Path += "/query"
+	req := vdc.client.NewRequest(params, http.MethodGet, queryUrl, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
+
+	return getResult(vdc.client, req)
+}
+
 // QueryWithNotEncodedParams uses Query API to search for requested data
 func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
 	queryUlr := client.VCDHREF
@@ -43,28 +52,11 @@ func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEnc
 }
 
 func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, vcdCli.QueryHREF, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
-
-	return getResult(&vcdCli.Client, req)
-}
-
-func (vdc *Vdc) Query(params map[string]string) (Results, error) {
-	queryUrl := vdc.client.VCDHREF
-	queryUrl.Path += "/query"
-	req := vdc.client.NewRequest(params, http.MethodGet, queryUrl, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
-
-	return getResult(vdc.client, req)
+	return vcdCli.Client.QueryWithNotEncodedParams(params, notEncodedParams)
 }
 
 func (vdc *Vdc) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	queryUrl := vdc.client.VCDHREF
-	queryUrl.Path += "/query"
-	req := vdc.client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, queryUrl, nil)
-	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
-
-	return getResult(vdc.client, req)
+	return vdc.client.QueryWithNotEncodedParams(params, notEncodedParams)
 }
 
 func getResult(client *Client, request *http.Request) (Results, error) {

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -31,6 +31,16 @@ func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 	return getResult(&vcdCli.Client, req)
 }
 
+func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	queryUlr := client.VCDHREF
+	queryUlr.Path += "/query"
+
+	req := client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, queryUlr, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+client.APIVersion)
+
+	return getResult(client, req)
+}
+
 func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
 	req := vcdCli.Client.NewRequestWitNotEncodedParams(params, notEncodedParams, http.MethodGet, vcdCli.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -31,6 +31,7 @@ func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
 	return getResult(&vcdCli.Client, req)
 }
 
+// QueryWithNotEncodedParams uses Query API to search for requested data
 func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
 	queryUlr := client.VCDHREF
 	queryUlr.Path += "/query"

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2113,6 +2113,7 @@ type QueryResultRecordsType struct {
 	VirtualCenterRecord             []*QueryResultVirtualCenterRecordType             `xml:"VirtualCenterRecord"`             // A record representing a vSphere server
 	PortGroupRecord                 []*PortGroupRecordType                            `xml:"PortgroupRecord"`                 // A record representing a port group
 	OrgVdcNetworkRecord             []*QueryResultOrgVdcNetworkRecordType             `xml:"OrgVdcNetworkRecord"`             // A record representing a org VDC network
+	CatalogRecord                   []*CatalogRecordType                              `xml:"AdminCatalogRecord"`              // A record representing a catalog
 }
 
 // QueryResultEdgeGatewayRecordType represents an edge gateway record as query result.
@@ -2624,4 +2625,31 @@ type User struct {
 	GroupReferences *GroupReference  `xml:"GroupReferences,omitempty"`
 	Password        string           `xml:"Password,omitempty"`
 	Tasks           *TasksInProgress `xml:"Tasks"`
+}
+
+// Type: CatalogRecord
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// https://code.vmware.com/apis/287/vcloud#/doc/doc/types/QueryResultCatalogRecordType.html
+// Issue that description partly matches with what is returned
+// Description: Represents Catalog record
+// Since: 1.5
+type CatalogRecordType struct {
+	HREF                    string    `xml:"href,attr,omitempty"`
+	ID                      string    `xml:"id,attr,omitempty"`
+	Type                    string    `xml:"type,attr,omitempty"`
+	Name                    string    `xml:"name,attr,omitempty"`
+	Description             string    `xml:"description,attr,omitempty"`
+	IsPublished             bool      `xml:"isPublished,attr,omitempty"`
+	IsShared                bool      `xml:"isShared,attr,omitempty"`
+	CreationDate            string    `xml:"creationDate,attr,omitempty"`
+	OrgName                 string    `xml:"orgName,attr,omitempty"`
+	OwnerName               string    `xml:"ownerName,attr,omitempty"`
+	NumberOfVAppTemplates   int64     `xml:"numberOfVAppTemplates,attr,omitempty"`
+	NumberOfMedia           int64     `xml:"numberOfMedia,attr,omitempty"`
+	Owner                   string    `xml:"owner,attr,omitempty"`
+	PublishSubscriptionType string    `xml:"publishSubscriptionType,attr,omitempty"`
+	Version                 int64     `xml:"version,attr,omitempty"`
+	Status                  string    `xml:"status,attr,omitempty"`
+	Link                    *Link     `xml:"Link,omitempty"`
+	Vdc                     *Metadata `xml:"Metadata,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2113,7 +2113,7 @@ type QueryResultRecordsType struct {
 	VirtualCenterRecord             []*QueryResultVirtualCenterRecordType             `xml:"VirtualCenterRecord"`             // A record representing a vSphere server
 	PortGroupRecord                 []*PortGroupRecordType                            `xml:"PortgroupRecord"`                 // A record representing a port group
 	OrgVdcNetworkRecord             []*QueryResultOrgVdcNetworkRecordType             `xml:"OrgVdcNetworkRecord"`             // A record representing a org VDC network
-	CatalogRecord                   []*CatalogRecordType                              `xml:"AdminCatalogRecord"`              // A record representing a catalog
+	AdminCatalogRecord              []*AdminCatalogRecord                             `xml:"AdminCatalogRecord"`              // A record representing a catalog
 }
 
 // QueryResultEdgeGatewayRecordType represents an edge gateway record as query result.
@@ -2627,13 +2627,13 @@ type User struct {
 	Tasks           *TasksInProgress `xml:"Tasks"`
 }
 
-// Type: CatalogRecord
+// Type: AdminCatalogRecord
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // https://code.vmware.com/apis/287/vcloud#/doc/doc/types/QueryResultCatalogRecordType.html
 // Issue that description partly matches with what is returned
 // Description: Represents Catalog record
 // Since: 1.5
-type CatalogRecordType struct {
+type AdminCatalogRecord struct {
 	HREF                    string    `xml:"href,attr,omitempty"`
 	ID                      string    `xml:"id,attr,omitempty"`
 	Type                    string    `xml:"type,attr,omitempty"`


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/312

Change which validates that catalog is from same organization and valid to delete. Issue is with API return structure, where shared catalogs are showed as own with no distinction.

Couldn't make verify test as we don't have functionality yet to create shared folders. Verified manually.
