### PR TITLE
Add support for multiple external network subnets in edge gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ to allow understand if value was returned or not.
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 
 BUGS FIXED:
-* Added support for multiple subnets in external network configuration [#XXX]()
+* Take into account all subnets (SubnetParticipation) on edge gateway interface instead of the first
+  one [#xx]()
 
 ## 2.4.0 (October 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 to allow understand if value was returned or not. 
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 
+BUGS FIXED:
+* Added support for multiple subnets in external network configuration [#XXX]()
+
 ## 2.4.0 (October 28, 2019)
 
 * Deprecated functions `GetOrgByName` and `GetAdminOrgByName`

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1041,11 +1041,16 @@ func (egw *EdgeGateway) HasDefaultGateway() bool {
 	if egw.EdgeGateway.Configuration != nil &&
 		egw.EdgeGateway.Configuration.GatewayInterfaces != nil {
 		for _, gw := range egw.EdgeGateway.Configuration.GatewayInterfaces.GatewayInterface {
-			if gw.UseForDefaultRoute &&
-				gw.SubnetParticipation != nil &&
-				gw.SubnetParticipation.Gateway != "" &&
-				gw.SubnetParticipation.Netmask != "" {
-				return true
+			// Check if the interface is used for default route
+			if gw.UseForDefaultRoute {
+				// Look for a specific subnet which is used as a default route
+				for _, subnetParticipation := range gw.SubnetParticipation {
+					if subnetParticipation.UseForDefaultRoute &&
+						subnetParticipation.Gateway != "" &&
+						subnetParticipation.Netmask != "" {
+						return true
+					}
+				}
 			}
 		}
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -114,8 +114,8 @@ func getUuidFromHref(href string) (string, error) {
 // CreateEdgeGatewayAsync creates an edge gateway using a simplified configuration structure
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/POST-CreateEdgeGateway.html
 //
-// Note. This function does not allow to pick exact subnet inin external network to use for edge
-// gateway
+// Note. This function does not allow to pick exact subnet in external network to use for edge
+// gateway. It will pick first one instead.
 func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, error) {
 
 	distributed := egwc.DistributedRoutingEnabled

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -113,6 +113,9 @@ func getUuidFromHref(href string) (string, error) {
 
 // CreateEdgeGatewayAsync creates an edge gateway using a simplified configuration structure
 // https://code.vmware.com/apis/442/vcloud-director/doc/doc/operations/POST-CreateEdgeGateway.html
+//
+// Note. This function does not allow to pick exact subnet inin external network to use for edge
+// gateway
 func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, error) {
 
 	distributed := egwc.DistributedRoutingEnabled
@@ -185,7 +188,7 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 				Name: extNet.ExternalNetwork.Name,
 			},
 			UseForDefaultRoute:  egwc.DefaultGateway == extNet.ExternalNetwork.Name,
-			SubnetParticipation: subnetParticipation,
+			SubnetParticipation: []*types.SubnetParticipation{subnetParticipation},
 		}
 
 		egwConfiguration.Configuration.GatewayInterfaces.GatewayInterface =

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1591,15 +1591,15 @@ type GatewayInterfaces struct {
 // Description: Gateway Interface configuration.
 // Since: 5.1
 type GatewayInterface struct {
-	Name                string               `xml:"Name,omitempty"`                // Internally generated name for the Gateway Interface.
-	DisplayName         string               `xml:"DisplayName,omitempty"`         // Gateway Interface display name.
-	Network             *Reference           `xml:"Network"`                       // A reference to the network connected to the gateway interface.
-	InterfaceType       string               `xml:"InterfaceType"`                 // The type of interface: One of: Uplink, Internal
-	SubnetParticipation *SubnetParticipation `xml:"SubnetParticipation,omitempty"` // IP allocation per subnet.
-	ApplyRateLimit      bool                 `xml:"ApplyRateLimit,omitempty"`      // True if rate limiting is applied on this interface.
-	InRateLimit         float64              `xml:"InRateLimit,omitempty"`         // Incoming rate limit expressed as Gbps.
-	OutRateLimit        float64              `xml:"OutRateLimit,omitempty"`        // Outgoing rate limit expressed as Gbps.
-	UseForDefaultRoute  bool                 `xml:"UseForDefaultRoute,omitempty"`  // True if this network is default route for the gateway.
+	Name                string                 `xml:"Name,omitempty"`                // Internally generated name for the Gateway Interface.
+	DisplayName         string                 `xml:"DisplayName,omitempty"`         // Gateway Interface display name.
+	Network             *Reference             `xml:"Network"`                       // A reference to the network connected to the gateway interface.
+	InterfaceType       string                 `xml:"InterfaceType"`                 // The type of interface: One of: Uplink, Internal
+	SubnetParticipation []*SubnetParticipation `xml:"SubnetParticipation,omitempty"` // IP allocation per subnet.
+	ApplyRateLimit      bool                   `xml:"ApplyRateLimit,omitempty"`      // True if rate limiting is applied on this interface.
+	InRateLimit         float64                `xml:"InRateLimit,omitempty"`         // Incoming rate limit expressed as Gbps.
+	OutRateLimit        float64                `xml:"OutRateLimit,omitempty"`        // Outgoing rate limit expressed as Gbps.
+	UseForDefaultRoute  bool                   `xml:"UseForDefaultRoute,omitempty"`  // True if this network is default route for the gateway.
 }
 
 // SubnetParticipation allows to chose which subnets a gateway can be a part of
@@ -1608,10 +1608,11 @@ type GatewayInterface struct {
 // Description: Allows to chose which subnets a gateway can be part of
 // Since: 5.1
 type SubnetParticipation struct {
-	Gateway   string    `xml:"Gateway"`             // Gateway for subnet
-	IPAddress string    `xml:"IpAddress,omitempty"` // Ip Address to be assigned. Keep empty or omit element for auto assignment
-	IPRanges  *IPRanges `xml:"IpRanges,omitempty"`  // Range of IP addresses available for external interfaces.
-	Netmask   string    `xml:"Netmask"`             // Netmask for the subnet
+	Gateway            string    `xml:"Gateway"`                      // Gateway for subnet
+	IPAddress          string    `xml:"IpAddress,omitempty"`          // Ip Address to be assigned. Keep empty or omit element for auto assignment
+	IPRanges           *IPRanges `xml:"IpRanges,omitempty"`           // Range of IP addresses available for external interfaces.
+	Netmask            string    `xml:"Netmask"`                      // Netmask for the subnet
+	UseForDefaultRoute bool      `xml:"UseForDefaultRoute,omitempty"` // True if this network is default route for the gateway.
 }
 
 type EdgeGatewayServiceConfiguration struct {

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1595,7 +1595,7 @@ type GatewayInterface struct {
 	DisplayName         string                 `xml:"DisplayName,omitempty"`         // Gateway Interface display name.
 	Network             *Reference             `xml:"Network"`                       // A reference to the network connected to the gateway interface.
 	InterfaceType       string                 `xml:"InterfaceType"`                 // The type of interface: One of: Uplink, Internal
-	SubnetParticipation []*SubnetParticipation `xml:"SubnetParticipation,omitempty"` // IP allocation per subnet.
+	SubnetParticipation []*SubnetParticipation `xml:"SubnetParticipation,omitempty"` // Slice of subnets for IP allocations.
 	ApplyRateLimit      bool                   `xml:"ApplyRateLimit,omitempty"`      // True if rate limiting is applied on this interface.
 	InRateLimit         float64                `xml:"InRateLimit,omitempty"`         // Incoming rate limit expressed as Gbps.
 	OutRateLimit        float64                `xml:"OutRateLimit,omitempty"`        // Outgoing rate limit expressed as Gbps.


### PR DESCRIPTION
As part of needs for PRs https://github.com/terraform-providers/terraform-provider-vcd/issues/308 and https://github.com/terraform-providers/terraform-provider-vcd/issues/323 I have spotted that edge gateway structure does not pick up all assigned external network subnets for edge gateway because the type is not an array, but a single element.
This PR changes type and patches codebase to work as it was working before.