### PR TITLE
Do not check for portgroup name when looking up vNic index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ BUGS FIXED:
 * Take into account all subnets (SubnetParticipation) on edge gateway interface instead of the first
   one [#260](https://github.com/vmware/go-vcloud-director/pull/260)
 * Fix `OrgVdcNetwork` data structure to retrieve description. Previously, the description would not be retrieved because it was misplaced in the sequence.
+* Fix a bug where function `GetAnyVnicIndexByNetworkName` and `GetVnicIndexByNetworkNameAndType`
+  would not find vNic index when user is not authenticated as sysadmin
+  [#275](https://github.com/vmware/go-vcloud-director/pull/275)
 
 ## 2.4.0 (October 28, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ BUGS FIXED:
 * Take into account all subnets (SubnetParticipation) on edge gateway interface instead of the first
   one [#260](https://github.com/vmware/go-vcloud-director/pull/260)
 * Fix `OrgVdcNetwork` data structure to retrieve description. Previously, the description would not be retrieved because it was misplaced in the sequence.
-* Fix a bug where function `GetAnyVnicIndexByNetworkName` and `GetVnicIndexByNetworkNameAndType`
-  would not find vNic index when user is not authenticated as sysadmin
+* Fix a bug where functions `GetAnyVnicIndexByNetworkName` and `GetVnicIndexByNetworkNameAndType`
+  would not find vNic index when user is authenticated as org admin (not sysadmin)
   [#275](https://github.com/vmware/go-vcloud-director/pull/275)
 
 ## 2.4.0 (October 28, 2019)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1348,8 +1348,10 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 	foundCount := 0
 
 	for _, vnic := range vnics.EdgeInterface {
-		// Look for matching portgroup name and network type
-		if vnic.Name == networkName && vnic.Type == networkType {
+		// Look for matching portgroup name and network type. If the PortgroupName is no empty -
+		// check that it contains network name as well.
+		if vnic.Name == networkName && vnic.Type == networkType &&
+			(vnic.PortgroupName == networkName || vnic.PortgroupName == "") {
 			foundIndex = vnic.Index
 			foundCount++
 		}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1348,7 +1348,7 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 	foundCount := 0
 
 	for _, vnic := range vnics.EdgeInterface {
-		// Look for matching portgroup name and network type. If the PortgroupName is no empty -
+		// Look for matching portgroup name and network type. If the PortgroupName is not empty -
 		// check that it contains network name as well.
 		if vnic.Name == networkName && vnic.Type == networkType &&
 			(vnic.PortgroupName == networkName || vnic.PortgroupName == "") {

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1349,7 +1349,7 @@ func getVnicIndexByNetworkNameAndType(networkName, networkType string, vnics *ty
 
 	for _, vnic := range vnics.EdgeInterface {
 		// Look for matching portgroup name and network type
-		if vnic.Name == networkName && vnic.PortgroupName == networkName && vnic.Type == networkType {
+		if vnic.Name == networkName && vnic.Type == networkType {
 			foundIndex = vnic.Index
 			foundCount++
 		}

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -83,7 +83,7 @@ func Test_getVnicIndexFromNetworkNameType(t *testing.T) {
             </addressGroup>
         </addressGroups>
         <portgroupId>f2547dd9-e0f7-4d81-97c1-dd33e5e0fbbf</portgroupId>
-        <portgroupName>my-ext-network</portgroupName>
+        <portgroupName></portgroupName>
         <isConnected>true</isConnected>
     </edgeInterface>
     <edgeInterface>


### PR DESCRIPTION
This PR addresses a problem when API call for vNic index lookup (endpoint `https://hostname/network/edges/77ccbdcd-ac04-4111-bf08-8ac294a3185b/vdcNetworks`) does not return field `portgroupName` when a user is not connected as a sysadmin.

Terraform provider will pull in with this PR https://github.com/terraform-providers/terraform-provider-vcd/pull/419