### PR TITLE
Add helper function which handles eject with refresh

### DIFF
--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -555,7 +555,8 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 }
 
 // Helper function which finds media, calls EjectMedia, waits for task to complete and answer question.
-// Also waits until vm status refreshes - this added as current VCD version has lag in status update.
+// Also waits until VM status refreshes - this added as current vCD version has lag in status update.
+// answerYes - handles question risen when VM is running. True value enforces ejection.
 func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string, answerYes bool) (*VM, error) {
 	task, err := vm.HandleEjectMedia(org, catalogName, mediaName)
 	if err != nil {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -555,7 +555,7 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 }
 
 // HandleEjectMediaAndAnswer helper function which finds media, calls EjectMedia, waits for task to complete and answer question.
-// Also waits until VM status refreshes - this added as 8.2-10.0 vCD version has lag in status update.
+// Also waits until VM status refreshes - this added as 9.7-10.0 vCD versions has lag in status update.
 // answerYes - handles question risen when VM is running. True value enforces ejection.
 func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string, answerYes bool) (*VM, error) {
 	task, err := vm.HandleEjectMedia(org, catalogName, mediaName)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -566,21 +566,19 @@ func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string,
 	if err != nil {
 		return nil, fmt.Errorf("error: %s", err)
 	}
-	for i := 1; i < 4; i++ {
-		time.Sleep(200 * time.Millisecond)
+
+	for i := 0; i < 3; i++ {
 		err = vm.Refresh()
 		if err != nil {
 			return nil, fmt.Errorf("error: %s", err)
 		}
 		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
-			break
+			return vm, nil
 		}
-		if i == 3 {
-			return nil, fmt.Errorf("eject media executed but waiting for state update failed")
-		}
+		time.Sleep(200 * time.Millisecond)
 	}
 
-	return vm, nil
+	return nil, fmt.Errorf("eject media executed but waiting for state update failed")
 }
 
 // check resource subtype for specific value which means media is injected

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -554,6 +554,45 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 	})
 }
 
+// Helper function which finds media, calls EjectMedia, waits for task to complete and answer question.
+// Also waits until vm status refreshes - this added as current VCD version has lag in status update.
+func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string, answerYes bool) (*VM, error) {
+	task, err := vm.HandleEjectMedia(org, catalogName, mediaName)
+	if err != nil {
+		return nil, fmt.Errorf("error: %s", err)
+	}
+
+	err = task.WaitTaskCompletion(answerYes)
+	if err != nil {
+		return nil, fmt.Errorf("error: %s", err)
+	}
+	for i := 1; i < 4; i++ {
+		time.Sleep(200 * time.Millisecond)
+		err = vm.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error: %s", err)
+		}
+		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
+			break
+		}
+		if i == 3 {
+			return nil, fmt.Errorf("eject media executed but waiting for state update failed")
+		}
+	}
+
+	return vm, nil
+}
+
+// check resource subtype for specific value which means media is injected
+func isMediaInjected(items []*types.VirtualHardwareItem) bool {
+	for _, hardwareItem := range items {
+		if hardwareItem.ResourceSubType == types.VMsCDResourceSubType {
+			return true
+		}
+	}
+	return false
+}
+
 // Helper function which finds media and calls EjectMedia
 func (vm *VM) HandleEjectMedia(org *Org, catalogName, mediaName string) (EjectTask, error) {
 	media, err := FindMediaAsCatalogItem(org, catalogName, mediaName)

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -554,8 +554,8 @@ func (vm *VM) HandleInsertMedia(org *Org, catalogName, mediaName string) (Task, 
 	})
 }
 
-// Helper function which finds media, calls EjectMedia, waits for task to complete and answer question.
-// Also waits until VM status refreshes - this added as current vCD version has lag in status update.
+// HandleEjectMediaAndAnswer helper function which finds media, calls EjectMedia, waits for task to complete and answer question.
+// Also waits until VM status refreshes - this added as 8.2-10.0 vCD version has lag in status update.
 // answerYes - handles question risen when VM is running. True value enforces ejection.
 func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string, answerYes bool) (*VM, error) {
 	task, err := vm.HandleEjectMedia(org, catalogName, mediaName)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -501,7 +501,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
 
-	// Skipping this test due bug in vCD. VM refresh status returns old state, though eject task is finished.
+	// Skipping this test due to a bug in vCD. VM refresh status returns old state, though eject task is finished.
 	if vcd.client.APIClientVersionIs("<= 31.0, >= 34.0") {
 		check.Skip("Skipping test because this vCD version has bug")
 	}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -500,6 +500,12 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
+
+	// Skipping this test due bug in vCD. VM refresh status returns old state, though eject task is finished.
+	if vcd.client.APIClientVersionIs("<= 31.0, >= 34.0") {
+		check.Skip("Skipping test because this vCD version has bug")
+	}
+
 	itemName := "TestInsertOrEjectMedia"
 
 	// Find VApp

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -503,7 +503,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 
 	// Skipping this test due to a bug in vCD. VM refresh status returns old state, though eject task is finished.
 	if vcd.client.APIVCDMaxVersionIs(">= 32.0, <= 33.0") {
-		check.Skip("Skipping test because this vCD version has bug")
+		check.Skip("Skipping test because this vCD version has a bug")
 	}
 
 	itemName := "TestInsertOrEjectMedia"

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -502,7 +502,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	}
 
 	// Skipping this test due to a bug in vCD. VM refresh status returns old state, though eject task is finished.
-	if vcd.client.APIClientVersionIs(">= 32.0, <= 33.0") {
+	if vcd.client.APIVCDMaxVersionIs(">= 32.0, <= 33.0") {
 		check.Skip("Skipping test because this vCD version has bug")
 	}
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -502,7 +502,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	}
 
 	// Skipping this test due to a bug in vCD. VM refresh status returns old state, though eject task is finished.
-	if vcd.client.APIClientVersionIs("<= 31.0, >= 34.0") {
+	if vcd.client.APIClientVersionIs(">= 32.0, <= 33.0") {
 		check.Skip("Skipping test because this vCD version has bug")
 	}
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -487,15 +487,10 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, true)
 
-	ejectMediaTask, err := vm.HandleEjectMedia(vcd.org, vcd.config.VCD.Catalog.Name, itemName)
-	check.Assert(err, IsNil)
-
-	err = ejectMediaTask.WaitTaskCompletion(true)
+	vm, err = vm.HandleEjectMediaAndAnswer(vcd.org, vcd.config.VCD.Catalog.Name, itemName, true)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
-	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
 
@@ -574,16 +569,6 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	err = vm.Refresh()
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
-}
-
-// check resource subtype for specific value which means media is injected
-func isMediaInjected(items []*types.VirtualHardwareItem) bool {
-	for _, hardwareItem := range items {
-		if hardwareItem.ResourceSubType == types.VMsCDResourceSubType {
-			return true
-		}
-	}
-	return false
 }
 
 // Test Insert or Eject Media for VM


### PR DESCRIPTION
Ref: Issue we got on VCD 10 version quite often is that checking state of detached media was updated with lag. This issue comes only in unit tests due how tests verify eject of media. In terraform we don't read state after eject of media.

I added helper function which helps handling such case. Though current test work with lower level of abstraction function and couldn't be fixed in SDK level, only on unit test level when we need.
