### PR TITLE
Small fixes

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -50,22 +50,26 @@ var debugShowRequestEnabled = os.Getenv("GOVCD_SHOW_REQ") != ""
 var debugShowResponseEnabled = os.Getenv("GOVCD_SHOW_RESP") != ""
 
 // Enables the debugging hook to show requests as they are processed.
+//lint:ignore U1000 this function is used on request for debugging purposes
 func enableDebugShowRequest() {
 	debugShowRequestEnabled = true
 }
 
 // Disables the debugging hook to show requests as they are processed.
+//lint:ignore U1000 this function is used on request for debugging purposes
 func disableDebugShowRequest() {
 	debugShowRequestEnabled = false
 	_ = os.Setenv("GOVCD_SHOW_REQ", "")
 }
 
 // Enables the debugging hook to show responses as they are processed.
+//lint:ignore U1000 this function is used on request for debugging purposes
 func enableDebugShowResponse() {
 	debugShowResponseEnabled = true
 }
 
 // Disables the debugging hook to show responses as they are processed.
+//lint:ignore U1000 this function is used on request for debugging purposes
 func disableDebugShowResponse() {
 	debugShowResponseEnabled = false
 	_ = os.Setenv("GOVCD_SHOW_RESP", "")

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -77,7 +77,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 	vcdCli.Client.VCDToken = resp.Header.Get("x-vcloud-authorization")
 	vcdCli.Client.VCDAuthHeader = "x-vcloud-authorization"
 	vcdCli.Client.IsSysAdmin = false
-	if "system" == strings.ToLower(org) {
+	if strings.ToLower(org) == "system" {
 		vcdCli.Client.IsSysAdmin = true
 	}
 	// Get query href

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -310,7 +310,7 @@ func FindDiskByHREF(client *Client, href string) (*Disk, error) {
 // Find independent disk using disk name. Returns VMRecord query return type
 func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
 
-	if "" == diskName {
+	if diskName == "" {
 		return DiskRecord{}, fmt.Errorf("disk name can not be empty")
 	}
 

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -154,7 +154,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 
 	if mediaForUpload.Tasks != nil {
 		for _, task := range mediaForUpload.Tasks.Task {
-			if "error" == task.Status && mediaName == mediaForUpload.Name {
+			if task.Status == "error" && mediaName == mediaForUpload.Name {
 				util.Logger.Printf("[Error] issue with creating media %#v", task.Error)
 				return nil, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 			}
@@ -210,7 +210,7 @@ func queryMedia(client *Client, mediaUrl string, newItemName string) (*types.Med
 	}
 
 	for _, task := range mediaParsed.Tasks.Task {
-		if "error" == task.Status && newItemName == task.Owner.Name {
+		if task.Status == "error" && newItemName == task.Owner.Name {
 			util.Logger.Printf("[Error] %#v", task.Error)
 			return mediaParsed, fmt.Errorf("error in vcd returned error code: %d, error: %s and message: %s ", task.Error.MajorErrorCode, task.Error.MinorErrorCode, task.Error.Message)
 		}

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -387,7 +387,16 @@ func (vapp *VApp) GetStatus() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error refreshing vApp: %v", err)
 	}
-	return types.VAppStatuses[vapp.VApp.Status], nil
+	// Trying to make this function future-proof:
+	// If a new status is added to a future vCD API and the status map in types.go
+	// is not updated, we may get a panic.
+	// Using the ", ok" construct we take control of the data lookup and are able to fail
+	// gracefully.
+	statusText, ok := types.VAppStatuses[vapp.VApp.Status]
+	if ok {
+		return statusText, nil
+	}
+	return "", fmt.Errorf("status %d does not have a description in types.VappStatuses", vapp.VApp.Status)
 }
 
 // BlockWhileStatus blocks until the status of vApp exits unwantedStatus.

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -241,7 +241,9 @@ func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, e
 	}
 	for _, an := range vdc.Vdc.AvailableNetworks {
 		for _, reference := range an.Network {
-			if reference.ID == id {
+			// Some versions of vCD do not return an ID in the network reference
+			// We use equalIds to overcome this issue
+			if equalIds(id, reference.ID, reference.HREF) {
 				return vdc.GetOrgVdcNetworkByHref(reference.HREF)
 			}
 		}

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -29,6 +29,7 @@ func (vcd *TestVCD) Test_FindVDCNetwork(check *C) {
 	// find Invalid Network
 	net, err = vcd.vdc.GetOrgVdcNetworkByName("INVALID", false)
 	check.Assert(err, NotNil)
+	check.Assert(net, IsNil)
 }
 
 // Tests Network retrieval by name, by ID, and by a combination of name and ID

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -739,7 +739,7 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 func (vm *VM) AnswerQuestion(questionId string, choiceId int) error {
 
 	//validate input
-	if "" == questionId {
+	if questionId == "" {
 		return fmt.Errorf("questionId can not be empty")
 	}
 


### PR DESCRIPTION
1. Fix GetOrgVdcNetworkById behavior with 9.1. (fixes terraform-provider-vcd issue 330)
   Some old version of vCD don't report the network ID in reference structures
2. Make vapp.GetStatus future proof
3. Fix staticcheck warnings
   Some small adjustments to silence linter complaints


