### PR TITLE
Update OrgNetwork structure

### DIFF
--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -322,21 +322,22 @@ type InstantiationParams struct {
 // Description: Represents an Org VDC network in the vCloud model.
 // Since: 5.1
 type OrgVDCNetwork struct {
-	XMLName       xml.Name              `xml:"OrgVdcNetwork"`
-	Xmlns         string                `xml:"xmlns,attr,omitempty"`
-	HREF          string                `xml:"href,attr,omitempty"`
-	Type          string                `xml:"type,attr,omitempty"`
-	ID            string                `xml:"id,attr,omitempty"`
-	OperationKey  string                `xml:"operationKey,attr,omitempty"`
-	Name          string                `xml:"name,attr"`
-	Status        string                `xml:"status,attr,omitempty"`
-	Configuration *NetworkConfiguration `xml:"Configuration,omitempty"`
-	Description   string                `xml:"Description,omitempty"`
-	EdgeGateway   *Reference            `xml:"EdgeGateway,omitempty"`
-	IsShared      bool                  `xml:"IsShared"`
-	Link          []Link                `xml:"Link,omitempty"`
-	ServiceConfig *GatewayFeatures      `xml:"ServiceConfig,omitempty"` // Specifies the service configuration for an isolated Org VDC networks
-	Tasks         *TasksInProgress      `xml:"Tasks,omitempty"`
+	XMLName         xml.Name              `xml:"OrgVdcNetwork"`
+	Xmlns           string                `xml:"xmlns,attr,omitempty"`
+	HREF            string                `xml:"href,attr,omitempty"`
+	Type            string                `xml:"type,attr,omitempty"`
+	ID              string                `xml:"id,attr,omitempty"`
+	OperationKey    string                `xml:"operationKey,attr,omitempty"`
+	Name            string                `xml:"name,attr"`
+	Status          string                `xml:"status,attr,omitempty"`
+	Configuration   *NetworkConfiguration `xml:"Configuration,omitempty"`
+	Description     string                `xml:"Description,omitempty"`
+	EdgeGateway     *Reference            `xml:"EdgeGateway,omitempty"`
+	ServiceConfig   *GatewayFeatures      `xml:"ServiceConfig,omitempty"` // Specifies the service configuration for an isolated Org VDC networks
+	IsShared        bool                  `xml:"IsShared"`
+	VimPortGroupRef []*VimObjectRef       `xml:"VimPortGroupRef,omitempty"` // Needed to set up DHCP inside ServiceConfig
+	Link            []Link                `xml:"Link,omitempty"`
+	Tasks           *TasksInProgress      `xml:"Tasks,omitempty"`
 }
 
 // SupportedHardwareVersions contains a list of VMware virtual hardware versions supported in this vDC.


### PR DESCRIPTION
The reason for this addition (VimPortGroupRef) is that when
we manipulate DHCP records, the API complains about this element
being missed. We don't need to add anything inside VimPortGroupRef,
but it needs to be there or we can't add DHCP definitions.

Note that, before this addition, DHCP was created automatically
using the leftwovers of static IP pool. For example, if the static
IP pool was 192.168.0.2-192.168.0.100, the DHCP pool, was
192.168.0.101-192.168.0.254.

Note that this change doesn't affect go-vcloud-director, as the network operations keeps working as before, but it is vital for Terraform provider, where DHCP settings need to be enforced (even when there are none) because the automatic behavior affects terraform state. 