### PR TITLE
Fix missing fields in user data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ BUGS FIXED:
 * Fix bug in VDC creation when name with space caused an error
 * Fix bug in Org Delete, which would remove catalogs shared from other organizations.
 * Fix Vcd.StorageProfiles type from array to single.
+* Fix AdminOrg.CreateUserSimple, where the Telephone field was ignored.
 
 ## 2.3.1 (Jul 29, 2019)
 

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -304,6 +304,7 @@ func (adminOrg *AdminOrg) CreateUserSimple(userData OrgUserConfiguration) (*OrgU
 		FullName:        userData.FullName,
 		EmailAddress:    userData.EmailAddress,
 		Description:     userData.Description,
+		Telephone:       userData.Telephone,
 		IM:              userData.IM,
 		Role:            &types.Reference{HREF: role.HREF},
 	}

--- a/govcd/user_test.go
+++ b/govcd/user_test.go
@@ -160,7 +160,7 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 			IsEnabled:       true,
 			IM:              "TextIM",
 			EmailAddress:    "somename@somedomain.com",
-			Telephone:       "TextTelephone",
+			Telephone:       "999 888-7777",
 		}
 
 		user, err := adminOrg.CreateUserSimple(userDefinition)
@@ -176,6 +176,7 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 		check.Assert(user.User.FullName, Equals, userDefinition.FullName)
 		check.Assert(user.User.EmailAddress, Equals, userDefinition.EmailAddress)
 		check.Assert(user.User.IM, Equals, userDefinition.IM)
+		check.Assert(user.User.Telephone, Equals, userDefinition.Telephone)
 		check.Assert(user.User.StoredVmQuota, Equals, userDefinition.StoredVmQuota)
 		check.Assert(user.User.DeployedVmQuota, Equals, userDefinition.DeployedVmQuota)
 


### PR DESCRIPTION
Add missing field "telephone" to user data.
This change will fix terraform-provider-vcd User resource when that repository will point at the updated tag after we merge.