### PR TITLE
Added method GetGuestCustomizationSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ which use the proxied NSX-V API of advanced edge gateway for handling NAT rules 
 * Added methods `Vdc.GetVappByHref`, `Vdc.GetVAppByName` and related `GetVAppById`, `GetVAppByNameOrId`
 * Added methods `Client.GetVMByHref` `Vapp.GetVAMByName` and related `GetVMById`, `GetVAMByNameOrId`
 * Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
+* Added method`Vm.GetGuestCustomizationSection` 
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ which use the proxied NSX-V API of advanced edge gateway for handling NAT rules 
 * Added methods `Vdc.GetVappByHref`, `Vdc.GetVAppByName` and related `GetVAppById`, `GetVAppByNameOrId`
 * Added methods `Client.GetVMByHref` `Vapp.GetVAMByName` and related `GetVMById`, `GetVAMByNameOrId`
 * Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
-* Added method `Vm.GetGuestCustomizationSection` 
+* Added methods `Vm.GetGuestCustomizationSection` and `Vm.SetGuestCustomizationSection`  
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ which use the proxied NSX-V API of advanced edge gateway for handling NAT rules 
 * Added methods `Vdc.GetVappByHref`, `Vdc.GetVAppByName` and related `GetVAppById`, `GetVAppByNameOrId`
 * Added methods `Client.GetVMByHref` `Vapp.GetVAMByName` and related `GetVMById`, `GetVAMByNameOrId`
 * Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
-* Added method`Vm.GetGuestCustomizationSection` 
+* Added method `Vm.GetGuestCustomizationSection` 
 
 IMPROVEMENTS:
 

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -92,3 +92,33 @@ func propertyTester(vcd *TestVCD, check *C, object productSectionListGetSetter) 
 	check.Assert(gotproductSection.ProductSection.Property, DeepEquals, productSection.ProductSection.Property)
 	check.Assert(getproductSection, DeepEquals, gotproductSection)
 }
+
+// guestPropertyGetSetter interface is used for covering tests
+type getGuestCustomizationSectionGetSetter interface {
+	GetGuestCustomizationSection() (*types.GuestCustomizationSection, error)
+}
+
+// guestCustomizationPropertyTester is a guest customization property get and setter accepting guestPropertyGetSetter interface for trying
+// out settings on all objects implementing such interface
+func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCustomizationSectionGetSetter) {
+	guestCustomizationSection, err := object.GetGuestCustomizationSection()
+	check.Assert(err, IsNil)
+
+	// Check that values were set from API
+	check.Assert(guestCustomizationSection, NotNil)
+
+	check.Assert(guestCustomizationSection.Enabled, Equals, true)
+	check.Assert(guestCustomizationSection.JoinDomainEnabled, Equals, false)
+	check.Assert(guestCustomizationSection.UseOrgSettings, Equals, false)
+	check.Assert(guestCustomizationSection.DomainUserName, Equals, "")
+	check.Assert(guestCustomizationSection.DomainName, Equals, "")
+	check.Assert(guestCustomizationSection.DomainUserPassword, Equals, "")
+	check.Assert(guestCustomizationSection.AdminPasswordEnabled, Equals, true)
+	check.Assert(guestCustomizationSection.AdminPasswordAuto, Equals, true)
+	check.Assert(guestCustomizationSection.AdminPassword, Equals, "")
+	check.Assert(guestCustomizationSection.AdminAutoLogonCount, Equals, 0)
+	check.Assert(guestCustomizationSection.AdminAutoLogonEnabled, Equals, false)
+	check.Assert(guestCustomizationSection.ResetPasswordRequired, Equals, false)
+	check.Assert(guestCustomizationSection.CustomizationScript, Equals, "")
+	check.Assert(guestCustomizationSection.ComputerName, Equals, "PhotonOS-001")
+}

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -120,5 +120,5 @@ func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCus
 	check.Assert(guestCustomizationSection.AdminAutoLogonEnabled, Equals, false)
 	check.Assert(guestCustomizationSection.ResetPasswordRequired, Equals, false)
 	check.Assert(guestCustomizationSection.CustomizationScript, Equals, "")
