### PR TITLE
Get methods for vApp and VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ vApp guest properties [#235](https://github.com/vmware/go-vcloud-director/pull/2
 * Added methods `CreateNsxvNatRule()`, `UpdateNsxvNatRule()`, `GetNsxvNatRuleById()`, `DeleteNsxvNatRuleById()`
 which use the proxied NSX-V API of advanced edge gateway for handling NAT rules [#241](https://github.com/vmware/go-vcloud-director/pull/241)
 * Added methods `GetVnicIndexByNetworkNameAndType()` and `GetNetworkNameAndTypeByVnicIndex()` [#241](https://github.com/vmware/go-vcloud-director/pull/241)
+* Added methods `Vdc.GetVappByHref`, `Vdc.GetVAppByName` and related `GetVAppById`, `GetVAppByNameOrId`
+* Added methods `Client.GetVMByHref` `Vapp.GetVAMByName` and related `GetVMById`, `GetVAMByNameOrId`
+* Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
 
 IMPROVEMENTS:
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -556,8 +556,8 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 	vcd.infoCleanup(introMsg, entity.EntityType, entity.Name, entity.CreatedBy)
 	switch entity.EntityType {
 	case "vapp":
-		vapp, err := vcd.vdc.FindVAppByName(entity.Name)
-		if vapp == (VApp{}) || err != nil {
+		vapp, err := vcd.vdc.GetVAppByName(entity.Name, true)
+		if err != nil {
 			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name)
 			return
 		}
@@ -775,7 +775,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			vcd.infoCleanup("removeLeftoverEntries: [INFO] Deleting %s '%s', VM: '%s|%s', disk is attached, detaching disk\n",
 				entity.EntityType, entity.Name, vmRef.Name, vmRef.HREF)
 
-			vm, err := vcd.client.Client.FindVMByHREF(vmRef.HREF)
+			vm, err := vcd.client.Client.GetVMByHref(vmRef.HREF)
 			if err != nil {
 				vcd.infoCleanup(
 					"removeLeftoverEntries: [ERROR] Deleting %s '%s', VM: '%s|%s', cannot find the VM details: %s\n",
@@ -1068,7 +1068,7 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
 	}
 	// Get VApp
-	vapp, err := vcd.vdc.FindVAppByName(name)
+	vapp, err := vcd.vdc.GetVAppByName(name, true)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error getting vapp: %v", err)
 	}
@@ -1078,7 +1078,7 @@ func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
 		return VApp{}, fmt.Errorf("error waiting for created test vApp to have working state: %s", err)
 	}
 
-	return vapp, err
+	return *vapp, err
 }
 
 func Test_splitParent(t *testing.T) {

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -342,7 +342,7 @@ func (vcd *TestVCD) detachIndependentDisk(disk Disk) error {
 	// If the disk is attached to the VM, detach disk from the VM
 	if vmRef != nil {
 
-		vm, err := vcd.client.Client.FindVMByHREF(vmRef.HREF)
+		vm, err := vcd.client.Client.GetVMByHref(vmRef.HREF)
 		if err != nil {
 			return err
 		}

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -65,6 +65,12 @@ func (network *OrgVDCNetwork) id() string   { return network.OrgVDCNetwork.ID }
 func (egw *EdgeGateway) name() string { return egw.EdgeGateway.Name }
 func (egw *EdgeGateway) id() string   { return egw.EdgeGateway.ID }
 
+func (vapp *VApp) name() string { return vapp.VApp.Name }
+func (vapp *VApp) id() string   { return vapp.VApp.ID }
+
+func (vm *VM) name() string { return vm.VM.Name }
+func (vm *VM) id() string   { return vm.VM.ID }
+
 // Semi-generic tests that check the complete set of Get methods for an entity
 // GetEntityByName
 // GetEntityById

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -61,7 +61,7 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	// Compose Raw vApp
 	err = vdc.ComposeRawVApp(TestLb)
 	check.Assert(err, IsNil)
-	vapp, err := vdc.FindVAppByName(TestLb)
+	vapp, err := vdc.GetVAppByName(TestLb, true)
 	check.Assert(err, IsNil)
 	// vApp was created - let's add it to cleanup list
 	AddToCleanupList(TestLb, "vapp", "", "createTestVapp")
@@ -94,9 +94,9 @@ func (vcd *TestVCD) Test_LB(check *C) {
 			NetworkConnectionIndex:  0,
 		})
 
-	vm1, err := spawnVM("FirstNode", *vdc, vapp, desiredNetConfig, vappTemplate, check)
+	vm1, err := spawnVM("FirstNode", *vdc, *vapp, desiredNetConfig, vappTemplate, check)
 	check.Assert(err, IsNil)
-	vm2, err := spawnVM("SecondNode", *vdc, vapp, desiredNetConfig, vappTemplate, check)
+	vm2, err := spawnVM("SecondNode", *vdc, *vapp, desiredNetConfig, vappTemplate, check)
 	check.Assert(err, IsNil)
 
 	// Get IPs alocated to the VMs
@@ -182,7 +182,7 @@ func spawnVM(name string, vdc Vdc, vapp VApp, net types.NetworkConnectionSection
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-	vm, err := vdc.FindVMByName(vapp, name)
+	vm, err := vapp.GetVMByName(name, true)
 	check.Assert(err, IsNil)
 	fmt.Printf(". Done\n")
 
@@ -217,7 +217,7 @@ func spawnVM(name string, vdc Vdc, vapp VApp, net types.NetworkConnectionSection
 	check.Assert(err, IsNil)
 	fmt.Printf(". Done\n")
 
-	return vm, nil
+	return *vm, nil
 }
 
 // buildLB establishes an HTTP load balancer for 2 IPs specified as arguments

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -501,7 +501,7 @@ func (vcdClient *VCDClient) GetExternalNetworks() (*types.ExternalNetworkReferen
 }
 
 // GetExternalNetworkByName returns an ExternalNetwork reference if the network name matches an existing one.
-// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+// If no valid external network is found, it returns a nil ExternalNetwork reference and an error
 func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*ExternalNetwork, error) {
 
 	extNetworkRefs, err := vcdClient.GetExternalNetworks()
@@ -527,7 +527,7 @@ func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*Exter
 }
 
 // GetExternalNetworkById returns an ExternalNetwork reference if the network ID matches an existing one.
-// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+// If no valid external network is found, it returns a nil ExternalNetwork reference and an error
 func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork, error) {
 
 	extNetworkRefs, err := vcdClient.GetExternalNetworks()
@@ -555,7 +555,7 @@ func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork,
 }
 
 // GetExternalNetworkByNameOrId returns an ExternalNetwork reference if either the network name or ID matches an existing one.
-// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+// If no valid external network is found, it returns a nil ExternalNetwork reference and an error
 func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*ExternalNetwork, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
 	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -861,6 +861,8 @@ func (vapp *VApp) GetProductSectionList() (*types.ProductSectionList, error) {
 
 // GetVMByHref returns a VM reference by running a vCD API call
 // If no valid VM is found, it returns a nil VM reference and an error
+// Note that the pointer receiver here is a Client instead of a VApp, because
+// there are cases where we know the VM HREF but not which VApp it belongs to.
 func (client *Client) GetVMByHref(vmHref string) (*VM, error) {
 
 	newVm := NewVM(client)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -860,7 +860,7 @@ func (vapp *VApp) GetProductSectionList() (*types.ProductSectionList, error) {
 }
 
 // GetVMByHref returns a VM reference by running a vCD API call
-// If no valid VM is found, it returns an empty VM reference and an error
+// If no valid VM is found, it returns a nil VM reference and an error
 func (client *Client) GetVMByHref(vmHref string) (*VM, error) {
 
 	newVm := NewVM(client)
@@ -877,7 +877,7 @@ func (client *Client) GetVMByHref(vmHref string) (*VM, error) {
 }
 
 // GetVMByName returns a VM reference if the VM name matches an existing one.
-// If no valid VM is found, it returns an empty VM reference and an error
+// If no valid VM is found, it returns a nil VM reference and an error
 func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
 	if refresh {
 		err := vapp.Refresh()
@@ -905,7 +905,7 @@ func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
 }
 
 // GetVMById returns a VM reference if the VM ID matches an existing one.
-// If no valid VM is found, it returns an empty VM reference and an error
+// If no valid VM is found, it returns a nil VM reference and an error
 func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
 	if refresh {
 		err := vapp.Refresh()
@@ -932,7 +932,7 @@ func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
 }
 
 // GetVMByNameOrId returns a VM reference if either the VM name or ID matches an existing one.
-// If no valid VM is found, it returns an empty VM reference and an error
+// If no valid VM is found, it returns a nil VM reference and an error
 func (vapp *VApp) GetVMByNameOrId(identifier string, refresh bool) (*VM, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) { return vapp.GetVMByName(name, refresh) }
 	getById := func(id string, refresh bool) (interface{}, error) { return vapp.GetVMById(id, refresh) }

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -858,3 +858,87 @@ func (vapp *VApp) SetProductSectionList(productSection *types.ProductSectionList
 func (vapp *VApp) GetProductSectionList() (*types.ProductSectionList, error) {
 	return getProductSectionList(vapp.client, vapp.VApp.HREF)
 }
+
+// GetVMByHref returns a VM reference by running a vCD API call
+// If no valid VM is found, it returns an empty VM reference and an error
+func (client *Client) GetVMByHref(vmHref string) (*VM, error) {
+
+	newVm := NewVM(client)
+
+	_, err := client.ExecuteRequest(vmHref, http.MethodGet,
+		"", "error retrieving vm: %s", nil, newVm.VM)
+
+	if err != nil {
+
+		return nil, err
+	}
+
+	return newVm, nil
+}
+
+// GetVMByName returns a VM reference if the VM name matches an existing one.
+// If no valid VM is found, it returns an empty VM reference and an error
+func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
+	if refresh {
+		err := vapp.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vapp: %s", err)
+		}
+	}
+
+	//vApp Might Not Have Any VMs
+	if vapp.VApp.Children == nil {
+		return nil, ErrorEntityNotFound
+	}
+
+	util.Logger.Printf("[TRACE] Looking for VM: %s", vmName)
+	for _, child := range vapp.VApp.Children.VM {
+
+		util.Logger.Printf("[TRACE] Looking at: %s", child.Name)
+		if child.Name == vmName {
+			return vapp.client.GetVMByHref(child.HREF)
+		}
+
+	}
+	util.Logger.Printf("[TRACE] Couldn't find VM: %s", vmName)
+	return nil, ErrorEntityNotFound
+}
+
+// GetVMById returns a VM reference if the VM ID matches an existing one.
+// If no valid VM is found, it returns an empty VM reference and an error
+func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
+	if refresh {
+		err := vapp.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vapp: %s", err)
+		}
+	}
+
+	//vApp Might Not Have Any VMs
+	if vapp.VApp.Children == nil {
+		return nil, ErrorEntityNotFound
+	}
+
+	util.Logger.Printf("[TRACE] Looking for VM: %s", id)
+	for _, child := range vapp.VApp.Children.VM {
+
+		util.Logger.Printf("[TRACE] Looking at: %s", child.Name)
+		if equalIds(id, child.ID, child.HREF) {
+			return vapp.client.GetVMByHref(child.HREF)
+		}
+	}
+	util.Logger.Printf("[TRACE] Couldn't find VM: %s", id)
+	return nil, ErrorEntityNotFound
+}
+
+// GetVMByNameOrId returns a VM reference if either the VM name or ID matches an existing one.
+// If no valid VM is found, it returns an empty VM reference and an error
+func (vapp *VApp) GetVMByNameOrId(identifier string, refresh bool) (*VM, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vapp.GetVMByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vapp.GetVMById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
+	return entity.(*VM), err
+}

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -20,7 +20,7 @@ func (vcd *TestVCD) Test_VAPPRefreshConcurrent(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
+	vapp, err := vcd.vdc.GetVAppByName(vcd.vapp.VApp.Name, false)
 	check.Assert(err, IsNil)
 
 	for counter := 0; counter < 5; counter++ {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func (vcd *TestVCD) TestGetParentVDC(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp, err := vcd.vdc.FindVAppByName(vcd.vapp.VApp.Name)
+	vapp, err := vcd.vdc.GetVAppByName(vcd.vapp.VApp.Name, false)
 	check.Assert(err, IsNil)
 
 	vdc, err := vapp.getParentVDC()
@@ -464,13 +465,11 @@ func (vcd *TestVCD) Test_AddNewVMNilNIC(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	vdc, err := vapp.getParentVDC()
-	check.Assert(err, IsNil)
-	vm, err := vdc.FindVMByName(vapp, check.TestName())
+	vm, err := vapp.GetVMByName(check.TestName(), true)
 	check.Assert(err, IsNil)
 
 	// Cleanup the created VM
-	err = vapp.RemoveVM(vm)
+	err = vapp.RemoveVM(*vm)
 	check.Assert(err, IsNil)
 }
 
@@ -550,10 +549,7 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	vdc, err := vapp.getParentVDC()
-	check.Assert(err, IsNil)
-
-	vm, err := vdc.FindVMByName(vapp, check.TestName())
+	vm, err := vapp.GetVMByName(check.TestName(), true)
 	check.Assert(err, IsNil)
 
 	// Ensure network config was valid
@@ -563,7 +559,7 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	verifyNetworkConnectionSection(check, actualNetConfig, desiredNetConfig)
 
 	// Cleanup
-	err = vapp.RemoveVM(vm)
+	err = vapp.RemoveVM(*vm)
 	check.Assert(err, IsNil)
 
 	// Ensure network is detached from vApp to avoid conflicts in other tests
@@ -689,4 +685,57 @@ func (vcd *TestVCD) Test_VappSetProductSectionList(check *C) {
 	}
 	vapp := vcd.findFirstVapp()
 	propertyTester(vcd, check, &vapp)
+}
+
+// Tests VM retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_GetVM(check *C) {
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp wasn't properly created")
+	}
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_GetVapp: Org name not given.")
+		return
+	}
+	if vcd.config.VCD.Vdc == "" {
+		check.Skip("Test_GetVapp: VDC name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
+
+	vapp := vcd.findFirstVapp()
+
+	if vapp.VApp == nil || vapp.VApp.HREF == "" || vapp.client == nil {
+		check.Skip("no suitable vApp found")
+	}
+	_, vmName := vcd.findFirstVm(vapp)
+
+	if vmName == "" {
+		check.Skip("no suitable VM found")
+	}
+
+	getByName := func(name string, refresh bool) (genericEntity, error) {
+		return vapp.GetVMByName(name, refresh)
+	}
+	getById := func(id string, refresh bool) (genericEntity, error) { return vapp.GetVMById(id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
+		return vapp.GetVMByNameOrId(id, refresh)
+	}
+
+	var def = getterTestDefinition{
+		parentType:    "VApp",
+		parentName:    vapp.VApp.Name,
+		entityType:    "VM",
+		entityName:    vmName,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -581,6 +581,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 		types.MimeComposeVappParams, "error instantiating a new vApp: %s", vcomp)
 }
 
+// Deprecated: use vdc.GetVAppByName instead
 func (vdc *Vdc) FindVAppByName(vapp string) (VApp, error) {
 
 	err := vdc.Refresh()
@@ -606,6 +607,7 @@ func (vdc *Vdc) FindVAppByName(vapp string) (VApp, error) {
 	return VApp{}, fmt.Errorf("can't find vApp: %s", vapp)
 }
 
+// Deprecated: use vapp.GetVMByName instead
 func (vdc *Vdc) FindVMByName(vapp VApp, vm string) (VM, error) {
 
 	err := vdc.Refresh()
@@ -681,6 +683,7 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 	return *newVM, nil
 }
 
+// Deprecated: use vdc.GetVAppById instead
 func (vdc *Vdc) FindVAppByID(vappid string) (VApp, error) {
 
 	// Horrible hack to fetch a vapp with its id.
@@ -741,4 +744,73 @@ func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
 
 	util.Logger.Printf("[TRACE] Found media record by name: %#v \n", mediaResults)
 	return *newMediaItem, nil
+}
+
+// GetVappByHref returns a vApp reference by running a vCD API call
+// If no valid vApp is found, it returns an empty VApp reference and an error
+func (vdc *Vdc) GetVAppByHref(vappHref string) (*VApp, error) {
+
+	newVapp := NewVApp(vdc.client)
+
+	_, err := vdc.client.ExecuteRequest(vappHref, http.MethodGet,
+		"", "error retrieving vApp: %s", nil, newVapp.VApp)
+
+	if err != nil {
+		return nil, err
+	}
+	return newVapp, nil
+}
+
+// GetVappByName returns a vApp reference if the vApp Name matches an existing one.
+// If no valid vApp is found, it returns an empty VApp reference and an error
+func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
+
+	if refresh {
+		err := vdc.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing VDC: %s", err)
+		}
+	}
+
+	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
+		for _, resourceReference := range resourceEntities.ResourceEntity {
+			if resourceReference.Name == vappName && resourceReference.Type == "application/vnd.vmware.vcloud.vApp+xml" {
+				return vdc.GetVAppByHref(resourceReference.HREF)
+			}
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVappById returns a vApp reference if the vApp ID matches an existing one.
+// If no valid vApp is found, it returns an empty VApp reference and an error
+func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
+
+	if refresh {
+		err := vdc.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing VDC: %s", err)
+		}
+	}
+
+	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
+		for _, resourceReference := range resourceEntities.ResourceEntity {
+			if equalIds(id, resourceReference.ID, resourceReference.HREF) {
+				return vdc.GetVAppByHref(resourceReference.HREF)
+			}
+		}
+	}
+	return nil, ErrorEntityNotFound
+}
+
+// GetVappByNameOrId returns a vApp reference if either the vApp name or ID matches an existing one.
+// If no valid vApp is found, it returns an empty VApp reference and an error
+func (vdc *Vdc) GetVAppByNameOrId(identifier string, refresh bool) (*VApp, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVAppByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVAppById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
+	return entity.(*VApp), err
 }

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -198,7 +198,7 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 }
 
 // GetOrgVdcNetworkByHref returns an Org VDC Network reference if the network HREF matches an existing one.
-// If no valid external network is found, it returns an nil Network reference and an error
+// If no valid external network is found, it returns a nil Network reference and an error
 func (vdc *Vdc) GetOrgVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
 
 	orgNet := NewOrgVDCNetwork(vdc.client)
@@ -211,7 +211,7 @@ func (vdc *Vdc) GetOrgVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
 }
 
 // GetOrgVdcNetworkByName returns an Org VDC Network reference if the network name matches an existing one.
-// If no valid external network is found, it returns an nil Network reference and an error
+// If no valid external network is found, it returns a nil Network reference and an error
 func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
 		err := vdc.Refresh()
@@ -231,7 +231,7 @@ func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwor
 }
 
 // GetOrgVdcNetworkById returns an Org VDC Network reference if the network ID matches an existing one.
