### PR TITLE
Improve VM creation and remove linter warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.0 (Unreleased)
 
-* Added method VApp.AddNewVMWithStorage that adds a VM with custom storage profile.
+* Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 
 ## 2.4.0 (October 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0 (Unreleased)
+
+* Added method VApp.AddNewVMWithStorage that adds a VM with custom storage profile.
+
 ## 2.4.0 (October 28, 2019)
 
 * Deprecated functions `GetOrgByName` and `GetAdminOrgByName`

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -166,7 +166,7 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	// Get admin HREF
 	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
 	if err != nil {
-		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
+		return fmt.Errorf("error getting AdminOrg HREF %s : %s", adminOrg.AdminOrg.HREF, err)
 	}
 	req := adminOrg.client.NewRequest(map[string]string{
 		"force":     strconv.FormatBool(force),
@@ -189,7 +189,7 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 func (adminOrg *AdminOrg) Disable() error {
 	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
 	if err != nil {
-		return fmt.Errorf("error getting AdminOrg HREF %s : %v", adminOrg.AdminOrg.HREF, err)
+		return fmt.Errorf("error getting AdminOrg HREF %s : %s", adminOrg.AdminOrg.HREF, err)
 	}
 	orgHREF.Path += "/action/disable"
 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -123,7 +123,7 @@ func (adminOrg *AdminOrg) CreateVdcWait(vdcDefinition *types.VdcConfiguration) e
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("couldn't finish creating vdc %#v", err)
+		return fmt.Errorf("couldn't finish creating vdc %s", err)
 	}
 	return nil
 }
@@ -135,27 +135,27 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 		//undeploys vapps
 		err := adminOrg.undeployAllVApps()
 		if err != nil {
-			return fmt.Errorf("error could not undeploy: %#v", err)
+			return fmt.Errorf("error could not undeploy: %s", err)
 		}
 		//removes vapps
 		err = adminOrg.removeAllVApps()
 		if err != nil {
-			return fmt.Errorf("error could not remove vapp: %#v", err)
+			return fmt.Errorf("error could not remove vapp: %s", err)
 		}
 		//removes catalogs
 		err = adminOrg.removeCatalogs()
 		if err != nil {
-			return fmt.Errorf("error could not remove all catalogs: %#v", err)
+			return fmt.Errorf("error could not remove all catalogs: %s", err)
 		}
 		//removes networks
 		err = adminOrg.removeAllOrgNetworks()
 		if err != nil {
-			return fmt.Errorf("error could not remove all networks: %#v", err)
+			return fmt.Errorf("error could not remove all networks: %s", err)
 		}
 		//removes org vdcs
 		err = adminOrg.removeAllOrgVDCs()
 		if err != nil {
-			return fmt.Errorf("error could not remove all vdcs: %#v", err)
+			return fmt.Errorf("error could not remove all vdcs: %s", err)
 		}
 	}
 	// Disable org
@@ -333,7 +333,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 		}
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("couldn't finish removing vdc %#v", err)
+			return fmt.Errorf("couldn't finish removing vdc %s", err)
 		}
 
 	}
