### PR TITLE
Add ability to connect using authorization tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 * Added command `make static` to run staticcheck on all packages
 * Added `make static` to Travis regular checks
+* Added ability to connect to the vCD using an authorization token
+* Added method `VCDClient.SetToken`
+* Added method `VCDClient.GetAuthResponse`
+* Added script `scripts/get_token.sh`
 
 BUGS FIXED:
 

--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ For the token, you use:
 	err := vcdClient.SetToken(Org, govcd.AuthorizationHeader, Token)
 ```
 
-The file `scripts/get_token.sh` provides a handy method of extracting the token for future use.
+The file `scripts/get_token.sh` provides a handy method of extracting the token (`x-vcloud-authorization` value) for future use.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For the first two methods, you use:
 
 ```go
 	err := vcdClient.Authenticate(User, Password, Org)
-    // or
+	// or
 	resp, err := vcdClient.GetAuthResponse(User, Password, Org)
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	org, err := govcd.GetOrgByName(client, config.Org)
+	org, err := client.GetOrgByName(config.Org)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	vdc, err := org.GetVdcByName(config.VDC)
+	vdc, err := org.GetVDCByName(config.VDC)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -116,8 +116,8 @@ func main() {
 
 You can authenticate to the vCD in three ways:
 
-* With a system administration user and password (`administrator@system`)
-* With an Organization user and password (`tenant-admin@org_name)
+* With a System Administration user and password (`administrator@system`)
+* With an Organization user and password (`tenant-admin@org-name`)
 * With an authorization token
 
 For the first two methods, you use:
@@ -130,7 +130,7 @@ For the first two methods, you use:
 
 For the token, you use:
 
-```
+```go
 	err := vcdClient.SetToken(Org, govcd.AuthorizationHeader, Token)
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,3 +111,28 @@ func main() {
 }
 
 ```
+
+## Authentication
+
+You can authenticate to the vCD in three ways:
+
+* With a system administration user and password (`administrator@system`)
+* With an Organization user and password (`tenant-admin@org_name)
+* With an authorization token
+
+For the first two methods, you use:
+
+```go
+	err := vcdClient.Authenticate(User, Password, Org)
+    // or
+	resp, err := vcdClient.GetAuthResponse(User, Password, Org)
+```
+
+For the token, you use:
+
+```
+	err := vcdClient.SetToken(Org, govcd.AuthorizationHeader, Token)
+```
+
+The file `scripts/get_token.sh` provides a handy method of extracting the token for future use.
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -327,6 +327,8 @@ While running tests, the following environment variables can be used:
 * `GOVCD_IGNORE_CLEANUP_FILE` Ignore the cleanup file if it is left behind after a test failure.
     This could be useful after running a single test, when we need to check how the test behaves with the resource still
     in place.
+* `VCD_TOKEN` : specifies the authorization token to use instead of username/password
+   (Use `./scripts/get_token.sh` to retrieve one)
 
 # Final Words
 Be careful about using our tests as these tests run on a real vcd. If you don't have 1 gb of ram and 2 vcpus available then you should not be running tests that deploy your vm/change memory and cpu. However everything created will be removed at the end of testing.

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -36,6 +36,9 @@ type Client struct {
 	MaxRetryTimeout int
 }
 
+// The header key used by default to set the authorization token.
+const AuthorizationHeader = "X-Vcloud-Authorization"
+
 // General purpose error to be used whenever an entity is not found from a "GET" request
 // Allows a simpler checking of the call result
 // such as

--- a/govcd/sample_govcd_test_config.json
+++ b/govcd/sample_govcd_test_config.json
@@ -3,6 +3,8 @@
 	"provider": {
 		"user": "someuser",
 		"password": "somepassword",
+    "//": "If token is provided, username and password are ignored",
+    "token": "an_auth_token",
 		"url": "https://11.111.1.111/api",
 		"sysOrg": "System",
 		"//": "(Optional) In some cases the vCloud Director SDK must wait. It can be",

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -11,6 +11,8 @@ provider:
     # (Providing org credentials will skip some tests)
     user: someuser
     password: somepassword
+    # If token is provided, username and password are ignored
+    token: an_auth_token
     #
     # The vCD address, in the format https://vCD_IP/api
     # or https://vCD_host_name/api

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -818,7 +818,7 @@ func (vcdClient *VCDClient) GetOrgByName(orgName string) (*Org, error) {
 	org := NewOrg(&vcdClient.Client)
 
 	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
-		"", "error retrieving org list: %s", nil, org.Org)
+		"", "error retrieving org: %s", nil, org.Org)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script will connect to the vCD using username and password,
+# and show the header that cointains an authorization token.
+#
+user=$1
+password=$2
+org=$3
+IP=$4
+
+if [ -z "$IP" ]
+then
+    echo "Syntax $0 user password organization IP_address"
+    exit 1
+fi
+
+auth=$(echo -n "$user@$org:$password" |base64)
+
+curl -I -k --header "Accept: application/*;version=27.0" \
+    --header "Authorization: Basic $auth" \
+    --request POST https://$IP/api/sessions
+
+# If successful, the output of this command will include a line like the following
+# x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
+#
+# The string after `x-vcloud-authorization:` is the token.

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -9,7 +9,7 @@ IP=$4
 
 if [ -z "$IP" ]
 then
-    echo "Syntax $0 user password organization hostname_or_IP_address)"
+    echo "Syntax $0 user password organization hostname_or_IP_address"
     exit 1
 fi
 

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -9,7 +9,7 @@ IP=$4
 
 if [ -z "$IP" ]
 then
-    echo "Syntax $0 user password organization IP_address"
+    echo "Syntax $0 user password organization hostname_or_IP_address)"
     exit 1
 fi
 

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -15,7 +15,7 @@ fi
 
 auth=$(echo -n "$user@$org:$password" |base64)
 
-curl -I -k --header "Accept: application/*;version=27.0" \
+curl -I -k --header "Accept: application/*;version=29.0" \
     --header "Authorization: Basic $auth" \
     --request POST https://$IP/api/sessions
 


### PR DESCRIPTION
* Added method `VCDClient.SetToken`
* Added method `VCDClient.GetAuthResponse`
* Added script `scripts/get_token.sh`

Implementation notes:

* When using a token, we don't know by which user it was created. This may not be a problem for most users, but it is for a team like ours, where we need to test with different users.
* Using a token generated by an org admin for tasks that require an admin user will fail.
* Similarly, a token shows no relationship with the server that generated it. Using in server X a token that was generated for server Y will fail.
