### PR TITLE
Add support for NAT rules using proxied NSX-V API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 * Added methods `vapp.SetProductSectionList` and `vapp.GetProductSectionList` allowing to manipulate
 vApp guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 * Added method GetStorageProfileByHref
+* Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()` [#xx]()
+* Added methods `GetVnicIndexFromNetworkNameType()` and `GetNetworkNameTypeFromVnicIndex()` [#xx]()
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ vApp guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/2
 * Added method GetStorageProfileByHref
 * Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()`
 which use the proxied NSX-V API for handling NAT rules [#241](https://github.com/vmware/go-vcloud-director/pull/241)
-* Added methods `GetVnicIndexFromNetworkNameType()` and `GetNetworkNameTypeFromVnicIndex()` [#241](https://github.com/vmware/go-vcloud-director/pull/241)
+* Added methods `GetVnicIndexByNetworkNameAndType()` and `GetNetworkNameAndTypeByVnicIndex()` [#241](https://github.com/vmware/go-vcloud-director/pull/241)
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 vApp guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 * Added method GetStorageProfileByHref
 * Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()`
-which use the proxied NSX-V API for handling NAT rules [#241](https://github.com/vmware/go-vcloud-director/pull/241)
+which use the proxied NSX-V API of advanced edge gateway for handling NAT rules [#241](https://github.com/vmware/go-vcloud-director/pull/241)
 * Added methods `GetVnicIndexByNetworkNameAndType()` and `GetNetworkNameAndTypeByVnicIndex()` [#241](https://github.com/vmware/go-vcloud-director/pull/241)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 * Added methods `vapp.SetProductSectionList` and `vapp.GetProductSectionList` allowing to manipulate
 vApp guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/235)
 * Added method GetStorageProfileByHref
-* Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()` [#xx]()
-* Added methods `GetVnicIndexFromNetworkNameType()` and `GetNetworkNameTypeFromVnicIndex()` [#xx]()
+* Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()`
+which use the proxied NSX-V API for handling NAT rules [#241](https://github.com/vmware/go-vcloud-director/pull/241)
+* Added methods `GetVnicIndexFromNetworkNameType()` and `GetNetworkNameTypeFromVnicIndex()` [#241](https://github.com/vmware/go-vcloud-director/pull/241)
 
 IMPROVEMENTS:
 

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/vmware/go-vcloud-director v2.0.0+incompatible h1:3B121XZVdEOxRhv5ARswKVxXt4KznAbun8GoXNbbZWs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/vmware/go-vcloud-director v2.0.0+incompatible h1:3B121XZVdEOxRhv5ARswKVxXt4KznAbun8GoXNbbZWs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1168,9 +1168,9 @@ func validateUpdateLBGeneralParams(logLevel string) error {
 	return nil
 }
 
-// GetVnics retrieves a structure of type EdgeGatewayVnics which contains network interfaces
+// getVnics retrieves a structure of type EdgeGatewayVnics which contains network interfaces
 // available in Edge Gateway
-func (egw *EdgeGateway) GetVnics() (*types.EdgeGatewayVnics, error) {
+func (egw *EdgeGateway) getVnics() (*types.EdgeGatewayVnics, error) {
 	if !egw.HasAdvancedNetworking() {
 		return nil, fmt.Errorf("only advanced edge gateway supports vNics")
 	}
@@ -1195,7 +1195,7 @@ func (egw *EdgeGateway) GetVnics() (*types.EdgeGatewayVnics, error) {
 // networkType one of: 'internal', 'uplink', 'trunk', 'subinterface'
 // networkName cannot be empty
 func (egw *EdgeGateway) GetVnicIndexFromNetworkNameType(networkName, networkType string) (*int, error) {
-	vnics, err := egw.GetVnics()
+	vnics, err := egw.getVnics()
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve vNic configuration: %s", err)
 	}
@@ -1205,7 +1205,7 @@ func (egw *EdgeGateway) GetVnicIndexFromNetworkNameType(networkName, networkType
 // GetNetworkNameTypeFromVnicIndex returns network name and network type for given vNic index
 // returned networkType can be one of: 'internal', 'uplink', 'trunk', 'subinterface'
 func (egw *EdgeGateway) GetNetworkNameTypeFromVnicIndex(vNicIndex int) (string, string, error) {
-	vnics, err := egw.GetVnics()
+	vnics, err := egw.getVnics()
 	if err != nil {
 		return "", "", fmt.Errorf("cannot retrieve vNic configuration: %s", err)
 	}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1191,29 +1191,29 @@ func (egw *EdgeGateway) getVnics() (*types.EdgeGatewayVnics, error) {
 	return vnicConfig, nil
 }
 
-// GetVnicIndexFromNetworkNameType returns *int of vNic index for specified network name and network type
+// GetVnicIndexByNetworkNameAndType returns *int of vNic index for specified network name and network type
 // networkType one of: 'internal', 'uplink', 'trunk', 'subinterface'
 // networkName cannot be empty
-func (egw *EdgeGateway) GetVnicIndexFromNetworkNameType(networkName, networkType string) (*int, error) {
+func (egw *EdgeGateway) GetVnicIndexByNetworkNameAndType(networkName, networkType string) (*int, error) {
 	vnics, err := egw.getVnics()
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve vNic configuration: %s", err)
 	}
-	return getVnicIndexFromNetworkNameType(networkName, networkType, vnics)
+	return GetVnicIndexByNetworkNameAndType(networkName, networkType, vnics)
 }
 
-// GetNetworkNameTypeFromVnicIndex returns network name and network type for given vNic index
+// GetNetworkNameAndTypeByVnicIndex returns network name and network type for given vNic index
 // returned networkType can be one of: 'internal', 'uplink', 'trunk', 'subinterface'
-func (egw *EdgeGateway) GetNetworkNameTypeFromVnicIndex(vNicIndex int) (string, string, error) {
+func (egw *EdgeGateway) GetNetworkNameAndTypeByVnicIndex(vNicIndex int) (string, string, error) {
 	vnics, err := egw.getVnics()
 	if err != nil {
 		return "", "", fmt.Errorf("cannot retrieve vNic configuration: %s", err)
 	}
-	return getNetworkNameTypeFromVnicIndex(vNicIndex, vnics)
+	return GetNetworkNameAndTypeByVnicIndex(vNicIndex, vnics)
 }
 
-// getVnicIndexFromNetworkNameType is wrapped and used by public function GetVnicIndexFromNetworkNameType
-func getVnicIndexFromNetworkNameType(networkName, networkType string, vnics *types.EdgeGatewayVnics) (*int, error) {
+// GetVnicIndexByNetworkNameAndType is wrapped and used by public function GetVnicIndexByNetworkNameAndType
+func GetVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *types.EdgeGatewayVnics) (*int, error) {
 	if networkName == "" {
 		return nil, fmt.Errorf("network name cannot be empty")
 	}
@@ -1257,8 +1257,8 @@ func getVnicIndexFromNetworkNameType(networkName, networkType string, vnics *typ
 	return foundIndex, nil
 }
 
-// getNetworkNameTypeFromVnicIndex is wrapped and used by public function GetNetworkNameTypeFromVnicIndex
-func getNetworkNameTypeFromVnicIndex(vNicIndex int, vnics *types.EdgeGatewayVnics) (string, string, error) {
+// GetNetworkNameAndTypeByVnicIndex is wrapped and used by public function GetNetworkNameAndTypeByVnicIndex
+func GetNetworkNameAndTypeByVnicIndex(vNicIndex int, vnics *types.EdgeGatewayVnics) (string, string, error) {
 	if vNicIndex < 0 {
 		return "", "", fmt.Errorf("vNic index cannot be negative")
 	}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1167,3 +1167,22 @@ func validateUpdateLBGeneralParams(logLevel string) error {
 
 	return nil
 }
+
+// GetVnics retrieves a structure of type EdgeGatewayVnics which contains network interfaces
+// available in Edge Gateway
+func (egw *EdgeGateway) GetVnics() (*types.EdgeGatewayVnics, error) {
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeVnicConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+
+	vnicConfig := &types.EdgeGatewayVnics{}
+	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
+		"unable to edge gateway vnic configuration: %s", nil, vnicConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return vnicConfig, nil
+}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1257,6 +1257,7 @@ func getVnicIndexFromNetworkNameType(networkName, networkType string, vnics *typ
 	return foundIndex, nil
 }
 
+// getNetworkNameTypeFromVnicIndex is wrapped and used by public function GetNetworkNameTypeFromVnicIndex
 func getNetworkNameTypeFromVnicIndex(vNicIndex int, vnics *types.EdgeGatewayVnics) (string, string, error) {
 	if vNicIndex < 0 {
 		return "", "", fmt.Errorf("vNic index cannot be negative")

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -596,13 +596,26 @@ func (vcd *TestVCD) TestEdgeGateway_GetVnics(check *C) {
 
 	vnics, err := edge.getVnics()
 	check.Assert(err, IsNil)
+
+	foundExtNet := false
+	foundOrgNet := false
+
 	check.Assert(len(vnics.Vnic) > 1, Equals, true)
-	check.Assert(vnics.Vnic[0].Name, Equals, vcd.config.VCD.ExternalNetwork)
-	check.Assert(vnics.Vnic[0].PortgroupName, Equals, vcd.config.VCD.ExternalNetwork)
-	check.Assert(vnics.Vnic[0].AddressGroups.AddressGroup.PrimaryAddress, Equals, vcd.config.VCD.ExternalIp)
-	check.Assert(vnics.Vnic[0].Type, Equals, "uplink")
+	// Look for both - external and Org networks in returned edge gateway vNics
+	for _, vnic := range vnics.Vnic {
+		// Look for external network attached to Edge gateway
+		if vnic.PortgroupName == vcd.config.VCD.ExternalNetwork {
+			check.Assert(vnic.AddressGroups.AddressGroup.PrimaryAddress, Equals, vcd.config.VCD.ExternalIp)
+			check.Assert(vnic.Type, Equals, "uplink")
+			foundExtNet = true
+		}
 
-	check.Assert(vnics.Vnic[1].Type, Equals, "internal")
-	check.Assert(vnics.Vnic[1].PortgroupName, Equals, vcd.config.VCD.Network.Net1)
-
+		// Look for org network 1 attached
+		if vnic.PortgroupName == vcd.config.VCD.Network.Net1 {
+			check.Assert(vnic.Type, Equals, "internal")
+			foundOrgNet = true
+		}
+	}
+	check.Assert(foundExtNet, Equals, true)
+	check.Assert(foundOrgNet, Equals, true)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -594,7 +594,7 @@ func (vcd *TestVCD) TestEdgeGateway_GetVnics(check *C) {
 		check.Skip("Skipping test because the edge gateway does not have advanced networking enabled")
 	}
 
-	vnics, err := edge.GetVnics()
+	vnics, err := edge.getVnics()
 	check.Assert(err, IsNil)
 	check.Assert(len(vnics.Vnic) > 1, Equals, true)
 	check.Assert(vnics.Vnic[0].Name, Equals, vcd.config.VCD.ExternalNetwork)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -582,3 +582,27 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	// Validate load balancer configuration against initially cached version
 	testCheckLoadBalancerConfig(beforeLb, beforeLbXml, edge, check)
 }
+
+func (vcd *TestVCD) TestEdgeGateway_GetVnics(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gatway given")
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	if !edge.HasAdvancedNetworking() {
+		check.Skip("Skipping test because the edge gateway does not have advanced networking enabled")
+	}
+
+	vnics, err := edge.GetVnics()
+	check.Assert(err, IsNil)
+	check.Assert(len(vnics.Vnic) > 1, Equals, true)
+	check.Assert(vnics.Vnic[0].Name, Equals, vcd.config.VCD.ExternalNetwork)
+	check.Assert(vnics.Vnic[0].PortgroupName, Equals, vcd.config.VCD.ExternalNetwork)
+	check.Assert(vnics.Vnic[0].AddressGroups.AddressGroup.PrimaryAddress, Equals, vcd.config.VCD.ExternalIp)
+	check.Assert(vnics.Vnic[0].Type, Equals, "uplink")
+
+	check.Assert(vnics.Vnic[1].Type, Equals, "internal")
+	check.Assert(vnics.Vnic[1].PortgroupName, Equals, vcd.config.VCD.Network.Net1)
+
+}

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -273,7 +273,7 @@ func Test_getVnicIndexFromNetworkNameType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vnicIndex, err := getVnicIndexFromNetworkNameType(tt.networkName, tt.networkType, vnicObject)
+			vnicIndex, err := GetVnicIndexByNetworkNameAndType(tt.networkName, tt.networkType, vnicObject)
 
 			if !tt.hasError && err != nil {
 				t.Errorf("error was not expected: %s", err)
@@ -534,7 +534,7 @@ func Test_getNetworkNameTypeFromVnicIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			networkName, networkType, err := getNetworkNameTypeFromVnicIndex(tt.vnicIndex, vnicObject)
+			networkName, networkType, err := GetNetworkNameAndTypeByVnicIndex(tt.vnicIndex, vnicObject)
 
 			if !tt.hasError && err != nil {
 				t.Errorf("error was not expected: %s", err)

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -7,8 +7,13 @@
 package govcd
 
 import (
+	"encoding/xml"
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func TestGetPseudoUUID(t *testing.T) {
@@ -29,4 +34,266 @@ func TestGetPseudoUUID(t *testing.T) {
 		}
 		seen[uuid] = N
 	}
+}
+
+func Test_getVnicIndexFromNetworkNameType(t *testing.T) {
+	// sample body for unit testing. vNic4 interface is made to contain duplicate network
+	// name on purpose (not a real respone from API)
+	sampleBody := []byte(`
+	<vnics>
+  <vnic>
+    <label>vNic_0</label>
+    <name>my-ext-network</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>192.168.1.110</primaryAddress>
+        <secondaryAddresses>
+          <ipAddress>192.168.1.118</ipAddress>
+          <ipAddress>192.168.1.115</ipAddress>
+          <ipAddress>192.168.1.116</ipAddress>
+          <ipAddress>192.168.1.117</ipAddress>
+        </secondaryAddresses>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>uplink</type>
+    <isConnected>true</isConnected>
+    <index>0</index>
+    <portgroupId>f2547dd9-e0f7-4d81-97c1-dd33e5e0fbbf</portgroupId>
+    <portgroupName>my-ext-network</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_1</label>
+    <name>vnic1</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>10.10.10.5</primaryAddress>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>true</isConnected>
+    <index>1</index>
+    <portgroupId>95bffe8e-7e67-452d-abf2-535ac298db2b</portgroupId>
+    <portgroupName>my-vdc-int-net</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_2</label>
+    <name>vdcf9daf2da-b4f9-4921-a2f4-d77a943a381c</name>
+    <addressGroups/>
+    <mtu>1600</mtu>
+    <type>trunk</type>
+    <subInterfaces>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_10</label>
+        <name>vnic1-subinterface</name>
+        <index>10</index>
+        <tunnelId>1</tunnelId>
+        <logicalSwitchId>9a222ba9-23bc-41bf-b10f-0168f87b80ab</logicalSwitchId>
+        <logicalSwitchName>with-subinterfaces</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>3.3.3.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_11</label>
+        <name>vnic2-subinterface</name>
+        <index>11</index>
+        <tunnelId>2</tunnelId>
+        <logicalSwitchId>aecdf098-13ea-4ddf-9c4b-6a06372aa163</logicalSwitchId>
+        <logicalSwitchName>subinterface2</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>7.7.7.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_12</label>
+        <name>vnic3-subinterface</name>
+        <index>12</index>
+        <tunnelId>3</tunnelId>
+        <logicalSwitchId>c489d85d-df17-409c-810e-12af5aa5c1c2</logicalSwitchId>
+        <logicalSwitchName>subinterface-subnet-clash</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>4.3.3.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+    </subInterfaces>
+    <isConnected>true</isConnected>
+    <index>2</index>
+    <portgroupId>dvportgroup-20228</portgroupId>
+    <portgroupName>dvs.VCDVS-Trunk-Portgroup-vdcf9daf2da-b4f9-4921-a2f4-d77a943a381c</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_3</label>
+    <name>vnic3</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>13.13.1.1</primaryAddress>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>true</isConnected>
+    <index>3</index>
+    <portgroupId>96a68fd4-c21a-41d6-98a4-fbf32c96480f</portgroupId>
+    <portgroupName>my-vdc-int-net2</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_4</label>
+    <name>vnic4</name>
+    <addressGroups>
+	<addressGroup>
+		<primaryAddress>13.13.1.1</primaryAddress>
+		<subnetMask>255.255.255.0</subnetMask>
+		<subnetPrefixLength>24</subnetPrefixLength>
+	</addressGroup>
+	</addressGroups>
+	<mtu>1500</mtu>
+	<type>internal</type>
+	<isConnected>true</isConnected>
+	<index>3</index>
+	<portgroupId>96a68fd4-c21a-41d6-98a4-fbf32c96480f</portgroupId>
+	<portgroupName>my-vdc-int-net2</portgroupName>
+	<enableProxyArp>false</enableProxyArp>
+	<enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_5</label>
+    <name>vnic5</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>5</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_6</label>
+    <name>vnic6</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>6</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_7</label>
+    <name>vnic7</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>7</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_8</label>
+    <name>vnic8</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>8</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_9</label>
+    <name>vnic9</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>9</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+</vnics>`)
+	vnicObject := &types.EdgeGatewayVnics{}
+
+	_ = xml.Unmarshal(sampleBody, vnicObject)
+
+	tests := []struct {
+		name              string
+		networkName       string
+		networkType       string
+		expectedVnicIndex *int
+		hasError          bool
+		expectedError     error
+	}{
+		{"ExtNetwork", "my-ext-network", types.EdgeGatewayVnicTypeUplink, takeAddress(0), false, nil},
+		{"OrgNetwork", "my-vdc-int-net", types.EdgeGatewayVnicTypeInternal, takeAddress(1), false, nil},
+		{"WithSubinterfaces", "with-subinterfaces", types.EdgeGatewayVnicTypeSubinterface, takeAddress(10), false, nil},
+		{"WithSubinterfaces2", "subinterface2", types.EdgeGatewayVnicTypeSubinterface, takeAddress(11), false, nil},
+		{"Trunk", "dvs.VCDVS-Trunk-Portgroup-vdcf9daf2da-b4f9-4921-a2f4-d77a943a381c", types.EdgeGatewayVnicTypeTrunk, takeAddress(2), false, nil},
+		{"NonExistingUplink", "invalid-network-name", types.EdgeGatewayVnicTypeUplink, nil, true, ErrorEntityNotFound},
+		{"NonExistingInternal", "invalid-network-name", types.EdgeGatewayVnicTypeInternal, nil, true, ErrorEntityNotFound},
+		{"NonExistingSubinterface", "invalid-network-name", types.EdgeGatewayVnicTypeSubinterface, nil, true, ErrorEntityNotFound},
+		{"NonExistingTrunk", "invalid-network-name", types.EdgeGatewayVnicTypeTrunk, nil, true, ErrorEntityNotFound},
+		{"MoreThanOne", "my-vdc-int-net2", types.EdgeGatewayVnicTypeInternal, nil, true,
+			fmt.Errorf("more than one (2) networks of type 'internal' with name 'my-vdc-int-net2' found")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vnicIndex, err := getVnicIndexFromNetworkNameType(tt.networkName, tt.networkType, vnicObject)
+
+			if !tt.hasError && err != nil {
+				t.Errorf("error was not expected: %s", err)
+			}
+
+			if tt.hasError && !strings.Contains(err.Error(), tt.expectedError.Error()) {
+				t.Errorf("Got unexpected error: %s, expected: %s", err, tt.expectedError)
+			}
+
+			if vnicIndex != nil && tt.expectedVnicIndex != nil && *vnicIndex != *tt.expectedVnicIndex {
+				t.Errorf("Got unexpected vNic name: %d, expected: %d", vnicIndex, tt.expectedVnicIndex)
+			}
+
+		})
+	}
+
+}
+
+// takeAddress is a helper which can gives address of `int`
+func takeAddress(x int) *int {
+	return &x
 }

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -249,7 +249,6 @@ func Test_getVnicIndexFromNetworkNameType(t *testing.T) {
   </vnic>
 </vnics>`)
 	vnicObject := &types.EdgeGatewayVnics{}
-
 	_ = xml.Unmarshal(sampleBody, vnicObject)
 
 	tests := []struct {
@@ -291,6 +290,251 @@ func Test_getVnicIndexFromNetworkNameType(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_getNetworkNameTypeFromVnicIndex(t *testing.T) {
+	// sample body for unit testing. vNic4 interface is made to contain duplicate network
+	// name on purpose (not a real respone from API)
+	sampleBody := []byte(`
+	<vnics>
+  <vnic>
+    <label>vNic_0</label>
+    <name>my-ext-network</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>192.168.1.110</primaryAddress>
+        <secondaryAddresses>
+          <ipAddress>192.168.1.118</ipAddress>
+          <ipAddress>192.168.1.115</ipAddress>
+          <ipAddress>192.168.1.116</ipAddress>
+          <ipAddress>192.168.1.117</ipAddress>
+        </secondaryAddresses>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>uplink</type>
+    <isConnected>true</isConnected>
+    <index>0</index>
+    <portgroupId>f2547dd9-e0f7-4d81-97c1-dd33e5e0fbbf</portgroupId>
+    <portgroupName>my-ext-network</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_1</label>
+    <name>vnic1</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>10.10.10.5</primaryAddress>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>true</isConnected>
+    <index>1</index>
+    <portgroupId>95bffe8e-7e67-452d-abf2-535ac298db2b</portgroupId>
+    <portgroupName>my-vdc-int-net</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_2</label>
+    <name>vdcf9daf2da-b4f9-4921-a2f4-d77a943a381c</name>
+    <addressGroups/>
+    <mtu>1600</mtu>
+    <type>trunk</type>
+    <subInterfaces>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_10</label>
+        <name>vnic1-subinterface</name>
+        <index>10</index>
+        <tunnelId>1</tunnelId>
+        <logicalSwitchId>9a222ba9-23bc-41bf-b10f-0168f87b80ab</logicalSwitchId>
+        <logicalSwitchName>with-subinterfaces</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>3.3.3.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_11</label>
+        <name>vnic2-subinterface</name>
+        <index>11</index>
+        <tunnelId>2</tunnelId>
+        <logicalSwitchId>aecdf098-13ea-4ddf-9c4b-6a06372aa163</logicalSwitchId>
+        <logicalSwitchName>subinterface2</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>7.7.7.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+      <subInterface>
+        <isConnected>true</isConnected>
+        <label>vNic_12</label>
+        <name>vnic3-subinterface</name>
+        <index>12</index>
+        <tunnelId>3</tunnelId>
+        <logicalSwitchId>c489d85d-df17-409c-810e-12af5aa5c1c2</logicalSwitchId>
+        <logicalSwitchName>subinterface-subnet-clash</logicalSwitchName>
+        <enableSendRedirects>true</enableSendRedirects>
+        <mtu>1500</mtu>
+        <addressGroups>
+          <addressGroup>
+            <primaryAddress>4.3.3.1</primaryAddress>
+            <subnetMask>255.255.255.0</subnetMask>
+            <subnetPrefixLength>24</subnetPrefixLength>
+          </addressGroup>
+        </addressGroups>
+      </subInterface>
+    </subInterfaces>
+    <isConnected>true</isConnected>
+    <index>2</index>
+    <portgroupId>dvportgroup-20228</portgroupId>
+    <portgroupName>dvs.VCDVS-Trunk-Portgroup-vdcf9daf2da-b4f9-4921-a2f4-d77a943a381c</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_3</label>
+    <name>vnic3</name>
+    <addressGroups>
+      <addressGroup>
+        <primaryAddress>13.13.1.1</primaryAddress>
+        <subnetMask>255.255.255.0</subnetMask>
+        <subnetPrefixLength>24</subnetPrefixLength>
+      </addressGroup>
+    </addressGroups>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>true</isConnected>
+    <index>3</index>
+    <portgroupId>96a68fd4-c21a-41d6-98a4-fbf32c96480f</portgroupId>
+    <portgroupName>my-vdc-int-net2</portgroupName>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_4</label>
+    <name>vnic4</name>
+    <addressGroups>
+	<addressGroup>
+		<primaryAddress>13.13.1.1</primaryAddress>
+		<subnetMask>255.255.255.0</subnetMask>
+		<subnetPrefixLength>24</subnetPrefixLength>
+	</addressGroup>
+	</addressGroups>
+	<mtu>1500</mtu>
+	<type>internal</type>
+	<isConnected>true</isConnected>
+	<index>3</index>
+	<portgroupId>96a68fd4-c21a-41d6-98a4-fbf32c96480f</portgroupId>
+	<portgroupName>my-vdc-int-net2</portgroupName>
+	<enableProxyArp>false</enableProxyArp>
+	<enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_5</label>
+    <name>vnic5</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>5</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_6</label>
+    <name>vnic6</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>6</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_7</label>
+    <name>vnic7</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>7</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_8</label>
+    <name>vnic8</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>8</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+  <vnic>
+    <label>vNic_9</label>
+    <name>vnic9</name>
+    <addressGroups/>
+    <mtu>1500</mtu>
+    <type>internal</type>
+    <isConnected>false</isConnected>
+    <index>9</index>
+    <enableProxyArp>false</enableProxyArp>
+    <enableSendRedirects>true</enableSendRedirects>
+  </vnic>
+</vnics>`)
+	vnicObject := &types.EdgeGatewayVnics{}
+	_ = xml.Unmarshal(sampleBody, vnicObject)
+
+	tests := []struct {
+		name                string
+		vnicIndex           int
+		expectednetworkName string
+		expectednetworkType string
+		hasError            bool
+		expectedError       error
+	}{
+		{"0", 0, "my-ext-network", "uplink", false, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vnicIndex, err := getVnicIndexFromNetworkNameType(tt.networkName, tt.networkType, vnicObject)
+
+			if !tt.hasError && err != nil {
+				t.Errorf("error was not expected: %s", err)
+			}
+
+			if tt.hasError && !strings.Contains(err.Error(), tt.expectedError.Error()) {
+				t.Errorf("Got unexpected error: %s, expected: %s", err, tt.expectedError)
+			}
+
+			if vnicIndex != nil && tt.expectedVnicIndex != nil && *vnicIndex != *tt.expectedVnicIndex {
+				t.Errorf("Got unexpected vNic name: %d, expected: %d", vnicIndex, tt.expectedVnicIndex)
+			}
+
+		})
+	}
 }
 
 // takeAddress is a helper which can gives address of `int`

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -69,8 +69,11 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	// Wait until vApp becomes configurable
 	initialVappStatus, err := vapp.GetStatus()
 	check.Assert(err, IsNil)
-	err = vapp.BlockWhileStatus(initialVappStatus, vapp.client.MaxRetryTimeout)
-	check.Assert(err, IsNil)
+	if initialVappStatus != "RESOLVED" { // RESOLVED vApp is ready to accept operations
+		err = vapp.BlockWhileStatus(initialVappStatus, vapp.client.MaxRetryTimeout)
+		check.Assert(err, IsNil)
+	}
+
 	fmt.Printf(". Done\n")
 
 	fmt.Printf("# Attaching vDC network '%s' to vApp '%s'", vcd.config.VCD.Network.Net1, TestLb)

--- a/govcd/nat.go
+++ b/govcd/nat.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func (egw *EdgeGateway) CreateSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
+	if err := validateCreateSnatRule(snatRuleConfig, egw); err != nil {
+		return nil, err
+	}
+
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+	// We expect to get http.StatusCreated or if not an error of type types.NSXError
+	resp, err := egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPost, types.AnyXMLMime,
+		"error creating SNAT rule: %s", snatRuleConfig, &types.NSXError{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Location header should look similar to:
+	// [/network/edges/edge-3/loadbalancer/config/applicationrules/applicationRule-4]
+	lbAppRuleId, err := extractNsxObjectIdFromPath(resp.Header.Get("Location"))
+	if err != nil {
+		return nil, err
+	}
+
+	readAppRule, err := egw.GetSnatRule(&types.EdgeSnatRule{ID: lbAppRuleId})
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve application rule with ID (%s) after creation: %s",
+			lbAppRuleId, err)
+	}
+	return readAppRule, nil
+}
+
+func (egw *EdgeGateway) UpdateSnatRule(SnatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
+	return nil, nil
+}
+
+func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
+	if err := validateGetSnatRule(snatRuleConfig, egw); err != nil {
+		return nil, err
+	}
+
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeNatPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+
+	// Anonymous struct to unwrap response
+	natRuleResponse := &struct {
+		EdgeSnatRules []*types.EdgeSnatRule `xml:"natRules"`
+	}{}
+
+	// This query returns all application rules as the API does not have filtering options
+	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
+		"unable to read SNAT rule: %s", nil, natRuleResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	// Search for nat rule by ID or by Name
+	for _, rule := range natRuleResponse.EdgeSnatRules {
+		// If ID was specified for lookup - look for the same ID
+		if rule.ID != "" && rule.ID == snatRuleConfig.ID {
+			return rule, nil
+		}
+	}
+
+	// 	// If Name was specified for lookup - look for the same Name
+	// 	if lbAppRuleConfig.Name != "" && rule.Name == lbAppRuleConfig.Name {
+	// 		// We found it by name. Let's verify if search ID was specified and it matches the lookup object
+	// 		if lbAppRuleConfig.ID != "" && rule.ID != lbAppRuleConfig.ID {
+	// 			return nil, fmt.Errorf("load balancer application rule was found by name (%s)"+
+	// 				", but its ID (%s) does not match specified ID (%s)",
+	// 				rule.Name, rule.ID, lbAppRuleConfig.ID)
+	// 		}
+	// 		return rule, nil
+	// 	}
+	// }
+
+	return nil, ErrorEntityNotFound
+}
+
+func (egw *EdgeGateway) DeleteSnatRule(SnatRuleConfig *types.EdgeSnatRule) error {
+	return nil
+}
+
+func validateCreateSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
+	if !egw.HasAdvancedNetworking() {
+		return fmt.Errorf("only advanced edge gateways support SNAT rules")
+	}
+
+	// if snatRuleConfig.RuleType == "" {
+	// 	return fmt.Errorf("SnatRule")
+	// }
+
+	return nil
+}
+
+func validateGetSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
+	if !egw.HasAdvancedNetworking() {
+		return fmt.Errorf("only advanced edge gateways support SNAT rules")
+	}
+
+	// if snatRuleConfig.RuleType == "" {
+	// 	return fmt.Errorf("SnatRule")
+	// }
+
+	return nil
+}

