### PR TITLE
Increment vCD API version to 29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 * Added method `VCDClient.GetAuthResponse`
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
-* Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
-* Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link,	MetaData` to `QueryResultVMRecordType`
+** Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
+** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to NetworkConfiguration, `RegenerateBiosUuid` to VMGeneralParams
+** Change `DistributedRoutingEnabled` to pointer in GatewayConfiguration 
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Increment vCD API version used to 29.0
 ** Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
 ** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to NetworkConfiguration, `RegenerateBiosUuid` to VMGeneralParams
-** Change `DistributedRoutingEnabled` to pointer in GatewayConfiguration 
+** Change `DistributedRoutingEnabled` to pointer in GatewayConfiguration and `DistributedInterface` in NetworkConfiguration.
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Increment vCD API version used to 29.0
     * Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
     * Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
-    * Change `DistributedRoutingEnabled` to pointer in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`.
+    * Change to pointers `DistributedRoutingEnabled` in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added method `VCDClient.SetToken`
 * Added method `VCDClient.GetAuthResponse`
 * Added script `scripts/get_token.sh`
-* Increment vCD API version used to 29.0
+* Increment vCD API version used from 27.0 to 29.0
     * Remove fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
     * Add fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
     * Change to pointers `DistributedRoutingEnabled` in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 * Added method `VCDClient.GetAuthResponse`
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
-** Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
-** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
-** Change `DistributedRoutingEnabled` to pointer in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`.
+    * Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
+    * Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
+    * Change `DistributedRoutingEnabled` to pointer in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`.
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
 ** Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
-** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to NetworkConfiguration, `RegenerateBiosUuid` to `VMGeneralParams`
+** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
 ** Change `DistributedRoutingEnabled` to pointer in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`.
 
 BUGS FIXED:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Added method `VCDClient.GetAuthResponse`
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
+* Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
+* Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link,	MetaData` to `QueryResultVMRecordType`
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 * Added command `make static` to run staticcheck on all packages
 * Added `make static` to Travis regular checks
+* Increment vCD API version to 29.0
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added method VApp.AddNewVMWithStorageProfile that adds a VM with custom storage profile.
 * Added command `make static` to run staticcheck on all packages
 * Added `make static` to Travis regular checks
-* Increment vCD API version to 29.0
+* Increment vCD API version used to 29.0
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
 ** Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
-** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to NetworkConfiguration, `RegenerateBiosUuid` to VMGeneralParams
-** Change `DistributedRoutingEnabled` to pointer in GatewayConfiguration and `DistributedInterface` in NetworkConfiguration.
+** Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to NetworkConfiguration, `RegenerateBiosUuid` to `VMGeneralParams`
+** Change `DistributedRoutingEnabled` to pointer in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`.
 
 BUGS FIXED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 * Added method `VCDClient.GetAuthResponse`
 * Added script `scripts/get_token.sh`
 * Increment vCD API version used to 29.0
-    * Removed fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
-    * Added fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
+    * Remove fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
+    * Add fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
     * Change to pointers `DistributedRoutingEnabled` in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`
 
 BUGS FIXED:

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -87,12 +87,12 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 }
 
 // NewVCDClient initializes VMware vCloud Director client with reasonable defaults.
