### PR TITLE
Clean up lint errors

### DIFF
--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -185,8 +185,8 @@ func (vcd *TestVCD) Test_UploadOvf_ShowUploadProgress_works(check *C) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	uploadTask.ShowUploadProgress()
-
+	err = uploadTask.ShowUploadProgress()
+	check.Assert(err, IsNil)
 	w.Close()
 	//read stdin
 	result, _ := ioutil.ReadAll(r)
@@ -373,8 +373,8 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_ShowUploadProgress_works(check 
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	uploadTask.ShowUploadProgress()
-
+	err = uploadTask.ShowUploadProgress()
+	check.Assert(err, IsNil)
 	w.Close()
 	//read stdin
 	result, _ := ioutil.ReadAll(r)

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -96,7 +96,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 		return Task{}, err
 	}
 	// Obtain disk task
-	if disk.Disk.Tasks.Task == nil || len(disk.Disk.Tasks.Task) <= 0 {
+	if disk.Disk.Tasks.Task == nil || len(disk.Disk.Tasks.Task) == 0 {
 		return Task{}, errors.New("error cannot find disk creation task in API response")
 	}
 	task := NewTask(vdc.client)

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -128,7 +128,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 		fmt.Printf("# Detected entity type %s\n", reflect.TypeOf(entity1))
 	}
 
-	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity1)), Equals, wantedType)
+	check.Assert(reflect.TypeOf(entity1).String(), Equals, wantedType)
 
 	check.Assert(entity1, NotNil)
 	check.Assert(entity1.name(), Equals, entityName)
@@ -144,7 +144,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	check.Assert(entity2, NotNil)
 	check.Assert(entity2.name(), Equals, entityName)
 	check.Assert(entity2.id(), Equals, entityId)
