### PR TITLE
Add Get* functions for network and edge gateway

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1023,7 +1023,7 @@ func TestVCDClient_Authenticate(t *testing.T) {
 func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	net, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error finding network : %v", err)
 	}

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -661,9 +661,16 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		if err != nil {
 			vcd.infoCleanup("%s", err)
 		}
+		_, errExists := vdc.GetOrgVdcNetworkByName(entity.Name, false)
+		networkExists := errExists == nil
+
 		err = RemoveOrgVdcNetworkIfExists(*vdc, entity.Name)
 		if err == nil {
-			vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
+			if networkExists {
+				vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
+			} else {
+				vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name)
+			}
 		} else {
 			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
 		}

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -498,23 +498,23 @@ func splitParent(parent string, separator string) (first, second, third string) 
 	return
 }
 
-func getOrgVdcEdgeByNames(vcd *TestVCD, orgName, vdcName, edgeName string) (*Org, *Vdc, EdgeGateway, error) {
+func getOrgVdcEdgeByNames(vcd *TestVCD, orgName, vdcName, edgeName string) (*Org, *Vdc, *EdgeGateway, error) {
 	if orgName == "" || vdcName == "" || edgeName == "" {
-		return nil, nil, EdgeGateway{}, fmt.Errorf("orgName, vdcName, edgeName cant be empty")
+		return nil, nil, nil, fmt.Errorf("orgName, vdcName, edgeName cant be empty")
 	}
 
 	org, _ := vcd.client.GetOrgByName(orgName)
 	if org == nil {
 		vcd.infoCleanup("could not find org '%s'", orgName)
-		return nil, nil, EdgeGateway{}, fmt.Errorf("can't find org")
+		return nil, nil, nil, fmt.Errorf("can't find org")
 	}
 	vdc, err := org.GetVDCByName(vdcName, false)
 	if err != nil {
 		vcd.infoCleanup("could not find vdc '%s'", vdcName)
-		return nil, nil, EdgeGateway{}, fmt.Errorf("can't find org")
+		return nil, nil, nil, fmt.Errorf("can't find org")
 	}
 
-	edge, err := vdc.FindEdgeGateway(edgeName)
+	edge, err := vdc.GetEdgeGatewayByName(edgeName, false)
 
 	if err != nil {
 		vcd.infoCleanup("could not find edge '%s': %s", edgeName, err)
@@ -644,7 +644,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		if err != nil {
 			return
 		}
-		edge, err := vdc.FindEdgeGateway(entity.Name)
+		edge, err := vdc.GetEdgeGatewayByName(entity.Name, false)
 		if err != nil {
 			vcd.infoCleanup("removeLeftoverEntries: [INFO] edge gateway '%s' not found\n", entity.Name)
 			return
@@ -1023,7 +1023,7 @@ func TestVCDClient_Authenticate(t *testing.T) {
 func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error finding network : %v", err)
 	}

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -477,7 +477,7 @@ func (vcd *TestVCD) Test_CatalogGetItem(check *C) {
 
 	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
-	check.Assert(org, NotNil)
+	check.Assert(catalog, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
 		return catalog.GetCatalogItemByName(name, refresh)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -13,11 +13,11 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_Refresh(check *C) {
+func (vcd *TestVCD) Test_RefreshEdgeGateway(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	copyEdge := edge
@@ -39,11 +39,11 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -87,11 +87,11 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -136,7 +136,7 @@ func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edgegatway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	task, err := edge.Create1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "description")
@@ -156,7 +156,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edgegatway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -253,10 +253,10 @@ func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 	if vcd.config.VCD.Network.Net1 == "" {
 		check.Skip("Skipping test because no network given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	network, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	network, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	isRouted := false
 	// If the network is not linked to the edge gateway, we won't check for its name in the network list
@@ -301,11 +301,11 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	description1 := "my Description 1"
 	description2 := "my Description 2"
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -369,11 +369,11 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -449,11 +449,11 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -554,7 +554,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gatway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 
 	if !edge.HasAdvancedNetworking() {
@@ -562,7 +562,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	}
 
 	// Cache current load balancer settings for change validation in the end
-	beforeLb, beforeLbXml := testCacheLoadBalancer(edge, check)
+	beforeLb, beforeLbXml := testCacheLoadBalancer(*edge, check)
 
 	_, err = edge.UpdateLBGeneralParams(true, true, true, "critical")
 	check.Assert(err, IsNil)
@@ -580,5 +580,5 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	check.Assert(err, IsNil)
 
 	// Validate load balancer configuration against initially cached version
-	testCheckLoadBalancerConfig(beforeLb, beforeLbXml, edge, check)
+	testCheckLoadBalancerConfig(beforeLb, beforeLbXml, *edge, check)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -43,7 +43,7 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -91,7 +91,7 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -256,7 +256,7 @@ func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	network, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	isRouted := false
 	// If the network is not linked to the edge gateway, we won't check for its name in the network list
@@ -305,7 +305,7 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -373,7 +373,7 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
@@ -453,7 +453,7 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -59,6 +59,12 @@ func (orgUser *OrgUser) id() string   { return orgUser.User.ID }
 func (vdc *Vdc) name() string { return vdc.Vdc.Name }
 func (vdc *Vdc) id() string   { return vdc.Vdc.ID }
 
+func (network *OrgVDCNetwork) name() string { return network.OrgVDCNetwork.Name }
+func (network *OrgVDCNetwork) id() string   { return network.OrgVDCNetwork.ID }
+
+func (egw *EdgeGateway) name() string { return egw.EdgeGateway.Name }
+func (egw *EdgeGateway) id() string   { return egw.EdgeGateway.ID }
+
 // Semi-generic tests that check the complete set of Get methods for an entity
 // GetEntityByName
 // GetEntityById

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -75,7 +75,7 @@ func (vcd *TestVCD) Test_LB(check *C) {
 
 	fmt.Printf("# Attaching vDC network '%s' to vApp '%s'", vcd.config.VCD.Network.Net1, TestLb)
 	// Attach vDC network to vApp so that VMs can use it
-	net, err := vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	net, err := vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	task, err := vapp.AddRAWNetworkConfig([]*types.OrgVDCNetwork{net.OrgVDCNetwork})
 	check.Assert(err, IsNil)

--- a/govcd/lbappprofile_test.go
+++ b/govcd/lbappprofile_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -41,7 +41,7 @@ func (vcd *TestVCD) Test_LBAppProfile(check *C) {
 		ServerSslEnabled:              false,
 	}
 
-	err = deleteLbAppProfileIfExists(edge, lbAppProfileConfig.Name)
+	err = deleteLbAppProfileIfExists(*edge, lbAppProfileConfig.Name)
 	check.Assert(err, IsNil)
 	createdLbAppProfile, err := edge.CreateLbAppProfile(lbAppProfileConfig)
 	check.Assert(err, IsNil)

--- a/govcd/lbapprule_test.go
+++ b/govcd/lbapprule_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_LBAppRule(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -34,7 +34,7 @@ func (vcd *TestVCD) Test_LBAppRule(check *C) {
 		Script: "acl vmware_page url_beg / vmware redirect location https://www.vmware.com/ ifvmware_page",
 	}
 
-	err = deleteLbAppRuleIfExists(edge, lbAppRuleConfig.Name)
+	err = deleteLbAppRuleIfExists(*edge, lbAppRuleConfig.Name)
 	check.Assert(err, IsNil)
 	createdLbAppRule, err := edge.CreateLbAppRule(lbAppRuleConfig)
 	check.Assert(err, IsNil)

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -40,7 +40,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 		MaxRetries: 3,
 		Type:       "http",
 	}
-	err = deleteLbServiceMonitorIfExists(edge, lbMon.Name)
+	err = deleteLbServiceMonitorIfExists(*edge, lbMon.Name)
 	check.Assert(err, IsNil)
 	lbMonitor, err := edge.CreateLbServiceMonitor(lbMon)
 	check.Assert(err, IsNil)
@@ -74,7 +74,7 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 		},
 	}
 
-	err = deleteLbServerPoolIfExists(edge, lbMon.Name)
+	err = deleteLbServerPoolIfExists(*edge, lbMon.Name)
 	check.Assert(err, IsNil)
 	createdLbPool, err := edge.CreateLbServerPool(lbPoolConfig)
 	check.Assert(err, IsNil)

--- a/govcd/lbservicemonitor_test.go
+++ b/govcd/lbservicemonitor_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_LBServiceMonitor(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -41,7 +41,7 @@ func (vcd *TestVCD) Test_LBServiceMonitor(check *C) {
 		Type:       "http",
 	}
 
-	err = deleteLbServiceMonitorIfExists(edge, lbMon.Name)
+	err = deleteLbServiceMonitorIfExists(*edge, lbMon.Name)
 	check.Assert(err, IsNil)
 	lbMonitor, err := edge.CreateLbServiceMonitor(lbMon)
 	check.Assert(err, IsNil)

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -32,7 +32,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 		check.Skip("Skipping test because no edge gateway external IP given")
 	}
 
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -41,7 +41,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	}
 
 	serviceMonitorId, serverPoolId, appProfileId, appRuleId := buildTestLBVirtualServerPrereqs("1.1.1.1", "2.2.2.2",
-		TestLbVirtualServer, check, vcd, edge)
+		TestLbVirtualServer, check, vcd, *edge)
 
 	// Configure creation object including reference to service monitor
 	lbVirtualServerConfig := &types.LbVirtualServer{
@@ -58,7 +58,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 		DefaultPoolId:        serverPoolId,
 	}
 
-	err = deleteLbVirtualServerIfExists(edge, lbVirtualServerConfig.Name)
+	err = deleteLbVirtualServerIfExists(*edge, lbVirtualServerConfig.Name)
 	check.Assert(err, IsNil)
 	createdLbVirtualServer, err := edge.CreateLbVirtualServer(lbVirtualServerConfig)
 	check.Assert(err, IsNil)

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -89,7 +89,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 
 // Looks for an Org Vdc network and, if found, will delete it.
 func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
-	network, err := vdc.GetVdcNetworkByName(networkName, false)
+	network, err := vdc.GetOrgVdcNetworkByName(networkName, false)
 	if err == nil {
 		task, err := network.Delete()
 		if err != nil {

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -89,8 +89,8 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 
 // Looks for an Org Vdc network and, if found, will delete it.
 func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
-	network, err := vdc.FindVDCNetwork(networkName)
-	if err == nil && network != (OrgVDCNetwork{}) {
+	network, err := vdc.GetVdcNetworkByName(networkName, false)
+	if err == nil {
 		task, err := network.Delete()
 		if err != nil {
 			return fmt.Errorf("error deleting network [phase 1] %s", networkName)

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -89,16 +89,24 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 
 // Looks for an Org Vdc network and, if found, will delete it.
 func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
-	network, err := vdc.GetOrgVdcNetworkByName(networkName, false)
-	if err == nil {
-		task, err := network.Delete()
-		if err != nil {
-			return fmt.Errorf("error deleting network [phase 1] %s", networkName)
-		}
-		err = task.WaitTaskCompletion()
-		if err != nil {
-			return fmt.Errorf("error deleting network [task] %s", networkName)
-		}
+	network, err := vdc.GetOrgVdcNetworkByName(networkName, true)
+
+	if IsNotFound(err) {
+		// Network not found. No action needed
+		return nil
+	}
+	if err != nil {
+		// Some other error happened during retrieval. We pass it along
+		return err
+	}
+	// The network was found. We attempt deletion
+	task, err := network.Delete()
+	if err != nil {
+		return fmt.Errorf("error deleting network [phase 1] %s", networkName)
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error deleting network [task] %s", networkName)
 	}
 	return nil
 }

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -172,9 +172,10 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	if vcd.config.VCD.ExternalNetwork == "" {
 		check.Skip("[Test_CreateOrgVdcNetworkDirect] external network not provided")
 	}
-	externalNetwork, err := GetExternalNetworkByName(vcd.client, vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
 	if err != nil {
 		check.Skip("[Test_CreateOrgVdcNetworkDirect] parent network not found")
+		return
 	}
 	// Note that there is no IPScope for this type of network
 	var networkConfig = types.OrgVDCNetwork{
@@ -183,9 +184,9 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 		Configuration: &types.NetworkConfiguration{
 			FenceMode: types.FenceModeBridged,
 			ParentNetwork: &types.Reference{
-				HREF: externalNetwork.HREF,
-				Name: externalNetwork.Name,
-				Type: externalNetwork.Type,
+				HREF: externalNetwork.ExternalNetwork.HREF,
+				Name: externalNetwork.ExternalNetwork.Name,
+				Type: externalNetwork.ExternalNetwork.Type,
 			},
 			BackwardCompatibilityMode: true,
 		},
@@ -210,7 +211,26 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	// err = task.WaitTaskCompletion()
 	err = task.WaitInspectTaskCompletion(LogTask, 10)
 	if err != nil {
-		fmt.Printf("error performing task: %#v", err)
+		fmt.Printf("error performing task: %s", err)
 	}
+	check.Assert(err, IsNil)
+
+	// Testing RemoveOrgVdcNetworkIfExists:
+	// (1) Make sure the network exists
+	newNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(TestCreateOrgVdcNetworkDirect, true)
+	check.Assert(err, IsNil)
+	check.Assert(newNetwork, NotNil)
+
+	// (2) Removing the network. It should return nil, as a successful deletion
+	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, TestCreateOrgVdcNetworkDirect)
+	check.Assert(err, IsNil)
+
+	// (3) Look for the network again. It should be deleted
+	_, err = vcd.vdc.GetOrgVdcNetworkByName(TestCreateOrgVdcNetworkDirect, true)
+	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
+
+	// (4) Attempting a second conditional deletion. It should also return nil, as the network was not found
+	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, TestCreateOrgVdcNetworkDirect)
 	check.Assert(err, IsNil)
 }

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -20,7 +20,7 @@ func (vcd *TestVCD) Test_NetRefresh(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
 
-	network, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 
 	check.Assert(err, IsNil)
 	check.Assert(network.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -20,7 +20,7 @@ func (vcd *TestVCD) Test_NetRefresh(check *C) {
 
 	fmt.Printf("Running: %s\n", check.TestName())
 
-	network, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	network, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 
 	check.Assert(err, IsNil)
 	check.Assert(network.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
@@ -53,7 +53,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkEGW(check *C) {
 	if edgeGWName == "" {
 		check.Skip("Edge Gateway not provided")
 	}
-	edgeGateway, err := vcd.vdc.FindEdgeGateway(edgeGWName)
+	edgeGateway, err := vcd.vdc.GetEdgeGatewayByName(edgeGWName, false)
 	if err != nil {
 		check.Skip(fmt.Sprintf("Edge Gateway %s not found", edgeGWName))
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -280,11 +280,11 @@ func createEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfig
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	egw, err := vdc.FindEdgeGateway(egwc.Name)
+	egw, err := vdc.GetEdgeGatewayByName(egwc.Name, false)
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	return egw, nil
+	return *egw, nil
 }
 
 // CreateAndConfigureEdgeGateway creates an edge gateway using a full configuration structure

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -187,8 +187,10 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
 			check.Assert(err, IsNil)
 			err = task.WaitTaskCompletion()
 			check.Assert(err, IsNil)
-			edge, err = vcd.vdc.FindEdgeGateway(egc.Name)
+			newEdge, err := vcd.vdc.GetEdgeGatewayByName(egc.Name, true)
 			check.Assert(err, IsNil)
+			check.Assert(newEdge, NotNil)
+			edge = *newEdge
 		}
 
 		AddToCleanupList(egc.Name, "edgegateway", orgName+"|"+vdcName, "Test_CreateDeleteEdgeGateway")
@@ -218,9 +220,9 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
 		}
 
 		// Once deleted, look for the edge gateway again. It should return an error
-		edge, err = vcd.vdc.FindEdgeGateway(egc.Name)
+		newEdge, err := vcd.vdc.GetEdgeGatewayByName(egc.Name, true)
 		check.Assert(err, NotNil)
-		check.Assert(edge, Equals, EdgeGateway{})
+		check.Assert(newEdge, IsNil)
 	}
 }
 

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -521,7 +521,7 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	// Test with two different networks if we have them
 	if config.VCD.Network.Net2 != "" {
 		// Attach second vdc network to vApp
-		vdcNetwork2, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net2, false)
+		vdcNetwork2, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net2, false)
 		check.Assert(err, IsNil)
 		orgvdcnetworks := []*types.OrgVDCNetwork{vdcNetwork2.OrgVDCNetwork}
 		task, err := vapp.AddRAWNetworkConfig(orgvdcnetworks)

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -521,7 +521,7 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	// Test with two different networks if we have them
 	if config.VCD.Network.Net2 != "" {
 		// Attach second vdc network to vApp
-		vdcNetwork2, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net2)
+		vdcNetwork2, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net2, false)
 		check.Assert(err, IsNil)
 		orgvdcnetworks := []*types.OrgVDCNetwork{vdcNetwork2.OrgVDCNetwork}
 		task, err := vapp.AddRAWNetworkConfig(orgvdcnetworks)

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -172,6 +172,7 @@ func (vdc *Vdc) DeleteWait(force bool, recursive bool) error {
 	return nil
 }
 
+// Deprecated: use GetVdcNetworkByName
 func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
 	err := vdc.Refresh()
@@ -194,6 +195,71 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 	}
 
 	return OrgVDCNetwork{}, fmt.Errorf("can't find VDC Network: %s", network)
+}
+
+// GetVdcNetworkByHref returns an Org VDC Network reference if the network HREF matches an existing one.
+// If no valid external network is found, it returns an nil Network reference and an error
+func (vdc *Vdc) GetVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
+
+	orgNet := NewOrgVDCNetwork(vdc.client)
+
+	_, err := vdc.client.ExecuteRequest(href, http.MethodGet,
+		"", "error retrieving org vdc network: %s", nil, orgNet.OrgVDCNetwork)
+
+	// The request was successful
+	return orgNet, err
+}
+
+// GetVdcNetworkByName returns an Org VDC Network reference if the network name matches an existing one.
+// If no valid external network is found, it returns an nil Network reference and an error
+func (vdc *Vdc) GetVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, error) {
+	if refresh {
+		err := vdc.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vdc: %s", err)
+		}
+	}
+	for _, an := range vdc.Vdc.AvailableNetworks {
+		for _, reference := range an.Network {
+			if reference.Name == name {
+				return vdc.GetVdcNetworkByHref(reference.HREF)
+			}
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetVdcNetworkById returns an Org VDC Network reference if the network ID matches an existing one.
+// If no valid external network is found, it returns an nil Network reference and an error
+func (vdc *Vdc) GetVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, error) {
+	if refresh {
+		err := vdc.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vdc: %s", err)
+		}
+	}
+	for _, an := range vdc.Vdc.AvailableNetworks {
+		for _, reference := range an.Network {
+			if reference.ID == id {
+				return vdc.GetVdcNetworkByHref(reference.HREF)
+			}
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetVdcNetworkByNameOrId returns a VDC Network reference if either the network name or ID matches an existing one.
+// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+func (vdc *Vdc) GetVdcNetworkByNameOrId(identifier string, refresh bool) (*OrgVDCNetwork, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVdcNetworkByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVdcNetworkById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
+	return entity.(*OrgVDCNetwork), err
 }
 
 func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error) {
@@ -226,6 +292,7 @@ func (vdc *Vdc) GetDefaultStorageProfileReference(storageprofiles *types.QueryRe
 	return types.Reference{}, fmt.Errorf("can't find Default VDC Storage_profile")
 }
 
+// Deprecated: use GetEdgeGatewayByName
 func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
 	err := vdc.Refresh()
@@ -238,7 +305,7 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 			query := new(types.QueryResultEdgeGatewayRecordsType)
 
 			_, err := vdc.client.ExecuteRequest(av.HREF, http.MethodGet,
-				"", "error quering edge gateways: %s", nil, query)
+				"", "error querying edge gateways: %s", nil, query)
 			if err != nil {
 				return EdgeGateway{}, err
 			}
@@ -284,6 +351,117 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 	}
 	return EdgeGateway{}, fmt.Errorf("can't find Edge Gateway")
 
+}
+
+// getEdgeGatewayByHref retrieves an edge gateway from VDC
+// by querying directly its HREF.
+// The name passed as parameter is only used for error reporting
+func (vdc *Vdc) getEdgeGatewayByHref(name, href string) (*EdgeGateway, error) {
+	if href == "" {
+		return nil, fmt.Errorf("empty HREF for edge gateway '%s'", name)
+	}
+
+	edge := NewEdgeGateway(vdc.client)
+
+	_, err := vdc.client.ExecuteRequest(href, http.MethodGet,
+		"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
+
+	// TODO - remove this if a solution is found or once 9.7 is deprecated
+	// vCD 9.7 has a bug and sometimes it fails to retrieve edge gateway with weird error.
+	// At this point in time the solution is to retry a few times as it does not fail to
+	// retrieve when retried.
+	//
+	// GitHUB issue - https://github.com/vmware/go-vcloud-director/issues/218
+	if err != nil {
+		util.Logger.Printf("[DEBUG] vCD 9.7 is known to sometimes respond with error on edge gateway (%s) "+
+			"retrieval. As a workaround this is done a few times before failing. Retrying: ", name)
+		for i := 1; i < 4 && err != nil; i++ {
+			time.Sleep(200 * time.Millisecond)
+			util.Logger.Printf("%d ", i)
+			_, err = vdc.client.ExecuteRequest(href, http.MethodGet,
+				"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
+		}
+		util.Logger.Printf("\n")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return edge, nil
+}
+
+// getEdgeGatewayRecordsType retrieves a list of edge gateways from VDC
+func (vdc *Vdc) getEdgeGatewayRecordsType(refresh bool) (*types.QueryResultEdgeGatewayRecordsType, error) {
+
+	if refresh {
+		err := vdc.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vdc: %s", err)
+		}
+	}
+	for _, av := range vdc.Vdc.Link {
+		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
+
+			edgeGatewayRecordsType := new(types.QueryResultEdgeGatewayRecordsType)
+
+			_, err := vdc.client.ExecuteRequest(av.HREF, http.MethodGet,
+				"", "error querying edge gateways: %s", nil, edgeGatewayRecordsType)
+			if err != nil {
+				return nil, err
+			}
+			return edgeGatewayRecordsType, nil
+		}
+	}
+	return nil, fmt.Errorf("no edge gateway query link found in VDC %s", vdc.Vdc.Name)
+}
+
+// GetEdgeGatewayByName search the VDC list of edge gateways for a given name.
+// If the name matches, it returns a pointer to an edge gateway object.
+// On failure, it returns a nil object and an error
+func (vdc *Vdc) GetEdgeGatewayByName(name string, refresh bool) (*EdgeGateway, error) {
+	edgeGatewayRecord, err := vdc.getEdgeGatewayRecordsType(refresh)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving edge gateways list: %s", err)
+	}
+
+	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
+		if edge.Name == name {
+			return vdc.getEdgeGatewayByHref(edge.Name, edge.HREF)
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetEdgeGatewayById search VDC list of edge gateways for a given ID.
+// If the id matches, it returns a pointer to an edge gateway object.
+// On failure, it returns a nil object and an error
+func (vdc *Vdc) GetEdgeGatewayById(id string, refresh bool) (*EdgeGateway, error) {
+	edgeGatewayRecord, err := vdc.getEdgeGatewayRecordsType(refresh)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving edge gateways list: %s", err)
+	}
+
+	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
+		if equalIds(id, "", edge.HREF) {
+			return vdc.getEdgeGatewayByHref(edge.Name, edge.HREF)
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// GetEdgeGatewayByNameOrId search the VDC list of edge gateways for a given name or ID.
+// If the name or the ID match, it returns a pointer to an edge gateway object.
+// On failure, it returns a nil object and an error
+func (vdc *Vdc) GetEdgeGatewayByNameOrId(identifier string, refresh bool) (*EdgeGateway, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetEdgeGatewayByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetEdgeGatewayById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
+	return entity.(*EdgeGateway), err
 }
 
 func (vdc *Vdc) ComposeRawVApp(name string) error {

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -172,7 +172,7 @@ func (vdc *Vdc) DeleteWait(force bool, recursive bool) error {
 	return nil
 }
 
-// Deprecated: use GetVdcNetworkByName
+// Deprecated: use GetOrgVdcNetworkByName
 func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
 	err := vdc.Refresh()
@@ -197,9 +197,9 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 	return OrgVDCNetwork{}, fmt.Errorf("can't find VDC Network: %s", network)
 }
 
-// GetVdcNetworkByHref returns an Org VDC Network reference if the network HREF matches an existing one.
+// GetOrgVdcNetworkByHref returns an Org VDC Network reference if the network HREF matches an existing one.
 // If no valid external network is found, it returns an nil Network reference and an error
-func (vdc *Vdc) GetVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
 
 	orgNet := NewOrgVDCNetwork(vdc.client)
 
@@ -210,9 +210,9 @@ func (vdc *Vdc) GetVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
 	return orgNet, err
 }
 
-// GetVdcNetworkByName returns an Org VDC Network reference if the network name matches an existing one.
+// GetOrgVdcNetworkByName returns an Org VDC Network reference if the network name matches an existing one.
 // If no valid external network is found, it returns an nil Network reference and an error
-func (vdc *Vdc) GetVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
 		err := vdc.Refresh()
 		if err != nil {
@@ -222,7 +222,7 @@ func (vdc *Vdc) GetVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, 
 	for _, an := range vdc.Vdc.AvailableNetworks {
 		for _, reference := range an.Network {
 			if reference.Name == name {
-				return vdc.GetVdcNetworkByHref(reference.HREF)
+				return vdc.GetOrgVdcNetworkByHref(reference.HREF)
 			}
 		}
 	}
@@ -230,9 +230,9 @@ func (vdc *Vdc) GetVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, 
 	return nil, ErrorEntityNotFound
 }
 
-// GetVdcNetworkById returns an Org VDC Network reference if the network ID matches an existing one.
+// GetOrgVdcNetworkById returns an Org VDC Network reference if the network ID matches an existing one.
 // If no valid external network is found, it returns an nil Network reference and an error
-func (vdc *Vdc) GetVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
 		err := vdc.Refresh()
 		if err != nil {
@@ -242,7 +242,7 @@ func (vdc *Vdc) GetVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, erro
 	for _, an := range vdc.Vdc.AvailableNetworks {
 		for _, reference := range an.Network {
 			if reference.ID == id {
-				return vdc.GetVdcNetworkByHref(reference.HREF)
+				return vdc.GetOrgVdcNetworkByHref(reference.HREF)
 			}
 		}
 	}
@@ -250,11 +250,11 @@ func (vdc *Vdc) GetVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, erro
 	return nil, ErrorEntityNotFound
 }
 
-// GetVdcNetworkByNameOrId returns a VDC Network reference if either the network name or ID matches an existing one.
+// GetOrgVdcNetworkByNameOrId returns a VDC Network reference if either the network name or ID matches an existing one.
 // If no valid external network is found, it returns an empty ExternalNetwork reference and an error
-func (vdc *Vdc) GetVdcNetworkByNameOrId(identifier string, refresh bool) (*OrgVDCNetwork, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVdcNetworkByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVdcNetworkById(id, refresh) }
+func (vdc *Vdc) GetOrgVdcNetworkByNameOrId(identifier string, refresh bool) (*OrgVDCNetwork, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkById(id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 	}
 	fmt.Printf("Running: %s\n", check.TestName())
 
-	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, true)
 
 	check.Assert(err, IsNil)
 	check.Assert(net, NotNil)
@@ -27,8 +27,47 @@ func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 	check.Assert(net.OrgVDCNetwork.HREF, Not(Equals), "")
 
 	// find Invalid Network
-	net, err = vcd.vdc.FindVDCNetwork("INVALID")
+	net, err = vcd.vdc.GetVdcNetworkByName("INVALID", false)
 	check.Assert(err, NotNil)
+}
+
+// Tests Network retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_GetOrgVDCNetwork(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_GetOrgVDCNetwork: Org name not given.")
+		return
+	}
+	if vcd.config.VCD.Vdc == "" {
+		check.Skip("Test_GetOrgVDCNetwork: VDC name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
+
+	getByName := func(name string, refresh bool) (genericEntity, error) {
+		return vdc.GetVdcNetworkByName(name, refresh)
+	}
+	getById := func(id string, refresh bool) (genericEntity, error) { return vdc.GetVdcNetworkById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
+		return vdc.GetVdcNetworkByNameOrId(id, refresh)
+	}
+
+	var def = getterTestDefinition{
+		parentType:    "Vdc",
+		parentName:    vcd.config.VCD.Vdc,
+		entityType:    "OrgVDCNetwork",
+		entityName:    vcd.config.VCD.Network.Net1,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }
 
 func (vcd *TestVCD) Test_NewVdc(check *C) {
@@ -118,7 +157,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.FindVDCNetwork(vcd.config.VCD.Network.Net1)
+	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	networks = append(networks, net.OrgVDCNetwork)
 	check.Assert(err, IsNil)
@@ -238,4 +277,43 @@ func (vcd *TestVCD) Test_QueryVM(check *C) {
 
 func init() {
 	testingTags["vdc"] = "vdc_test.go"
+}
+
+// Tests Edge Gateway retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_GetEdgeGateway(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_GetEdgeGateway: Org name not given.")
+		return
+	}
+	if vcd.config.VCD.Vdc == "" {
+		check.Skip("Test_GetEdgeGateway: VDC name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
+
+	getByName := func(name string, refresh bool) (genericEntity, error) {
+		return vdc.GetEdgeGatewayByName(name, refresh)
+	}
+	getById := func(id string, refresh bool) (genericEntity, error) { return vdc.GetEdgeGatewayById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
+		return vdc.GetEdgeGatewayByNameOrId(id, refresh)
+	}
+
+	var def = getterTestDefinition{
+		parentType:    "Vdc",
+		parentName:    vcd.config.VCD.Vdc,
+		entityType:    "EdgeGateway",
+		entityName:    vcd.config.VCD.EdgeGateway,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 	}
 	fmt.Printf("Running: %s\n", check.TestName())
 
-	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, true)
+	net, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, true)
 
 	check.Assert(err, IsNil)
 	check.Assert(net, NotNil)
@@ -27,7 +27,7 @@ func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 	check.Assert(net.OrgVDCNetwork.HREF, Not(Equals), "")
 
 	// find Invalid Network
-	net, err = vcd.vdc.GetVdcNetworkByName("INVALID", false)
+	net, err = vcd.vdc.GetOrgVdcNetworkByName("INVALID", false)
 	check.Assert(err, NotNil)
 }
 
@@ -51,11 +51,11 @@ func (vcd *TestVCD) Test_GetOrgVDCNetwork(check *C) {
 	check.Assert(vdc, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return vdc.GetVdcNetworkByName(name, refresh)
+		return vdc.GetOrgVdcNetworkByName(name, refresh)
 	}
-	getById := func(id string, refresh bool) (genericEntity, error) { return vdc.GetVdcNetworkById(id, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return vdc.GetOrgVdcNetworkById(id, refresh) }
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return vdc.GetVdcNetworkByNameOrId(id, refresh)
+		return vdc.GetOrgVdcNetworkByNameOrId(id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -157,7 +157,7 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 	// Populate OrgVDCNetwork
 	networks := []*types.OrgVDCNetwork{}
-	net, err := vcd.vdc.GetVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	net, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	networks = append(networks, net.OrgVDCNetwork)
 	check.Assert(err, IsNil)


### PR DESCRIPTION
* Add GetEdgeGatewayBy{Name|Id|NameOrId}
* Add GetVdcNetworkBy{Name|Id|NameOrId}
* Deprecate FindVDCNetwork and FindEdgeGateway
* Replace deprecated functions with new methods throughout the library
* Add tests for new Get* methods

This work is preparation for network and edge gateway data sources in terraform-provider-vcd