### PR TITLE
Add change disk size

### DIFF
--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -394,10 +394,11 @@ func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 		types.MimeRasdItem, "error changing memory size: %s", newMem)
 }
 
+// ChangeDiskSize alters the Capacity (in megabytes) of a non-independent disk attached to the VM. Disk sizes may only be increased.
 func (vm *VM) ChangeDiskSize(index int, size int) (Task, error) {
 	err := vm.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	items := &types.RasdItemsList{

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -670,6 +670,7 @@ func (vcd *TestVCD) Test_VMChangeRootDiskSize(check *C) {
 	// The VM should have at least 1 disk (resource type 17) attached at AddressOnParent 0, indicating the root disk. Fetch the initial capacity from that disk.
 	if existingVm.VirtualHardwareSection != nil && existingVm.VirtualHardwareSection.Item != nil {
 		for _, item := range existingVm.VirtualHardwareSection.Item {
+			fmt.Printf("%+v\n", item)
 			if item.ResourceType == types.ResourceTypeDisk && item.AddressOnParent == 0 {
 				currentDiskCapacity = item.VirtualQuantity / (1024 * 1024)
 				break
@@ -681,7 +682,7 @@ func (vcd *TestVCD) Test_VMChangeRootDiskSize(check *C) {
 	check.Assert(err, IsNil)
 
 	// Increase the disk size by 1MB
-	task, err := vm.ChangeDiskSize(0, currentDiskCapacity+1)
+	task, err := vm.ChangeDiskSize(0, 0, currentDiskCapacity+1)
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -73,6 +73,8 @@ const (
 	MimeNetworkConnectionSection = "application/vnd.vmware.vcloud.networkConnectionSection+xml"
 	// Mime for Item
 	MimeRasdItem = "application/vnd.vmware.vcloud.rasdItem+xml"
+	// Mime for Item list
+	MimeRasdItemList = "application/vnd.vmware.vcloud.rasdItemsList+xml"
 	// Mime for guest customization section
 	MimeGuestCustomizationSection = "application/vnd.vmware.vcloud.guestCustomizationSection+xml"
 	// Mime for guest customization status

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1403,12 +1403,13 @@ type VirtualHardwareConnection struct {
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // def8435d-a54a-4923-b26a-e2d1915b09c3/vcloud_sp_api_guide_30_0.pdf
 type VirtualHardwareHostResource struct {
-	BusType           int    `xml:"busType,attr,omitempty"`
-	BusSubType        string `xml:"busSubType,attr,omitempty"`
-	Capacity          int    `xml:"capacity,attr,omitempty"`
-	StorageProfile    string `xml:"storageProfileHref,attr,omitempty"`
-	OverrideVmDefault bool   `xml:"storageProfileOverrideVmDefault,attr,omitempty"`
-	Disk              string `xml:"disk,attr,omitempty"`
+	XmlnsVCloud       string `xml:"xmlns:vcloud,attr,omitempty"`
+	BusType           int    `xml:"vcloud:busType,attr,omitempty"`
+	BusSubType        string `xml:"vcloud:busSubType,attr,omitempty"`
+	Capacity          int    `xml:"vcloud:capacity,attr,omitempty"`
+	StorageProfile    string `xml:"vcloud:storageProfileHref,attr,omitempty"`
+	OverrideVmDefault bool   `xml:"vcloud:storageProfileOverrideVmDefault,attr,omitempty"`
+	Disk              string `xml:"vcloud:disk,attr,omitempty"`
 	//Iops              int    `xml:"iops,attr,omitempty"`
 	//OsType            string `xml:"osType,attr,omitempty"`
 }
@@ -1439,16 +1440,37 @@ type OVFItem struct {
 	XmlnsVmw        string   `xml:"xmlns:vmw,attr,omitempty"`
 	VCloudHREF      string   `xml:"vcloud:href,attr"`
 	VCloudType      string   `xml:"vcloud:type,attr"`
-	AllocationUnits string   `xml:"rasd:AllocationUnits"`
-	Description     string   `xml:"rasd:Description"`
-	ElementName     string   `xml:"rasd:ElementName"`
-	InstanceID      int      `xml:"rasd:InstanceID"`
-	Reservation     int      `xml:"rasd:Reservation"`
-	ResourceType    int      `xml:"rasd:ResourceType"`
-	VirtualQuantity int      `xml:"rasd:VirtualQuantity"`
-	Weight          int      `xml:"rasd:Weight"`
-	CoresPerSocket  *int     `xml:"vmw:CoresPerSocket,omitempty"`
-	Link            *Link    `xml:"vcloud:Link"`
+	Address         string   `xml:"rasd:Address,omitempty"`
+	AddressOnParent *int     `xml:"rasd:AddressOnParent,omitempty"`
+
+	AllocationUnits string                       `xml:"rasd:AllocationUnits"`
+	Description     string                       `xml:"rasd:Description"`
+	ElementName     string                       `xml:"rasd:ElementName"`
+	HostResource    *VirtualHardwareHostResource `xml:"rasd:HostResource,omitempty"`
+	InstanceID      int                          `xml:"rasd:InstanceID"`
+	Parent          *int                         `xml:"rasd:Parent,omitempty"`
+	Reservation     int                          `xml:"rasd:Reservation"`
+	ResourceSubType string                       `xml:"rasd:ResourceSubType,omitempty"`
+	ResourceType    int                          `xml:"rasd:ResourceType"`
+
+	VirtualQuantity int   `xml:"rasd:VirtualQuantity"`
+	Weight          int   `xml:"rasd:Weight"`
+	CoresPerSocket  *int  `xml:"vmw:CoresPerSocket,omitempty"`
+	Link            *Link `xml:"vcloud:Link"`
+}
+
+// Used to write a list of RASD items, generally for modifying disks attached to a VM
+type RasdItemsList struct {
+	XMLName     xml.Name `xml:"vcloud:RasdItemsList"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	XmlnsVCloud string   `xml:"xmlns:vcloud,attr"`
+	XmlnsRasd   string   `xml:"xmlns:rasd,attr"`
+	XmlnsXsi    string   `xml:"xmlns:xsi,attr"`
+	XmlnsVmw    string   `xml:"xmlns:vmw,attr,omitempty"`
+	Type        string   `xml:"type,attr"`
+	HREF        string   `xml:"href,attr"`
+	Link        *Link    `xml:"vcloud:Link"`
+	Items       []*OVFItem
 }
 
 // DeployVAppParams are the parameters to a deploy vApp request

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1459,7 +1459,9 @@ type OVFItem struct {
 	Link            *Link `xml:"vcloud:Link"`
 }
 
-// Used to write a list of RASD items, generally for modifying disks attached to a VM
+// Used to write a list of RASD (ResourceAllocationSettingData) items, generally for modifying disks attached to a VM
+// https://pubs.vmware.com/vcd-56/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
+// https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/RasdItemsListType.html
 type RasdItemsList struct {
 	XMLName     xml.Name `xml:"vcloud:RasdItemsList"`
 	Xmlns       string   `xml:"xmlns,attr"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1403,7 +1403,25 @@ type VirtualHardwareConnection struct {
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // def8435d-a54a-4923-b26a-e2d1915b09c3/vcloud_sp_api_guide_30_0.pdf
 type VirtualHardwareHostResource struct {
-	XmlnsVCloud       string `xml:"xmlns:vcloud,attr,omitempty"`
+	BusType           int    `xml:"busType,attr,omitempty"`
+	BusSubType        string `xml:"busSubType,attr,omitempty"`
+	Capacity          int    `xml:"capacity,attr,omitempty"`
+	StorageProfile    string `xml:"storageProfileHref,attr,omitempty"`
+	OverrideVmDefault bool   `xml:"storageProfileOverrideVmDefault,attr,omitempty"`
+	Disk              string `xml:"disk,attr,omitempty"`
+	//Iops              int    `xml:"iops,attr,omitempty"`
+	//OsType            string `xml:"osType,attr,omitempty"`
+}
+
+/*
+VirtualHardwareHostResourceForWrite is an AWFUL hack, but I can't figure out how to get it to work cleanly otherwise.
+The HostResource belongs to the rasd namespace, but all its attributes belong to the vcloud namespace.
+If we specify the vcloud namespace in VirtualHardwareHostResource, it doesn't parse correctly, as
+VCD sends those with an aliased namespace, not literally "vcloud".
+Someone with a better understanding of Go's struct-to-XML marshalling and how it interacts with mixed namespaces between
+the element and attributes might be able to untangle this and unify VirtualHardwareHostResource with VirtualHardwareHostResourceForWrite.
+*/
+type VirtualHardwareHostResourceForWrite struct {
 	BusType           int    `xml:"vcloud:busType,attr,omitempty"`
 	BusSubType        string `xml:"vcloud:busSubType,attr,omitempty"`
 	Capacity          int    `xml:"vcloud:capacity,attr,omitempty"`
@@ -1433,37 +1451,39 @@ type SnapshotItem struct {
 
 // OVFItem is a horrible kludge to process OVF, needs to be fixed with proper types.
 type OVFItem struct {
-	XMLName         xml.Name `xml:"vcloud:Item"`
-	XmlnsRasd       string   `xml:"xmlns:rasd,attr"`
-	XmlnsVCloud     string   `xml:"xmlns:vcloud,attr"`
-	XmlnsXsi        string   `xml:"xmlns:xsi,attr"`
-	XmlnsVmw        string   `xml:"xmlns:vmw,attr,omitempty"`
-	VCloudHREF      string   `xml:"vcloud:href,attr"`
-	VCloudType      string   `xml:"vcloud:type,attr"`
-	Address         string   `xml:"rasd:Address,omitempty"`
-	AddressOnParent *int     `xml:"rasd:AddressOnParent,omitempty"`
+	XMLName     xml.Name `xml:"vcloud:Item"`
+	XmlnsRasd   string   `xml:"xmlns:rasd,attr"`
+	XmlnsVCloud string   `xml:"xmlns:vcloud,attr"`
+	XmlnsXsi    string   `xml:"xmlns:xsi,attr"`
+	XmlnsVmw    string   `xml:"xmlns:vmw,attr,omitempty"`
 
-	AllocationUnits string                       `xml:"rasd:AllocationUnits"`
-	Description     string                       `xml:"rasd:Description"`
-	ElementName     string                       `xml:"rasd:ElementName"`
-	HostResource    *VirtualHardwareHostResource `xml:"rasd:HostResource,omitempty"`
-	InstanceID      int                          `xml:"rasd:InstanceID"`
-	Parent          *int                         `xml:"rasd:Parent,omitempty"`
-	Reservation     int                          `xml:"rasd:Reservation"`
-	ResourceSubType string                       `xml:"rasd:ResourceSubType,omitempty"`
-	ResourceType    int                          `xml:"rasd:ResourceType"`
+	VCloudHREF string `xml:"vcloud:href,attr"`
+	VCloudType string `xml:"vcloud:type,attr"`
 
-	VirtualQuantity int   `xml:"rasd:VirtualQuantity"`
-	Weight          int   `xml:"rasd:Weight"`
-	CoresPerSocket  *int  `xml:"vmw:CoresPerSocket,omitempty"`
-	Link            *Link `xml:"vcloud:Link"`
+	Address              string                               `xml:"rasd:Address,omitempty"`
+	AddressOnParent      *int                                 `xml:"rasd:AddressOnParent,omitempty"`
+	AllocationUnits      string                               `xml:"rasd:AllocationUnits"`
+	Description          string                               `xml:"rasd:Description"`
+	ElementName          string                               `xml:"rasd:ElementName"`
+	HostResource         *VirtualHardwareHostResourceForWrite `xml:"rasd:HostResource,omitempty"`
+	InstanceID           int                                  `xml:"rasd:InstanceID"`
+	Parent               *int                                 `xml:"rasd:Parent,omitempty"`
+	Reservation          int                                  `xml:"rasd:Reservation"`
+	ResourceSubType      string                               `xml:"rasd:ResourceSubType,omitempty"`
+	ResourceType         int                                  `xml:"rasd:ResourceType"`
+	VirtualQuantity      int                                  `xml:"rasd:VirtualQuantity"`
+	VirtualQuantityUnits int                                  `xml:"rasd:VirtualQuantityUnits"`
+	Weight               int                                  `xml:"rasd:Weight"`
+
+	CoresPerSocket *int  `xml:"vmw:CoresPerSocket,omitempty"`
+	Link           *Link `xml:"vcloud:Link"`
 }
 
 // Used to write a list of RASD (ResourceAllocationSettingData) items, generally for modifying disks attached to a VM
 // https://pubs.vmware.com/vcd-56/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-E1BA999D-87FA-4E2C-B638-24A211AB8160.html
 // https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/RasdItemsListType.html
 type RasdItemsList struct {
-	XMLName     xml.Name `xml:"vcloud:RasdItemsList"`
+	XMLName     xml.Name `xml:"RasdItemsList"`
 	Xmlns       string   `xml:"xmlns,attr"`
 	XmlnsVCloud string   `xml:"xmlns:vcloud,attr"`
 	XmlnsRasd   string   `xml:"xmlns:rasd,attr"`


### PR DESCRIPTION
## Description

Related issue: #250

govcd doesn't currently provide a mechanism for managing the RasdItemsList attached to a VM. While any number of items could be managed, the one I'm immediately interested in is the ability to change disk sizes. This PR adds `vm.ChangeDiskSize(index, size)`, which permits this action.

I plan to submit a sibling PR to the terraform provider allowing users to specify the root disk size.

I've written a test, but I don't have infrastructure set up to execute it. However, I've tested this against my 9.1 vCD environment and it works well.