### PR TITLE
List functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    
 * Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync`
+* Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref`
 
 ## 2.5.1 (December 12, 2019)
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@ module github.com/vmware/go-vcloud-director/v2
 
 require (
 	github.com/hashicorp/go-version v1.2.0
-	github.com/kr/pretty v0.1.0 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	// github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/vmware/go-vcloud-director/v2
 require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.0 // indirect
-	// github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,12 @@
+//github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+//github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+//github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+//github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+//github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,3 @@
-//github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-//github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-//github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-//github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-//github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -24,7 +23,6 @@ type VCDClient struct {
 	Client      Client  // Client for the underlying VCD instance
 	sessionHREF url.URL // HREF for the session API
 	QueryHREF   url.URL // HREF for the query API
-	Mutex       sync.Mutex
 }
 
 func (vcdCli *VCDClient) vcdloginurl() error {

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1406,7 +1406,7 @@ func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
 	resp, err := checkResp(vcd.client.Client.Http.Do(req))
 	check.Assert(err, IsNil)
 
-	check.Assert(resp.Header.Get("Content-Type"), Equals, "application/vnd.vmware.vcloud.query.records+xml;version="+apiVersion)
+	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+apiVersion)
 
 	// Repeats the call without API version change
 	req = vcd.client.Client.NewRequestWitNotEncodedParams(nil, map[string]string{"type": "media",
@@ -1416,7 +1416,7 @@ func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
 	check.Assert(err, IsNil)
 
 	// Checks that the regularAPI version was not affected by the previous call
-	check.Assert(resp.Header.Get("Content-Type"), Equals, "application/vnd.vmware.vcloud.query.records+xml;version="+vcd.client.Client.APIVersion)
+	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+vcd.client.Client.APIVersion)
 
 	fmt.Printf("Test: %s run with api Version: %s\n", check.TestName(), apiVersion)
 }

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -692,6 +692,21 @@ func (cat *Catalog) GetCatalogItemByHref(catalogItemHref string) (*CatalogItem, 
 	return catItem, nil
 }
 
+// GetVappTemplateByHref finds a vApp template by HREF
+// On success, returns a pointer to the vApp template structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *Catalog) GetVappTemplateByHref(href string) (*VAppTemplate, error) {
+
+	vappTemplate := NewVAppTemplate(cat.client)
+
+	_, err := cat.client.ExecuteRequest(href, http.MethodGet,
+		"", "error retrieving catalog item: %s", nil, vappTemplate.VAppTemplate)
+	if err != nil {
+		return nil, err
+	}
+	return vappTemplate, nil
+}
+
 // GetCatalogItemByName finds a CatalogItem by Name
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
 	. "gopkg.in/check.v1"
 )
@@ -529,4 +530,42 @@ func (vcd *TestVCD) Test_CatalogGetItem(check *C) {
 		getByNameOrId: getByNameOrId,
 	}
 	vcd.testFinderGetGenericEntity(def, check)