-// It accepts functions of type VCDClientOption for adjusting defaults.
+// It accepts functions of type VCDClientOption for adjustedgegateway_test.going defaults.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	// Setting defaults
 	vcdClient := &VCDClient{
 		Client: Client{
-			APIVersion: "27.0", // supported by vCD 8.20, 9.0, 9.1, 9.5, 9.7
+			APIVersion: "29.0", // supported by vCD 9.0, 9.1, 9.5, 9.7, 10.0
 			VCDHREF:    vcdEndpoint,
 			Http: http.Client{
 				Transport: &http.Transport{

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -87,7 +87,7 @@ func (vcdCli *VCDClient) vcdauthorize(user, pass, org string) error {
 }
 
 // NewVCDClient initializes VMware vCloud Director client with reasonable defaults.
-// It accepts functions of type VCDClientOption for adjustedgegateway_test.going defaults.
+// It accepts functions of type VCDClientOption for adjusting defaults.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	// Setting defaults
 	vcdClient := &VCDClient{

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -556,7 +556,6 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 // identical except <version></version> tag which is versioning the configuration
 func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip("Skipping test because no edge gatway given")
 		check.Skip("Skipping test because no edge gateway given")
 	}
 	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -743,31 +743,24 @@ func testCheckFirewallConfig(beforeFw *types.FirewallConfigWithXml, beforeFwXml 
 	afterFw.Version = ""
 
 	// Because the test enables and disables firewall configuration, main firewall rule has its ID
-	// and ruleTag changed during the test and we must ignore this change while comparing. This is
-	// always the first rule kept at the top so we are replacing `id` and `ruletag` fields in
-	// "before" and "after" values.
-	beforeFw.FirewallRules.Text = replaceFirstMatch(beforeFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
-	beforeFw.FirewallRules.Text = replaceFirstMatch(beforeFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
-	afterFw.FirewallRules.Text = replaceFirstMatch(afterFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
-	afterFw.FirewallRules.Text = replaceFirstMatch(afterFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	// and ruleTag changed during the test and we must ignore this change while comparing.
+	beforeFw.FirewallRules.Text = replaceAllMatches(beforeFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
+	beforeFw.FirewallRules.Text = replaceAllMatches(beforeFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	afterFw.FirewallRules.Text = replaceAllMatches(afterFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
+	afterFw.FirewallRules.Text = replaceAllMatches(afterFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
 
-	beforeFwXml = replaceFirstMatch(beforeFwXml, `<id>\d*</id>`, "<id>99999</id>")
-	beforeFwXml = replaceFirstMatch(beforeFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
-	afterFwXml = replaceFirstMatch(afterFwXml, `<id>\d*</id>`, "<id>99999</id>")
-	afterFwXml = replaceFirstMatch(afterFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	beforeFwXml = replaceAllMatches(beforeFwXml, `<id>\d*</id>`, "<id>99999</id>")
+	beforeFwXml = replaceAllMatches(beforeFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	afterFwXml = replaceAllMatches(afterFwXml, `<id>\d*</id>`, "<id>99999</id>")
+	afterFwXml = replaceAllMatches(afterFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
 
 	check.Assert(beforeFw, DeepEquals, afterFw)
 	check.Assert(beforeFwXml, DeepEquals, afterFwXml)
 }
 
-// replaceFirstMatch replaces first `regex` matched in `text` with `replacement` and returns it
+// replaceAllMatches replaces `regex` matched in `text` with `replacement` and returns it
 // It will panic if regex is invalid.
-func replaceFirstMatch(text, regex, replacement string) string {
+func replaceAllMatches(text, regex, replacement string) string {
 	re := regexp.MustCompile(regex)
-	// Replace leftmost found string
-	found := re.FindString(text)
-	if found != "" {
-		return strings.Replace(text, found, replacement, 1)
-	}
-	return ""
+	return re.ReplaceAllString(text, replacement)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -556,6 +556,7 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 // identical except <version></version> tag which is versioning the configuration
 func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gatway given")
 		check.Skip("Skipping test because no edge gateway given")
 	}
 	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
@@ -743,24 +744,31 @@ func testCheckFirewallConfig(beforeFw *types.FirewallConfigWithXml, beforeFwXml 
 	afterFw.Version = ""
 
 	// Because the test enables and disables firewall configuration, main firewall rule has its ID
-	// and ruleTag changed during the test and we must ignore this change while comparing.
-	beforeFw.FirewallRules.Text = replaceAllMatches(beforeFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
-	beforeFw.FirewallRules.Text = replaceAllMatches(beforeFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
-	afterFw.FirewallRules.Text = replaceAllMatches(afterFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
-	afterFw.FirewallRules.Text = replaceAllMatches(afterFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	// and ruleTag changed during the test and we must ignore this change while comparing. This is
+	// always the first rule kept at the top so we are replacing `id` and `ruletag` fields in
+	// "before" and "after" values.
+	beforeFw.FirewallRules.Text = replaceFirstMatch(beforeFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
+	beforeFw.FirewallRules.Text = replaceFirstMatch(beforeFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	afterFw.FirewallRules.Text = replaceFirstMatch(afterFw.FirewallRules.Text, `<id>\d*</id>`, "<id>99999</id>")
+	afterFw.FirewallRules.Text = replaceFirstMatch(afterFw.FirewallRules.Text, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
 
-	beforeFwXml = replaceAllMatches(beforeFwXml, `<id>\d*</id>`, "<id>99999</id>")
-	beforeFwXml = replaceAllMatches(beforeFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
-	afterFwXml = replaceAllMatches(afterFwXml, `<id>\d*</id>`, "<id>99999</id>")
-	afterFwXml = replaceAllMatches(afterFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	beforeFwXml = replaceFirstMatch(beforeFwXml, `<id>\d*</id>`, "<id>99999</id>")
+	beforeFwXml = replaceFirstMatch(beforeFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
+	afterFwXml = replaceFirstMatch(afterFwXml, `<id>\d*</id>`, "<id>99999</id>")
+	afterFwXml = replaceFirstMatch(afterFwXml, `<ruleTag>\d*</ruleTag>`, "<ruleTag>99999</ruleTag>")
 
 	check.Assert(beforeFw, DeepEquals, afterFw)
 	check.Assert(beforeFwXml, DeepEquals, afterFwXml)
 }
 
-// replaceAllMatches replaces `regex` matched in `text` with `replacement` and returns it
+// replaceFirstMatch replaces first `regex` matched in `text` with `replacement` and returns it
 // It will panic if regex is invalid.
-func replaceAllMatches(text, regex, replacement string) string {
+func replaceFirstMatch(text, regex, replacement string) string {
 	re := regexp.MustCompile(regex)
-	return re.ReplaceAllString(text, replacement)
+	// Replace leftmost found string
+	found := re.FindString(text)
+	if found != "" {
+		return strings.Replace(text, found, replacement, 1)
+	}
+	return ""
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -132,7 +132,7 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 			HaEnabled:                  egwc.HAEnabled,
 			GatewayBackingConfig:       egwc.BackingConfiguration,
 			AdvancedNetworkingEnabled:  egwc.AdvancedNetworkingEnabled,
-			DistributedRoutingEnabled:  distributed,
+			DistributedRoutingEnabled:  &distributed,
 			GatewayInterfaces: &types.GatewayInterfaces{
 				GatewayInterface: []*types.GatewayInterface{},
 			},

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -211,6 +211,7 @@ type NetworkConfiguration struct {
 	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
 	Features                       *NetworkFeatures `xml:"Features,omitempty"`
 	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
+	DistributedInterface           *bool            `xml:"DistributedInterface,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`
@@ -1134,6 +1135,7 @@ type VMGeneralParams struct {
 	Name               string `xml:"Name,omitempty"`               // Name of VM
 	Description        string `xml:"Description,omitempty"`        // VM description
 	NeedsCustomization bool   `xml:"NeedsCustomization,omitempty"` // True if this VM needs guest customization
+	RegenerateBiosUuid bool   `xml:"RegenerateBiosUuid,omitempty"` // True if BIOS UUID of the virtual machine should be regenerated so that it is unique, and not the same as the source virtual machine's BIOS UUID.
 }
 
 // VApp represents a vApp
@@ -1572,7 +1574,7 @@ type GatewayConfiguration struct {
 	EdgeGatewayServiceConfiguration *GatewayFeatures   `xml:"EdgeGatewayServiceConfiguration,omitempty"` // Represents Gateway Features.
 	HaEnabled                       bool               `xml:"HaEnabled,omitempty"`                       // True if this gateway is highly available. (Requires two vShield edge VMs.)
 	AdvancedNetworkingEnabled       bool               `xml:"AdvancedNetworkingEnabled,omitempty"`       // True if the gateway uses advanced networking
-	DistributedRoutingEnabled       bool               `xml:"DistributedRoutingEnabled,omitempty"`       // True if gateway is attached to a Distributed Logical Router
+	DistributedRoutingEnabled       *bool              `xml:"DistributedRoutingEnabled,omitempty"`       // True if gateway is attached to a Distributed Logical Router
 	UseDefaultRouteForDNSRelay      bool               `xml:"UseDefaultRouteForDnsRelay,omitempty"`      // True if the default gateway on the external network selected for default route should be used as the DNS relay.
 }
 
@@ -1778,7 +1780,7 @@ type LbPoolMember struct {
 	Port        int    `xml:"port"`
 	MaxConn     int    `xml:"maxConn,omitempty"`
 	MinConn     int    `xml:"minConn,omitempty"`
-	Condition   string `xml:"condition,omitempty"`
+	Condition   string `xml:"condition"`
 }
 
 type LbPoolMembers []LbPoolMember
@@ -2240,31 +2242,40 @@ type QueryResultEdgeGatewayRecordType struct {
 // QueryResultVMRecordType represents a VM record as query result.
 type QueryResultVMRecordType struct {
 	// Attributes
-	HREF                    string `xml:"href,attr,omitempty"`       // The URI of the entity.
-	Name                    string `xml:"name,attr,omitempty"`       // VM name.
-	Deployed                bool   `xml:"isDeployed,attr,omitempty"` // True if the virtual machine is deployed.
-	Status                  string `xml:"status,attr,omitempty"`
-	Busy                    bool   `xml:"isBusy,attr,omitempty"`
-	Deleted                 bool   `xml:"isDeleted,attr,omitempty"`
-	MaintenanceMode         bool   `xml:"isInMaintenanceMode,attr,omitempty"`
-	Published               bool   `xml:"isPublished,attr,omitempty"`
-	VAppTemplate            bool   `xml:"isVAppTemplate,attr,omitempty"`
-	VdcEnabled              bool   `xml:"isVdcEnabled,attr,omitempty"`
-	VdcHREF                 string `xml:"vdc,attr,omitempty"`
-	VAppParentHREF          string `xml:"container,attr,omitempty"`
-	VAppParentName          string `xml:"containerName,attr,omitempty"`
-	HardwareVersion         int    `xml:"hardwareVersion,attr,omitempty"`
-	HighestSupportedVersion int    `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
-	VmToolsVersion          string `xml:"vmToolsVersion,attr,omitempty"`
-	GuestOS                 string `xml:"guestOs,attr,omitempty"`
-	MemoryMB                int    `xml:"memoryMB,attr,omitempty"`
-	Cpus                    int    `xml:"numberOfCpus,attr,omitempty"`
-	StorageProfileName      string `xml:"storageProfileName,attr,omitempty"`
-	NetworkName             string `xml:"networkName,attr,omitempty"`
-	TaskHREF                string `xml:"task,attr,omitempty"`
-	TaskStatusName          string `xml:"taskStatusName,attr,omitempty"`
-	TaskDetails             string `xml:"taskDetails,attr,omitempty"`
-	TaskStatus              string `xml:"TaskStatus,attr,omitempty"`
+	HREF                 string    `xml:"href,attr,omitempty"` // The URI of the entity.
+	ID                   string    `xml:"id,attr,omitempty"`
+	Name                 string    `xml:"name,attr,omitempty"`          // VM name.
+	Type                 string    `xml:"type,attr,omitempty"`          // Contains the type of the resource.
+	ContainerName        string    `xml:"containerName,attr,omitempty"` // The name of the vApp or vApp template that contains this VM.
+	ContainerID          string    `xml:"container,attr,omitempty"`     // The ID of the vApp or vApp template that contains this VM.
+	OwnerName            string    `xml:"ownerName,attr,omitempty"`
+	Owner                string    `xml:"owner,attr,omitempty"`
+	VdcHREF              string    `xml:"vdc,attr,omitempty"`
+	VAppTemplate         bool      `xml:"isVAppTemplate,attr,omitempty"`
+	Deleted              bool      `xml:"isDeleted,attr,omitempty"`
+	GuestOS              string    `xml:"guestOs,attr,omitempty"`
+	Cpus                 int       `xml:"numberOfCpus,attr,omitempty"`
+	MemoryMB             int       `xml:"memoryMB,attr,omitempty"`
+	Status               string    `xml:"status,attr,omitempty"`
+	NetworkName          string    `xml:"networkName,attr,omitempty"`
+	NetworkHref          string    `xml:"network,attr,omitempty"`
+	IpAddress            string    `xml:"ipAddress,attr,omitempty"` // If configured, the IP Address of the VM on the primary network, otherwise empty.
+	Busy                 bool      `xml:"isBusy,attr,omitempty"`
+	Deployed             bool      `xml:"isDeployed,attr,omitempty"` // True if the virtual machine is deployed.
+	Published            bool      `xml:"isPublished,attr,omitempty"`
+	CatalogName          string    `xml:"catalogName,attr,omitempty"`
+	HardwareVersion      int       `xml:"hardwareVersion,attr,omitempty"`
+	VmToolsStatus        string    `xml:"vmToolsStatus,attr,omitempty"`
+	MaintenanceMode      bool      `xml:"isInMaintenanceMode,attr,omitempty"`
+	AutoNature           bool      `xml:"isAutoNature,attr,omitempty"` //  	True if the parent vApp is a managed vApp
+	StorageProfileName   string    `xml:"storageProfileName,attr,omitempty"`
+	GcStatus             string    `xml:"gcStatus,attr,omitempty"` // GC status of this VM.
+	AutoUndeployDate     string    `xml:"autoUndeployDate,attr,omitempty"`
+	AutoDeleteDate       string    `xml:"autoDeleteDate,attr,omitempty"`
+	AutoUndeployNotified bool      `xml:"isAutoUndeployNotified,attr,omitempty"`
+	AutoDeleteNotified   bool      `xml:"isAutoDeleteNotified,attr,omitempty"`
+	Link                 []*Link   `xml:"Link,omitempty"`
+	MetaData             *Metadata `xml:"Metadata,omitempty"`
 }
 
 // QueryResultVAppRecordType represents a VM record as query result.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1780,7 +1780,7 @@ type LbPoolMember struct {
 	Port        int    `xml:"port"`
 	MaxConn     int    `xml:"maxConn,omitempty"`
 	MinConn     int    `xml:"minConn,omitempty"`
-	Condition   string `xml:"condition"`
+	Condition   string `xml:"condition,omitempty"`
 }
 
 type LbPoolMembers []LbPoolMember


### PR DESCRIPTION
Ref: We dropped support for vCD 8.2 and for new functionality we need access features which are on higher API versions.
Documentaion :https://code.vmware.com/apis/220/vcloud/doc/diff/index.html

* Increase from 27.0 (vCD 8.2) to 29 (vCD 9.0)
* Updated some types to correspond new API

