### PR TITLE
Support for routed network subinterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@
 * Added method `EdgeGateway.GetLbVirtualServers` that gets all virtual servers configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
 * Added method `EdgeGateway.GetLbServerPools` that gets all pools configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
 * Added method `EdgeGateway.GetLbServiceMonitors` that gets all service monitors configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
+* Added field `SubInterface` to `NetworkConfiguration`. [#321](https://github.com/terraform-providers/terraform-provider-vcd/issues/321)
 
 BUGS FIXED:
 * Remove parentheses from filtering since they weren't treated correctly in some environment [#256]
   (https://github.com/vmware/go-vcloud-director/pull/256)
 * Take into account all subnets (SubnetParticipation) on edge gateway interface instead of the first
   one [#260](https://github.com/vmware/go-vcloud-director/pull/260)
+* Fix `OrgVdcNetwork` data structure to retrieve description. Previously, the description would not be retrieved because it was misplaced in the sequence.
 
 ## 2.4.0 (October 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Added method `EdgeGateway.GetLbServerPools` that gets all pools configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
 * Added method `EdgeGateway.GetLbServiceMonitors` that gets all service monitors configured on NSX load balancer. [#266](https://github.com/vmware/go-vcloud-director/pull/266)
 * Added field `SubInterface` to `NetworkConfiguration`. [#321](https://github.com/terraform-providers/terraform-provider-vcd/issues/321)
+* Added methods `Vdc.FindEdgeGatewayNameByNetwork` and `Vdc.GetNetworkList`
 
 BUGS FIXED:
 * Remove parentheses from filtering since they weren't treated correctly in some environment [#256]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -48,7 +48,7 @@ const (
 	TestDeleteCatalogItem         = "TestDeleteCatalogItem"
 	TestCreateOrgVdc              = "TestCreateOrgVdc"
 	TestRefreshOrgVdc             = "TestRefreshOrgVdc"
-	TestCreateOrgVdcNetworkEGW    = "TestCreateOrgVdcNetworkEGW"
+	TestCreateOrgVdcNetworkRouted = "TestCreateOrgVdcNetworkRouted"
 	TestCreateOrgVdcNetworkIso    = "TestCreateOrgVdcNetworkIso"
 	TestCreateOrgVdcNetworkDirect = "TestCreateOrgVdcNetworkDirect"
 	TestUploadMedia               = "TestUploadMedia"

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -194,19 +194,21 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 	return Task{}, fmt.Errorf("network creation failed: no operational link found")
 }
 
+// GetNetworkList returns a list of networks for the VDC
+func (vdc *Vdc) GetNetworkList() ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
+	// Find the list of networks with the wanted name
+	result, err := vdc.client.QueryWithNotEncodedParams(nil, map[string]string{
+		"type":   "orgVdcNetwork",
+		"filter": fmt.Sprintf("vdc==%s", url.QueryEscape(vdc.Vdc.ID)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("[findEdgeGatewayConnection] error returning the list of networks for VDC: %s", err)
+	}
+	return result.Results.OrgVdcNetworkRecord, nil
+}
+
 // FindEdgeGatewayNameByNetwork searches the VDC for a connection between an edge gateway and a given network.
 // On success, returns the name of the edge gateway
-//
-// CAVEAT: this function should only be called on routed networks.
-// There is a slim chance that this function returns a misleading result when BOTH the following
-// conditions are met:
-// (a) we query an isolated or direct network instead of a routed one
-// AND
-// (b) the network has the same name of an existing edge gateway
-// In normal operations (like retrieving the edge gateway name for a routed network data source) this will work
-// as expected.
-// If this function is used to detect the network type (i.e. if it is connected to an edge gateway it's routed)
-// it may fail its purpose if the above mentioned circumstance apply.
 func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error) {
 
 	// Find the list of networks with the wanted name
@@ -219,31 +221,13 @@ func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error)
 	}
 	netList := result.Results.OrgVdcNetworkRecord
 
-	// Find the list of edge gateways
-	edgeGatewayResult := new(types.QueryResultEdgeGatewayRecordsType)
-	for _, av := range vdc.Vdc.Link {
-		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
-
-			_, err := vdc.client.ExecuteRequest(av.HREF, http.MethodGet,
-				"", "error querying edge gateways: %s", nil, edgeGatewayResult)
-			if err != nil {
-				return "", err
-			}
-		}
-	}
-
-	var isAnEdgeGateway = func(gwName string) bool {
-		for _, gw := range edgeGatewayResult.EdgeGatewayRecord {
-			if gw.Name == gwName {
-				return true
-			}
-		}
-		return false
-	}
-
 	for _, net := range netList {
 		if net.Name == networkName {
-			if net.ConnectedTo != "" && isAnEdgeGateway(net.ConnectedTo) {
+			// linkType is not well documented, but empiric tests show that:
+			// 0 = direct
+			// 1 = routed
+			// 2 = isolated
+			if net.ConnectedTo != "" && net.LinkType == 1 { // We only want routed networks
 				return net.ConnectedTo, nil
 			}
 		}

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -158,6 +158,29 @@ func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, sub
 	check.Assert(err, IsNil)
 }
 
+// Tests that we can get a network list, and a known network is retrieved from that list
+func (vcd *TestVCD) Test_GetNetworkList(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+	networkName := vcd.config.VCD.Network.Net1
+	if networkName == "" {
+		check.Skip("no network name provided")
+	}
+	networks, err := vcd.vdc.GetNetworkList()
+	check.Assert(err, IsNil)
+	found := false
+	for _, net := range networks {
+		// Check that we don't get invalid fields
+		knownType := net.LinkType == 0 || net.LinkType == 1 || net.LinkType == 2
+		check.Assert(knownType, Equals, true)
+		// Check that the `ConnectTo` field is not empty
+		check.Assert(net.ConnectedTo, Not(Equals), "")
+		if net.Name == networkName {
+			found = true
+		}
+	}
+	check.Assert(found, Equals, true)
+}
+
 // Tests the creation of an isolated Org VDC network
 func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -145,8 +145,13 @@ func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, sub
 		check.Assert(network.OrgVDCNetwork.Configuration.SubInterface, NotNil)
 		check.Assert(*network.OrgVDCNetwork.Configuration.SubInterface, Equals, true)
 	}
-	err = edgeGateway.Refresh()
+
+	// Tests FindEdgeGatewayNameByNetwork
+	// Note: is should work without refreshing either VDC or edge gateway
+	connectedGw, err := vcd.vdc.FindEdgeGatewayNameByNetwork(networkName)
 	check.Assert(err, IsNil)
+	check.Assert(connectedGw, Equals, edgeGWName)
+
 	task, err := network.Delete()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -211,6 +211,7 @@ type NetworkConfiguration struct {
 	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
 	Features                       *NetworkFeatures `xml:"Features,omitempty"`
 	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
+	SubInterface                   *bool            `xml:"SubInterface,omitempty"`
 	DistributedInterface           *bool            `xml:"DistributedInterface,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
@@ -331,8 +332,8 @@ type OrgVDCNetwork struct {
 	OperationKey    string                `xml:"operationKey,attr,omitempty"`
 	Name            string                `xml:"name,attr"`
 	Status          string                `xml:"status,attr,omitempty"`
-	Configuration   *NetworkConfiguration `xml:"Configuration,omitempty"`
 	Description     string                `xml:"Description,omitempty"`
+	Configuration   *NetworkConfiguration `xml:"Configuration,omitempty"`
 	EdgeGateway     *Reference            `xml:"EdgeGateway,omitempty"`
 	ServiceConfig   *GatewayFeatures      `xml:"ServiceConfig,omitempty"` // Specifies the service configuration for an isolated Org VDC networks
 	IsShared        bool                  `xml:"IsShared"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2691,7 +2691,7 @@ type QueryResultOrgVdcNetworkRecordType struct {
 	Dns1               string  `xml:"dns1,attr,omitempty"`
 	Dns2               string  `xml:"dns2,attr,omitempty"`
 	DnsSuffix          string  `xml:"dnsSuffix,attr,omitempty"`
-	LinkType           int     `xml:"linkType,attr,omitempty"`
+	LinkType           int     `xml:"linkType,attr,omitempty"` // 0 = direct, 1 = routed, 2 = isolated
 	ConnectedTo        string  `xml:"connectedTo,attr,omitempty"`
 	Vdc                string  `xml:"vdc,attr,omitempty"`
 	IsBusy             bool    `xml:"isBusy,attr,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -211,8 +211,13 @@ type NetworkConfiguration struct {
 	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
 	Features                       *NetworkFeatures `xml:"Features,omitempty"`
 	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
-	SubInterface                   *bool            `xml:"SubInterface,omitempty"`
-	DistributedInterface           *bool            `xml:"DistributedInterface,omitempty"`
+
+	// SubInterface and DistributedInterface are mutually exclusive
+	// When they are both nil, it means the "internal" interface (the default) will be used.
+	// When one of them is set, the corresponding interface will be used.
+	// They cannot be both set (we'll get an API error if we do).
+	SubInterface         *bool `xml:"SubInterface,omitempty"`
+	DistributedInterface *bool `xml:"DistributedInterface,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`


### PR DESCRIPTION
* Add support for routed network subinterface
* Fix network description management. The field was not retrieved due to its misplacement in the data structure.