-	check.Assert(guestCustomizationSection.ComputerName, Equals, "PhotonOS-001")
+	check.Assert(guestCustomizationSection.ComputerName, Not(Equals), "")
 }

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -96,12 +96,20 @@ func propertyTester(vcd *TestVCD, check *C, object productSectionListGetSetter) 
 // guestPropertyGetSetter interface is used for covering tests
 type getGuestCustomizationSectionGetSetter interface {
 	GetGuestCustomizationSection() (*types.GuestCustomizationSection, error)
+	SetGuestCustomizationSection(guestCustomizationSection *types.GuestCustomizationSection) (*types.GuestCustomizationSection, error)
 }
 
 // guestCustomizationPropertyTester is a guest customization property get and setter accepting guestPropertyGetSetter interface for trying
 // out settings on all objects implementing such interface
 func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCustomizationSectionGetSetter) {
-	guestCustomizationSection, err := object.GetGuestCustomizationSection()
+	setupedGuestCustomizationSection := &types.GuestCustomizationSection{
+		Enabled: true, JoinDomainEnabled: false, UseOrgSettings: false,
+		DomainUserName: "", DomainName: "", DomainUserPassword: "",
+		AdminPasswordEnabled: true, AdminPassword: "adminPass", AdminPasswordAuto: false,
+		AdminAutoLogonEnabled: true, AdminAutoLogonCount: 15, ResetPasswordRequired: true,
+		CustomizationScript: "ls", ComputerName: "Cname18"}
+
+	guestCustomizationSection, err := object.SetGuestCustomizationSection(setupedGuestCustomizationSection)
 	check.Assert(err, IsNil)
 
 	// Check that values were set from API
@@ -114,11 +122,11 @@ func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCus
 	check.Assert(guestCustomizationSection.DomainName, Equals, "")
 	check.Assert(guestCustomizationSection.DomainUserPassword, Equals, "")
 	check.Assert(guestCustomizationSection.AdminPasswordEnabled, Equals, true)
-	check.Assert(guestCustomizationSection.AdminPasswordAuto, Equals, true)
-	check.Assert(guestCustomizationSection.AdminPassword, Equals, "")
-	check.Assert(guestCustomizationSection.AdminAutoLogonCount, Equals, 0)
-	check.Assert(guestCustomizationSection.AdminAutoLogonEnabled, Equals, false)
-	check.Assert(guestCustomizationSection.ResetPasswordRequired, Equals, false)
-	check.Assert(guestCustomizationSection.CustomizationScript, Equals, "")
-	check.Assert(guestCustomizationSection.ComputerName, Not(Equals), "")
+	check.Assert(guestCustomizationSection.AdminPasswordAuto, Equals, false)
+	check.Assert(guestCustomizationSection.AdminPassword, Equals, "adminPass")
+	check.Assert(guestCustomizationSection.AdminAutoLogonCount, Equals, 15)
+	check.Assert(guestCustomizationSection.AdminAutoLogonEnabled, Equals, true)
+	check.Assert(guestCustomizationSection.ResetPasswordRequired, Equals, true)
+	check.Assert(guestCustomizationSection.CustomizationScript, Equals, "ls")
+	check.Assert(guestCustomizationSection.ComputerName, Equals, "Cname18")
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -799,3 +799,20 @@ func (vm *VM) SetProductSectionList(productSection *types.ProductSectionList) (*
 func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 	return getProductSectionList(vm.client, vm.VM.HREF)
 }
+
+// GetGuestCustomizationSection retrieves  guest customization section for a VM. It allows to read VM guest customization properties.
+func (vm *VM) GetGuestCustomizationSection() (*types.GuestCustomizationSection, error) {
+	if vm == nil || vm.VM.HREF == "" {
+		return nil, fmt.Errorf("vm or href cannot be empty to get  guest customization section")
+	}
+	guestCustomizationSection := &types.GuestCustomizationSection{}
+
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/guestCustomizationSection", http.MethodGet,
+		types.MimeGuestCustomizationSection, "error retrieving guest customization section : %s", nil, guestCustomizationSection)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve guest customization section: %s", err)
+	}
+
+	return guestCustomizationSection, nil
+}

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -800,7 +800,7 @@ func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 	return getProductSectionList(vm.client, vm.VM.HREF)
 }
 