+}
+
+// TestGetVappTemplateByHref tests that we can find a vApp template using
+// the HREF from the Entity section of a known Catalog Item
+func (vcd *TestVCD) TestGetVappTemplateByHref(check *C) {
+
+	fmt.Printf("Running: %s\n", check.TestName())
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_CatalogGetItem: Org name not given")
+		return
+	}
+	if vcd.config.VCD.Catalog.Name == "" {
+		check.Skip("Test_CatalogGetItem: Catalog name not given")
+		return
+	}
+	if vcd.config.VCD.Catalog.CatalogItem == "" {
+		check.Skip("Test_CatalogGetItem: Catalog item name not given")
+		return
+	}
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
+
+	catalogItem, err := catalog.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
+	check.Assert(err, IsNil)
+	check.Assert(catalogItem, NotNil)
+	check.Assert(catalogItem.CatalogItem.Entity, NotNil)
+
+	vappTemplate, err := catalog.GetVappTemplateByHref(catalogItem.CatalogItem.Entity.HREF)
+	check.Assert(err, IsNil)
+	check.Assert(vappTemplate, NotNil)
+	check.Assert(vappTemplate.VAppTemplate.ID, Not(Equals), catalogItem.CatalogItem.ID)
+	check.Assert(vappTemplate.VAppTemplate.Type, Equals, types.MimeVAppTemplate)
 }

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -568,4 +568,5 @@ func (vcd *TestVCD) TestGetVappTemplateByHref(check *C) {
 	check.Assert(vappTemplate, NotNil)
 	check.Assert(vappTemplate.VAppTemplate.ID, Not(Equals), catalogItem.CatalogItem.ID)
 	check.Assert(vappTemplate.VAppTemplate.Type, Equals, types.MimeVAppTemplate)
+	check.Assert(vappTemplate.VAppTemplate.Name, Equals, catalogItem.CatalogItem.Name)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -781,14 +781,14 @@ func (vcd *TestVCD) TestListEdgeGateway(check *C) {
 	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge, NotNil)
-	edgeList, err := vcd.vdc.GetEdgeGatewayReferenceList(false)
+	edgeRec, err := vcd.vdc.GetEdgeGatewayRecordsType(false)
 	check.Assert(err, IsNil)
-	check.Assert(edgeList, NotNil)
-	check.Assert(len(edgeList) > 0, Equals, true)
+	check.Assert(edgeRec, NotNil)
+	check.Assert(len(edgeRec.EdgeGatewayRecord) > 0, Equals, true)
 	foundName := false
 	foundHref := false
-	for _, ref := range edgeList {
-		if ref.Name == vcd.config.VCD.EdgeGateway {
+	for _, ref := range edgeRec.EdgeGatewayRecord {
+		if ref.Name == edge.EdgeGateway.Name {
 			foundName = true
 			if ref.HREF == edge.EdgeGateway.HREF {
 				foundHref = true

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -629,7 +629,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateFwGeneralParams(check *C) {
 
 func (vcd *TestVCD) TestEdgeGateway_GetVdcNetworks(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
-		check.Skip("Skipping test because no edge gatway given")
+		check.Skip("Skipping test because no edge gateway given")
 	}
 	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
@@ -770,4 +770,31 @@ func replaceFirstMatch(text, regex, replacement string) string {
 		return strings.Replace(text, found, replacement, 1)
 	}
 	return ""
+}
+
+// TestListEdgeGateway tests that at least one edge gateway is found,
+// and the list contains the element defined in the configuration file
+func (vcd *TestVCD) TestListEdgeGateway(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gateway given")
+	}
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	check.Assert(err, IsNil)
+	check.Assert(edge, NotNil)
+	edgeList, err := vcd.vdc.GetEdgeGatewayReferenceList(false)
+	check.Assert(err, IsNil)
+	check.Assert(edgeList, NotNil)
+	check.Assert(len(edgeList) > 0, Equals, true)
+	foundName := false
+	foundHref := false
+	for _, ref := range edgeList {
+		if ref.Name == vcd.config.VCD.EdgeGateway {
+			foundName = true
+			if ref.HREF == edge.EdgeGateway.HREF {
+				foundHref = true
+			}
+		}
+	}
+	check.Assert(foundName, Equals, true)
+	check.Assert(foundHref, Equals, true)
 }

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -119,6 +119,10 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVapp(check *C) {
 func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
 	// Find VApp
 	if vcd.vapp.VApp == nil {
 		check.Skip("skipping test because no vApp is found")
@@ -150,6 +154,10 @@ func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
 
 func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 
 	// Find VApp
 	if vcd.vapp.VApp == nil {

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -439,7 +439,7 @@ func QueryPortGroups(vcdCli *VCDClient, filter string) ([]*types.PortGroupRecord
 	return results.Results.PortGroupRecord, nil
 }
 
-// GetExternalNetwork returns an ExternalNetwork reference if user the network name matches an existing one.
+// GetExternalNetwork returns an ExternalNetwork reference if the network name matches an existing one.
 // If no valid external network is found, it returns an empty ExternalNetwork reference and an error
 // Deprecated: use vcdClient.GetExternalNetworkByName instead
 func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -436,6 +436,11 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedNetwork(check *C) {
 
 // Test_AddNewVMNilNIC creates VM with nil network configuration
 func (vcd *TestVCD) Test_AddNewVMNilNIC(check *C) {
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
 	// Find VApp
 	if vcd.vapp.VApp == nil {
 		check.Skip("skipping test because no vApp is found")
@@ -475,6 +480,11 @@ func (vcd *TestVCD) Test_AddNewVMNilNIC(check *C) {
 
 // Test_AddNewVMMultiNIC creates a new VM in vApp with multiple network cards
 func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
 	config := vcd.config
 	if config.VCD.Network.Net1 == "" {
 		check.Skip("Skipping test because no network was given")

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -299,7 +299,7 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 		return EdgeGateway{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
 	for _, av := range vdc.Vdc.Link {
-		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
+		if av.Rel == "edgeGateways" && av.Type == types.MimeQueryRecords {
 
 			query := new(types.QueryResultEdgeGatewayRecordsType)
 
@@ -355,9 +355,9 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 // GetEdgeGatewayByHref retrieves an edge gateway from VDC
 // by querying directly its HREF.
 // The name passed as parameter is only used for error reporting
-func (vdc *Vdc) GetEdgeGatewayByHref(name, href string) (*EdgeGateway, error) {
+func (vdc *Vdc) GetEdgeGatewayByHref(href string) (*EdgeGateway, error) {
 	if href == "" {
-		return nil, fmt.Errorf("empty HREF for edge gateway '%s'", name)
+		return nil, fmt.Errorf("empty edge gateway HREF")
 	}
 
 	edge := NewEdgeGateway(vdc.client)
@@ -372,8 +372,8 @@ func (vdc *Vdc) GetEdgeGatewayByHref(name, href string) (*EdgeGateway, error) {
 	//
 	// GitHUB issue - https://github.com/vmware/go-vcloud-director/issues/218
 	if err != nil {
-		util.Logger.Printf("[DEBUG] vCD 9.7 is known to sometimes respond with error on edge gateway (%s) "+
-			"retrieval. As a workaround this is done a few times before failing. Retrying: ", name)
+		util.Logger.Printf("[DEBUG] vCD 9.7 is known to sometimes respond with error on edge gateway " +
+			"retrieval. As a workaround this is done a few times before failing. Retrying:")
 		for i := 1; i < 4 && err != nil; i++ {
 			time.Sleep(200 * time.Millisecond)
 			util.Logger.Printf("%d ", i)
@@ -399,7 +399,7 @@ func (vdc *Vdc) getEdgeGatewayRecordsType(refresh bool) (*types.QueryResultEdgeG
 		}
 	}
 	for _, av := range vdc.Vdc.Link {
-		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
+		if av.Rel == "edgeGateways" && av.Type == types.MimeQueryRecords {
 
 			edgeGatewayRecordsType := new(types.QueryResultEdgeGatewayRecordsType)
 
@@ -425,7 +425,7 @@ func (vdc *Vdc) GetEdgeGatewayByName(name string, refresh bool) (*EdgeGateway, e
 
 	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
 		if edge.Name == name {
-			return vdc.GetEdgeGatewayByHref(edge.Name, edge.HREF)
+			return vdc.GetEdgeGatewayByHref(edge.HREF)
 		}
 	}
 
@@ -443,7 +443,7 @@ func (vdc *Vdc) GetEdgeGatewayById(id string, refresh bool) (*EdgeGateway, error
 
 	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
 		if equalIds(id, "", edge.HREF) {
-			return vdc.GetEdgeGatewayByHref(edge.Name, edge.HREF)
+			return vdc.GetEdgeGatewayByHref(edge.HREF)
 		}
 	}
 
@@ -849,7 +849,7 @@ func (vdc *Vdc) GetEdgeGatewayReferenceList(refresh bool) ([]*types.Reference, e
 		}
 	}
 	for _, av := range vdc.Vdc.Link {
-		if av.Rel == "edgeGateways" && av.Type == "application/vnd.vmware.vcloud.query.records+xml" {
+		if av.Rel == "edgeGateways" && av.Type == types.MimeQueryRecords {
 
 			edgeGatewayRecordsType := new(types.QueryResultEdgeGatewayRecordsType)
 

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -218,6 +218,10 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 func (vcd *TestVCD) Test_FindVApp(check *C) {
 
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
 	if vcd.vapp.VApp == nil {
 		check.Skip("No vApp provided")
 	}
@@ -236,6 +240,10 @@ func (vcd *TestVCD) Test_FindVApp(check *C) {
 // Tests function QueryVM by searching vm created
 // by test suite
 func (vcd *TestVCD) Test_QueryVM(check *C) {
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
 
 	if vcd.vapp.VApp == nil {
 		check.Skip("No Vapp provided")

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -204,6 +204,11 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 
 // Test attach disk to VM
 func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
+
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vapp was not successfully created at setup")
+	}
+
 	if vcd.config.VCD.Disk.Size <= 0 {
 		check.Skip("skipping test because disk size is 0")
 	}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -40,7 +40,7 @@ const (
 	// MimeVApp mime for a vApp
 	MimeVApp = "application/vnd.vmware.vcloud.vApp+xml"
 	// MimeQueryRecords mime for the query records
-	MimeQueryRecords = "application/vnd.vmware.vchs.query.records+xml"
+	MimeQueryRecords = "application/vnd.vmware.vcloud.query.records+xml"
 	// MimeAPIExtensibility mime for api extensibility
 	MimeAPIExtensibility = "application/vnd.vmware.vcloud.apiextensibility+xml"
 	// MimeEntity mime for vcloud entity


### PR DESCRIPTION
Add a few functions that are needed for list manipulation in other libraries or applications. (`GetVappTemplateByHref` and `GetEdgeGatewayReferenceList`)

Remove unused fields in `VCDClient` and `Vdc`.
Export function `GetEdgeGatewayByHref`