@@ -359,7 +359,7 @@ func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
 		}
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("couldn't finish removing network %#v", err)
+			return fmt.Errorf("couldn't finish removing network %s", err)
 		}
 	}
 	return nil

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -416,7 +416,7 @@ func executeRequestCustomErr(pathURL, requestType, contentType string, payload i
 
 		marshaledXml, err := xml.MarshalIndent(payload, "  ", "    ")
 		if err != nil {
-			return &http.Response{}, fmt.Errorf("error marshalling xml data %v", err)
+			return &http.Response{}, fmt.Errorf("error marshalling xml data %s", err)
 		}
 		body := bytes.NewBufferString(xml.Header + string(marshaledXml))
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1107,7 +1107,7 @@ func TestVCDClient_Authenticate(t *testing.T) {
 
 func (vcd *TestVCD) createTestVapp(name string) (*VApp, error) {
 	// ========================= issue#252 ==================================
-	// To be enabled when issue#252 is resolved.
+	// TODO: To be enabled when issue#252 is resolved.
 	// Allows re-using a pre-created vApp
 	// existingVapp, err := vcd.vdc.GetVAppByName(name, false)
 	// if err == nil {

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -156,7 +156,7 @@ type TestVCD struct {
 	client         *VCDClient
 	org            *Org
 	vdc            *Vdc
-	vapp           VApp
+	vapp           *VApp
 	config         TestConfig
 	skipVappTests  bool
 	skipAdminTests bool
@@ -332,11 +332,11 @@ func GetConfigStruct() (TestConfig, error) {
 	}
 	yamlFile, err := ioutil.ReadFile(config)
 	if err != nil {
-		return TestConfig{}, fmt.Errorf("could not read config file %s: %v", config, err)
+		return TestConfig{}, fmt.Errorf("could not read config file %s: %s", config, err)
 	}
 	err = yaml.Unmarshal(yamlFile, &configStruct)
 	if err != nil {
-		return TestConfig{}, fmt.Errorf("could not unmarshal yaml file: %v", err)
+		return TestConfig{}, fmt.Errorf("could not unmarshal yaml file: %s", err)
 	}
 	return configStruct, nil
 }
@@ -460,10 +460,10 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		vcd.vapp, err = vcd.createTestVapp(TestSetUpSuite)
 		// If no vApp is created, we skip all vApp tests
 		if err != nil {
-			fmt.Printf("%v\n", err)
+			fmt.Printf("%s\n", err)
 			panic("Creation failed - Bailing out")
 		}
-		if vcd.vapp == (VApp{}) {
+		if vcd.vapp == nil {
 			fmt.Printf("Creation of vApp %s failed unexpectedly. No error was reported, but vApp is empty\n", TestSetUpSuite)
 			panic("initial vApp is empty - bailing out")
 		}
@@ -1021,16 +1021,16 @@ func (vcd *TestVCD) TearDownSuite(check *C) {
 func TestClient_getloginurl(t *testing.T) {
 	config, err := GetConfigStruct()
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err: %s", err)
 	}
 	client, err := GetTestVCDFromYaml(config)
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err: %s", err)
 	}
 
 	err = client.vcdloginurl()
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err: %s", err)
 	}
 
 	if client.sessionHREF.Path != "/api/sessions" {
@@ -1042,70 +1042,79 @@ func TestClient_getloginurl(t *testing.T) {
 func TestVCDClient_Authenticate(t *testing.T) {
 	config, err := GetConfigStruct()
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err: %s", err)
 	}
 	client, err := GetTestVCDFromYaml(config)
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("err: %s", err)
 	}
 	err = client.Authenticate(config.Provider.User, config.Provider.Password, config.Provider.SysOrg)
 	if err != nil {
-		t.Fatalf("Error authenticating: %v", err)
+		t.Fatalf("Error authenticating: %s", err)
 	}
 }
 
-func (vcd *TestVCD) createTestVapp(name string) (VApp, error) {
+func (vcd *TestVCD) createTestVapp(name string) (*VApp, error) {
+	// ========================= issue#252 ==================================
+	// To be enabled when issue#252 is resolved.
+	// Allows re-using a pre-created vApp
+	// existingVapp, err := vcd.vdc.GetVAppByName(name, false)
+	// if err == nil {
+	// 	fmt.Printf("vApp %s already exists. Skipping creation\n",name)
+	// 	return existingVapp, nil
+	// }
+	// ======================================================================
 	// Populate OrgVDCNetwork
-	networks := []*types.OrgVDCNetwork{}
+	var networks []*types.OrgVDCNetwork
 	net, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error finding network : %v", err)
+		return nil, fmt.Errorf("error finding network : %s", err)
 	}
 	networks = append(networks, net.OrgVDCNetwork)
 	// Populate Catalog
 	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil || cat == nil {
-		return VApp{}, fmt.Errorf("error finding catalog : %v", err)
+		return nil, fmt.Errorf("error finding catalog : %s", err)
 	}
 	// Populate Catalog Item
 	catitem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error finding catalog item : %v", err)
+		return nil, fmt.Errorf("error finding catalog item : %s", err)
 	}
 	// Get VAppTemplate
 	vAppTemplate, err := catitem.GetVAppTemplate()
 	if err != nil {
-		return VApp{}, fmt.Errorf("error finding vapptemplate : %v", err)
+		return nil, fmt.Errorf("error finding vapptemplate : %s", err)
 	}
 	// Get StorageProfileReference
 	storageProfileRef, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error finding storage profile: %v", err)
+		return nil, fmt.Errorf("error finding storage profile: %s", err)
 	}
 	// Compose VApp
 	task, err := vcd.vdc.ComposeVApp(networks, vAppTemplate, storageProfileRef, name, "description", true)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
+		return nil, fmt.Errorf("error composing vapp: %s", err)
 	}
 	// After a successful creation, the entity is added to the cleanup list.
 	// If something fails after this point, the entity will be removed
 	AddToCleanupList(name, "vapp", "", "createTestVapp")
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return VApp{}, fmt.Errorf("error composing vapp: %v", err)
+		return nil, fmt.Errorf("error composing vapp: %s", err)
 	}
 	// Get VApp
 	vapp, err := vcd.vdc.GetVAppByName(name, true)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error getting vapp: %v", err)
+		return nil, fmt.Errorf("error getting vapp: %s", err)
 	}
 
 	err = vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
 	if err != nil {
-		return VApp{}, fmt.Errorf("error waiting for created test vApp to have working state: %s", err)
+		return nil, fmt.Errorf("error waiting for created test vApp to have working state: %s", err)
 	}
 
-	return *vapp, err
+	return vapp, err
 }
 
 func Test_splitParent(t *testing.T) {

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -131,22 +131,22 @@ func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadP
 
 	filesAbsPaths, tmpDir, err := util.Unpack(ovaFileName)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("%v. Unpacked files for checking are accessible in: "+tmpDir, err)
+		return UploadTask{}, fmt.Errorf("%s. Unpacked files for checking are accessible in: "+tmpDir, err)
 	}
 
 	ovfFilePath, err := getOvfPath(filesAbsPaths)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("%v. Unpacked files for checking are accessible in: "+tmpDir, err)
+		return UploadTask{}, fmt.Errorf("%s. Unpacked files for checking are accessible in: "+tmpDir, err)
 	}
 
 	ovfFileDesc, err := getOvf(ovfFilePath)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("%v. Unpacked files for checking are accessible in: "+tmpDir, err)
