### PR TITLE
Deprecated find disk functions and added new get Disk functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ which use the proxied NSX-V API of advanced edge gateway for handling NAT rules 
 * Added methods `Client.GetVMByHref` `Vapp.GetVAMByName` and related `GetVMById`, `GetVAMByNameOrId`
 * Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
 * Added methods `Vm.GetGuestCustomizationSection` and `Vm.SetGuestCustomizationSection`  
+* Deprecated methods `VDC.FindDiskByHREF` and `FindDiskByHREF`
+* Added methods `VDC.GetDiskByHref` `VDC.GetDiskByName` and related `GetDiskById`, `GetDiskByNameOrId`
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ which use the proxied NSX-V API of advanced edge gateway for handling NAT rules 
 * Deprecated methods `Client.FindVMByHREF`, `Vdc.FindVMByName`, `Vdc.FindVAppByID`, and `Vdc.FindVAppByName`
 * Added methods `Vm.GetGuestCustomizationSection` and `Vm.SetGuestCustomizationSection`  
 * Deprecated methods `VDC.FindDiskByHREF` and `FindDiskByHREF`
-* Added methods `VDC.GetDiskByHref` `VDC.GetDiskByName` and related `GetDiskById`, `GetDiskByNameOrId`
+* Added methods `VDC.GetDiskByHref` `VDC.GetDisksByName` and related `GetDiskById`
 
 IMPROVEMENTS:
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -756,7 +756,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 	case "disk":
 		// Find disk by href rather than find disk by name, because disk name can be duplicated in VDC,
 		// so the unique href is required for finding the disk.
-		disk, err := vcd.vdc.GetDiskByHref(entity.Parent)
+		disk, err := vcd.vdc.GetDiskByHref(entity.Name)
 		if err != nil {
 			// If the disk is not found, we just need to show that it was not found, as
 			// it was likely deleted during the regular tests

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -756,8 +756,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 	case "disk":
 		// Find disk by href rather than find disk by name, because disk name can be duplicated in VDC,
 		// so the unique href is required for finding the disk.
-		// [0] = disk's entity name, [1] = disk href
-		disk, err := vcd.vdc.FindDiskByHREF(strings.Split(entity.Name, "|")[1])
+		disk, err := vcd.vdc.GetDiskByHref(entity.Parent)
 		if err != nil {
 			// If the disk is not found, we just need to show that it was not found, as
 			// it was likely deleted during the regular tests

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -365,11 +365,11 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 }
 
 // GetDisksByName finds one or more Disks by Name
-// On success, returns a pointer to the Disk array and a nil error
+// On success, returns a pointer to the Disk list and a nil error
 // On failure, returns a nil pointer and an error
 func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Name: %s\n", diskName)
-	var diskArray []Disk
+	var diskList []Disk
 	if refresh {
 		err := vdc.Refresh()
 		if err != nil {
@@ -383,14 +383,14 @@ func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 				if err != nil {
 					return nil, err
 				}
-				diskArray = append(diskArray, *disk)
+				diskList = append(diskList, *disk)
 			}
 		}
 	}
