### PR TITLE
Change for handling state of vdc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.0 
 
-* Change fields ResourceGuaranteedCpu, VCpuInMhz, IsThinProvision, NetworkPoolReference,ProviderVdcReference and UsesFastProvisioning in AdminVdc to pointers
+* Change fields ResourceGuaranteedCpu, VCpuInMhz, IsThinProvision, NetworkPoolReference, ProviderVdcReference and UsesFastProvisioning in AdminVdc to pointers
+to allow understand if value was returned or not. 
 
 ## 2.4.0 (October 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0 
+
+* Change fields ResourceGuaranteedCpu, VCpuInMhz, IsThinProvision, NetworkPoolReference,ProviderVdcReference and UsesFastProvisioning in AdminVdc to pointers
+
 ## 2.4.0 (October 28, 2019)
 
 * Deprecated functions `GetOrgByName` and `GetAdminOrgByName`

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -652,12 +652,13 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	adminVdc.AdminVdc.Description = updateDescription
 	adminVdc.AdminVdc.ComputeCapacity = computeCapacity
 	adminVdc.AdminVdc.IsEnabled = false
-	adminVdc.AdminVdc.IsThinProvision = false
+	falseRef := false
+	adminVdc.AdminVdc.IsThinProvision = &falseRef
 	adminVdc.AdminVdc.NetworkQuota = quota
 	adminVdc.AdminVdc.VMQuota = quota
 	adminVdc.AdminVdc.OverCommitAllowed = false
 	adminVdc.AdminVdc.VCpuInMhz = vCpu
-	adminVdc.AdminVdc.UsesFastProvisioning = false
+	adminVdc.AdminVdc.UsesFastProvisioning = &falseRef
 	adminVdc.AdminVdc.ResourceGuaranteedCpu = &guaranteed
 	adminVdc.AdminVdc.ResourceGuaranteedMemory = &guaranteed
 
@@ -667,12 +668,12 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	check.Assert(updatedVdc.AdminVdc.Description, Equals, updateDescription)
 	check.Assert(updatedVdc.AdminVdc.ComputeCapacity[0].CPU.Allocated, Equals, computeCapacity[0].CPU.Allocated)
 	check.Assert(updatedVdc.AdminVdc.IsEnabled, Equals, false)
-	check.Assert(updatedVdc.AdminVdc.IsThinProvision, Equals, false)
+	check.Assert(*updatedVdc.AdminVdc.IsThinProvision, Equals, false)
 	check.Assert(updatedVdc.AdminVdc.NetworkQuota, Equals, quota)
 	check.Assert(updatedVdc.AdminVdc.VMQuota, Equals, quota)
 	check.Assert(updatedVdc.AdminVdc.OverCommitAllowed, Equals, false)
 	check.Assert(updatedVdc.AdminVdc.VCpuInMhz, Equals, vCpu)
-	check.Assert(updatedVdc.AdminVdc.UsesFastProvisioning, Equals, false)
+	check.Assert(*updatedVdc.AdminVdc.UsesFastProvisioning, Equals, false)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedCpu-guaranteed) < 0.001, Equals, true)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedMemory-guaranteed) < 0.001, Equals, true)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -657,7 +657,7 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	adminVdc.AdminVdc.NetworkQuota = quota
 	adminVdc.AdminVdc.VMQuota = quota
 	adminVdc.AdminVdc.OverCommitAllowed = false
-	adminVdc.AdminVdc.VCpuInMhz = vCpu
+	adminVdc.AdminVdc.VCpuInMhz = &vCpu
 	adminVdc.AdminVdc.UsesFastProvisioning = &falseRef
 	adminVdc.AdminVdc.ResourceGuaranteedCpu = &guaranteed
 	adminVdc.AdminVdc.ResourceGuaranteedMemory = &guaranteed
@@ -672,7 +672,7 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	check.Assert(updatedVdc.AdminVdc.NetworkQuota, Equals, quota)
 	check.Assert(updatedVdc.AdminVdc.VMQuota, Equals, quota)
 	check.Assert(updatedVdc.AdminVdc.OverCommitAllowed, Equals, false)
-	check.Assert(updatedVdc.AdminVdc.VCpuInMhz, Equals, vCpu)
+	check.Assert(*updatedVdc.AdminVdc.VCpuInMhz, Equals, vCpu)
 	check.Assert(*updatedVdc.AdminVdc.UsesFastProvisioning, Equals, false)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedCpu-guaranteed) < 0.001, Equals, true)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedMemory-guaranteed) < 0.001, Equals, true)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -399,10 +399,10 @@ type AdminVdc struct {
 	ResourceGuaranteedMemory *float64   `xml:"ResourceGuaranteedMemory,omitempty"`
 	ResourceGuaranteedCpu    *float64   `xml:"ResourceGuaranteedCpu,omitempty"`
 	VCpuInMhz                int64      `xml:"VCpuInMhz,omitempty"`
-	IsThinProvision          bool       `xml:"IsThinProvision,omitempty"`
+	IsThinProvision          *bool      `xml:"IsThinProvision,omitempty"`
 	NetworkPoolReference     *Reference `xml:"NetworkPoolReference,omitempty"`
 	ProviderVdcReference     *Reference `xml:"ProviderVdcReference"`
-	UsesFastProvisioning     bool       `xml:"UsesFastProvisioning,omitempty"`
+	UsesFastProvisioning     *bool      `xml:"UsesFastProvisioning,omitempty"`
 	OverCommitAllowed        bool       `xml:"OverCommitAllowed,omitempty"`
 	VmDiscoveryEnabled       bool       `xml:"VmDiscoveryEnabled,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -398,7 +398,7 @@ type AdminVdc struct {
 
 	ResourceGuaranteedMemory *float64   `xml:"ResourceGuaranteedMemory,omitempty"`
 	ResourceGuaranteedCpu    *float64   `xml:"ResourceGuaranteedCpu,omitempty"`
-	VCpuInMhz                int64      `xml:"VCpuInMhz,omitempty"`
+	VCpuInMhz                *int64     `xml:"VCpuInMhz,omitempty"`
 	IsThinProvision          *bool      `xml:"IsThinProvision,omitempty"`
 	NetworkPoolReference     *Reference `xml:"NetworkPoolReference,omitempty"`
 	ProviderVdcReference     *Reference `xml:"ProviderVdcReference"`


### PR DESCRIPTION
ref: https://github.com/terraform-providers/terraform-provider-vcd/pull/380

Changes needed to handle system admin and org admin diff set data provided from API.

This allows to know when provisioning isn't returned.