+		return UploadTask{}, fmt.Errorf("%s. Unpacked files for checking are accessible in: "+tmpDir, err)
 	}
 
 	err = validateOvaContent(filesAbsPaths, &ovfFileDesc, tmpDir)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("%v. Unpacked files for checking are accessible in: "+tmpDir, err)
+		return UploadTask{}, fmt.Errorf("%s. Unpacked files for checking are accessible in: "+tmpDir, err)
 	}
 
 	catalogItemUploadURL, err := findCatalogItemUploadLink(cat, "application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml")
@@ -590,7 +590,7 @@ func removeCatalogItemOnError(client *Client, vappTemplateLink *url.URL, itemNam
 			time.Sleep(time.Second * 5)
 			vAppTemplate, err = queryVappTemplate(client, vappTemplateLink, itemName)
 			if err != nil {
-				util.Logger.Printf("[Error] Error deleting Catalog item %v: %s", vappTemplateLink, err)
+				util.Logger.Printf("[Error] Error deleting Catalog item %s: %s", vappTemplateLink, err)
 			}
 			if len(vAppTemplate.Tasks.Task) > 0 {
 				util.Logger.Printf("[TRACE] Task found. Will try to cancel.\n")

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -659,7 +659,7 @@ func (egw *EdgeGateway) AddNATPortMappingWithUplink(network *types.OrgVDCNetwork
 func (egw *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types.FirewallRule) (Task, error) {
 	err := egw.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error: %v", err)
+		return Task{}, fmt.Errorf("error: %s", err)
 	}
 
 	newRules := &types.EdgeGatewayServiceConfiguration{
@@ -674,7 +674,7 @@ func (egw *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types
 
 	output, err := xml.MarshalIndent(newRules, "  ", "    ")
 	if err != nil {
-		return Task{}, fmt.Errorf("error: %v", err)
+		return Task{}, fmt.Errorf("error: %s", err)
 	}
 
 	var resp *http.Response
@@ -734,7 +734,7 @@ func (egw *EdgeGateway) Remove1to1Mapping(internal, external string) (Task, erro
 	// Refresh EdgeGateway rules
 	err := egw.Refresh()
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error: %s\n", err)
 	}
 
 	var uplinkif string
@@ -845,7 +845,7 @@ func (egw *EdgeGateway) Create1to1Mapping(internal, external, description string
 	// Refresh EdgeGateway rules
 	err := egw.Refresh()
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error: %s\n", err)
 	}
 
 	var uplinkif string
@@ -939,7 +939,7 @@ func (egw *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 
 	err := egw.Refresh()
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error: %s\n", err)
 	}
 
 	apiEndpoint, _ := url.ParseRequestURI(egw.EdgeGateway.HREF)
@@ -955,7 +955,7 @@ func (egw *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 func (egw *EdgeGateway) RemoveIpsecVPN() (Task, error) {
 	err := egw.Refresh()
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error: %s\n", err)
 	}
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
 		Xmlns: types.XMLNamespaceVCloud,

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -206,7 +206,7 @@ func (egw *EdgeGateway) RemoveNATPortMapping(natType, externalIP, externalPort, 
 func (egw *EdgeGateway) RemoveNATRule(id string) error {
 	task, err := egw.RemoveNATRuleAsync(id)
 	if err != nil {
-		return fmt.Errorf("error removing DNAT rule: %#v", err)
+		return fmt.Errorf("error removing DNAT rule: %s", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
@@ -226,7 +226,7 @@ func (egw *EdgeGateway) RemoveNATRuleAsync(id string) (Task, error) {
 
 	err := egw.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing edge gateway: %#v", err)
+		return Task{}, fmt.Errorf("error refreshing edge gateway: %s", err)
 	}
 
 	natServiceToUpdate := egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService
@@ -282,7 +282,7 @@ func (egw *EdgeGateway) AddDNATRule(ruleDetails NatRule) (*types.NatRule, error)
 	ruleDetails.NatType = "DNAT"
 	task, err := egw.AddNATRuleAsync(ruleDetails)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DNAT rule: %#v", err)
+		return nil, fmt.Errorf("error creating DNAT rule: %s", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
@@ -293,7 +293,7 @@ func (egw *EdgeGateway) AddDNATRule(ruleDetails NatRule) (*types.NatRule, error)
 
 	err = egw.Refresh()
 	if err != nil {
-		return nil, fmt.Errorf("error refreshing edge gateway: %#v", err)
+		return nil, fmt.Errorf("error refreshing edge gateway: %s", err)
 	}
 
 	for _, natRule := range egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
@@ -332,7 +332,7 @@ func (egw *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, descrip
 		ExternalPort: "any", InternalIP: internalIP, InternalPort: "any",
 		IcmpSubType: "", Protocol: "any", Description: mappingId})
 	if err != nil {
-		return nil, fmt.Errorf("error creating SNAT rule: %#v", err)
+		return nil, fmt.Errorf("error creating SNAT rule: %s", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
@@ -343,7 +343,7 @@ func (egw *EdgeGateway) AddSNATRule(networkHref, externalIP, internalIP, descrip
 
 	err = egw.Refresh()
 	if err != nil {
-		return nil, fmt.Errorf("error refreshing edge gateway: %#v", err)
+		return nil, fmt.Errorf("error refreshing edge gateway: %s", err)
 	}
 
 	for _, natRule := range egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule {
@@ -380,7 +380,7 @@ func getPseudoUuid() (string, error) {
 func (egw *EdgeGateway) UpdateNatRule(natRule *types.NatRule) (*types.NatRule, error) {
 	task, err := egw.UpdateNatRuleAsync(natRule)
 	if err != nil {
-		return nil, fmt.Errorf("error updating NAT rule: %#v", err)
+		return nil, fmt.Errorf("error updating NAT rule: %s", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
@@ -402,7 +402,7 @@ func (egw *EdgeGateway) UpdateNatRuleAsync(natRule *types.NatRule) (Task, error)
 
 	err := egw.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing edge gateway: %#v", err)
+		return Task{}, fmt.Errorf("error refreshing edge gateway: %s", err)
 	}
 
 	natServiceToUpdate := egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService
@@ -434,7 +434,7 @@ func (egw *EdgeGateway) UpdateNatRuleAsync(natRule *types.NatRule) (Task, error)
 func (egw *EdgeGateway) GetNatRule(id string) (*types.NatRule, error) {
 	err := egw.Refresh()
 	if err != nil {
-		return nil, fmt.Errorf("error refreshing edge gateway: %#v", err)
+		return nil, fmt.Errorf("error refreshing edge gateway: %s", err)
 	}
 
 	if egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService != nil {

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -128,7 +128,7 @@ func executeUpload(client *Client, mediaItem *types.Media, mediaFilePath, mediaN
 func createMedia(client *Client, link, mediaName, mediaDescription string, fileSize int64) (*types.Media, error) {
 	uploadUrl, err := url.ParseRequestURI(link)
 	if err != nil {
-		return nil, fmt.Errorf("error getting vdc href: %v", err)
+		return nil, fmt.Errorf("error getting vdc href: %s", err)
 	}
 
 	reqBody := bytes.NewBufferString(
@@ -302,7 +302,7 @@ func RemoveMediaImageIfExists(vdc Vdc, mediaName string) error {
 			return fmt.Errorf("error deleting media [task] %s", mediaName)
 		}
 	} else {
-		util.Logger.Printf("[TRACE] Media not foun or error: %v - %#v \n", err, mediaItem)
+		util.Logger.Printf("[TRACE] Media not foun or error: %s - %#v \n", err, mediaItem)
 	}
 	return nil
 }

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -81,12 +81,12 @@ func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, u
 
 	isISOGood, err := verifyIso(mediaFilePath)
 	if err != nil || !isISOGood {
-		return UploadTask{}, fmt.Errorf("[ERROR] File %s isn't correct iso file: %#v", mediaFilePath, err)
+		return UploadTask{}, fmt.Errorf("[ERROR] File %s isn't correct iso file: %s", mediaFilePath, err)
 	}
 
 	mediaList, err := getExistingMedia(vdc)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("[ERROR] Checking existing media files failed: %#v", err)
+		return UploadTask{}, fmt.Errorf("[ERROR] Checking existing media files failed: %s", err)
 	}
 
 	for _, media := range mediaList {
@@ -103,7 +103,7 @@ func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, u
 
 	media, err := createMedia(vdc.client, vdc.Vdc.HREF+"/media", mediaName, mediaDescription, fileSize)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("[ERROR] Issue creating media: %#v", err)
+		return UploadTask{}, fmt.Errorf("[ERROR] Issue creating media: %s", err)
 	}
 
 	return executeUpload(vdc.client, media, mediaFilePath, mediaName, fileSize, uploadPieceSize)
@@ -112,7 +112,7 @@ func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, u
 func executeUpload(client *Client, media *types.Media, mediaFilePath, mediaName string, fileSize, uploadPieceSize int64) (UploadTask, error) {
 	uploadLink, err := getUploadLink(media.Files)
 	if err != nil {
-		return UploadTask{}, fmt.Errorf("[ERROR] Issue getting upload link: %#v", err)
+		return UploadTask{}, fmt.Errorf("[ERROR] Issue getting upload link: %s", err)
 	}
 
 	callBack, uploadProgress := getCallBackFunction()
@@ -217,7 +217,7 @@ func removeImageOnError(client *Client, media *types.Media, itemName string) {
 				task.Task = taskItem
 				err = task.CancelTask()
 				if err != nil {
-					util.Logger.Printf("[ERROR] Error canceling task for media upload %#v", err)
+					util.Logger.Printf("[ERROR] Error canceling task for media upload %s", err)
 				}
 			}
 		}
@@ -307,7 +307,7 @@ func queryMediaWithFilter(vdc *Vdc, filter string) ([]*types.MediaRecordType, er
 
 	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": filter})
 	if err != nil {
-		return nil, fmt.Errorf("error querying medias %#v", err)
+		return nil, fmt.Errorf("error querying medias %s", err)
 	}
 
 	mediaResults := results.Results.MediaRecord
@@ -331,7 +331,7 @@ func RemoveMediaImageIfExists(vdc Vdc, mediaName string) error {
 			return fmt.Errorf("error deleting media [task] %s", mediaName)
 		}
 	} else {
-		util.Logger.Printf("[TRACE] Media not found or error: %v - %#v \n", err, mediaItem)
+		util.Logger.Printf("[TRACE] Media not found or error: %s - %#v \n", err, mediaItem)
 	}
 	return nil
 }
@@ -349,7 +349,7 @@ func (adminCatalog *AdminCatalog) RemoveMediaIfExists(mediaName string) error {
 			return fmt.Errorf("error deleting media [task] %s", mediaName)
 		}
 	} else {
-		util.Logger.Printf("[TRACE] Media not found or error: %v - %#v \n", err, media)
+		util.Logger.Printf("[TRACE] Media not found or error: %s - %#v \n", err, media)
 	}
 	return nil
 }
@@ -387,12 +387,12 @@ func FindMediaAsCatalogItem(org *Org, catalogName, mediaName string) (CatalogIte
 
 	catalog, err := org.FindCatalog(catalogName)
 	if err != nil || catalog == (Catalog{}) {
-		return CatalogItem{}, fmt.Errorf("catalog not found or error %#v", err)
+		return CatalogItem{}, fmt.Errorf("catalog not found or error %s", err)
 	}
 
 	media, err := catalog.FindCatalogItem(mediaName)
 	if err != nil || media == (CatalogItem{}) {
-		return CatalogItem{}, fmt.Errorf("media not found or error %#v", err)
+		return CatalogItem{}, fmt.Errorf("media not found or error %s", err)
 	}
 	return media, nil
 }
@@ -488,7 +488,7 @@ func (catalog *Catalog) GetMediaById(mediaId string) (*Media, error) {
 	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
 		"filter": fmt.Sprintf("catalogName==%s", url.QueryEscape(catalog.Catalog.Name))})
 	if err != nil {
-		return nil, fmt.Errorf("error querying medias %#v", err)
+		return nil, fmt.Errorf("error querying medias %s", err)
 	}
 
 	mediaResults := results.Results.MediaRecord
@@ -573,7 +573,7 @@ func (catalog *Catalog) QueryMedia(mediaName string) (*MediaRecord, error) {
 			url.QueryEscape(mediaName),
 			url.QueryEscape(catalog.Catalog.Name))})
 	if err != nil {
-		return nil, fmt.Errorf("error querying medias %#v", err)
+		return nil, fmt.Errorf("error querying medias %s", err)
 	}
 	newMediaRecord := NewMediaRecord(catalog.client)
 

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -163,12 +163,12 @@ func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTe
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return nil, fmt.Errorf("error completing add metadata for vApp template task: %#v", err)
+		return nil, fmt.Errorf("error completing add metadata for vApp template task: %s", err)
 	}
 
 	err = vAppTemplate.Refresh()
 	if err != nil {
-		return nil, fmt.Errorf("error refreshing vApp template: %#v", err)
+		return nil, fmt.Errorf("error refreshing vApp template: %s", err)
 	}
 
 	return vAppTemplate, nil
@@ -188,7 +188,7 @@ func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error completing delete metadata for vApp template task: %#v", err)
+		return fmt.Errorf("error completing delete metadata for vApp template task: %s", err)
 	}
 
 	return nil

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -126,7 +126,7 @@ func (vdc *Vdc) CreateOrgVDCNetworkWait(networkConfig *types.OrgVDCNetwork) erro
 	err = task.WaitTaskCompletion()
 	// err = task.WaitInspectTaskCompletion(InspectTask, 10)
 	if err != nil {
-		return fmt.Errorf("error performing task: %#v", err)
+		return fmt.Errorf("error performing task: %s", err)
 	}
 	return nil
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -305,7 +305,7 @@ func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (EdgeGate
 func GetOrgByName(vcdClient *VCDClient, orgName string) (Org, error) {
 	orgUrl, err := getOrgHREF(vcdClient, orgName)
 	if err != nil {
-		return Org{}, fmt.Errorf("organization '%s' fetch failed: %#v", orgName, err)
+		return Org{}, fmt.Errorf("organization '%s' fetch failed: %s", orgName, err)
 	}
 	org := NewOrg(&vcdClient.Client)
 

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -322,7 +322,7 @@ func (vcd *TestVCD) Test_QueryOrgVdcNetworkByNameWithSpace(check *C) {
 	// err = task.WaitTaskCompletion()
 	err = task.WaitInspectTaskCompletion(LogTask, 10)
 	if err != nil {
-		fmt.Printf("error performing task: %#v", err)
+		fmt.Printf("error performing task: %s", err)
 	}
 	check.Assert(err, IsNil)
 

--- a/govcd/upload.go
+++ b/govcd/upload.go
@@ -57,14 +57,14 @@ func uploadFile(client *Client, filePath string, uDetails uploadDetails) (int64,
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		util.Logger.Printf("[ERROR] during upload process - file open issue : %s, error %#v ", filePath, err)
+		util.Logger.Printf("[ERROR] during upload process - file open issue : %s, error %s ", filePath, err)
 		*uDetails.uploadError = err
 		return 0, err
 	}
 
 	fileInfo, err := file.Stat()
 	if err != nil {
-		util.Logger.Printf("[ERROR] during upload process - file issue : %s, error %#v ", filePath, err)
+		util.Logger.Printf("[ERROR] during upload process - file issue : %s, error %s ", filePath, err)
 		*uDetails.uploadError = err
 		return 0, err
 	}
@@ -81,7 +81,7 @@ func uploadFile(client *Client, filePath string, uDetails uploadDetails) (int64,
 		uDetails.uploadedBytes += int64(count)
 		uDetails.uploadedBytesForCallback += int64(count)
 		if err != nil {
-			util.Logger.Printf("[ERROR] during upload process: %s, error %#v ", filePath, err)
+			util.Logger.Printf("[ERROR] during upload process: %s, error %s ", filePath, err)
 			*uDetails.uploadError = err
 			return 0, err
 		}
@@ -91,12 +91,12 @@ func uploadFile(client *Client, filePath string, uDetails uploadDetails) (int64,
 	if err == io.ErrUnexpectedEOF {
 		err = uploadPartFile(client, part[:count], int64(count), uDetails)
 		if err != nil {
-			util.Logger.Printf("[ERROR] during upload process: %s, error %#v ", filePath, err)
+			util.Logger.Printf("[ERROR] during upload process: %s, error %s ", filePath, err)
 			*uDetails.uploadError = err
 			return 0, err
 		}
 	} else {
-		util.Logger.Printf("Error Uploading: %s, error %#v ", filePath, err)
+		util.Logger.Printf("Error Uploading: %s, error %s ", filePath, err)
 		*uDetails.uploadError = err
 		return 0, err
 	}

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -343,7 +343,7 @@ func (user *OrgUser) Delete(takeOwnership bool) error {
 
 	userHREF, err := url.ParseRequestURI(user.User.Href)
 	if err != nil {
-		return fmt.Errorf("error getting HREF for user %s : %v", user.User.Name, err)
+		return fmt.Errorf("error getting HREF for user %s : %s", user.User.Name, err)
 	}
 	util.Logger.Printf("[TRACE] Url for deleting user : %#v and name: %s", userHREF, user.User.Name)
 
@@ -410,7 +410,7 @@ func (user *OrgUser) Update() error {
 
 	userHREF, err := url.ParseRequestURI(user.User.Href)
 	if err != nil {
-		return fmt.Errorf("error getting HREF for user %s : %v", user.User.Name, err)
+		return fmt.Errorf("error getting HREF for user %s : %s", user.User.Name, err)
 	}
 	util.Logger.Printf("[TRACE] Url for updating user : %#v and name: %s", userHREF, user.User.Name)
 
@@ -500,7 +500,7 @@ func (user *OrgUser) TakeOwnership() error {
 
 	userHREF, err := url.ParseRequestURI(user.User.Href + "/action/takeOwnership")
 	if err != nil {
-		return fmt.Errorf("error getting HREF for user %s : %v", user.User.Name, err)
+		return fmt.Errorf("error getting HREF for user %s : %s", user.User.Name, err)
 	}
 	util.Logger.Printf("[TRACE] Url for taking ownership from user : %#v and name: %s", userHREF, user.User.Name)
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -145,11 +145,11 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 
 // AddNewVM adds VM from vApp template with custom NetworkConnectionSection
 func (vapp *VApp) AddNewVM(name string, vappTemplate VAppTemplate, network *types.NetworkConnectionSection, acceptAllEulas bool) (Task, error) {
-	return vapp.AddNewVMWithStorage(name, vappTemplate, network, nil, acceptAllEulas)
+	return vapp.AddNewVMWithStorageProfile(name, vappTemplate, network, nil, acceptAllEulas)
 }
 
-// AddNewVMWithStorage adds VM from vApp template with custom NetworkConnectionSection and optional storage profile
-func (vapp *VApp) AddNewVMWithStorage(name string, vappTemplate VAppTemplate,
+// AddNewVMWithStorageProfile adds VM from vApp template with custom NetworkConnectionSection and optional storage profile
+func (vapp *VApp) AddNewVMWithStorageProfile(name string, vappTemplate VAppTemplate,
 	network *types.NetworkConnectionSection,
 	storageProfileRef *types.Reference, acceptAllEulas bool) (Task, error) {
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -227,7 +227,7 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 			task.Task = taskItem
 			err := task.WaitTaskCompletion()
 			if err != nil {
-				return fmt.Errorf("error performing task: %#v", err)
+				return fmt.Errorf("error performing task: %s", err)
 			}
 		}
 	}
@@ -252,7 +252,7 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 
 	err = deleteTask.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error performing removing VM task: %#v", err)
+		return fmt.Errorf("error performing removing VM task: %s", err)
 	}
 
 	return nil
@@ -722,7 +722,7 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 
 	vAppNetworkConfig, err := vapp.GetNetworkConfig()
 	if err != nil {
-		return Task{}, fmt.Errorf("error getting vApp networks: %#v", err)
+		return Task{}, fmt.Errorf("error getting vApp networks: %s", err)
 	}
 	networkConfigurations := vAppNetworkConfig.NetworkConfig
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -215,7 +215,7 @@ func (vapp *VApp) AddNewVMWithStorage(name string, vappTemplate VAppTemplate,
 }
 
 // ========================= issue#252 ==================================
-// To be refactored, handling networks better. See issue#252 for details
+// TODO: To be refactored, handling networks better. See issue#252 for details
 // https://github.com/vmware/go-vcloud-director/issues/252
 // ======================================================================
 func (vapp *VApp) RemoveVM(vm VM) error {

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -145,6 +145,13 @@ func (vapp *VApp) AddVM(orgVdcNetworks []*types.OrgVDCNetwork, vappNetworkName s
 
 // AddNewVM adds VM from vApp template with custom NetworkConnectionSection
 func (vapp *VApp) AddNewVM(name string, vappTemplate VAppTemplate, network *types.NetworkConnectionSection, acceptAllEulas bool) (Task, error) {
+	return vapp.AddNewVMWithStorage(name, vappTemplate, network, nil, acceptAllEulas)
+}
+
+// AddNewVMWithStorage adds VM from vApp template with custom NetworkConnectionSection and optional storage profile
+func (vapp *VApp) AddNewVMWithStorage(name string, vappTemplate VAppTemplate,
+	network *types.NetworkConnectionSection,
+	storageProfileRef *types.Reference, acceptAllEulas bool) (Task, error) {
 
 	if vappTemplate == (VAppTemplate{}) || vappTemplate.VAppTemplate == nil {
 		return Task{}, fmt.Errorf("vApp Template can not be empty")
@@ -172,7 +179,7 @@ func (vapp *VApp) AddNewVM(name string, vappTemplate VAppTemplate, network *type
 		}
 	}
 
-	vcomp := &types.ReComposeVAppParams{
+	vAppComposition := &types.ReComposeVAppParams{
 		Ovf:         types.XMLNamespaceOVF,
 		Xsi:         types.XMLNamespaceXSI,
 		Xmlns:       types.XMLNamespaceVCloud,
@@ -190,18 +197,27 @@ func (vapp *VApp) AddNewVM(name string, vappTemplate VAppTemplate, network *type
 		AllEULAsAccepted: acceptAllEulas,
 	}
 
+	// Add storage profile
+	if storageProfileRef != nil && storageProfileRef.HREF != "" {
+		vAppComposition.SourcedItem.StorageProfile = storageProfileRef
+	}
+
 	// Inject network config
-	vcomp.SourcedItem.InstantiationParams.NetworkConnectionSection = network
+	vAppComposition.SourcedItem.InstantiationParams.NetworkConnectionSection = network
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/recomposeVApp"
 
 	// Return the task
 	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		types.MimeRecomposeVappParams, "error instantiating a new VM: %s", vcomp)
+		types.MimeRecomposeVappParams, "error instantiating a new VM: %s", vAppComposition)
 
 }
 
+// ========================= issue#252 ==================================
+// To be refactored, handling networks better. See issue#252 for details
+// https://github.com/vmware/go-vcloud-director/issues/252
+// ======================================================================
 func (vapp *VApp) RemoveVM(vm VM) error {
 
 	vapp.Refresh()
@@ -352,7 +368,7 @@ func (vapp *VApp) RunCustomizationScript(computername, script string) (Task, err
 func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	// Check if VApp Children is populated
@@ -385,7 +401,7 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 func (vapp *VApp) GetStatus() (string, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return "", fmt.Errorf("error refreshing vApp: %v", err)
+		return "", fmt.Errorf("error refreshing vApp: %s", err)
 	}
 	// Trying to make this function future-proof:
 	// If a new status is added to a future vCD API and the status map in types.go
@@ -456,7 +472,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	// Check if VApp Children is populated
@@ -498,7 +514,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	if vapp.VApp.Children == nil || len(vapp.VApp.Children.VM) == 0 {
@@ -529,7 +545,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -552,7 +568,7 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -589,7 +605,7 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	if vapp.VApp.Children == nil {
@@ -649,7 +665,7 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 
 	err := vapp.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
 	}
 
 	// Check if VApp Children is populated

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -549,12 +549,13 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 		sp, _ = vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
 	}
 
+	// TODO: explore the feasibility of adding a test for either case (with or without storage profile).
 	if sp.HREF != "" {
 		if testVerbose {
 			fmt.Printf("Custom storage profile found. Using AddNewVMWithStorage \n")
 		}
 		customSP = true
-		task, err = vapp.AddNewVMWithStorage(check.TestName(), vapptemplate, desiredNetConfig, &sp, true)
+		task, err = vapp.AddNewVMWithStorageProfile(check.TestName(), vapptemplate, desiredNetConfig, &sp, true)
 	} else {
 		if testVerbose {
 			fmt.Printf("Custom storage profile not found. Using AddNewVM\n")

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -550,9 +550,15 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 	}
 
 	if sp.HREF != "" {
+		if testVerbose {
+			fmt.Printf("Custom storage profile found. Using AddNewVMWithStorage \n")
+		}
 		customSP = true
 		task, err = vapp.AddNewVMWithStorage(check.TestName(), vapptemplate, desiredNetConfig, &sp, true)
 	} else {
+		if testVerbose {
+			fmt.Printf("Custom storage profile not found. Using AddNewVM\n")
+		}
 		task, err = vapp.AddNewVM(check.TestName(), vapptemplate, desiredNetConfig, true)
 	}
 

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -27,7 +27,7 @@ func NewVAppTemplate(cli *Client) *VAppTemplate {
 func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateParams) error {
 	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)
 	if err != nil {
-		return fmt.Errorf("error getting vdc href: %v", err)
+		return fmt.Errorf("error getting vdc href: %s", err)
 	}
 	vdcHref.Path += "/action/instantiateVAppTemplate"
 

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -44,7 +44,7 @@ func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateP
 		task.Task = taskItem
 		err = task.WaitTaskCompletion()
 		if err != nil {
-			return fmt.Errorf("error performing task: %#v", err)
+			return fmt.Errorf("error performing task: %s", err)
 		}
 	}
 	return nil

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -97,7 +97,7 @@ func (vdc *Vdc) removeAllVdcVApps() error {
 				}
 				err = task.WaitTaskCompletion()
 				if err != nil {
-					return fmt.Errorf("couldn't finish removing vapp %#v", err)
+					return fmt.Errorf("couldn't finish removing vapp %s", err)
 				}
 			}
 		}
@@ -167,7 +167,7 @@ func (vdc *Vdc) DeleteWait(force bool, recursive bool) error {
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("couldn't finish removing vdc %#v", err)
+		return fmt.Errorf("couldn't finish removing vdc %s", err)
 	}
 	return nil
 }
@@ -483,12 +483,12 @@ func (vdc *Vdc) ComposeRawVApp(name string) error {
 	task, err := vdc.client.ExecuteTaskRequest(vdcHref.String(), http.MethodPost,
 		types.MimeComposeVappParams, "error instantiating a new vApp:: %s", vcomp)
 	if err != nil {
-		return fmt.Errorf("error executing task request: %#v", err)
+		return fmt.Errorf("error executing task request: %s", err)
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error performing task: %#v", err)
+		return fmt.Errorf("error performing task: %s", err)
 	}
 
 	return nil
@@ -666,7 +666,7 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
 		"filter": "(name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName) + ")"})
 	if err != nil {
-		return VMRecord{}, fmt.Errorf("error querying vm %#v", err)
+		return VMRecord{}, fmt.Errorf("error querying vm %s", err)
 	}
 
 	vmResults := results.Results.VMRecord

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -476,7 +476,7 @@ func (vdc *Vdc) ComposeRawVApp(name string) error {
 
 	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)
 	if err != nil {
-		return fmt.Errorf("error getting vdc href: %v", err)
+		return fmt.Errorf("error getting vdc href: %s", err)
 	}
 	vdcHref.Path += "/action/composeVApp"
 
@@ -575,7 +575,7 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 
 	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)
 	if err != nil {
-		return Task{}, fmt.Errorf("error getting vdc href: %v", err)
+		return Task{}, fmt.Errorf("error getting vdc href: %s", err)
 	}
 	vdcHref.Path += "/action/composeVApp"
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -44,7 +44,7 @@ func NewVMRecord(cli *Client) *VMRecord {
 func (vm *VM) GetStatus() (string, error) {
 	err := vm.Refresh()
 	if err != nil {
-		return "", fmt.Errorf("error refreshing VM: %v", err)
+		return "", fmt.Errorf("error refreshing VM: %s", err)
 	}
 	return types.VAppStatuses[vm.VM.Status], nil
 }
@@ -53,7 +53,7 @@ func (vm *VM) GetStatus() (string, error) {
 func (vm *VM) IsDeployed() (bool, error) {
 	err := vm.Refresh()
 	if err != nil {
-		return false, fmt.Errorf("error refreshing VM: %v", err)
+		return false, fmt.Errorf("error refreshing VM: %s", err)
 	}
 	return vm.VM.Deployed, nil
 }
@@ -229,7 +229,7 @@ func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (
 
 	err := vm.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	newCpu := &types.OVFItem{
@@ -333,17 +333,17 @@ func (vm *VM) updateNicParameters(networks []map[string]interface{}, networkSect
 func (vm *VM) ChangeNetworkConfig(networks []map[string]interface{}) (Task, error) {
 	err := vm.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	networkSection, err := vm.GetNetworkConnectionSection()
 	if err != nil {
-		return Task{}, fmt.Errorf("could not retrieve network connection for VM: %v", err)
+		return Task{}, fmt.Errorf("could not retrieve network connection for VM: %s", err)
 	}
 
 	err = vm.updateNicParameters(networks, networkSection)
 	if err != nil {
-		return Task{}, fmt.Errorf("failed processing NIC parameters: %v", err)
+		return Task{}, fmt.Errorf("failed processing NIC parameters: %s", err)
 	}
 
 	networkSection.Xmlns = types.XMLNamespaceVCloud
@@ -362,7 +362,7 @@ func (vm *VM) ChangeMemorySize(size int) (Task, error) {
 
 	err := vm.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	newMem := &types.OVFItem{
@@ -446,7 +446,7 @@ func (vm *VM) BlockWhileGuestCustomizationStatus(unwantedStatus string, timeOutA
 func (vm *VM) Customize(computername, script string, changeSid bool) (Task, error) {
 	err := vm.Refresh()
 	if err != nil {
-		return Task{}, fmt.Errorf("error refreshing VM before running customization: %v", err)
+		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
 	}
 
 	vu := &types.GuestCustomizationSection{


### PR DESCRIPTION
Add method `VApp.AddNewVMWithStorage`, needed  in terraform-provider-vcd to make VM creation totally independent from vApp.

Small changes to silent staticcheck warnings.