-// GetGuestCustomizationSection retrieves  guest customization section for a VM. It allows to read VM guest customization properties.
+// GetGuestCustomizationSection retrieves guest customization section for a VM. It allows to read VM guest customization properties.
 func (vm *VM) GetGuestCustomizationSection() (*types.GuestCustomizationSection, error) {
 	if vm == nil || vm.VM.HREF == "" {
 		return nil, fmt.Errorf("vm or href cannot be empty to get  guest customization section")
@@ -815,4 +815,28 @@ func (vm *VM) GetGuestCustomizationSection() (*types.GuestCustomizationSection, 
 	}
 
 	return guestCustomizationSection, nil
+}
+
+// SetGuestCustomizationSection sets guest customization section for a VM. It allows to change VM guest customization properties.
+func (vm *VM) SetGuestCustomizationSection(guestCustomizationSection *types.GuestCustomizationSection) (*types.GuestCustomizationSection, error) {
+	if vm == nil || vm.VM.HREF == "" {
+		return nil, fmt.Errorf("vm or href cannot be empty to get  guest customization section")
+	}
+
+	guestCustomizationSection.Xmlns = types.XMLNamespaceVCloud
+	guestCustomizationSection.Ovf = types.XMLNamespaceOVF
+
+	task, err := vm.client.ExecuteTaskRequest(vm.VM.HREF+"/guestCustomizationSection", http.MethodPut,
+		types.MimeGuestCustomizationSection, "error setting product section: %s", guestCustomizationSection)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to set guest customization section: %s", err)
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("task for setting guest customization section failed: %s", err)
+	}
+
+	return vm.GetGuestCustomizationSection()
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -987,6 +987,21 @@ func (vcd *TestVCD) Test_VMSetProductSectionList(check *C) {
 	propertyTester(vcd, check, vm)
 }
 
+// Test_VMGetGuestCustomizationSection retrieves guest customization and checks if properties are right.
+func (vcd *TestVCD) Test_VMGetGuestCustomizationSection(check *C) {
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+	vapp := vcd.findFirstVapp()
+	existingVm, vmName := vcd.findFirstVm(vapp)
+	if vmName == "" {
+		check.Skip("skipping test because no VM is found")
+	}
+	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	check.Assert(err, IsNil)
+	guestCustomizationPropertyTester(vcd, check, vm)
+}
+
 // Test gathering VM virtual hardware items
 func (vcd *TestVCD) Test_GetVirtualHardwareSection(check *C) {
 	itemName := "TestGetVirtualHardwareSection"

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -987,8 +987,8 @@ func (vcd *TestVCD) Test_VMSetProductSectionList(check *C) {
 	propertyTester(vcd, check, vm)
 }
 
-// Test_VMGetGuestCustomizationSection retrieves guest customization and checks if properties are right.
-func (vcd *TestVCD) Test_VMGetGuestCustomizationSection(check *C) {
+// Test_VMSetGetGuestCustomizationSection sets and when retrieves guest customization and checks if properties are right.
+func (vcd *TestVCD) Test_VMSetGetGuestCustomizationSection(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/pull/334

Added func `GetGuestCustomizationSection` to allow read VM values, particularly needed `computer_name` for terraform read functionality.