### PR TITLE
Add handling name spaces improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    
 * Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync`
 * Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref`
+* Improved functions to not expect XML namespaces provided in argument structure 
 
 ## 2.5.1 (December 12, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.6.0 (Unreleased)
 
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    
-* Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync`
-* Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref`
-* Improved functions to not expect XML namespaces provided in argument structure 
+* Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync` [#272] https://github.com/vmware/go-vcloud-director/pull/272
+* Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref` [#278] https://github.com/vmware/go-vcloud-director/pull/278
+* Improved functions to not expect XML namespaces provided in argument structure [#284] https://github.com/vmware/go-vcloud-director/pull/284
 
 ## 2.5.1 (December 12, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.6.0 (Unreleased)
 
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    
-* Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync` [#272] https://github.com/vmware/go-vcloud-director/pull/272
-* Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref` [#278] https://github.com/vmware/go-vcloud-director/pull/278
-* Improved functions to not expect XML namespaces provided in argument structure [#284] https://github.com/vmware/go-vcloud-director/pull/284
+* Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync` [#272](https://github.com/vmware/go-vcloud-director/pull/272)
+* Added methods `vdc.GetEdgeGatewayReferenceList` and `catalog.GetVappTemplateByHref` [#278](https://github.com/vmware/go-vcloud-director/pull/278)
+* Improved functions to not expect XML namespaces provided in argument structure [#284](https://github.com/vmware/go-vcloud-director/pull/284)
 
 ## 2.5.1 (December 12, 2019)
 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -95,6 +95,8 @@ func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (T
 		return Task{}, err
 	}
 
+	vdcConfiguration.Xmlns = types.XMLNamespaceVCloud
+
 	vdcCreateHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
 	if err != nil {
 		return Task{}, fmt.Errorf("error parsing admin org url: %s", err)

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -942,6 +942,8 @@ func (egw *EdgeGateway) AddIpsecVPN(ipsecVPNConfig *types.EdgeGatewayServiceConf
 		fmt.Printf("error: %s\n", err)
 	}
 
+	ipsecVPNConfig.Xmlns = types.XMLNamespaceVCloud
+
 	apiEndpoint, _ := url.ParseRequestURI(egw.EdgeGateway.HREF)
 	apiEndpoint.Path += "/action/configureServices"
 

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -198,7 +198,6 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	tunnels := make([]*types.GatewayIpsecVpnTunnel, 1)
 	tunnels[0] = tunnel
 	ipsecVPNConfig := &types.EdgeGatewayServiceConfiguration{
-		Xmlns: types.XMLNamespaceVCloud,
 		GatewayIpsecVpnService: &types.GatewayIpsecVpnService{
 			IsEnabled: true,
 			Tunnel:    tunnels,

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -78,7 +78,6 @@ func (vcd *TestVCD) testCreateExternalNetwork(testName, networkName, dnsSuffix s
 		Name:        networkName,
 		Description: "Test Create External Network",
 		Configuration: &types.NetworkConfiguration{
-			Xmlns: types.XMLNamespaceVCloud,
 			IPScopes: &types.IPScopes{
 				IPScope: []*types.IPScope{&types.IPScope{
 					Gateway:   "192.168.201.1",

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -134,9 +134,6 @@ func (org *Org) CreateCatalog(name, description string) (Catalog, error) {
 }
 
 func validateVdcConfiguration(vdcDefinition *types.VdcConfiguration) error {
-	if vdcDefinition.Xmlns == "" {
-		return errors.New("VdcConfiguration missing required field: Xmlns")
-	}
 	if vdcDefinition.Name == "" {
 		return errors.New("VdcConfiguration missing required field: Name")
 	}

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -287,7 +287,6 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	for i, allocationModel := range allocationModels {
 		vdcConfiguration := &types.VdcConfiguration{
 			Name:            fmt.Sprintf("%s%d", TestCreateOrgVdc, i),
-			Xmlns:           types.XMLNamespaceVCloud,
 			AllocationModel: allocationModel,
 			ComputeCapacity: []*types.ComputeCapacity{
 				&types.ComputeCapacity{
@@ -566,7 +565,6 @@ func setupVDc(vcd *TestVCD, check *C) (AdminOrg, *types.VdcConfiguration, error)
 	networkPoolHref := results.Results.NetworkPoolRecord[0].HREF
 	vdcConfiguration := &types.VdcConfiguration{
 		Name:            TestCreateOrgVdc + "ForRefresh",
-		Xmlns:           types.XMLNamespaceVCloud,
 		AllocationModel: "AllocationPool",
 		ComputeCapacity: []*types.ComputeCapacity{
 			&types.ComputeCapacity{

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -145,6 +145,8 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 				return Task{}, fmt.Errorf("error decoding vdc response: %s", err)
 			}
 
+			networkConfig.Xmlns = types.XMLNamespaceVCloud
+
 			output, err := xml.MarshalIndent(networkConfig, "  ", "    ")
 			if err != nil {
 				return Task{}, fmt.Errorf("error marshaling OrgVDCNetwork compose: %s", err)

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -79,7 +79,6 @@ func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, sub
 
 	networkDescription := "Created by govcd tests"
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        networkName,
 		Description: networkDescription,
 		Configuration: &types.NetworkConfiguration{
@@ -192,8 +191,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
 	}
 
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: types.XMLNamespaceVCloud,
-		Name:  networkName,
+		Name: networkName,
 		// Description: "Created by govcd tests",
 		Configuration: &types.NetworkConfiguration{
 			FenceMode: types.FenceModeIsolated,
@@ -259,8 +257,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	}
 	// Note that there is no IPScope for this type of network
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: types.XMLNamespaceVCloud,
-		Name:  networkName,
+		Name: networkName,
 		Configuration: &types.NetworkConfiguration{
 			FenceMode: types.FenceModeBridged,
 			ParentNetwork: &types.Reference{

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -206,6 +206,9 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 	if egwConfiguration.Name != egwName {
 		return Task{}, fmt.Errorf("name mismatch: '%s' used as parameter but '%s' in the configuration structure", egwName, egwConfiguration.Name)
 	}
+
+	egwConfiguration.Xmlns = types.XMLNamespaceVCloud
+
 	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
 	if err != nil {
 		return Task{}, err
@@ -636,6 +639,9 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.Exte
 	externalNetwork.OperationKey = externalNetworkData.OperationKey
 	externalNetwork.Link = externalNetworkData.Link
 	externalNetwork.Configuration = externalNetworkData.Configuration
+	if externalNetwork.Configuration != nil {
+		externalNetwork.Configuration.Xmlns = types.XMLNamespaceVCloud
+	}
 	externalNetwork.VCloudExtension = externalNetworkData.VCloudExtension
 	externalNetwork.XmlnsVmext = types.XMLNamespaceExtension
 	externalNetwork.XmlnsVcloud = types.XMLNamespaceVCloud

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -252,7 +252,6 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGatewayAdvanced(check *C) {
 	edgeName := "Test-Multi-Scope-Gw"
 	// Initialize edge gateway structure
 	edgeGatewayConfig := &types.EdgeGateway{
-		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        edgeName,
 		Description: edgeName,
 		Configuration: &types.GatewayConfiguration{
@@ -438,8 +437,7 @@ func (vcd *TestVCD) Test_QueryOrgVdcNetworkByNameWithSpace(check *C) {
 	}
 	// Note that there is no IPScope for this type of network
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: types.XMLNamespaceVCloud,
-		Name:  networkName,
+		Name: networkName,
 		Configuration: &types.NetworkConfiguration{
 			FenceMode: types.FenceModeBridged,
 			ParentNetwork: &types.Reference{


### PR DESCRIPTION
To avoid such issues in future https://github.com/vmware/go-vcloud-director/issues/279 we need to stop expect users will provide needed XML name spaces.

Change handles name spaces inside functions as we did in other places - this makes our code more consistent and user friendly for users. Also errors are very nasty when name space isn't provided, so let's take care of them.