--- a/govcd/nat.go
+++ b/govcd/nat.go
@@ -14,9 +14,9 @@ import (
 
 // wrappedEdgeSnatRules is used to unwrap response when retrieving
 type wrappedEdgeSnatRules struct {
-	XMLName  xml.Name `xml:"nat"`
-	Version  string   `xml:"version"`
-	NatR types.EdgeSnatRules   `xml:"natRules"`
+	XMLName xml.Name            `xml:"nat"`
+	Version string              `xml:"version"`
+	NatR    types.EdgeSnatRules `xml:"natRules"`
 }
 
 func (egw *EdgeGateway) CreateSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
@@ -80,12 +80,11 @@ func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.
 		return nil, err
 	}
 
-
 	fmt.Printf("whole struct %+#v\n", natRuleResponse)
 
 	// Search for nat rule by ID or by Name
 	// for _, rule := range natRuleResponse.NatRules.EdgeSnatRules  {
-	for _, rule := range natRuleResponse.NatR.EdgeSnatRules  {
+	for _, rule := range natRuleResponse.NatR.EdgeSnatRules {
 		// If ID was specified for lookup - look for the same ID
 		fmt.Printf("checking %+#v\n", rule)
 		if rule.ID != "" && rule.ID == snatRuleConfig.ID {
@@ -132,10 +131,6 @@ func validateGetSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) e
 	if !egw.HasAdvancedNetworking() {
 		return fmt.Errorf("only advanced edge gateways support SNAT rules")
 	}
-
-	// if snatRuleConfig.RuleType == "" {
-	// 	return fmt.Errorf("SnatRule")
-	// }
 
 	return nil
 }

--- a/govcd/nat.go
+++ b/govcd/nat.go
@@ -12,28 +12,28 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-// requestEdgeSnatRules nests EdgeSnatRule as a convenience for unmarshalling POST requests
-type requestEdgeSnatRules struct {
+// requestEdgeNatRules nests EdgeNatRule as a convenience for unmarshalling POST requests
+type requestEdgeNatRules struct {
 	XMLName       xml.Name              `xml:"natRules"`
-	EdgeSnatRules []*types.EdgeSnatRule `xml:"natRule"`
+	EdgeNatRules []*types.EdgeNatRule `xml:"natRule"`
 }
 
-// responseEdgeSnatRules is used to unwrap response when retrieving
-type responseEdgeSnatRules struct {
+// responseEdgeNatRules is used to unwrap response when retrieving
+type responseEdgeNatRules struct {
 	XMLName  xml.Name             `xml:"nat"`
 	Version  string               `xml:"version"`
-	NatRules requestEdgeSnatRules `xml:"natRules"`
+	NatRules requestEdgeNatRules `xml:"natRules"`
 }
 
-// CreateSnatRule
-func (egw *EdgeGateway) CreateSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
-	if err := validateCreateSnatRule(snatRuleConfig, egw); err != nil {
+// CreateNatRule
+func (egw *EdgeGateway) CreateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
+	if err := validateCreateNsxvNatRule(natRuleConfig, egw); err != nil {
 		return nil, err
 	}
 
 	// Wrap the provided rule for POST request
-	natRuleRequest := requestEdgeSnatRules{
-		EdgeSnatRules: []*types.EdgeSnatRule{snatRuleConfig},
+	natRuleRequest := requestEdgeNatRules{
+		EdgeNatRules: []*types.EdgeNatRule{natRuleConfig},
 	}
 
 	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath)
@@ -42,54 +42,54 @@ func (egw *EdgeGateway) CreateSnatRule(snatRuleConfig *types.EdgeSnatRule) (*typ
 	}
 	// We expect to get http.StatusCreated or if not an error of type types.NSXError
 	resp, err := egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPost, types.AnyXMLMime,
-		"error creating SNAT rule: %s", natRuleRequest, &types.NSXError{})
+		"error creating NAT rule: %s", natRuleRequest, &types.NSXError{})
 	if err != nil {
 		return nil, err
 	}
 
 	// Location header should look similar to:
 	// [/network/edges/edge-1/nat/config/rules/197157]
-	snatRuleId, err := extractNsxObjectIdFromPath(resp.Header.Get("Location"))
+	natRuleId, err := extractNsxObjectIdFromPath(resp.Header.Get("Location"))
 	if err != nil {
 		return nil, err
 	}
 
-	readSnatRule, err := egw.GetSnatRule(&types.EdgeSnatRule{ID: snatRuleId})
+	readNatRule, err := egw.GetNsxvNatRule(&types.EdgeNatRule{ID: natRuleId})
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve SNAT rule with ID (%s) after creation: %s",
-			snatRuleId, err)
+		return nil, fmt.Errorf("unable to retrieve NAT rule with ID (%s) after creation: %s",
+			natRuleId, err)
 	}
