### PR TITLE
Add ability to get all virtualserver/pools/service monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@
     * Remove fields `VdcEnabled`, `VAppParentHREF`, `VAppParentName`, `HighestSupportedVersion`, `VmToolsVersion`, `TaskHREF`, `TaskStatusName`, `TaskDetails`, `TaskStatus` from `QueryResultVMRecordType`
     * Add fields `ID, Type, ContainerName, ContainerID, OwnerName, Owner, NetworkHref, IpAddress, CatalogName, VmToolsStatus, GcStatus, AutoUndeployDate, AutoDeleteDate, AutoUndeployNotified, AutoDeleteNotified, Link, MetaData` to `QueryResultVMRecordType`, `DistributedInterface` to `NetworkConfiguration` and `RegenerateBiosUuid` to `VMGeneralParams`
     * Change to pointers `DistributedRoutingEnabled` in `GatewayConfiguration` and `DistributedInterface` in `NetworkConfiguration`
+* Added method `EdgeGateway.GetLbVirtualServers` that gets all virtual servers configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
+* Added method `EdgeGateway.GetLbServerPools` that gets all pools configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
+* Added method `EdgeGateway.GetLbServiceMonitors` that gets all service monitors configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
 
 BUGS FIXED:
-
 * Remove parentheses from filtering since they weren't treated correctly in some environment [#256]
   (https://github.com/vmware/go-vcloud-director/pull/256)
 * Take into account all subnets (SubnetParticipation) on edge gateway interface instead of the first

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -110,6 +110,11 @@ func (vcd *TestVCD) Test_LBServerPool(check *C) {
 
 	check.Assert(createdLbPool.Algorithm, Equals, lbPoolConfig.Algorithm)
 
+	// GetLbServerPools should return at least one pool which is ours.
+	pools, err := edge.GetLbServerPools()
+	check.Assert(err, IsNil)
+	check.Assert(pools, Not(HasLen), 0)
+
 	// Test updating fields
 	// Update algorithm
 	lbPoolByID.Algorithm = "ip-hash"

--- a/govcd/lbservicemonitor_test.go
+++ b/govcd/lbservicemonitor_test.go
@@ -68,6 +68,11 @@ func (vcd *TestVCD) Test_LBServiceMonitor(check *C) {
 	check.Assert(lbMonitor.Timeout, Equals, lbMonitorByID.Timeout)
 	check.Assert(lbMonitor.MaxRetries, Equals, lbMonitorByID.MaxRetries)
 
+	// GetLbServiceMonitors should return at least one vs which is ours.
+	lbMonitors, err := edge.GetLbServiceMonitors()
+	check.Assert(err, IsNil)
+	check.Assert(lbMonitors, Not(HasLen), 0)
+
 	// Test updating fields
 	// Update timeout
 	lbMonitorByID.Timeout = 35

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -8,7 +8,6 @@ package govcd
 
 import (
 	"fmt"
-
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
@@ -99,6 +98,11 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	check.Assert(createdLbVirtualServer.ID, Equals, lbVirtualServerByName.ID)
 	check.Assert(lbVirtualServerById.ID, Equals, lbVirtualServerByName.ID)
 	check.Assert(lbVirtualServerById.Name, Equals, lbVirtualServerByName.Name)
+
+	// GetLbVirtualServers should return at least one vs which is our.
+	servers, err := edge.GetLbVirtualServers()
+	check.Assert(err, IsNil)
+	check.Assert(servers, Not(HasLen), 0)
 
 	// Test updating fields
 	// Update algorithm

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -99,7 +99,7 @@ func (vcd *TestVCD) Test_LBVirtualServer(check *C) {
 	check.Assert(lbVirtualServerById.ID, Equals, lbVirtualServerByName.ID)
 	check.Assert(lbVirtualServerById.Name, Equals, lbVirtualServerByName.Name)
 
-	// GetLbVirtualServers should return at least one vs which is our.
+	// GetLbVirtualServers should return at least one vs which is ours.
 	servers, err := edge.GetLbVirtualServers()
 	check.Assert(err, IsNil)
 	check.Assert(servers, Not(HasLen), 0)


### PR DESCRIPTION
Added method `EdgeGateway.GetLbVirtualServers`
Added method `EdgeGateway.GetLbServiceMonitors`
Added method `EdgeGateway.GetLbServerPools`

Methods `EdgeGateway.getLbVirtualServer`, `EdgeGateway.getLbServerPool` and `EdgeGateway.getLbServiceMonitor` are now using public methods as base to get all resources

## Description

Related issue: ([Issue 265](https://github.com/vmware/go-vcloud-director/issues/265))

- (Required) Add methods to return all configured Virtual Servers, Server Pools or Service Monitors on NSX Load Balancer

- (Required) 
Added method `EdgeGateway.GetLbVirtualServers`
Added method `EdgeGateway.GetLbServiceMonitors`
Added method `EdgeGateway.GetLbServerPools`

Private methods `getLb*` are now utilizing the public one to get all resources and then make the filtering as before.
Added new tests which checks that those public methods will return at least 1 resource (which was created before that).