-	if len(diskArray) == 0 {
+	if len(diskList) == 0 {
 		return nil, ErrorEntityNotFound
 	}
-	return &diskArray, nil
+	return &diskList, nil
 }
 
 // GetDiskById finds a Disk by ID

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -358,7 +358,7 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 	Disk := NewDisk(vdc.client)
 
 	_, err := vdc.client.ExecuteRequest(diskHref, http.MethodGet,
-		"", "error retrieving Disk: %s", nil, Disk.Disk)
+		"", "error retrieving Disk: %#v", nil, Disk.Disk)
 	if err != nil && strings.Contains(err.Error(), "MajorErrorCode:403") {
 		return nil, ErrorEntityNotFound
 	}

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -227,7 +227,7 @@ func (disk *Disk) Delete() (Task, error) {
 func (disk *Disk) Refresh() error {
 	util.Logger.Printf("[TRACE] Disk refresh, HREF: %s\n", disk.Disk.HREF)
 
-	if *disk == (Disk{}) {
+	if disk.Disk == nil || disk.Disk.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
 
@@ -404,17 +404,17 @@ func (vdc *Vdc) GetDiskById(diskId string, refresh bool) (*Disk, error) {
 			return nil, err
 		}
 	}
-	diskHREF := vdc.client.VCDHREF
 
-	DiskBareId, err := getBareEntityUuid(diskId)
+	diskBareId, err := getBareEntityUuid(diskId)
 	if err != nil {
 		util.Logger.Printf("[Error] parsing bareID from diskId %s: %s", diskId, err)
 		return nil, ErrorEntityNotFound
 	}
-	if DiskBareId == "" {
+	if diskBareId == "" {
 		util.Logger.Printf("[Error] parsing bareID from diskId %s - empty bareID returned", diskId)
 		return nil, ErrorEntityNotFound
 	}
-	diskHREF.Path += fmt.Sprintf("/disk/%s", DiskBareId)
+	diskHREF := vdc.client.VCDHREF
+	diskHREF.Path += fmt.Sprintf("/disk/%s", diskBareId)
 	return vdc.GetDiskByHref(diskHREF.String())
 }

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -364,8 +364,8 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 	return Disk, nil
 }
 
-// GetDiskByName finds a Disk by Name
-// On success, returns a pointer to the Disk structure and a nil error
+// GetDisksByName finds a Disks by Name
+// On success, returns a pointer to the Disk array and a nil error
 // On failure, returns a nil pointer and an error
 func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Name: %s\n", diskName)

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -364,7 +364,7 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 	return Disk, nil
 }
 
-// GetDisksByName finds a Disks by Name
+// GetDisksByName finds one or more Disks by Name
 // On success, returns a pointer to the Disk array and a nil error
 // On failure, returns a nil pointer and an error
 func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -367,8 +367,9 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 // GetDiskByName finds a Disk by Name
 // On success, returns a pointer to the Disk structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vdc *Vdc) GetDiskByName(diskName string, refresh bool) (*Disk, error) {
+func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Name: %s\n", diskName)
+	var diskArray []Disk
 	if refresh {
 		err := vdc.Refresh()
 		if err != nil {
@@ -378,11 +379,18 @@ func (vdc *Vdc) GetDiskByName(diskName string, refresh bool) (*Disk, error) {
 	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
 		for _, resourceEntity := range resourceEntities.ResourceEntity {
 			if resourceEntity.Name == diskName && resourceEntity.Type == "application/vnd.vmware.vcloud.disk+xml" {
-				return vdc.GetDiskByHref(resourceEntity.HREF)
+				disk, err := vdc.GetDiskByHref(resourceEntity.HREF)
+				if err != nil {
+					return nil, err
+				}
+				diskArray = append(diskArray, *disk)
 			}
 		}
 	}
-	return nil, ErrorEntityNotFound
+	if len(diskArray) == 0 {
+		return nil, ErrorEntityNotFound
+	}
+	return &diskArray, nil
 }
 
 // GetDiskById finds a Disk by ID
@@ -409,18 +417,4 @@ func (vdc *Vdc) GetDiskById(diskId string, refresh bool) (*Disk, error) {
 	}
 	diskHREF.Path += fmt.Sprintf("/disk/%s", DiskBareId)
 	return vdc.GetDiskByHref(diskHREF.String())
-}
-
-// GetDiskByNameOrId finds a Disk by Name or ID
-// On success, returns a pointer to the Disk structure and a nil error
-// On failure, returns a nil pointer and an error
-func (vdc *Vdc) GetDiskByNameOrId(identifier string, refresh bool) (*Disk, error) {
-	util.Logger.Printf("[TRACE] Get Disk By Name or Id: %s\n", identifier)
-	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetDiskByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetDiskById(id, refresh) }
-	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
-	if entity == nil {
-		return nil, err
-	}
-	return entity.(*Disk), err
 }

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -46,7 +46,7 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -91,7 +91,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -153,7 +153,7 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -204,7 +204,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -286,7 +286,7 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -380,7 +380,7 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -422,7 +422,7 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -495,7 +495,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -586,7 +586,7 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -640,7 +640,7 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -667,7 +667,7 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF = task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	err = vcd.vdc.Refresh()
 	check.Assert(err, IsNil)

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -655,6 +655,12 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	check.Assert((*diskList)[0].Disk.Name, Equals, diskName)
 	check.Assert((*diskList)[0].Disk.Description, Equals, diskName+"Description")
 
