### PR TITLE
Improve attach tests

### DIFF
--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -495,7 +495,6 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 
 	//verify
 	vcd.waitUntilEjected(err, vm, check)
-
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 
@@ -584,13 +583,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 
 	//verify
 	// VCD is slow to change representative state
-	for i := 1; i < 5; i++ {
-		err = vm.Refresh()
-		check.Assert(err, IsNil)
-		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
-			break
-		}
-	}
+	vcd.waitUntilEjected(err, vm, check)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 
@@ -677,13 +670,7 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 
 	//verify
 	// VCD is slow to change representative state
-	for i := 1; i < 5; i++ {
-		err = vm.Refresh()
-		check.Assert(err, IsNil)
-		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
-			break
-		}
-	}
+	vcd.waitUntilEjected(err, vm, check)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -498,7 +498,7 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 
-// waitUntilEjected checks status until ready. We need this cause VCD is slow to change representative state
+// waitUntilEjected checks status until ready. We need this because VCD is slow to change representative state
 func (vcd *TestVCD) waitUntilEjected(err error, vm *VM, check *C) {
 
 	for i := 1; i < 5; i++ {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -494,9 +494,21 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
-	check.Assert(err, IsNil)
+	vcd.waitUntilEjected(err, vm, check)
+
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
+}
+
+// waitUntilEjected checks status until ready. We need this cause VCD is slow to change representative state
+func (vcd *TestVCD) waitUntilEjected(err error, vm *VM, check *C) {
+
+	for i := 1; i < 5; i++ {
+		err = vm.Refresh()
+		check.Assert(err, IsNil)
+		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
+			break
+		}
+	}
 }
 
 // Test Insert or Eject Media for VM
@@ -571,8 +583,14 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
-	check.Assert(err, IsNil)
+	// VCD is slow to change representative state
+	for i := 1; i < 5; i++ {
+		err = vm.Refresh()
+		check.Assert(err, IsNil)
+		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
+			break
+		}
+	}
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 
@@ -658,8 +676,14 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
-	check.Assert(err, IsNil)
+	// VCD is slow to change representative state
+	for i := 1; i < 5; i++ {
+		err = vm.Refresh()
+		check.Assert(err, IsNil)
+		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
+			break
+		}
+	}
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 


### PR DESCRIPTION
This improves attach media tests.
Issue we got on VCD 10 version quite often is that checking state of detached media was updated with lag. So added a few refresh for test not to fail.