-	return readSnatRule, nil
+	return readNatRule, nil
 }
 
-func (egw *EdgeGateway) UpdateSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
-	err := validateUpdateSnatRule(snatRuleConfig, egw)
+func (egw *EdgeGateway) UpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
+	err := validateUpdateNsxvNatRule(natRuleConfig, egw)
 	if err != nil {
 		return nil, err
 	}
 	
-	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath + "/" + snatRuleConfig.ID)
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath + "/" + natRuleConfig.ID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
 
 	// Result should be 204, if not we expect an error of type types.NSXError
 	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPut, types.AnyXMLMime,
-		"error while updating NAT rule : %s", snatRuleConfig, &types.NSXError{})
+		"error while updating NAT rule : %s", natRuleConfig, &types.NSXError{})
 	if err != nil {
 		return nil, err
 	}
 
-	readSnatRule, err := egw.GetSnatRuleById(snatRuleConfig.ID)
+	readNatRule, err := egw.GetNsxvNatRuleById(natRuleConfig.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve NAT rule with ID (%s) after update: %s",
-		readSnatRule.ID, err)
+		readNatRule.ID, err)
 	}
-	return readSnatRule, nil
+	return readNatRule, nil
 }
 
-func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.EdgeSnatRule, error) {
-	if err := validateGetSnatRule(snatRuleConfig, egw); err != nil {
+func (egw *EdgeGateway) GetNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
+	if err := validateGetNsxvNatRule(natRuleConfig, egw); err != nil {
 		return nil, err
 	}
 
@@ -98,11 +98,11 @@ func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.
 		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
 
-	natRuleResponse := &responseEdgeSnatRules{}
+	natRuleResponse := &responseEdgeNatRules{}
 
 	// This query returns all application rules as the API does not have filtering options
 	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
-		"unable to read SNAT rule: %s", nil, natRuleResponse)
+		"unable to read NAT rule: %s", nil, natRuleResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +110,11 @@ func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.
 	// fmt.Printf("whole struct %+#v\n", natRuleResponse)
 
 	// Search for nat rule by ID or by Name
-	// for _, rule := range natRuleResponse.NatRules.EdgeSnatRules  {
-	for _, rule := range natRuleResponse.NatRules.EdgeSnatRules {
+	// for _, rule := range natRuleResponse.NatRules.EdgeNatRules  {
+	for _, rule := range natRuleResponse.NatRules.EdgeNatRules {
 		// If ID was specified for lookup - look for the same ID
 		// fmt.Printf("checking %+#v\n", rule)
-		if rule.ID != "" && rule.ID == snatRuleConfig.ID {
+		if rule.ID != "" && rule.ID == natRuleConfig.ID {
 			return rule, nil
 		}
 	}
@@ -134,17 +134,17 @@ func (egw *EdgeGateway) GetSnatRule(snatRuleConfig *types.EdgeSnatRule) (*types.
 	return nil, ErrorEntityNotFound
 }
 
-func (egw *EdgeGateway) GetSnatRuleById(id string) (*types.EdgeSnatRule, error) {
-	return egw.GetSnatRule(&types.EdgeSnatRule{ID: id})
+func (egw *EdgeGateway) GetNsxvNatRuleById(id string) (*types.EdgeNatRule, error) {
+	return egw.GetNsxvNatRule(&types.EdgeNatRule{ID: id})
 }
 
-func (egw *EdgeGateway) DeleteSnatRule(snatRuleConfig *types.EdgeSnatRule) error {
-	err := validateDeleteSnatRule(snatRuleConfig, egw)
+func (egw *EdgeGateway) DeleteNsxvNatRule(natRuleConfig *types.EdgeNatRule) error {
+	err := validateDeleteNsxvNatRule(natRuleConfig, egw)
 	if err != nil {
 		return err
 	}
 
-	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath + "/" + snatRuleConfig.ID)
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath + "/" + natRuleConfig.ID)
 	if err != nil {
 		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
 	}
@@ -158,46 +158,46 @@ func (egw *EdgeGateway) DeleteSnatRule(snatRuleConfig *types.EdgeSnatRule) error
 	return nil
 }
 
-func (egw *EdgeGateway) DeleteSnatRuleById(id string) error {
-	return egw.DeleteSnatRule(&types.EdgeSnatRule{ID: id})
+func (egw *EdgeGateway) DeleteNsxvNatRuleById(id string) error {
+	return egw.DeleteNsxvNatRule(&types.EdgeNatRule{ID: id})
 }
 
-func validateCreateSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
+func validateCreateNsxvNatRule(natRuleConfig *types.EdgeNatRule, egw *EdgeGateway) error {
 	if !egw.HasAdvancedNetworking() {
-		return fmt.Errorf("only advanced edge gateways support SNAT rules")
+		return fmt.Errorf("only advanced edge gateways support NAT rules")
 	}
 
-	if snatRuleConfig.Action == "" {
+	if natRuleConfig.Action == "" {
 		return fmt.Errorf("NAT rule must have an action")
 	}
 
-	if snatRuleConfig.TranslatedAddress == "" {
+	if natRuleConfig.TranslatedAddress == "" {
 		return fmt.Errorf("NAT rule must translated address specified")
 	}
 
 	return nil
 }
 
-func validateUpdateSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
-	if snatRuleConfig.ID == "" {
+func validateUpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule, egw *EdgeGateway) error {
+	if natRuleConfig.ID == "" {
 		return fmt.Errorf("NAT rule must ID must be set for update")
 	}
 
-	return validateCreateSnatRule(snatRuleConfig, egw)
+	return validateCreateNsxvNatRule(natRuleConfig, egw)
 }
 
-func validateGetSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
+func validateGetNsxvNatRule(natRuleConfig *types.EdgeNatRule, egw *EdgeGateway) error {
 	if !egw.HasAdvancedNetworking() {
-		return fmt.Errorf("only advanced edge gateways support SNAT rules")
+		return fmt.Errorf("only advanced edge gateways support NAT rules")
 	}
 
-	if snatRuleConfig.ID == "" {
-		return fmt.Errorf("unable to retrieve SNAT rule without ID")
+	if natRuleConfig.ID == "" {
+		return fmt.Errorf("unable to retrieve NAT rule without ID")
 	}
 
 	return nil
 }
 
-func validateDeleteSnatRule(snatRuleConfig *types.EdgeSnatRule, egw *EdgeGateway) error {
-	return validateGetSnatRule(snatRuleConfig, egw)
+func validateDeleteNsxvNatRule(natRuleConfig *types.EdgeNatRule, egw *EdgeGateway) error {
+	return validateGetNsxvNatRule(natRuleConfig, egw)
 }

--- a/govcd/nat.go
+++ b/govcd/nat.go
@@ -26,7 +26,8 @@ type responseEdgeNatRules struct {
 	NatRules requestEdgeNatRules `xml:"natRules"`
 }
 
-// CreateNatRule
+// CreateNsxvNatRule creates NAT rule using proxied NSX-V API. It is a synchronuous operation.
+// It returns an object with all fields populated (including ID)
 func (egw *EdgeGateway) CreateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
 	if err := validateCreateNsxvNatRule(natRuleConfig, egw); err != nil {
 		return nil, err
@@ -57,7 +58,7 @@ func (egw *EdgeGateway) CreateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*ty
 
 	time.Sleep(5 * time.Second)
 
-	readNatRule, err := egw.GetNsxvNatRule(&types.EdgeNatRule{ID: natRuleId})
+	readNatRule, err := egw.getNsxvNatRule(&types.EdgeNatRule{ID: natRuleId})
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve NAT rule with ID (%s) after creation: %s",
 			natRuleId, err)
@@ -65,6 +66,8 @@ func (egw *EdgeGateway) CreateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*ty
 	return readNatRule, nil
 }
 
+// UpdateNsxvNatRule updates types.EdgeNatRule with all fields using proxied NSX-V API. ID is
+// mandatory to perform the update.
 func (egw *EdgeGateway) UpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
 	err := validateUpdateNsxvNatRule(natRuleConfig, egw)
 	if err != nil {
@@ -91,7 +94,7 @@ func (egw *EdgeGateway) UpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*ty
 	return readNatRule, nil
 }
 
-func (egw *EdgeGateway) GetNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
+func (egw *EdgeGateway) getNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types.EdgeNatRule, error) {
 	if err := validateGetNsxvNatRule(natRuleConfig, egw); err != nil {
 		return nil, err
 	}
@@ -119,8 +122,11 @@ func (egw *EdgeGateway) GetNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*types
 	return nil, ErrorEntityNotFound
 }
 
+// GetNsxvNatRuleById retrieves types.EdgeNatRule by NAT rule ID as shown in the UI using proxied
+// NSX-V API.
+// It returns and error `ErrorEntityNotFound` if the NAT rule is now found.
 func (egw *EdgeGateway) GetNsxvNatRuleById(id string) (*types.EdgeNatRule, error) {
-	return egw.GetNsxvNatRule(&types.EdgeNatRule{ID: id})
+	return egw.getNsxvNatRule(&types.EdgeNatRule{ID: id})
 }
 
 func (egw *EdgeGateway) deleteNsxvNatRule(natRuleConfig *types.EdgeNatRule) error {
@@ -149,6 +155,9 @@ func (egw *EdgeGateway) deleteNsxvNatRule(natRuleConfig *types.EdgeNatRule) erro
 	return nil
 }
 
+// DeleteNsxvNatRuleById deletes types.EdgeNatRule by NAT rule ID as shown in the UI using proxied
+// NSX-V API.
+// It returns and error `ErrorEntityNotFound` if the NAT rule is now found.
 func (egw *EdgeGateway) DeleteNsxvNatRuleById(id string) error {
 	return egw.deleteNsxvNatRule(&types.EdgeNatRule{ID: id})
 }

--- a/govcd/nat.go
+++ b/govcd/nat.go
@@ -14,14 +14,14 @@ import (
 
 // requestEdgeNatRules nests EdgeNatRule as a convenience for unmarshalling POST requests
 type requestEdgeNatRules struct {
-	XMLName       xml.Name              `xml:"natRules"`
+	XMLName      xml.Name             `xml:"natRules"`
 	EdgeNatRules []*types.EdgeNatRule `xml:"natRule"`
 }
 
 // responseEdgeNatRules is used to unwrap response when retrieving
 type responseEdgeNatRules struct {
-	XMLName  xml.Name             `xml:"nat"`
-	Version  string               `xml:"version"`
+	XMLName  xml.Name            `xml:"nat"`
+	Version  string              `xml:"version"`
 	NatRules requestEdgeNatRules `xml:"natRules"`
 }
 
@@ -67,7 +67,7 @@ func (egw *EdgeGateway) UpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*ty
 	if err != nil {
 		return nil, err
 	}
-	
+
 	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeCreateNatPath + "/" + natRuleConfig.ID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
@@ -83,7 +83,7 @@ func (egw *EdgeGateway) UpdateNsxvNatRule(natRuleConfig *types.EdgeNatRule) (*ty
 	readNatRule, err := egw.GetNsxvNatRuleById(natRuleConfig.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve NAT rule with ID (%s) after update: %s",
-		readNatRule.ID, err)
+			readNatRule.ID, err)
 	}
 	return readNatRule, nil
 }

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -1,0 +1,32 @@
+// +build edge nat functional ALL
+
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_NatRule(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gateway given")
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+
+	natRule := &types.EdgeSnatRule{
+		Name:              "asd",
+		Action:            "snat",
+		OriginalAddress:   "10.10.10.15",
+		TranslatedAddress: "192.168.1.110",
+	}
+
+	_, err = edge.CreateSnatRule(natRule)
+	check.Assert(err, IsNil)
+
+}

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -20,10 +20,18 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
 	natRule := &types.EdgeSnatRule{
-		Name:              "asd",
-		Action:            "snat",
-		OriginalAddress:   "10.10.10.15",
-		TranslatedAddress: "192.168.1.110",
+		RuleType: "user",
+		// Name:                        "asd",
+		Action:                      "snat",
+		OriginalAddress:             "10.10.10.15",
+		TranslatedAddress:           "192.168.1.110",
+		// SnatMatchDestinationAddress: "any",
+		Enabled:                     "true",
+		// LoggingEnabled:              "false",
+		// OriginalPort:                "3380",
+		// TranslatedPort:              "3380",
+		Protocol: "any",
+		Vnic: "0",
 	}
 
 	_, err = edge.CreateSnatRule(natRule)

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -23,7 +23,7 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 		Action:            "snat",
 		TranslatedAddress: vcd.config.VCD.ExternalIp, // Edge gateway address
 		OriginalAddress:   vcd.config.VCD.InternalIp,
-		Enabled:           "true",
+		Enabled:           true,
 		// RuleType: "user",
 		// Name:                        "asd",
 		// SnatMatchDestinationAddress: "any",
@@ -47,7 +47,6 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	updatedSnatRule, err := edge.UpdateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
 	check.Assert(updatedSnatRule.Description, Equals, natRule.Description)
-
 
 	err = edge.DeleteNsxvNatRuleById(gotSnatRule.ID)
 	check.Assert(err, IsNil)

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -21,11 +21,11 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 
 	natRule := &types.EdgeSnatRule{
 		Action:            "snat",
-		TranslatedAddress: "192.168.1.110",
+		TranslatedAddress: vcd.config.VCD.ExternalIp, // Edge gateway address
+		OriginalAddress:   vcd.config.VCD.InternalIp,
 		Enabled:           "true",
 		// RuleType: "user",
 		// Name:                        "asd",
-		// OriginalAddress:             "10.10.10.15",
 		// SnatMatchDestinationAddress: "any",
 		// LoggingEnabled:              "false",
 		// OriginalPort:                "3380",
@@ -34,7 +34,22 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 		// Vnic: "0",
 	}
 
-	_, err = edge.CreateSnatRule(natRule)
+	createdSnatRule, err := edge.CreateSnatRule(natRule)
+	check.Assert(err, IsNil)
+
+	gotSnatRule, err := edge.GetSnatRuleById(createdSnatRule.ID)
+	check.Assert(err, IsNil)
+	check.Assert(gotSnatRule.ID, Equals, createdSnatRule.ID)
+
+	// Set ID and update nat rule with description
+	natRule.ID = gotSnatRule.ID
+	natRule.Description = "Description for SNAT rule"
+	updatedSnatRule, err := edge.UpdateSnatRule(natRule)
+	check.Assert(err, IsNil)
+	check.Assert(updatedSnatRule.Description, Equals, natRule.Description)
+
+
+	err = edge.DeleteSnatRuleById(gotSnatRule.ID)
 	check.Assert(err, IsNil)
 
 }

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -20,13 +20,13 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
 	natRule := &types.EdgeSnatRule{
+		Action:            "snat",
+		TranslatedAddress: "192.168.1.110",
+		Enabled:           "true",
 		// RuleType: "user",
 		// Name:                        "asd",
-		Action:                      "snat", // mandatory
 		// OriginalAddress:             "10.10.10.15",
-		TranslatedAddress:           "192.168.1.110",	// mandatory
 		// SnatMatchDestinationAddress: "any",
-		Enabled:                     "true",	// mandatory
 		// LoggingEnabled:              "false",
 		// OriginalPort:                "3380",
 		// TranslatedPort:              "3380",

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -118,6 +118,7 @@ func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGa
 
 	gotNatRule, err := edge.GetNsxvNatRuleById(createdNatRule.ID)
 	check.Assert(err, IsNil)
+	check.Assert(gotNatRule, NotNil)
 	check.Assert(gotNatRule, DeepEquals, createdNatRule)
 	check.Assert(gotNatRule.ID, Equals, createdNatRule.ID)
 
@@ -126,6 +127,7 @@ func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGa
 	natRule.Description = "Description for NAT rule"
 	updatedNatRule, err := edge.UpdateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
+	check.Assert(updatedNatRule, NotNil)
 
 	check.Assert(updatedNatRule.Description, Equals, natRule.Description)
 

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	natRule := &types.EdgeSnatRule{
+	natRule := &types.EdgeNatRule{
 		Action:            "snat",
 		TranslatedAddress: vcd.config.VCD.ExternalIp, // Edge gateway address
 		OriginalAddress:   vcd.config.VCD.InternalIp,
@@ -34,22 +34,22 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 		// Vnic: "0",
 	}
 
-	createdSnatRule, err := edge.CreateSnatRule(natRule)
+	createdSnatRule, err := edge.CreateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
 
-	gotSnatRule, err := edge.GetSnatRuleById(createdSnatRule.ID)
+	gotSnatRule, err := edge.GetNsxvNatRuleById(createdSnatRule.ID)
 	check.Assert(err, IsNil)
 	check.Assert(gotSnatRule.ID, Equals, createdSnatRule.ID)
 
 	// Set ID and update nat rule with description
 	natRule.ID = gotSnatRule.ID
 	natRule.Description = "Description for SNAT rule"
-	updatedSnatRule, err := edge.UpdateSnatRule(natRule)
+	updatedSnatRule, err := edge.UpdateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
 	check.Assert(updatedSnatRule.Description, Equals, natRule.Description)
 
 
-	err = edge.DeleteSnatRuleById(gotSnatRule.ID)
+	err = edge.DeleteNsxvNatRuleById(gotSnatRule.ID)
 	check.Assert(err, IsNil)
 
 }

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -20,18 +20,18 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
 	natRule := &types.EdgeSnatRule{
-		RuleType: "user",
+		// RuleType: "user",
 		// Name:                        "asd",
-		Action:                      "snat",
-		OriginalAddress:             "10.10.10.15",
-		TranslatedAddress:           "192.168.1.110",
+		Action:                      "snat", // mandatory
+		// OriginalAddress:             "10.10.10.15",
+		TranslatedAddress:           "192.168.1.110",	// mandatory
 		// SnatMatchDestinationAddress: "any",
-		Enabled:                     "true",
+		Enabled:                     "true",	// mandatory
 		// LoggingEnabled:              "false",
 		// OriginalPort:                "3380",
 		// TranslatedPort:              "3380",
-		Protocol: "any",
-		Vnic: "0",
+		// Protocol: "any",
+		// Vnic: "0",
 	}
 
 	_, err = edge.CreateSnatRule(natRule)

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -21,7 +21,7 @@ func (vcd *TestVCD) Test_NsxvSnatRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	vnicIndex, err := edge.GetVnicIndexFromNetworkNameType(vcd.config.VCD.Network.Net1, "internal")
+	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(vcd.config.VCD.Network.Net1, "internal")
 	check.Assert(err, IsNil)
 
 	natRule := &types.EdgeNatRule{
@@ -47,7 +47,7 @@ func (vcd *TestVCD) Test_NsxvDnatRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	vnicIndex, err := edge.GetVnicIndexFromNetworkNameType(vcd.config.VCD.ExternalNetwork, "uplink")
+	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(vcd.config.VCD.ExternalNetwork, "uplink")
 	check.Assert(err, IsNil)
 
 	natRule := &types.EdgeNatRule{

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -7,11 +7,13 @@
 package govcd
 
 import (
+	"fmt"
+
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 
-func (vcd *TestVCD) Test_NatRule(check *C) {
+func (vcd *TestVCD) Test_NsxvSnatRule(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
@@ -19,28 +21,122 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
+	vnicIndex, err := edge.GetVnicIndexFromNetworkNameType(vcd.config.VCD.Network.Net1, "internal")
+	check.Assert(err, IsNil)
+
 	natRule := &types.EdgeNatRule{
 		Action:            "snat",
-		TranslatedAddress: vcd.config.VCD.ExternalIp, // Edge gateway address
+		Vnic:              vnicIndex,
 		OriginalAddress:   vcd.config.VCD.InternalIp,
+		TranslatedAddress: vcd.config.VCD.ExternalIp,
 		Enabled:           true,
+		LoggingEnabled:    true,
+		Description:       "my description",
+	}
+	if testVerbose {
+		fmt.Printf("# %s %s %s -> %s\n", natRule.Action, natRule.Protocol, natRule.OriginalAddress,
+			natRule.TranslatedAddress)
+	}
+	testNsxvNat(natRule, vcd, check, edge)
+}
+func (vcd *TestVCD) Test_NsxvDnatRule(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gateway given")
+	}
+	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+
+	vnicIndex, err := edge.GetVnicIndexFromNetworkNameType(vcd.config.VCD.ExternalNetwork, "uplink")
+	check.Assert(err, IsNil)
+
+	natRule := &types.EdgeNatRule{
+		Action:            "dnat",
+		Vnic:              vnicIndex,
+		Protocol:          "tcp",
+		OriginalAddress:   vcd.config.VCD.ExternalIp,
+		OriginalPort:      "443",
+		TranslatedAddress: vcd.config.VCD.InternalIp,
+		TranslatedPort:    "8443",
+		Enabled:           true,
+		LoggingEnabled:    true,
+		Description:       "my description",
+	}
+	if testVerbose {
+		fmt.Printf("# %s %s %s:%s -> %s:%s\n", natRule.Action, natRule.Protocol, natRule.OriginalAddress,
+			natRule.OriginalPort, natRule.TranslatedAddress, natRule.TranslatedPort)
 	}
 
-	createdSnatRule, err := edge.CreateNsxvNatRule(natRule)
+	testNsxvNat(natRule, vcd, check, edge)
+
+	natRule = &types.EdgeNatRule{
+		Action:            "dnat",
+		Vnic:              vnicIndex,
+		Protocol:          "icmp",
+		IcmpType:          "router-advertisement",
+		OriginalAddress:   vcd.config.VCD.ExternalIp,
+		TranslatedAddress: vcd.config.VCD.InternalIp,
+		Enabled:           true,
+		LoggingEnabled:    true,
+		Description:       "my description",
+	}
+	if testVerbose {
+		fmt.Printf("# %s %s:%s %s -> %s\n", natRule.Action, natRule.Protocol, natRule.IcmpType,
+			natRule.OriginalAddress, natRule.TranslatedAddress)
+	}
+	testNsxvNat(natRule, vcd, check, edge)
+
+	natRule = &types.EdgeNatRule{
+		Action:            "dnat",
+		Vnic:              vnicIndex,
+		Protocol:          "any",
+		OriginalAddress:   vcd.config.VCD.ExternalIp,
+		TranslatedAddress: vcd.config.VCD.InternalIp,
+		Enabled:           true,
+		LoggingEnabled:    true,
+		Description:       "my description",
+	}
+	if testVerbose {
+		fmt.Printf("# %s %s %s -> %s\n", natRule.Action, natRule.Protocol, natRule.OriginalAddress,
+			natRule.TranslatedAddress)
+	}
+	testNsxvNat(natRule, vcd, check, edge)
+}
+
+// testNsxvNat is a helper to test multiple configurations of NAT rules. It does the following
+// 1. Creates NAT rule with provided config
+// 2. Checks that it can be retrieve and verifies if IDs match
+// 3. Tries to update description field and validates that nothing else except description changes
+// 4. Deletes the rule
+// 5. Validates that the rule was deleted
+func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGateway) {
+	createdNatRule, err := edge.CreateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
 
-	gotSnatRule, err := edge.GetNsxvNatRuleById(createdSnatRule.ID)
+	parentEntity := vcd.org.Org.Name + "|" + vcd.vdc.Vdc.Name + "|" + vcd.config.VCD.EdgeGateway
+	AddToCleanupList(createdNatRule.ID, "nsxvNatRule", parentEntity, check.TestName())
+
+	gotNatRule, err := edge.GetNsxvNatRuleById(createdNatRule.ID)
 	check.Assert(err, IsNil)
-	check.Assert(gotSnatRule.ID, Equals, createdSnatRule.ID)
+	check.Assert(gotNatRule, DeepEquals, createdNatRule)
+	check.Assert(gotNatRule.ID, Equals, createdNatRule.ID)
 
 	// Set ID and update nat rule with description
-	natRule.ID = gotSnatRule.ID
-	natRule.Description = "Description for SNAT rule"
-	updatedSnatRule, err := edge.UpdateNsxvNatRule(natRule)
-	check.Assert(err, IsNil)
-	check.Assert(updatedSnatRule.Description, Equals, natRule.Description)
-
-	err = edge.DeleteNsxvNatRuleById(gotSnatRule.ID)
+	natRule.ID = gotNatRule.ID
+	natRule.Description = "Description for NAT rule"
+	updatedNatRule, err := edge.UpdateNsxvNatRule(natRule)
 	check.Assert(err, IsNil)
 
+	check.Assert(updatedNatRule.Description, Equals, natRule.Description)
+
+	// Check if the objects are deeply equal (except updated 'Description' field)
+	createdNatRule.Description = natRule.Description
+	check.Assert(updatedNatRule, DeepEquals, createdNatRule)
+
+	err = edge.DeleteNsxvNatRuleById(gotNatRule.ID)
+	check.Assert(err, IsNil)
+
+	// Ensure the rule does not exist anymore
+	_, err = edge.GetNsxvNatRuleById(createdNatRule.ID)
+	check.Assert(err, Equals, ErrorEntityNotFound)
 }

--- a/govcd/nat_test.go
+++ b/govcd/nat_test.go
@@ -24,14 +24,6 @@ func (vcd *TestVCD) Test_NatRule(check *C) {
 		TranslatedAddress: vcd.config.VCD.ExternalIp, // Edge gateway address
 		OriginalAddress:   vcd.config.VCD.InternalIp,
 		Enabled:           true,
-		// RuleType: "user",
-		// Name:                        "asd",
-		// SnatMatchDestinationAddress: "any",
-		// LoggingEnabled:              "false",
-		// OriginalPort:                "3380",
-		// TranslatedPort:              "3380",
-		// Protocol: "any",
-		// Vnic: "0",
 	}
 
 	createdSnatRule, err := edge.CreateNsxvNatRule(natRule)

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -9,6 +9,7 @@ package govcd
 import (
 	"fmt"
 	"regexp"
+	"sort"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
@@ -574,8 +575,21 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 }
 
 func verifyNetworkConnectionSection(check *C, actual, desired *types.NetworkConnectionSection) {
+
 	check.Assert(len(actual.NetworkConnection), Equals, len(desired.NetworkConnection))
 	check.Assert(actual.PrimaryNetworkConnectionIndex, Equals, desired.PrimaryNetworkConnectionIndex)
+
+	// sort both objects by index before comparison
+	sort.SliceStable(actual.NetworkConnection, func(i, j int) bool {
+		return actual.NetworkConnection[i].NetworkConnectionIndex <
+			actual.NetworkConnection[j].NetworkConnectionIndex
+	})
+
+	sort.SliceStable(desired.NetworkConnection, func(i, j int) bool {
+		return desired.NetworkConnection[i].NetworkConnectionIndex <
+			desired.NetworkConnection[j].NetworkConnectionIndex
+	})
+
 	for index := range actual.NetworkConnection {
 		actualNic := actual.NetworkConnection[index]
 		desiredNic := desired.NetworkConnection[index]

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -9,7 +9,6 @@ package govcd
 import (
 	"fmt"
 	"regexp"
-	"sort"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
@@ -578,17 +577,6 @@ func verifyNetworkConnectionSection(check *C, actual, desired *types.NetworkConn
 
 	check.Assert(len(actual.NetworkConnection), Equals, len(desired.NetworkConnection))
 	check.Assert(actual.PrimaryNetworkConnectionIndex, Equals, desired.PrimaryNetworkConnectionIndex)
-
-	// sort both objects by index before comparison
-	sort.SliceStable(actual.NetworkConnection, func(i, j int) bool {
-		return actual.NetworkConnection[i].NetworkConnectionIndex <
-			actual.NetworkConnection[j].NetworkConnectionIndex
-	})
-
-	sort.SliceStable(desired.NetworkConnection, func(i, j int) bool {
-		return desired.NetworkConnection[i].NetworkConnectionIndex <
-			desired.NetworkConnection[j].NetworkConnectionIndex
-	})
 
 	for index := range actual.NetworkConnection {
 		actualNic := actual.NetworkConnection[index]

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -163,10 +163,11 @@ const (
 	LbVirtualServerPath = "/loadbalancer/config/virtualservers/"
 )
 
-// Edge gateway NAT rule API endpoints
+// Edge gateway API endpoints
 const (
 	EdgeNatPath       = "/nat/config"
 	EdgeCreateNatPath = "/nat/config/rules"
+	EdgeVnicConfig    = "/vnics"
 )
 
 // Guest customization statuses. These are all known possible statuses

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -178,3 +178,11 @@ const (
 	GuestCustStatusFailed        = "GC_FAILED"
 	GuestCustStatusRebootPending = "REBOOT_PENDING"
 )
+
+// Edge gateway vNic types
+const (
+	EdgeGatewayVnicTypeUplink       = "uplink"
+	EdgeGatewayVnicTypeInternal     = "internal"
+	EdgeGatewayVnicTypeTrunk        = "trunk"
+	EdgeGatewayVnicTypeSubinterface = "subinterface"
+)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -163,6 +163,12 @@ const (
 	LbVirtualServerPath = "/loadbalancer/config/virtualservers/"
 )
 
+// Edge gateway NAT rule API endpoints
+const (
+	EdgeNatPath       = "/nat/config"
+	EdgeCreateNatPath = "/nat/config/rules"
+)
+
 // Guest customization statuses. These are all known possible statuses
 const (
 	GuestCustStatusPending       = "GC_PENDING"

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1826,10 +1826,10 @@ type EdgeNatRule struct {
 	ID                string   `xml:"ruleId,omitempty"`
 	RuleType          string   `xml:"ruleType,omitempty"`
 	RuleTag           string   `xml:"ruleTag,omitempty"`
-	Action            string   `xml:"action,omitempty"`
+	Action            string   `xml:"action"`
 	Vnic              *int     `xml:"vnic,omitempty"`
-	OriginalAddress   string   `xml:"originalAddress,omitempty"`
-	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
+	OriginalAddress   string   `xml:"originalAddress"`
+	TranslatedAddress string   `xml:"translatedAddress"`
 	LoggingEnabled    bool     `xml:"loggingEnabled"`
 	Enabled           bool     `xml:"enabled"`
 	Description       string   `xml:"description,omitempty"`
@@ -2702,42 +2702,41 @@ type EdgeGatewayVnics struct {
 		Name          string `xml:"name"`
 		AddressGroups struct {
 			AddressGroup struct {
-				PrimaryAddress     string `xml:"primaryAddress"`
+				PrimaryAddress     string `xml:"primaryAddress,omitempty"`
 				SecondaryAddresses struct {
-					IpAddress []string `xml:"ipAddress"`
-				} `xml:"secondaryAddresses"`
-				SubnetMask         string `xml:"subnetMask"`
-				SubnetPrefixLength string `xml:"subnetPrefixLength"`
-			} `xml:"addressGroup"`
-		} `xml:"addressGroups"`
-		Mtu                 string `xml:"mtu"`
-		Type                string `xml:"type"`
-		IsConnected         string `xml:"isConnected"`
+					IpAddress []string `xml:"ipAddress,omitempty"`
+				} `xml:"secondaryAddresses,omitempty"`
+				SubnetMask         string `xml:"subnetMask,omitempty"`
+				SubnetPrefixLength string `xml:"subnetPrefixLength,omitempty"`
+			} `xml:"addressGroup,omitempty"`
+		} `xml:"addressGroups,omitempty"`
+		Mtu                 string `xml:"mtu,omitempty"`
+		Type                string `xml:"type,omitempty"`
+		IsConnected         string `xml:"isConnected,omitempty"`
 		Index               *int   `xml:"index"`
-		PortgroupId         string `xml:"portgroupId"`
-		PortgroupName       string `xml:"portgroupName"`
-		EnableProxyArp      string `xml:"enableProxyArp"`
-		EnableSendRedirects string `xml:"enableSendRedirects"`
+		PortgroupId         string `xml:"portgroupId,omitempty"`
+		PortgroupName       string `xml:"portgroupName,omitempty"`
+		EnableProxyArp      string `xml:"enableProxyArp,omitempty"`
+		EnableSendRedirects string `xml:"enableSendRedirects,omitempty"`
 		SubInterfaces       struct {
 			SubInterface []struct {
-				IsConnected         string `xml:"isConnected"`
-				Label               string `xml:"label"`
-				Name                string `xml:"name"`
-				Index               *int   `xml:"index"`
-				TunnelId            string `xml:"tunnelId"`
-				LogicalSwitchId     string `xml:"logicalSwitchId"`
-				LogicalSwitchName   string `xml:"logicalSwitchName"`
-				EnableSendRedirects string `xml:"enableSendRedirects"`
-				Mtu                 string `xml:"mtu"`
+				IsConnected         string `xml:"isConnected,omitempty"`
+				Label               string `xml:"label,omitempty"`
+				Name                string `xml:"name,omitempty"`
+				Index               *int   `xml:"index,omitempty"`
+				TunnelId            string `xml:"tunnelId,omitempty"`
+				LogicalSwitchId     string `xml:"logicalSwitchId,omitempty"`
+				LogicalSwitchName   string `xml:"logicalSwitchName,omitempty"`
+				EnableSendRedirects string `xml:"enableSendRedirects,omitempty"`
+				Mtu                 string `xml:"mtu,omitempty"`
 				AddressGroups       struct {
 					AddressGroup struct {
-						Text               string `xml:",chardata"`
-						PrimaryAddress     string `xml:"primaryAddress"`
-						SubnetMask         string `xml:"subnetMask"`
-						SubnetPrefixLength string `xml:"subnetPrefixLength"`
-					} `xml:"addressGroup"`
-				} `xml:"addressGroups"`
-			} `xml:"subInterface"`
-		} `xml:"subInterfaces"`
-	} `xml:"vnic"`
+						PrimaryAddress     string `xml:"primaryAddress,omitempty"`
+						SubnetMask         string `xml:"subnetMask,omitempty"`
+						SubnetPrefixLength string `xml:"subnetPrefixLength,omitempty"`
+					} `xml:"addressGroup,omitempty"`
+				} `xml:"addressGroups,omitempty"`
+			} `xml:"subInterface,omitempty"`
+		} `xml:"subInterfaces,omitempty"`
+	} `xml:"vnic,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1830,12 +1830,13 @@ type EdgeNatRule struct {
 	Vnic              string   `xml:"vnic,omitempty"`
 	OriginalAddress   string   `xml:"originalAddress,omitempty"`
 	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
-	LoggingEnabled    string   `xml:"loggingEnabled,omitempty"`
-	Enabled           string   `xml:"enabled,omitempty"`
+	LoggingEnabled    bool     `xml:"loggingEnabled"`
+	Enabled           bool     `xml:"enabled"`
 	Description       string   `xml:"description,omitempty"`
 	Protocol          string   `xml:"protocol,omitempty"`
 	OriginalPort      string   `xml:"originalPort,omitempty"`
 	TranslatedPort    string   `xml:"translatedPort,omitempty"`
+	IcmpType          string   `xml:"icmpType,omitempty"`
 
 	// Optional SNAT related fields
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2700,3 +2700,52 @@ type AdminCatalogRecord struct {
 	Link                    *Link     `xml:"Link,omitempty"`
 	Vdc                     *Metadata `xml:"Metadata,omitempty"`
 }
+
+// EdgeGatewayVnics is a data structure holding information of vNic configuration in NSX-V edge
+// gateway
+type EdgeGatewayVnics struct {
+	XMLName xml.Name `xml:"vnics"`
+	Vnic    []struct {
+		Label         string `xml:"label"`
+		Name          string `xml:"name"`
+		AddressGroups struct {
+			AddressGroup struct {
+				PrimaryAddress     string `xml:"primaryAddress"`
+				SecondaryAddresses struct {
+					IpAddress []string `xml:"ipAddress"`
+				} `xml:"secondaryAddresses"`
+				SubnetMask         string `xml:"subnetMask"`
+				SubnetPrefixLength string `xml:"subnetPrefixLength"`
+			} `xml:"addressGroup"`
+		} `xml:"addressGroups"`
+		Mtu                 string `xml:"mtu"`
+		Type                string `xml:"type"`
+		IsConnected         string `xml:"isConnected"`
+		Index               string `xml:"index"`
+		PortgroupId         string `xml:"portgroupId"`
+		PortgroupName       string `xml:"portgroupName"`
+		EnableProxyArp      string `xml:"enableProxyArp"`
+		EnableSendRedirects string `xml:"enableSendRedirects"`
+		SubInterfaces       struct {
+			SubInterface []struct {
+				IsConnected         string `xml:"isConnected"`
+				Label               string `xml:"label"`
+				Name                string `xml:"name"`
+				Index               string `xml:"index"`
+				TunnelId            string `xml:"tunnelId"`
+				LogicalSwitchId     string `xml:"logicalSwitchId"`
+				LogicalSwitchName   string `xml:"logicalSwitchName"`
+				EnableSendRedirects string `xml:"enableSendRedirects"`
+				Mtu                 string `xml:"mtu"`
+				AddressGroups       struct {
+					AddressGroup struct {
+						Text               string `xml:",chardata"`
+						PrimaryAddress     string `xml:"primaryAddress"`
+						SubnetMask         string `xml:"subnetMask"`
+						SubnetPrefixLength string `xml:"subnetPrefixLength"`
+					} `xml:"addressGroup"`
+				} `xml:"addressGroups"`
+			} `xml:"subInterface"`
+		} `xml:"subInterfaces"`
+	} `xml:"vnic"`
+}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1854,14 +1854,20 @@ type EdgeSnatRule struct {
 	Enabled           string   `xml:"enabled,omitempty"`
 	Description       string   `xml:"description,omitempty"`
 	Protocol          string   `xml:"protocol,omitempty"`
-	OriginalPort      string   `xml:"originalPort,omitempty"`
-	TranslatedPort    string   `xml:"translatedPort,omitempty"`
+	OriginalPort      int   `xml:"originalPort,omitempty"`
+	TranslatedPort    int   `xml:"translatedPort,omitempty"`
 
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
 	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
 }
 
-// type EdgeSnatRules []*types.EdgeSnatRule `xml:"natRules"`
+// EdgeSnatRules nests EdgeSnatRule as a convenience for mashalling
+type EdgeSnatRules struct {
+	XMLName       xml.Name `xml:"natRules"`
+	EdgeSnatRules []*EdgeSnatRule  `xml:"natRule"`
+}
+
+
 
 // EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields
 type EdgeDnatRule struct {

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1854,8 +1854,8 @@ type EdgeSnatRule struct {
 	Enabled           string   `xml:"enabled,omitempty"`
 	Description       string   `xml:"description,omitempty"`
 	Protocol          string   `xml:"protocol,omitempty"`
-	OriginalPort      int   `xml:"originalPort,omitempty"`
-	TranslatedPort    int   `xml:"translatedPort,omitempty"`
+	OriginalPort      int      `xml:"originalPort,omitempty"`
+	TranslatedPort    int      `xml:"translatedPort,omitempty"`
 
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
 	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
@@ -1863,11 +1863,9 @@ type EdgeSnatRule struct {
 
 // EdgeSnatRules nests EdgeSnatRule as a convenience for mashalling
 type EdgeSnatRules struct {
-	XMLName       xml.Name `xml:"natRules"`
-	EdgeSnatRules []*EdgeSnatRule  `xml:"natRule"`
+	XMLName       xml.Name        `xml:"natRules"`
+	EdgeSnatRules []*EdgeSnatRule `xml:"natRule"`
 }
-
-
 
 // EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields
 type EdgeDnatRule struct {

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2721,7 +2721,7 @@ type EdgeGatewayVnics struct {
 		Mtu                 string `xml:"mtu"`
 		Type                string `xml:"type"`
 		IsConnected         string `xml:"isConnected"`
-		Index               string `xml:"index"`
+		Index               *int   `xml:"index"`
 		PortgroupId         string `xml:"portgroupId"`
 		PortgroupName       string `xml:"portgroupName"`
 		EnableProxyArp      string `xml:"enableProxyArp"`
@@ -2731,7 +2731,7 @@ type EdgeGatewayVnics struct {
 				IsConnected         string `xml:"isConnected"`
 				Label               string `xml:"label"`
 				Name                string `xml:"name"`
-				Index               string `xml:"index"`
+				Index               *int   `xml:"index"`
 				TunnelId            string `xml:"tunnelId"`
 				LogicalSwitchId     string `xml:"logicalSwitchId"`
 				LogicalSwitchName   string `xml:"logicalSwitchName"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1819,6 +1819,56 @@ type LbVirtualServer struct {
 	ApplicationRuleIds   []string `xml:"applicationRuleId,omitempty"`
 }
 
+// EdgeNatRule contains shared structure for SNAT and DNAT rule configuration using
+// NSX-V proxied edge gateway endpoint
+type EdgeNatRule struct {
+	XMLName           xml.Name `xml:"natRule"`
+	ID                string   `xml:"ruleId,omitempty"`
+	Name              string   `xml:"name"`
+	RuleType          string   `xml:"ruleType"`
+	RuleTag           string   `xml:"ruleTag"`
+	Action            string   `xml:"action"`
+	Vnic              string   `xml:"vnic"`
+	OriginalAddress   string   `xml:"originalAddress"`
+	TranslatedAddress string   `xml:"translatedAddress"`
+	LoggingEnabled    string   `xml:"loggingEnabled"`
+	Enabled           string   `xml:"enabled"`
+	Description       string   `xml:"description"`
+	Protocol          string   `xml:"protocol"`
+	OriginalPort      string   `xml:"originalPort"`
+	TranslatedPort    string   `xml:"translatedPort"`
+}
+
+// EdgeSnatRule embeds EdgeNatRule and adds SNAT specific fields
+type EdgeSnatRule struct {
+	XMLName           xml.Name `xml:"natRule"`
+	ID                string   `xml:"ruleId,omitempty"`
+	Name              string   `xml:"name"`
+	RuleType          string   `xml:"ruleType"`
+	RuleTag           string   `xml:"ruleTag"`
+	Action            string   `xml:"action,omitempty"`
+	Vnic              string   `xml:"vnic,omitempty"`
+	OriginalAddress   string   `xml:"originalAddress,omitempty"`
+	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
+	LoggingEnabled    string   `xml:"loggingEnabled,omitempty"`
+	Enabled           string   `xml:"enabled,omitempty"`
+	Description       string   `xml:"description,omitempty"`
+	Protocol          string   `xml:"protocol,omitempty"`
+	OriginalPort      string   `xml:"originalPort,omitempty"`
+	TranslatedPort    string   `xml:"translatedPort,omitempty"`
+
+	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
+	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
+}
+
+// EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields
+type EdgeDnatRule struct {
+	EdgeNatRule
+
+	DnatMatchSourceAddress string `xml:"dnatMatchSourceAddress"`
+	DnatMatchSourcePort    string `xml:"dnatMatchSourcePort"`
+}
+
 // VendorTemplate is information about a vendor service template. This is optional.
 // Type: VendorTemplateType
 // Namespace: http://www.vmware.com/vcloud/v1.5

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1821,28 +1821,10 @@ type LbVirtualServer struct {
 
 // EdgeNatRule contains shared structure for SNAT and DNAT rule configuration using
 // NSX-V proxied edge gateway endpoint
+// // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type EdgeNatRule struct {
 	XMLName           xml.Name `xml:"natRule"`
 	ID                string   `xml:"ruleId,omitempty"`
-	Name              string   `xml:"name,omitempty"`
-	RuleType          string   `xml:"ruleType,omitempty"`
-	RuleTag           string   `xml:"ruleTag,omitempty"`
-	Action            string   `xml:"action,omitempty"`
-	Vnic              string   `xml:"vnic,omitempty"`
-	OriginalAddress   string   `xml:"originalAddress,omitempty"`
-	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
-	LoggingEnabled    string   `xml:"loggingEnabled,omitempty"`
-	Enabled           string   `xml:"enabled,omitempty"`
-	Description       string   `xml:"description,omitempty"`
-	Protocol          string   `xml:"protocol,omitempty"`
-	OriginalPort      string   `xml:"originalPort,omitempty"`
-	TranslatedPort    string   `xml:"translatedPort,omitempty"`
-}
-
-// EdgeSnatRule embeds EdgeNatRule and adds SNAT specific fields
-type EdgeSnatRule struct {
-	XMLName           xml.Name `xml:"natRule"`
-	ID                string   `xml:"ruleId,omitempty"`
 	RuleType          string   `xml:"ruleType,omitempty"`
 	RuleTag           string   `xml:"ruleTag,omitempty"`
 	Action            string   `xml:"action,omitempty"`
@@ -1856,16 +1838,13 @@ type EdgeSnatRule struct {
 	OriginalPort      string   `xml:"originalPort,omitempty"`
 	TranslatedPort    string   `xml:"translatedPort,omitempty"`
 
+	// Optional SNAT related fields
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
 	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
-}
 
-// EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields
-type EdgeDnatRule struct {
-	EdgeNatRule
-
-	DnatMatchSourceAddress string `xml:"dnatMatchSourceAddress"`
-	DnatMatchSourcePort    string `xml:"dnatMatchSourcePort"`
+	// Optional DNAT related fields
+	DnatMatchSourceAddress string `xml:"dnatMatchSourceAddress,omitempty"`
+	DnatMatchSourcePort    string `xml:"dnatMatchSourcePort,omitempty"`
 }
 
 // VendorTemplate is information about a vendor service template. This is optional.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1837,14 +1837,6 @@ type EdgeNatRule struct {
 	OriginalPort      string   `xml:"originalPort,omitempty"`
 	TranslatedPort    string   `xml:"translatedPort,omitempty"`
 	IcmpType          string   `xml:"icmpType,omitempty"`
-
-	// Optional SNAT related fields
-	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
-	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
-
-	// Optional DNAT related fields
-	DnatMatchSourceAddress string `xml:"dnatMatchSourceAddress,omitempty"`
-	DnatMatchSourcePort    string `xml:"dnatMatchSourcePort,omitempty"`
 }
 
 // VendorTemplate is information about a vendor service template. This is optional.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1843,9 +1843,9 @@ type EdgeNatRule struct {
 type EdgeSnatRule struct {
 	XMLName           xml.Name `xml:"natRule"`
 	ID                string   `xml:"ruleId,omitempty"`
-	Name              string   `xml:"name"`
-	RuleType          string   `xml:"ruleType"`
-	RuleTag           string   `xml:"ruleTag"`
+	Name              string   `xml:"name,omitempty"`
+	RuleType          string   `xml:"ruleType,omitempty"`
+	RuleTag           string   `xml:"ruleTag,omitempty"`
 	Action            string   `xml:"action,omitempty"`
 	Vnic              string   `xml:"vnic,omitempty"`
 	OriginalAddress   string   `xml:"originalAddress,omitempty"`
@@ -1860,6 +1860,8 @@ type EdgeSnatRule struct {
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
 	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
 }
+
+// type EdgeSnatRules []*types.EdgeSnatRule `xml:"natRules"`
 
 // EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields
 type EdgeDnatRule struct {

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1827,7 +1827,7 @@ type EdgeNatRule struct {
 	RuleType          string   `xml:"ruleType,omitempty"`
 	RuleTag           string   `xml:"ruleTag,omitempty"`
 	Action            string   `xml:"action,omitempty"`
-	Vnic              string   `xml:"vnic,omitempty"`
+	Vnic              *int     `xml:"vnic,omitempty"`
 	OriginalAddress   string   `xml:"originalAddress,omitempty"`
 	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
 	LoggingEnabled    bool     `xml:"loggingEnabled"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1824,25 +1824,6 @@ type LbVirtualServer struct {
 type EdgeNatRule struct {
 	XMLName           xml.Name `xml:"natRule"`
 	ID                string   `xml:"ruleId,omitempty"`
-	Name              string   `xml:"name"`
-	RuleType          string   `xml:"ruleType"`
-	RuleTag           string   `xml:"ruleTag"`
-	Action            string   `xml:"action"`
-	Vnic              string   `xml:"vnic"`
-	OriginalAddress   string   `xml:"originalAddress"`
-	TranslatedAddress string   `xml:"translatedAddress"`
-	LoggingEnabled    string   `xml:"loggingEnabled"`
-	Enabled           string   `xml:"enabled"`
-	Description       string   `xml:"description"`
-	Protocol          string   `xml:"protocol"`
-	OriginalPort      string   `xml:"originalPort"`
-	TranslatedPort    string   `xml:"translatedPort"`
-}
-
-// EdgeSnatRule embeds EdgeNatRule and adds SNAT specific fields
-type EdgeSnatRule struct {
-	XMLName           xml.Name `xml:"natRule"`
-	ID                string   `xml:"ruleId,omitempty"`
 	Name              string   `xml:"name,omitempty"`
 	RuleType          string   `xml:"ruleType,omitempty"`
 	RuleTag           string   `xml:"ruleTag,omitempty"`
@@ -1854,17 +1835,29 @@ type EdgeSnatRule struct {
 	Enabled           string   `xml:"enabled,omitempty"`
 	Description       string   `xml:"description,omitempty"`
 	Protocol          string   `xml:"protocol,omitempty"`
-	OriginalPort      int      `xml:"originalPort,omitempty"`
-	TranslatedPort    int      `xml:"translatedPort,omitempty"`
+	OriginalPort      string   `xml:"originalPort,omitempty"`
+	TranslatedPort    string   `xml:"translatedPort,omitempty"`
+}
+
+// EdgeSnatRule embeds EdgeNatRule and adds SNAT specific fields
+type EdgeSnatRule struct {
+	XMLName           xml.Name `xml:"natRule"`
+	ID                string   `xml:"ruleId,omitempty"`
+	RuleType          string   `xml:"ruleType,omitempty"`
+	RuleTag           string   `xml:"ruleTag,omitempty"`
+	Action            string   `xml:"action,omitempty"`
+	Vnic              string   `xml:"vnic,omitempty"`
+	OriginalAddress   string   `xml:"originalAddress,omitempty"`
+	TranslatedAddress string   `xml:"translatedAddress,omitempty"`
+	LoggingEnabled    string   `xml:"loggingEnabled,omitempty"`
+	Enabled           string   `xml:"enabled,omitempty"`
+	Description       string   `xml:"description,omitempty"`
+	Protocol          string   `xml:"protocol,omitempty"`
+	OriginalPort      string   `xml:"originalPort,omitempty"`
+	TranslatedPort    string   `xml:"translatedPort,omitempty"`
 
 	SnatMatchDestinationAddress string `xml:"dnatMatchDestinationAddress,omitempty"`
 	SnatMatchDestinationPort    string `xml:"dnatMatchDestinationPort,omitempty"`
-}
-
-// EdgeSnatRules nests EdgeSnatRule as a convenience for mashalling
-type EdgeSnatRules struct {
-	XMLName       xml.Name        `xml:"natRules"`
-	EdgeSnatRules []*EdgeSnatRule `xml:"natRule"`
 }
 
 // EdgeDnatRule embeds EdgeNatRule and adds DNAT specific fields


### PR DESCRIPTION
This PR aims to add support for methods to allow configuring Edge Gateway NAT rules using proxied NSX-V API.

It introduces a few new methods: `CreateNsxvNatRule`, `UpdateNsxvNatRule`, `GetNsxvNatRuleById` and `DeleteNsxvNatRuleById`.

The creation of above mentioned NAT rules requires to specify a vNic (network interface on edge gateway). To easen lookup of vNic and replicating similar behaviour as vCD UI two more methods are added: `GetVnicIndexByNetworkNameAndType` and `GetNetworkNameAndTypeByVnicIndex`. They allow to convert between vNic index number and network type and network name.

It should also be compatible with subinterfaces when we implement them in other places: https://github.com/terraform-providers/terraform-provider-vcd/issues/321