-// If no valid external network is found, it returns an nil Network reference and an error
+// If no valid external network is found, it returns a nil Network reference and an error
 func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
 		err := vdc.Refresh()
@@ -251,7 +251,7 @@ func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, e
 }
 
 // GetOrgVdcNetworkByNameOrId returns a VDC Network reference if either the network name or ID matches an existing one.
-// If no valid external network is found, it returns an empty ExternalNetwork reference and an error
+// If no valid external network is found, it returns a nil ExternalNetwork reference and an error
 func (vdc *Vdc) GetOrgVdcNetworkByNameOrId(identifier string, refresh bool) (*OrgVDCNetwork, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkByName(name, refresh) }
 	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkById(id, refresh) }
@@ -747,7 +747,7 @@ func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
 }
 
 // GetVappByHref returns a vApp reference by running a vCD API call
-// If no valid vApp is found, it returns an empty VApp reference and an error
+// If no valid vApp is found, it returns a nil VApp reference and an error
 func (vdc *Vdc) GetVAppByHref(vappHref string) (*VApp, error) {
 
 	newVapp := NewVApp(vdc.client)
@@ -762,7 +762,7 @@ func (vdc *Vdc) GetVAppByHref(vappHref string) (*VApp, error) {
 }
 
 // GetVappByName returns a vApp reference if the vApp Name matches an existing one.
-// If no valid vApp is found, it returns an empty VApp reference and an error
+// If no valid vApp is found, it returns a nil VApp reference and an error
 func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
 
 	if refresh {
@@ -783,7 +783,7 @@ func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
 }
 
 // GetVappById returns a vApp reference if the vApp ID matches an existing one.
-// If no valid vApp is found, it returns an empty VApp reference and an error
+// If no valid vApp is found, it returns a nil VApp reference and an error
 func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
 
 	if refresh {
@@ -804,7 +804,7 @@ func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
 }
 
 // GetVappByNameOrId returns a vApp reference if either the vApp name or ID matches an existing one.
-// If no valid vApp is found, it returns an empty VApp reference and an error
+// If no valid vApp is found, it returns a nil VApp reference and an error
 func (vdc *Vdc) GetVAppByNameOrId(identifier string, refresh bool) (*VApp, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVAppByName(name, refresh) }
 	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVAppById(id, refresh) }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -140,6 +140,7 @@ func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSe
 	return nil
 }
 
+// Deprecated: use client.GetVMByHref instead
 func (cli *Client) FindVMByHREF(vmHREF string) (VM, error) {
 
 	newVm := NewVM(cli)


### PR DESCRIPTION
This is the usual boilerplate to implement new Get methods.

* Add Get* methods for VM and VApp
* Deprecate methods FindVMByHREF, FindVMByName, FindVAppByID, and FindVAppByName
* Replace usage of deprecated Find* methods with new Get* methods