-	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity2)), Equals, wantedType)
+	check.Assert(reflect.TypeOf(entity2).String(), Equals, wantedType)
 
 	// 3. Get the entity by Name or ID, using a known ID
 	if testVerbose {
@@ -156,7 +156,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	check.Assert(entity3, NotNil)
 	check.Assert(entity3.name(), Equals, entityName)
 	check.Assert(entity3.id(), Equals, entityId)
-	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity3)), Equals, wantedType)
+	check.Assert(reflect.TypeOf(entity3).String(), Equals, wantedType)
 
 	// 4. Get the entity by Name or ID, using the entity name
 	if testVerbose {
@@ -168,7 +168,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	check.Assert(entity4, NotNil)
 	check.Assert(entity4.name(), Equals, entityName)
 	check.Assert(entity4.id(), Equals, entityId)
-	check.Assert(fmt.Sprintf("%s", reflect.TypeOf(entity4)), Equals, wantedType)
+	check.Assert(reflect.TypeOf(entity4).String(), Equals, wantedType)
 
 	// 5. Attempting a search by name with an invalid name
 	if testVerbose {

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -69,7 +69,8 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	// Wait until vApp becomes configurable
 	initialVappStatus, err := vapp.GetStatus()
 	check.Assert(err, IsNil)
-	vapp.BlockWhileStatus(initialVappStatus, vapp.client.MaxRetryTimeout)
+	err = vapp.BlockWhileStatus(initialVappStatus, vapp.client.MaxRetryTimeout)
+	check.Assert(err, IsNil)
 	fmt.Printf(". Done\n")
 
 	fmt.Printf("# Attaching vDC network '%s' to vApp '%s'", vcd.config.VCD.Network.Net1, TestLb)
@@ -94,7 +95,9 @@ func (vcd *TestVCD) Test_LB(check *C) {
 		})
 
 	vm1, err := spawnVM("FirstNode", *vdc, vapp, desiredNetConfig, vappTemplate, check)
+	check.Assert(err, IsNil)
 	vm2, err := spawnVM("SecondNode", *vdc, vapp, desiredNetConfig, vappTemplate, check)
+	check.Assert(err, IsNil)
 
 	// Get IPs alocated to the VMs
 	ip1 := vm1.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress
@@ -145,7 +148,6 @@ func (vcd *TestVCD) Test_LB(check *C) {
 
 	// Finally after some cleanups - check if querying succeeded
 	check.Assert(queryErr, IsNil)
-	return
 }
 
 // validateTestLbPrerequisites verifies the following:
@@ -188,10 +190,12 @@ func spawnVM(name string, vdc Vdc, vapp VApp, net types.NetworkConnectionSection
 	task, err = vm.ChangeCPUCount(2)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 
 	task, err = vm.ChangeMemorySize(512)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	fmt.Printf(". Done\n")
 
 	fmt.Printf("# Applying customization script for VM '%s'", name)
@@ -208,7 +212,9 @@ func spawnVM(name string, vdc Vdc, vapp VApp, net types.NetworkConnectionSection
 
 	fmt.Printf("# Powering on VM '%s'", name)
 	task, err = vm.PowerOn()
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 	fmt.Printf(". Done\n")
 
 	return vm, nil
@@ -345,7 +351,7 @@ func deleteFirewallRule(ruleDescription string, vdc Vdc, vcd *TestVCD, check *C)
 	edge, err := vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 	rules := edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.FirewallService.FirewallRule
-	for index, _ := range rules {
+	for index := range rules {
 		if rules[index].Description == ruleDescription {
 			rules = append(rules[:index], rules[index+1:]...)
 		}

--- a/govcd/lbappprofile_test.go
+++ b/govcd/lbappprofile_test.go
@@ -96,6 +96,7 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 	// Invalid persistence method invalid_method. Valid methods are: COOKIE|SSL-SESSIONID|SOURCEIP.
 	lbAppProfileByID.Persistence.Method = "invalid_method"
 	updatedAppProfile, err = edge.UpdateLbAppProfile(lbAppProfileByID)
+	check.Assert(updatedAppProfile, IsNil)
 	check.Assert(err, ErrorMatches, ".*Invalid persistence method .*Valid methods are:.*")
 
 	// Update should fail without name

--- a/govcd/lbapprule_test.go
+++ b/govcd/lbapprule_test.go
@@ -74,6 +74,7 @@ func (vcd *TestVCD) Test_LBAppRule(check *C) {
 	// Unknown keyword 'invalid_script'
 	lbAppRuleByID.Script = "invalid_script"
 	updatedAppProfile, err = edge.UpdateLbAppRule(lbAppRuleByID)
+	check.Assert(updatedAppProfile, IsNil)
 	check.Assert(err, ErrorMatches, ".*invalid applicationRule script.*")
 
 	// Update should fail without name

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -130,6 +130,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 	// Invalid algorithm hash. Valid algorithms are: IP-HASH|ROUND-ROBIN|URI|LEASTCONN|URL|HTTP-HEADER.
 	lbPoolByID.Algorithm = "invalid_algorithm"
 	updatedLBPool, err = edge.UpdateLbServerPool(lbPoolByID)
+	check.Assert(updatedLBPool, IsNil)
 	check.Assert(err, ErrorMatches, ".*Invalid algorithm.*Valid algorithms are:.*")
 
 	// Update should fail without name

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -122,6 +122,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	// vShield Edge [LoadBalancer] Invalid protocol invalid_protocol. Valid protocols are: HTTP|HTTPS|TCP|UDP. (API error: 14542)
 	lbVirtualServerById.Protocol = "invalid_protocol"
 	updatedLBPool, err = edge.UpdateLbVirtualServer(lbVirtualServerById)
+	check.Assert(updatedLBPool, IsNil)
 	check.Assert(err, ErrorMatches, ".*Invalid protocol.*Valid protocols are:.*")
 
 	// Update should fail without name

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -75,7 +75,8 @@ func (vcd *TestVCD) Test_UploadMediaImage_ShowUploadProgress_works(check *C) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	uploadTask.ShowUploadProgress()
+	err = uploadTask.ShowUploadProgress()
+	check.Assert(err, IsNil)
 
 	w.Close()
 	//read stdin
@@ -187,7 +188,8 @@ func (vcd *TestVCD) Test_RefreshMediaImage(check *C) {
 	check.Assert(mediaItem, Not(Equals), MediaItem{})
 
 	oldMediaItem := mediaItem
-	mediaItem.Refresh()
+	err = mediaItem.Refresh()
+	check.Assert(err, IsNil)
 
 	check.Assert(mediaItem, NotNil)
 	check.Assert(oldMediaItem.MediaItem.ID, Equals, mediaItem.MediaItem.ID)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -159,7 +159,8 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	if err != nil {
 		panic(err)
 	}
-	vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
+	err = vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
+	check.Check(err, IsNil)
 	vapp_status, err = vapp.GetStatus()
 	check.Check(err, IsNil)
 	check.Check(vapp_status, Equals, "POWERED_OFF")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -589,7 +589,7 @@ func (vm *VM) HandleEjectMediaAndAnswer(org *Org, catalogName, mediaName string,
 		if err != nil {
 			return nil, fmt.Errorf("error: %s", err)
 		}
-		if isMediaInjected(vm.VM.VirtualHardwareSection.Item) == false {
+		if !isMediaInjected(vm.VM.VirtualHardwareSection.Item) {
 			return vm, nil
 		}
 		time.Sleep(200 * time.Millisecond)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1179,7 +1179,6 @@ func (p *ProductSectionList) SortByPropertyKeyName() {
 	sort.SliceStable(p.ProductSection.Property, func(i, j int) bool {
 		return p.ProductSection.Property[i].Key < p.ProductSection.Property[j].Key
 	})
-	return
 }
 
 type ProductSection struct {

--- a/util/logging_test.go
+++ b/util/logging_test.go
@@ -13,10 +13,7 @@ import (
 
 func fileExists(filename string) bool {
 	_, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return os.IsNotExist(err)
 }
 
 func testLog(logn int, t *testing.T, filename string, want_enabled bool, success_msg, failure_msg string) {

--- a/util/logging_test.go
+++ b/util/logging_test.go
@@ -13,7 +13,7 @@ import (
 
 func fileExists(filename string) bool {
 	_, err := os.Stat(filename)
-	return os.IsNotExist(err)
+	return !os.IsNotExist(err)
 }
 
 func testLog(logn int, t *testing.T, filename string, want_enabled bool, success_msg, failure_msg string) {

--- a/util/tar.go
+++ b/util/tar.go
@@ -125,7 +125,7 @@ func sanitizedName(filename string) string {
 		filename = filename[2:]
 	}
 	filename = strings.TrimLeft(filename, "\\/.")
-	filename = strings.TrimLeft(filename, "../")
+	filename = strings.TrimLeft(filename, "./")
 	filename = strings.Replace(filename, "../../", "../", -1)
 	return strings.Replace(filename, "..\\", "", -1)
 }

--- a/util/tar_test.go
+++ b/util/tar_test.go
@@ -20,6 +20,7 @@ func TestSanitizedName(t *testing.T) {
 		{"C:/loo/bar2", "loo/bar2"},
 		{"C:\\loo\\bar2", "loo\\bar2"},
 		{"../../foo../../ba..r", "foo../ba..r"},
+		{"../my.file", "my.file"},
 	}
 	for _, table := range tables {
 		fixedPath := sanitizedName(table.badPath)


### PR DESCRIPTION
This repo contains quite a few lint reported problems. This PR has 0 impact on functionality, but cleans up quite a few lint errors.

Both govcd and Terraform tests pass:

This is the list of fixed lint errors:
```bash
govcd/catalog_test.go:188:31: Error return value of `uploadTask.ShowUploadProgress` is not checked (errcheck)
govcd/catalog_test.go:376:31: Error return value of `uploadTask.ShowUploadProgress` is not checked (errcheck)
govcd/lb_test.go:72:23: Error return value of `vapp.BlockWhileStatus` is not checked (errcheck)
govcd/media_test.go:78:31: Error return value of `uploadTask.ShowUploadProgress` is not checked (errcheck)
govcd/media_test.go:190:19: Error return value of `mediaItem.Refresh` is not checked (errcheck)
govcd/vdc_test.go:162:23: Error return value of `vapp.BlockWhileStatus` is not checked (errcheck)
govcd/disk.go:99:36: sloppyLen: len(disk.Disk.Tasks.Task) <= 0 can be len(disk.Disk.Tasks.Task) == 0 (gocritic)
govcd/entity_test.go:131:15: S1025: should use String() instead of fmt.Sprintf (gosimple)
govcd/entity_test.go:147:15: S1025: should use String() instead of fmt.Sprintf (gosimple)
govcd/entity_test.go:159:15: S1025: should use String() instead of fmt.Sprintf (gosimple)
govcd/lb_test.go:148:2: S1023: redundant `return` statement (gosimple)
govcd/lb_test.go:348:13: S1005: should omit value from range; this loop is equivalent to `for index := range ...` (gosimple)
govcd/vm.go:592:6: S1002: should omit comparison to bool constant, can be simplified to `!isMediaInjected(vm.VM.VirtualHardwareSection.Item)` (gosimple)
types/v56/types.go:1182:2: S1023: redundant `return` statement (gosimple)
util/logging_test.go:16:2: S1008: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (gosimple)
util/tar.go:128:29: SA1024: cutset contains duplicate characters (staticcheck)
```