### PR TITLE
Removed parentheses from filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 to allow understand if value was returned or not. 
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 
+BUGS FIXED:
+* Removed parentheses from filtering which in some env wasn't treated correctly [#256] (https://github.com/vmware/go-vcloud-director/pull/256)
+
 ## 2.4.0 (October 28, 2019)
 
 * Deprecated functions `GetOrgByName` and `GetAdminOrgByName`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ to allow understand if value was returned or not.
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 
 BUGS FIXED:
-* Removed parentheses from filtering which in some env wasn't treated correctly [#256] (https://github.com/vmware/go-vcloud-director/pull/256)
+* Remove parentheses from filtering since they weren't treated correctly in some environment [#256] (https://github.com/vmware/go-vcloud-director/pull/256)
 
 ## 2.4.0 (October 28, 2019)
 
@@ -18,7 +18,7 @@ BUGS FIXED:
 * Added method `VCDClient.QueryProviderVdcStorageProfiles` 
 * Added method `VCDClient.QueryNetworkPools` 
 * Added get/add/delete metadata functions for vApp template and media item [#225](https://github.com/vmware/go-vcloud-director/pull/225).
-* Added `UpdateNetworkConnectionSection` for updating VM network configuration [#229](https://github.com/vmware/go-vcloud-director/pull/229)
+* Added `UpdateNetworkConnectionSection` for updating VM network configuration [#229](https://gifiltering which in some env wasn'tthub.com/vmware/go-vcloud-director/pull/229)
 * Added `PowerOnAndForceCustomization`, `GetGuestCustomizationStatus`, `BlockWhileGuestCustomizationStatus` [#229](https://github.com/vmware/go-vcloud-director/pull/229)
 * Deprecated methods `AdminOrg.GetAdminVdcByName`, `AdminOrg.GetVdcByName`, `AdminOrg.FindAdminCatalog`, `AdminOrg.FindCatalog`
 * Deprecated methods `Catalog.FindCatalogItem`, `Org.FindCatalog`, `Org.GetVdcByName`

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -409,7 +409,7 @@ func (adminOrg *AdminOrg) FindAdminCatalogRecords(name string) ([]*types.AdminCa
 	util.Logger.Printf("[DEBUG] FindAdminCatalogRecords with name: %s and org name: %s", name, adminOrg.AdminOrg.Name)
 	results, err := adminOrg.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "adminCatalog",
-		"filter": fmt.Sprintf("(name==%s;orgName==%s)", url.QueryEscape(name), url.QueryEscape(adminOrg.AdminOrg.Name)),
+		"filter": fmt.Sprintf("name==%s;orgName==%s", url.QueryEscape(name), url.QueryEscape(adminOrg.AdminOrg.Name)),
 	})
 	if err != nil {
 		return nil, err

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -122,7 +122,7 @@ func ContainsNotFound(err error) bool {
 	return err != nil && strings.Contains(err.Error(), ErrorEntityNotFound.Error())
 }
 
-// Function allow to pass complex values params which shouldn't be encoded like for queries. e.g. /query?filter=(name=foo)
+// Function allow to pass complex values params which shouldn't be encoded like for queries. e.g. /query?filter=name=foo
 func (cli *Client) NewRequestWitNotEncodedParams(params map[string]string, notEncodedParams map[string]string, method string, reqUrl url.URL, body io.Reader) *http.Request {
 	reqValues := url.Values{}
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -122,7 +122,7 @@ func ContainsNotFound(err error) bool {
 	return err != nil && strings.Contains(err.Error(), ErrorEntityNotFound.Error())
 }
 
-// Function allow to pass complex values params which shouldn't be encoded like for queries. e.g. /query?filter=name=foo
+// NewRequestWitNotEncodedParams allows passing complex values params that shouldn't be encoded like for queries. e.g. /query?filter=name=foo
 func (cli *Client) NewRequestWitNotEncodedParams(params map[string]string, notEncodedParams map[string]string, method string, reqUrl url.URL, body io.Reader) *http.Request {
 	reqValues := url.Values{}
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -573,7 +573,7 @@ func isValidIcmpSubType(protocol string) bool {
 	return false
 }
 
-// Deprecated: Use eGW.AddNATFirewallRule()
+// Deprecated: Use eGW.AddDNATRule() or eGW.CreateNsxvNatRule() for NSX-V
 func (egw *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork, natType, externalIP, externalPort, internalIP, internalPort, protocol, icmpSubType string) (Task, error) {
 	// if a network is provided take it, otherwise find first uplink on the edge gateway
 	var uplinkRef string

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -52,7 +52,7 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 		return fmt.Sprintf("%s: Port group type isn't configured. Test can't proceed", testName), externalNetwork, Task{}, nil
 	}
 
-	virtualCenters, err := QueryVirtualCenters(vcd.client, fmt.Sprintf("(name==%s)", vcd.config.VCD.VimServer))
+	virtualCenters, err := QueryVirtualCenters(vcd.client, fmt.Sprintf("name==%s", vcd.config.VCD.VimServer))
 	if err != nil {
 		return "", externalNetwork, Task{}, err
 	}
@@ -62,7 +62,7 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 	vimServerHref := virtualCenters[0].HREF
 
 	// Resolve port group info
-	portGroups, err := QueryPortGroups(vcd.client, fmt.Sprintf("(name==%s;portgroupType==%s)", url.QueryEscape(vcd.config.VCD.ExternalNetworkPortGroup), vcd.config.VCD.ExternalNetworkPortGroupType))
+	portGroups, err := QueryPortGroups(vcd.client, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(vcd.config.VCD.ExternalNetworkPortGroup), vcd.config.VCD.ExternalNetworkPortGroupType))
 	if err != nil {
 		return "", externalNetwork, Task{}, err
 	}

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -569,7 +569,7 @@ func (catalog *Catalog) QueryMedia(mediaName string) (*MediaRecord, error) {
 	}
 
 	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
-		"filter": fmt.Sprintf("(name==%s;catalogName==%s)",
+		"filter": fmt.Sprintf("name==%s;catalogName==%s",
 			url.QueryEscape(mediaName),
 			url.QueryEscape(catalog.Catalog.Name))})
 	if err != nil {

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -255,7 +255,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 
 	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.Name),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.Name),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.VMWProviderVdcRecord) == 0 {
@@ -265,7 +265,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 
 	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.StorageProfile),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.StorageProfile),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.ProviderVdcStorageProfileRecord) == 0 {
@@ -275,7 +275,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 
 	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "networkPool",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.NetworkPool),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.NetworkPool),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.NetworkPoolRecord) == 0 {
@@ -539,7 +539,7 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 	check.Assert(adminOrg, NotNil)
 	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.Name),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.Name),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.VMWProviderVdcRecord) == 0 {
@@ -548,7 +548,7 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 	providerVdcHref := results.Results.VMWProviderVdcRecord[0].HREF
 	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.StorageProfile),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.StorageProfile),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.ProviderVdcStorageProfileRecord) == 0 {
@@ -557,7 +557,7 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 	providerVdcStorageProfileHref := results.Results.ProviderVdcStorageProfileRecord[0].HREF
 	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "networkPool",
-		"filter": fmt.Sprintf("(name==%s)", vcd.config.VCD.ProviderVdc.NetworkPool),
+		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.NetworkPool),
 	})
 	check.Assert(err, IsNil)
 	if len(results.Results.NetworkPoolRecord) == 0 {

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -400,7 +400,7 @@ func getOrgHREFById(vcdClient *VCDClient, orgId string) (string, error) {
 // Find a list of Virtual Centers matching the filter parameter.
 // Filter constructing guide: https://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-CDF04296-5EB5-47E1-9BEC-228837C584CE.html
 // Possible parameters are any attribute from QueryResultVirtualCenterRecordType struct
-// E.g. filter could look like: (name==vC1)
+// E.g. filter could look like: name==vC1
 func QueryVirtualCenters(vcdClient *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
 	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "virtualCenter",
@@ -415,12 +415,12 @@ func QueryVirtualCenters(vcdClient *VCDClient, filter string) ([]*types.QueryRes
 
 // Find a Network port group by name
 func QueryNetworkPortGroup(vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
-	return QueryPortGroups(vcdCli, fmt.Sprintf("(name==%s;portgroupType==%s)", url.QueryEscape(name), "NETWORK"))
+	return QueryPortGroups(vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "NETWORK"))
 }
 
 // Find a Distributed port group by name
 func QueryDistributedPortGroup(vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
-	return QueryPortGroups(vcdCli, fmt.Sprintf("(name==%s;portgroupType==%s)", url.QueryEscape(name), "DV_PORTGROUP"))
+	return QueryPortGroups(vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "DV_PORTGROUP"))
 }
 
 // Find a list of Port groups matching the filter parameter.
@@ -705,7 +705,7 @@ func GetStorageProfileByHref(vcdClient *VCDClient, url string) (*types.VdcStorag
 func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
-		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
+		"filter": fmt.Sprintf("name==%s", url.QueryEscape(name)),
 	})
 	if err != nil {
 		return nil, err
@@ -718,7 +718,7 @@ func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*ty
 func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResultNetworkPoolRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "networkPool",
-		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
+		"filter": fmt.Sprintf("name==%s", url.QueryEscape(name)),
 	})
 	if err != nil {
 		return nil, err
@@ -731,7 +731,7 @@ func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",
-		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
+		"filter": fmt.Sprintf("name==%s", url.QueryEscape(name)),
 	})
 	if err != nil {
 		return nil, err
@@ -794,7 +794,7 @@ func GetNetworkPoolByHREF(client *VCDClient, href string) (*types.VMWNetworkPool
 func QueryOrgVdcNetworkByName(vcdCli *VCDClient, name string) ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
 	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "orgVdcNetwork",
-		"filter": fmt.Sprintf("(name==%s)", url.QueryEscape(name)),
+		"filter": fmt.Sprintf("name==%s", url.QueryEscape(name)),
 	})
 	if err != nil {
 		return nil, err

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -664,7 +664,7 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 	}
 
 	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
-		"filter": "(name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName) + ")"})
+		"filter": "name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName) + ")"})
 	if err != nil {
 		return VMRecord{}, fmt.Errorf("error querying vm %#v", err)
 	}
@@ -729,7 +729,7 @@ func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
 	util.Logger.Printf("[TRACE] Querying medias by name\n")
 
 	mediaResults, err := queryMediaWithFilter(vdc,
-		fmt.Sprintf("(name==%s)", url.QueryEscape(mediaName)))
+		fmt.Sprintf("name==%s", url.QueryEscape(mediaName)))
 	if err != nil {
 		return MediaItem{}, err
 	}

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -664,7 +664,7 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 	}
 
 	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
-		"filter": "name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName) + ")"})
+		"filter": "name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName)})
 	if err != nil {
 		return VMRecord{}, fmt.Errorf("error querying vm %#v", err)
 	}


### PR DESCRIPTION
Fix for https://github.com/terraform-providers/terraform-provider-vcd/issues/287

Parentheses isn't needed(accordig documentation used when need to create sophisticated filtering) and if we will need to use them later - we have to figure out how to escape them, as in different env behaves differently.

Building query docs: https://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-CDF04296-5EB5-47E1-9BEC-228837C584CE.html#1_22_9_1