+	disk, err := vcd.vdc.GetDiskById((*diskList)[0].Disk.Id, false)
+	check.Assert(err, IsNil)
+	check.Assert(disk, NotNil)
+	check.Assert(disk.Disk.Name, Equals, diskName)
+	check.Assert(disk.Disk.Description, Equals, diskName+"Description")
+
 	diskList, err = vcd.vdc.GetDisksByName("INVALID", false)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -46,7 +46,7 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -91,7 +91,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -153,7 +153,7 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -204,7 +204,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -286,7 +286,7 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -380,7 +380,7 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -422,7 +422,7 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -495,7 +495,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -586,7 +586,7 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -640,7 +640,7 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -667,7 +667,7 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF = task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	err = vcd.vdc.Refresh()
 	check.Assert(err, IsNil)

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_NewDisk(check *C) {
 // Test create independent disk
 func (vcd *TestVCD) Test_CreateDisk(check *C) {
 	if vcd.config.VCD.Disk.Size == 0 {
-		check.Skip("Skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -65,7 +65,7 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 // Test update independent disk
 func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	if vcd.config.VCD.Disk.Size == 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.config.VCD.Disk.SizeForUpdate <= 0 {
@@ -129,7 +129,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 // Test delete independent disk
 func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 	if vcd.config.VCD.Disk.Size == 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -178,7 +178,7 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 // Test refresh independent disk info
 func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.config.VCD.Disk.SizeForUpdate <= 0 {
@@ -243,7 +243,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.skipVappTests {
@@ -358,7 +358,7 @@ func (vcd *TestVCD) detachIndependentDisk(disk Disk) error {
 // Test find Disk by Href in VDC struct
 func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -400,7 +400,7 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 // Test find disk by href and vdc client
 func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("Skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -448,7 +448,7 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 // Independent disk integration test
 func (vcd *TestVCD) Test_Disk(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.config.VCD.Disk.SizeForUpdate <= 0 {
@@ -562,7 +562,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 func (vcd *TestVCD) Test_QueryDisk(check *C) {
 
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("Skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -614,7 +614,7 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	if vcd.config.VCD.Disk.Size == 0 {
-		check.Skip("Skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.config.VCD.Vdc == "" {
@@ -693,7 +693,7 @@ func (vcd *TestVCD) Test_GetDiskByHref(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	if vcd.config.VCD.Disk.Size == 0 {
-		check.Skip("Skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.config.VCD.Vdc == "" {

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -609,7 +609,7 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 
 }
 
-// Tests Disk array retrieval by name, by ID
+// Tests Disk list retrieval by name, by ID
 func (vcd *TestVCD) Test_GetDisks(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
@@ -648,16 +648,17 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 
 	err = vcd.vdc.Refresh()
 	check.Assert(err, IsNil)
-	diskArray, err := vcd.vdc.GetDisksByName(diskName, false)
-	check.Assert(diskArray, NotNil)
-	check.Assert(len(*diskArray), Equals, 1)
-	check.Assert((*diskArray)[0].Disk.Name, Equals, diskName)
-	check.Assert((*diskArray)[0].Disk.Description, Equals, diskName+"Description")
+	diskList, err := vcd.vdc.GetDisksByName(diskName, false)
+	check.Assert(err, IsNil)
+	check.Assert(diskList, NotNil)
+	check.Assert(len(*diskList), Equals, 1)
+	check.Assert((*diskList)[0].Disk.Name, Equals, diskName)
+	check.Assert((*diskList)[0].Disk.Description, Equals, diskName+"Description")
 
-	diskArray, err = vcd.vdc.GetDisksByName("INVALID", false)
+	diskList, err = vcd.vdc.GetDisksByName("INVALID", false)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
-	check.Assert(diskArray, IsNil)
+	check.Assert(diskList, IsNil)
 
 	// test two disk with same name
 	task, err = vcd.vdc.CreateDisk(diskCreateParams)
@@ -670,8 +671,9 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 
 	err = vcd.vdc.Refresh()
 	check.Assert(err, IsNil)
-	diskArray, err = vcd.vdc.GetDisksByName(diskName, false)
-	check.Assert(diskArray, NotNil)
-	check.Assert(len(*diskArray), Equals, 2)
+	diskList, err = vcd.vdc.GetDisksByName(diskName, false)
+	check.Assert(err, IsNil)
+	check.Assert(diskList, NotNil)
+	check.Assert(len(*diskList), Equals, 2)
 
 }

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -46,8 +46,7 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -55,7 +54,7 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -92,8 +91,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -101,7 +99,7 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -155,12 +153,7 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer func() {
-		if err != nil {
-			PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
-		}
-	}()
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -168,7 +161,7 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -211,8 +204,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -220,7 +212,7 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -294,8 +286,7 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -303,7 +294,7 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -389,8 +380,7 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -432,8 +422,7 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -506,8 +495,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -515,7 +503,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -598,8 +586,7 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -620,4 +607,65 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 		fmt.Printf("%s: skipping disk description check (not available in vCD < 9.5) \n", check.TestName())
 	}
 
+}
+
+// Tests Disk retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_GetDisk(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	if vcd.config.VCD.Disk.Size == 0 {
+		check.Skip("Skipping test because disk size is <= 0")
+	}
+
+	if vcd.config.VCD.Vdc == "" {
+		check.Skip("Test_GetDisk: VDC name not given")
+		return
+	}
+
+	diskName := "TestGetDisk"
+	// Create disk
+	diskCreateParamsDisk := &types.Disk{
+		Name:        diskName,
+		Size:        vcd.config.VCD.Disk.Size,
+		Description: diskName + "Description",
+	}
+
+	diskCreateParams := &types.DiskCreateParams{
+		Disk: diskCreateParamsDisk,
+	}
+
+	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	check.Assert(err, IsNil)
+
+	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
+	diskHREF := task.Task.Owner.HREF
+
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+
+	// Wait for disk creation complete
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	getByName := func(name string, refresh bool) (genericEntity, error) {
+		err = vcd.vdc.Refresh()
+		check.Assert(err, IsNil)
+		return vcd.vdc.GetDiskByName(name, refresh)
+	}
+	getById := func(id string, refresh bool) (genericEntity, error) {
+		return vcd.vdc.GetDiskById(id, refresh)
+	}
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
+		return vcd.vdc.GetDiskByNameOrId(id, refresh)
+	}
+
+	var def = getterTestDefinition{
+		parentType:    "Catalog",
+		parentName:    vcd.config.VCD.Catalog.Name,
+		entityType:    "Disk",
+		entityName:    diskName,
+		getByName:     getByName,
+		getById:       getById,
+		getByNameOrId: getByNameOrId,
+	}
+	vcd.testFinderGetGenericEntity(def, check)
 }

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -78,7 +78,7 @@ func (vm *VM) id() string   { return vm.VM.ID }
 // Get invalid name or ID
 // To use this function, the entity must satisfy the interface genericEntity
 // and within the caller it must define the getter functions
-//
+//AddToCleanupList(diskCreateParamsDisk.Name
 // Example usage:
 //
 // func (vcd *TestVCD) Test_OrgGetVdc(check *C) {

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -71,9 +71,6 @@ func (vapp *VApp) id() string   { return vapp.VApp.ID }
 func (vm *VM) name() string { return vm.VM.Name }
 func (vm *VM) id() string   { return vm.VM.ID }
 
-func (disk *Disk) name() string { return disk.Disk.Name }
-func (disk *Disk) id() string   { return disk.Disk.Id }
-
 // Semi-generic tests that check the complete set of Get methods for an entity
 // GetEntityByName
 // GetEntityById

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -78,7 +78,6 @@ func (vm *VM) id() string   { return vm.VM.ID }
 // Get invalid name or ID
 // To use this function, the entity must satisfy the interface genericEntity
 // and within the caller it must define the getter functions
-//AddToCleanupList(diskCreateParamsDisk.Name
 // Example usage:
 //
 // func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
@@ -209,6 +208,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getById(invalidEntityId, false)
 	entity7 := ge.(genericEntity)
 	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity7, IsNil)
 
 	// 8. Attempting a search by name or ID with an invalid ID
@@ -218,5 +218,6 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getByNameOrId(invalidEntityId, false)
 	entity8 := ge.(genericEntity)
 	check.Assert(err, NotNil)
+	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity8, IsNil)
 }

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -71,6 +71,9 @@ func (vapp *VApp) id() string   { return vapp.VApp.ID }
 func (vm *VM) name() string { return vm.VM.Name }
 func (vm *VM) id() string   { return vm.VM.ID }
 
+func (disk *Disk) name() string { return disk.Disk.Name }
+func (disk *Disk) id() string   { return disk.Disk.Id }
+
 // Semi-generic tests that check the complete set of Get methods for an entity
 // GetEntityByName
 // GetEntityById
@@ -209,7 +212,6 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getById(invalidEntityId, false)
 	entity7 := ge.(genericEntity)
 	check.Assert(err, NotNil)
-	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity7, IsNil)
 
 	// 8. Attempting a search by name or ID with an invalid ID
@@ -219,6 +221,5 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getByNameOrId(invalidEntityId, false)
 	entity8 := ge.(genericEntity)
 	check.Assert(err, NotNil)
-	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(entity8, IsNil)
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -206,7 +206,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -296,7 +296,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -388,7 +388,7 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	diskHREF := task.Task.Owner.HREF
 
 	// Defer prepend the disk info to cleanup list until the function returns
-	AddToCleanupList(diskHREF, "disk", "", check.TestName())
+	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -206,8 +206,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -215,7 +214,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -297,8 +296,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -306,7 +304,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -390,7 +388,7 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	diskHREF := task.Task.Owner.HREF
 
 	// Defer prepend the disk info to cleanup list until the function returns
-	defer PrependToCleanupList(fmt.Sprintf("%s|%s", diskCreateParamsDisk.Name, diskHREF), "disk", "", check.TestName())
+	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -398,7 +396,7 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -206,7 +206,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -296,7 +296,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
 	diskHREF := task.Task.Owner.HREF
 
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()
@@ -388,7 +388,7 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	diskHREF := task.Task.Owner.HREF
 
 	// Defer prepend the disk info to cleanup list until the function returns
-	AddToCleanupList(diskCreateParamsDisk.Name, "disk", diskHREF, check.TestName())
+	AddToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
 	err = task.WaitTaskCompletion()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -163,7 +163,7 @@ func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
 // Test attach disk to VM and detach disk from VM
 func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	// Find VM
@@ -253,7 +253,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 // Test attach disk to VM
 func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.skipVappTests {
@@ -344,7 +344,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 
 	if vcd.config.VCD.Disk.Size <= 0 {
-		check.Skip("skipping test because disk size is <= 0")
+		check.Skip("skipping test because disk size is 0")
 	}
 
 	if vcd.skipVappTests {


### PR DESCRIPTION
Changes for independent disk datasource/read/import in Terraform.
* Deprecated methods `VDC.FindDiskByHREF` and `FindDiskByHREF`
* Added methods `VDC.GetDiskByHref` `VDC.GetDiskByName` and related `GetDiskById`, `GetDiskByNameOrId`