### PR TITLE
Update Org VDC Networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 2.6.0 (Unreleased)
+## 2.7.0 (Unreleased)
+
+* Added methods `OrgVdcNetwork.Update`, `OrgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename`
+* Added methods `EdgeGateway.Update` and `EdgeGateway.UpdateAsync`
+
+## 2.6.0 (March 13, 2010)
 
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    
 * Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync` [#272](https://github.com/vmware/go-vcloud-director/pull/272)
@@ -6,7 +11,6 @@
 * Improved functions to not expect XML namespaces provided in argument structure [#284](https://github.com/vmware/go-vcloud-director/pull/284)
 * Change `int` and `bool` fields from types.VAppTemplateLeaseSettings and VAppLeaseSettings into pointers
 * Added method `catalog.GetVappTemplateByHref`, and expose methods `vdc.GetEdgeGatewayByHref` and `vdc.GetEdgeGatewayRecordsType`
-* Added methods `orgVdcNetwork.Update`, `orgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename`
 * Added methods `adminOrg.CreateOrgVdc`, `adminOrg.CreateOrgVdcAsync` and improved existing to support Flex VDC model. These new methods are dynamic as they change invocation behind the scenes based on vCD version [#285](https://github.com/vmware/go-vcloud-director/pull/285) 
 * Deprecated functions `adminOrg.CreateVdc` and `adminOrg.CreateVdcWait` [#285](https://github.com/vmware/go-vcloud-director/pull/285)
 * Added methods `EdgeGateway.GetAllNsxvDhcpLeases()`, `EdgeGateway.GetNsxvActiveDhcpLeaseByMac()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.7.0 (Unreleased)
 
-* Added methods `OrgVdcNetwork.Update`, `OrgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename`
-* Added methods `EdgeGateway.Update` and `EdgeGateway.UpdateAsync`
+* Added methods `OrgVdcNetwork.Update`, `OrgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename` [#292](https://github.com/vmware/go-vcloud-director/pull/292)
+* Added methods `EdgeGateway.Update` and `EdgeGateway.UpdateAsync` [#292](https://github.com/vmware/go-vcloud-director/pull/292)
 
 ## 2.6.0 (March 13, 2010)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added methods `VM.AddInternalDisk`, `VM.GetInternalDiskById`, `VM.DeleteInternalDisk`, `VM.UpdateInternalDisks` and `VM.UpdateInternalDisksAsync`
 * Change `int` and `bool` fields from types.VAppTemplateLeaseSettings and VAppLeaseSettings into pointers
 * Added method `catalog.GetVappTemplateByHref`, and expose methods `vdc.GetEdgeGatewayByHref` and `vdc.GetEdgeGatewayRecordsType`
+* Added methods `orgVdcNetwork.Update`, `orgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename`
 
 ## 2.5.1 (December 12, 2019)
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test: testunit
 # testunit runs the unit tests
 testunit: fmtcheck
 	@echo "==> Running Unit Tests"
-	cd $(maindir)/govcd && go test -tags unit -v .
-	cd $(maindir)/util && go test -v .
+	cd $(maindir)/govcd && go test -tags unit -v
+	cd $(maindir)/util && go test -v
 
 # testrace runs the race checker
 testrace:
@@ -25,27 +25,27 @@ testconcurrent:
 
 # tests only catalog related features
 testcatalog:
-	cd govcd && go test -tags "catalog" -timeout 15m -check.vv .
+	cd govcd && go test -tags "catalog" -timeout 15m -check.vv
 
 # tests only vapp and vm features
 testvapp:
-	cd govcd && go test -tags "vapp vm" -timeout 25m -check.vv .
+	cd govcd && go test -tags "vapp vm" -timeout 25m -check.vv
 
 # tests only edge gateway features
 testgateway:
-	cd govcd && go test -tags "gateway" -timeout 15m -check.vv .
+	cd govcd && go test -tags "gateway" -timeout 15m -check.vv
 
 # tests only networking features
 testnetwork:
-	cd govcd && go test -tags "network" -timeout 15m -check.vv .
+	cd govcd && go test -tags "network" -timeout 15m -check.vv
 
 # tests only load balancer features
 testlb:
-	cd govcd && go test -tags "lb" -timeout 15m -check.vv .
+	cd govcd && go test -tags "lb" -timeout 15m -check.vv
 
 # tests only NSXV related features
 testnsxv:
-	cd govcd && go test -tags "nsxv" -timeout 15m -check.vv .
+	cd govcd && go test -tags "nsxv" -timeout 15m -check.vv
 
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
@@ -74,5 +74,5 @@ copyright:
 
 build:
 	@echo "==> Building govcd library"
-	cd govcd && go build . && go test -tags ALL -c .
+	cd govcd && go build . && go test -tags ALL -c
 

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/vmware/go-vcloud-director v2.0.0+incompatible h1:3B121XZVdEOxRhv5ARswKVxXt4KznAbun8GoXNbbZWs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1133,7 +1133,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			fastProvisioningValue = true
 		}
 
-		if *adminVdc.AdminVdc.UsesFastProvisioning != fastProvisioningValue {
+		if adminVdc != nil && *adminVdc.AdminVdc.UsesFastProvisioning != fastProvisioningValue {
 			adminVdc.AdminVdc.UsesFastProvisioning = &fastProvisioningValue
 			_, err = adminVdc.Update()
 			if err != nil {

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1405,6 +1405,7 @@ func getNetworkNameAndTypeByVnicIndex(vNicIndex int, vnics *types.EdgeGatewayInt
 	return networkName, networkType, nil
 }
 
+// UpdateAsync updates the edge gateway in place with the information contained in the internal structure
 func (egw *EdgeGateway) UpdateAsync() (Task, error) {
 
 	egw.EdgeGateway.Xmlns = types.XMLNamespaceVCloud
@@ -1416,12 +1417,17 @@ func (egw *EdgeGateway) UpdateAsync() (Task, error) {
 		types.MimeEdgeGateway, "error updating Edge Gateway: %s", egw.EdgeGateway)
 }
 
+// Update is a wrapper around UpdateAsync
+// The pointer receiver is refreshed after update
 func (egw *EdgeGateway) Update() error {
 
 	task, err := egw.UpdateAsync()
 	if err != nil {
 		return err
 	}
-	return task.WaitTaskCompletion()
-
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+	return egw.Refresh()
 }

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -1396,3 +1396,25 @@ func getNetworkNameAndTypeByVnicIndex(vNicIndex int, vnics *types.EdgeGatewayInt
 
 	return networkName, networkType, nil
 }
+
+func (egw *EdgeGateway) UpdateAsync() (Task, error) {
+
+	egw.EdgeGateway.Xmlns = types.XMLNamespaceVCloud
+	egw.EdgeGateway.Configuration.Xmlns =types.XMLNamespaceVCloud
+	egw.EdgeGateway.Tasks = nil
+
+	// Return the task
+	return egw.client.ExecuteTaskRequest(egw.EdgeGateway.HREF, http.MethodPut,
+		types.MimeEdgeGateway, "error updating Edge Gateway: %s", egw.EdgeGateway)
+}
+
+
+func (egw *EdgeGateway) Update() error {
+
+	task, err := egw.UpdateAsync()
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+
+}

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -53,6 +53,8 @@ type NatRule struct {
 	Description  string
 }
 
+// AddDhcpPool adds (or updates) the DHCP pool connected to a specific network.
+// TODO: this is legacy code from 2015, which requires a Terraform structure to work. It may need some re-thinking.
 func (egw *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []interface{}) (Task, error) {
 	newEdgeConfig := egw.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration
 	util.Logger.Printf("[DEBUG] EDGE GATEWAY: %#v", newEdgeConfig)
@@ -67,7 +69,11 @@ func (egw *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 
 			// Kludgy IF to avoid deleting DNAT rules not created by us.
 			// If matches, let's skip it and continue the loop
-			if dhcpPoolService.Network.HREF == network.HREF {
+			// Note: a simple comparison of HREF fields may fail if one of them is
+			// from a tenant object and the other from a provider object. They may have the
+			// same ID but different paths. Using 'equalIds' we determine equality even with
+			// different paths
+			if equalIds(network.HREF, "", dhcpPoolService.Network.HREF) {
 				continue
 			}
 
@@ -1400,14 +1406,13 @@ func getNetworkNameAndTypeByVnicIndex(vNicIndex int, vnics *types.EdgeGatewayInt
 func (egw *EdgeGateway) UpdateAsync() (Task, error) {
 
 	egw.EdgeGateway.Xmlns = types.XMLNamespaceVCloud
-	egw.EdgeGateway.Configuration.Xmlns =types.XMLNamespaceVCloud
+	egw.EdgeGateway.Configuration.Xmlns = types.XMLNamespaceVCloud
 	egw.EdgeGateway.Tasks = nil
 
 	// Return the task
 	return egw.client.ExecuteTaskRequest(egw.EdgeGateway.HREF, http.MethodPut,
 		types.MimeEdgeGateway, "error updating Edge Gateway: %s", egw.EdgeGateway)
 }
-
 
 func (egw *EdgeGateway) Update() error {
 

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -771,6 +771,12 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	err = edge.Update()
 	check.Assert(err, IsNil)
 
+	// The edge gateway should be updated in place
+	check.Assert(edge.EdgeGateway.HREF, Equals, saveEGW.HREF)
+	check.Assert(edge.EdgeGateway.Name, Equals, newName)
+	check.Assert(edge.EdgeGateway.Description, Equals, newDescription)
+
+	// Check that a new copy of the edge gateway contains the expected data
 	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
 	check.Assert(err, IsNil)
 
@@ -784,6 +790,12 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	err = edge.Update()
 	check.Assert(err, IsNil)
 
+	// checking the in-place values
+	check.Assert(saveEGW.Name, Equals, edge.EdgeGateway.Name)
+	check.Assert(saveEGW.Description, Equals, edge.EdgeGateway.Description)
+	check.Assert(saveEGW.HREF, Equals, edge.EdgeGateway.HREF)
+
+	// Checking values in a fresh copy of the edge gateway
 	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
 	check.Assert(err, IsNil)
 

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -754,11 +754,11 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	var saveEGW = types.EdgeGateway{
 		Name:        edge.EdgeGateway.Name,
-		ID:        edge.EdgeGateway.ID,
+		ID:          edge.EdgeGateway.ID,
 		Status:      edge.EdgeGateway.Status,
 		HREF:        edge.EdgeGateway.HREF,
 		Description: edge.EdgeGateway.Description,
-		Configuration:&types.GatewayConfiguration{
+		Configuration: &types.GatewayConfiguration{
 			AdvancedNetworkingEnabled: edge.EdgeGateway.Configuration.AdvancedNetworkingEnabled,
 		},
 	}

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -798,3 +798,51 @@ func (vcd *TestVCD) TestListEdgeGateway(check *C) {
 	check.Assert(foundName, Equals, true)
 	check.Assert(foundHref, Equals, true)
 }
+
+func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gateway given")
+	}
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+	var saveEGW = types.EdgeGateway{
+		Name:        edge.EdgeGateway.Name,
+		ID:        edge.EdgeGateway.ID,
+		Status:      edge.EdgeGateway.Status,
+		HREF:        edge.EdgeGateway.HREF,
+		Description: edge.EdgeGateway.Description,
+		Configuration:&types.GatewayConfiguration{
+			AdvancedNetworkingEnabled: edge.EdgeGateway.Configuration.AdvancedNetworkingEnabled,
+		},
+	}
+
+	newName := "UpdatedEGWName"
+	newDescription := "Updated description"
+
+	edge.EdgeGateway.Name = newName
+	edge.EdgeGateway.Description = newDescription
+
+	err = edge.Update()
+	check.Assert(err, IsNil)
+
+	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
+	check.Assert(err, IsNil)
+
+	check.Assert(edge.EdgeGateway.HREF, Equals, saveEGW.HREF)
+	check.Assert(edge.EdgeGateway.Name, Equals, newName)
+	check.Assert(edge.EdgeGateway.Description, Equals, newDescription)
+
+	edge.EdgeGateway.Name = saveEGW.Name
+	edge.EdgeGateway.Description = saveEGW.Description
+
+	err = edge.Update()
+	check.Assert(err, IsNil)
+
+	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
+	check.Assert(err, IsNil)
+
+	check.Assert(saveEGW.Name, Equals, edge.EdgeGateway.Name)
+	check.Assert(saveEGW.Description, Equals, edge.EdgeGateway.Description)
+	check.Assert(saveEGW.HREF, Equals, edge.EdgeGateway.HREF)
+}

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -1,4 +1,4 @@
-// +build api functional catalog org extnetwork vm vdc system user nsxv ALL
+// +build api functional catalog org extnetwork vm vdc system user nsxv network ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -250,6 +250,14 @@ func LogAdminCatalog(catalog types.AdminCatalog) {
 	out("log", prettyAdminCatalog(catalog))
 }
 
+func LogEdgeGateway(edgeGateway types.EdgeGateway) {
+	out("log", prettyEdgeGateway(edgeGateway))
+}
+
+func ShowEdgeGateway(edgeGateway types.EdgeGateway) {
+	out("screen", prettyEdgeGateway(edgeGateway))
+}
+
 // Auxiliary function to monitor a task
 // It can be used in association with WaitInspectTaskCompletion
 func outTask(destination string, task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -288,13 +288,13 @@ func (orgVdcNet *OrgVDCNetwork) getEdgeGateway() (*EdgeGateway, error) {
 // receiver data structure.
 func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 	if orgVdcNet.OrgVDCNetwork.HREF == "" {
-		return Task{}, fmt.Errorf("cannot update network: HREF is empty")
+		return Task{}, fmt.Errorf("cannot update Org VDC network: HREF is empty")
 	}
 	if orgVdcNet.OrgVDCNetwork.Name == "" {
-		return Task{}, fmt.Errorf("cannot update network: name is empty")
+		return Task{}, fmt.Errorf("cannot update Org VDC network: name is empty")
 	}
 	if orgVdcNet.OrgVDCNetwork.Configuration == nil {
-		return Task{}, fmt.Errorf("cannot update network: configuration is empty")
+		return Task{}, fmt.Errorf("cannot update Org VDC network: configuration is empty")
 	}
 
 	href := orgVdcNet.OrgVDCNetwork.HREF
@@ -309,7 +309,7 @@ func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 	if orgVdcNet.OrgVDCNetwork.Configuration.FenceMode == types.FenceModeNAT {
 		edgeGateway, err := orgVdcNet.getEdgeGateway()
 		if err != nil {
-			return Task{}, fmt.Errorf("error retrieving edge gateway for network %s : %s", orgVdcNet.OrgVDCNetwork.Name, err)
+			return Task{}, fmt.Errorf("error retrieving edge gateway for Org VDC network %s : %s", orgVdcNet.OrgVDCNetwork.Name, err)
 		}
 		orgVdcNet.OrgVDCNetwork.EdgeGateway = &types.Reference{
 			HREF: edgeGateway.EdgeGateway.HREF,
@@ -324,14 +324,18 @@ func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 
 // Update is a wrapper around UpdateAsync, where we
 // explicitly wait for the task to finish.
+// The pointer receiver is refreshed after update
 func (orgVdcNet *OrgVDCNetwork) Update() error {
 	task, err := orgVdcNet.UpdateAsync()
 	if err != nil {
 		return err
 	}
 	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
 
-	return err
+	return orgVdcNet.Refresh()
 }
 
 // Rename is a wrapper around Update(), where we only change the name of the network

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -235,20 +235,93 @@ func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error)
 	return "", fmt.Errorf("no edge gateway connection found")
 }
 
+// getParentVdc retrieves the VDC to which the network is attached
+func (orgVdcNet *OrgVDCNetwork) getParentVdc() (*Vdc, error) {
+	for _, link := range orgVdcNet.OrgVDCNetwork.Link {
+		if link.Type == "application/vnd.vmware.vcloud.vdc+xml" {
+
+			vdc := NewVdc(orgVdcNet.client)
+
+			_, err := orgVdcNet.client.ExecuteRequest(link.HREF, http.MethodGet,
+				"", "error retrieving parent vdc: %s", nil, vdc.Vdc)
+			if err != nil {
+				return nil, err
+			}
+
+			return vdc, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find a parent Vdc for network %s", orgVdcNet.OrgVDCNetwork.Name)
+}
+
+// getEdgeGateway retrieves the edge gateway connected to a routed network
+func (orgVdcNet *OrgVDCNetwork) getEdgeGateway() (*EdgeGateway, error) {
+	// If it is not routed, returns an error
+	if orgVdcNet.OrgVDCNetwork.Configuration.FenceMode != types.FenceModeNAT {
+		return nil, fmt.Errorf("network %s is not routed", orgVdcNet.OrgVDCNetwork.Name)
+	}
+	vdc, err := orgVdcNet.getParentVdc()
+	if err != nil {
+		return nil, err
+	}
+
+	// Since this function can be called from Update(), we must take into account the
+	// possibility of a name change. If this is happening, we need to retrieve the original
+	// name, which is still stored in the VDC.
+	oldNetwork, err := vdc.GetOrgVdcNetworkById(orgVdcNet.OrgVDCNetwork.ID, false)
+	if err != nil {
+		return nil, err
+	}
+	networkName := oldNetwork.OrgVDCNetwork.Name
+
+	edgeGatewayName, err := vdc.FindEdgeGatewayNameByNetwork(networkName)
+	if err != nil {
+		return nil, err
+	}
+
+	return vdc.GetEdgeGatewayByName(edgeGatewayName, false)
+}
+
+// UpdateAsync will change the contents of a network using the information in the
+// receiver data structure.
 func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 	if orgVdcNet.OrgVDCNetwork.HREF == "" {
-		return Task{}, fmt.Errorf("cannot Update, Object is empty")
+		return Task{}, fmt.Errorf("cannot update network: HREF is empty")
 	}
+	if orgVdcNet.OrgVDCNetwork.Name == "" {
+		return Task{}, fmt.Errorf("cannot update network: name is empty")
+	}
+	if orgVdcNet.OrgVDCNetwork.Configuration == nil {
+		return Task{}, fmt.Errorf("cannot update network: configuration is empty")
+	}
+
 	href := orgVdcNet.OrgVDCNetwork.HREF
 
 	if !strings.Contains(href, "/api/admin/") {
 		href = strings.ReplaceAll(href, "/api/", "/api/admin/")
 	}
 
+	// Routed networks need to have edge gateway information for both creation and update.
+	// Since the network data structure doesn't return edge gateway information,
+	// we fetch it explicitly.
+	if orgVdcNet.OrgVDCNetwork.Configuration.FenceMode == types.FenceModeNAT {
+		edgeGateway, err := orgVdcNet.getEdgeGateway()
+		if err != nil {
+			return Task{}, fmt.Errorf("error retrieving edge gateway for network %s : %s", orgVdcNet.OrgVDCNetwork.Name, err)
+		}
+		orgVdcNet.OrgVDCNetwork.EdgeGateway = &types.Reference{
+			HREF: edgeGateway.EdgeGateway.HREF,
+			ID:   edgeGateway.EdgeGateway.ID,
+			Type: edgeGateway.EdgeGateway.Type,
+			Name: edgeGateway.EdgeGateway.Name,
+		}
+	}
 	return orgVdcNet.client.ExecuteTaskRequest(href, http.MethodPut,
 		types.MimeOrgVdcNetwork, "error updating Org VDC network: %s", orgVdcNet.OrgVDCNetwork)
 }
 
+// Update is a wrapper around UpdateAsync, where we
+// explicitly wait for the task to finish.
 func (orgVdcNet *OrgVDCNetwork) Update() error {
 	task, err := orgVdcNet.UpdateAsync()
 	if err != nil {
@@ -259,3 +332,13 @@ func (orgVdcNet *OrgVDCNetwork) Update() error {
 	return err
 }
 
+// Rename is a wrapper around Update(), where we only change the name of the network
+// Since the purpose is explicitly changing the name, the function will fail if the new name
+// is not different from the existing one
+func (orgVdcNet *OrgVDCNetwork) Rename(newName string) error {
+	if orgVdcNet.OrgVDCNetwork.Name == newName {
+		return fmt.Errorf("new name is the same ase the existing name")
+	}
+	orgVdcNet.OrgVDCNetwork.Name = newName
+	return orgVdcNet.Update()
+}

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -234,3 +234,28 @@ func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error)
 	}
 	return "", fmt.Errorf("no edge gateway connection found")
 }
+
+func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
+	if orgVdcNet.OrgVDCNetwork.HREF == "" {
+		return Task{}, fmt.Errorf("cannot Update, Object is empty")
+	}
+	href := orgVdcNet.OrgVDCNetwork.HREF
+
+	if !strings.Contains(href, "/api/admin/") {
+		href = strings.ReplaceAll(href, "/api/", "/api/admin/")
+	}
+
+	return orgVdcNet.client.ExecuteTaskRequest(href, http.MethodPut,
+		types.MimeOrgVdcNetwork, "error updating Org VDC network: %s", orgVdcNet.OrgVDCNetwork)
+}
+
+func (orgVdcNet *OrgVDCNetwork) Update() error {
+	task, err := orgVdcNet.UpdateAsync()
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+
+	return err
+}
+

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -269,10 +269,10 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkIso(check *C) {
 						},
 					},
 					},
-					BackwardCompatibilityMode: true,
 				},
-				IsShared: false,
+				BackwardCompatibilityMode: true,
 			},
+			IsShared: false,
 		}
 	)
 
@@ -430,6 +430,7 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkDirect(check *C) {
 	// (1) Make sure the network exists
 	newNetwork, err = vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
 	check.Assert(err, IsNil)
+	check.Assert(newNetwork, NotNil)
 
 	// (2) Removing the network. It should return nil, as a successful deletion
 	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -415,6 +415,12 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkDirect(check *C) {
 		"network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
 		"Test_CreateOrgVdcNetworkDirect")
 
+	// Check the values of the updated entities. The new values should be available
+	// immediately.
+	check.Assert(newNetwork.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+	check.Assert(newNetwork.OrgVDCNetwork.Description, Equals, updatedDescription)
+
+	// Gets a new copy of the network and check the values.
 	newNetwork, err = vcd.vdc.GetOrgVdcNetworkByName(updatedNetworkName, true)
 	check.Assert(err, IsNil)
 	check.Assert(newNetwork, NotNil)
@@ -425,6 +431,7 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkDirect(check *C) {
 	newNetwork.OrgVDCNetwork.Name = networkName
 	err = newNetwork.Update()
 	check.Assert(err, IsNil)
+	check.Assert(newNetwork.OrgVDCNetwork.Name, Equals, networkName)
 
 	// Testing RemoveOrgVdcNetworkIfExists:
 	// (1) Make sure the network exists

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -40,20 +40,20 @@ func (vcd *TestVCD) Test_NetRefresh(check *C) {
 
 }
 
-func (vcd *TestVCD) Test_CreateOrgVdcNetworkRouted(check *C) {
-	vcd.testCreateOrgVdcNetworkRouted(check, "10.10.101", false, false)
+func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkRouted(check *C) {
+	vcd.testCreateUpdateOrgVdcNetworkRouted(check, "10.10.101", false, false)
 }
 
-func (vcd *TestVCD) Test_CreateOrgVdcNetworkRoutedSubInterface(check *C) {
-	vcd.testCreateOrgVdcNetworkRouted(check, "10.10.102", true, false)
+func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkRoutedSubInterface(check *C) {
+	vcd.testCreateUpdateOrgVdcNetworkRouted(check, "10.10.102", true, false)
 }
 
-func (vcd *TestVCD) Test_CreateOrgVdcNetworkRoutedDistributed(check *C) {
-	vcd.testCreateOrgVdcNetworkRouted(check, "10.10.103", false, true)
+func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkRoutedDistributed(check *C) {
+	vcd.testCreateUpdateOrgVdcNetworkRouted(check, "10.10.103", false, true)
 }
 
-// Tests the creation of an Org VDC network connected to an Edge Gateway
-func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, subInterface, distributed bool) {
+// Tests the creation and update of an Org VDC network connected to an Edge Gateway
+func (vcd *TestVCD) testCreateUpdateOrgVdcNetworkRouted(check *C, ipSubnet string, subInterface, distributed bool) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkRouted
 
@@ -142,6 +142,13 @@ func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, sub
 	check.Assert(network, NotNil)
 	check.Assert(network.OrgVDCNetwork.Name, Equals, networkName)
 	check.Assert(network.OrgVDCNetwork.Description, Equals, networkDescription)
+	check.Assert(network.OrgVDCNetwork.Configuration, NotNil)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Gateway, Equals, gateway)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, startAddress)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, endAddress)
+
 	if subInterface {
 		check.Assert(network.OrgVDCNetwork.Configuration.SubInterface, NotNil)
 		check.Assert(*network.OrgVDCNetwork.Configuration.SubInterface, Equals, true)
@@ -152,6 +159,34 @@ func (vcd *TestVCD) testCreateOrgVdcNetworkRouted(check *C, ipSubnet string, sub
 	connectedGw, err := vcd.vdc.FindEdgeGatewayNameByNetwork(networkName)
 	check.Assert(err, IsNil)
 	check.Assert(connectedGw, Equals, edgeGWName)
+
+	networkId := network.OrgVDCNetwork.ID
+	updatedNetworkName := networkName + "-updated"
+	updatedNetworkDescription := "Updated by govcd tests"
+	updatedStartAddress := ipSubnet + ".5"
+	updatedEndAddress := ipSubnet + ".30"
+	network.OrgVDCNetwork.Name = updatedNetworkName
+	network.OrgVDCNetwork.Description = updatedNetworkDescription
+	network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress = updatedStartAddress
+	network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress = updatedEndAddress
+
+	err = network.Update()
+	check.Assert(err, IsNil)
+	AddToCleanupList(updatedNetworkName,
+		"network",
+		vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkRouted")
+
+	network, err = vcd.vdc.GetOrgVdcNetworkById(networkId, true)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, updatedNetworkDescription)
+	check.Assert(network.OrgVDCNetwork.Configuration, NotNil)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Gateway, Equals, gateway)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, updatedStartAddress)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, updatedEndAddress)
 
 	task, err := network.Delete()
 	check.Assert(err, IsNil)
@@ -182,8 +217,8 @@ func (vcd *TestVCD) Test_GetNetworkList(check *C) {
 	check.Assert(found, Equals, true)
 }
 
-// Tests the creation of an isolated Org VDC network
-func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
+// Tests the creation and update of an isolated Org VDC network
+func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkIso(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkIso
 
@@ -192,53 +227,113 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkIso(check *C) {
 		check.Skip(fmt.Sprintf("Error deleting network : %s", err))
 	}
 
-	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: types.XMLNamespaceVCloud,
-		Name:  networkName,
-		// Description: "Created by govcd tests",
-		Configuration: &types.NetworkConfiguration{
-			FenceMode: types.FenceModeIsolated,
-			/*One of:
-				bridged (connected directly to the ParentNetwork),
-			  isolated (not connected to any other network),
-			  natRouted (connected to the ParentNetwork via a NAT service)
-			  https://code.vmware.com/apis/287/vcloud#/doc/doc/types/OrgVdcNetworkType.html
-			*/
-			IPScopes: &types.IPScopes{
-				IPScope: []*types.IPScope{&types.IPScope{
-					IsInherited: false,
-					Gateway:     "192.168.2.1",
-					Netmask:     "255.255.255.0",
-					DNS1:        "192.168.2.1",
-					DNS2:        "",
-					DNSSuffix:   "",
-					IPRanges: &types.IPRanges{
-						IPRange: []*types.IPRange{
-							&types.IPRange{
-								StartAddress: "192.168.2.2",
-								EndAddress:   "192.168.2.100"},
+	var (
+		gateway             = "192.168.2.1"
+		updatedNetworkName  = TestCreateOrgVdcNetworkIso + "updated"
+		startAddress        = "192.168.2.2"
+		updatedStartAddress = "192.168.2.5"
+		endAddress          = "192.168.2.100"
+		updatedEndAddress   = "192.168.2.50"
+		netmask             = "255.255.255.0"
+		dns1                = gateway
+		dns2                = "8.8.8.8"
+		dnsSuffix           = "vcloud.org"
+		description         = "Created by govcd tests"
+		updatedDescription  = "Updated by govcd tests"
+		networkConfig       = types.OrgVDCNetwork{
+			Xmlns:       types.XMLNamespaceVCloud,
+			Name:        networkName,
+			Description: description,
+			Configuration: &types.NetworkConfiguration{
+				FenceMode: types.FenceModeIsolated,
+				/*One of:
+					bridged (connected directly to the ParentNetwork),
+				  isolated (not connected to any other network),
+				  natRouted (connected to the ParentNetwork via a NAT service)
+				  https://code.vmware.com/apis/287/vcloud#/doc/doc/types/OrgVdcNetworkType.html
+				*/
+				IPScopes: &types.IPScopes{
+					IPScope: []*types.IPScope{&types.IPScope{
+						IsInherited: false,
+						Gateway:     gateway,
+						Netmask:     netmask,
+						DNS1:        dns1,
+						DNS2:        dns2,
+						DNSSuffix:   dnsSuffix,
+						IPRanges: &types.IPRanges{
+							IPRange: []*types.IPRange{
+								&types.IPRange{
+									StartAddress: startAddress,
+									EndAddress:   endAddress,
+								},
+							},
 						},
 					},
+					},
 				},
-				}},
-			BackwardCompatibilityMode: true,
-		},
-		IsShared: false,
-	}
+				BackwardCompatibilityMode: true,
+			},
+			IsShared: false,
+		}
+	)
+
 	LogNetwork(networkConfig)
 	err = vcd.vdc.CreateOrgVDCNetworkWait(&networkConfig)
 	if err != nil {
 		fmt.Printf("error creating Network <%s>: %s\n", networkName, err)
 	}
 	check.Assert(err, IsNil)
-	AddToCleanupList(TestCreateOrgVdcNetworkIso,
+	AddToCleanupList(networkName,
 		"network",
 		vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
 		"Test_CreateOrgVdcNetworkIso")
+
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, description)
+	check.Assert(network.OrgVDCNetwork.Configuration.FenceMode, Equals, types.FenceModeIsolated)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Gateway, Equals, gateway)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Netmask, Equals, netmask)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNS1, Equals, dns1)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNS2, Equals, dns2)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNSSuffix, Equals, dnsSuffix)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, startAddress)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, endAddress)
+
+	networkId := network.OrgVDCNetwork.ID
+	network.OrgVDCNetwork.Description = updatedDescription
+	network.OrgVDCNetwork.Name = updatedNetworkName
+	network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress = updatedStartAddress
+	network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress = updatedEndAddress
+	err = network.Update()
+	check.Assert(err, IsNil)
+	AddToCleanupList(updatedNetworkName,
+		"network",
+		vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkIso")
+
+	network, err = vcd.vdc.GetOrgVdcNetworkById(networkId, true)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, updatedDescription)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].Netmask, Equals, netmask)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNS2, Equals, dns2)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].DNSSuffix, Equals, dnsSuffix)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges, NotNil)
+	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange), Not(Equals), 0)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, updatedStartAddress)
+	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, updatedEndAddress)
+
 }
 
-// Tests the creation of a Org VDC network connected to an external network
-func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
+// Tests the creation and update of a Org VDC network connected to an external network
+func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkDirect(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	networkName := TestCreateOrgVdcNetworkDirect
 
@@ -259,9 +354,11 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 		return
 	}
 	// Note that there is no IPScope for this type of network
+	description := "Created by govcd test"
 	var networkConfig = types.OrgVDCNetwork{
-		Xmlns: types.XMLNamespaceVCloud,
-		Name:  networkName,
+		Xmlns:       types.XMLNamespaceVCloud,
+		Name:        networkName,
+		Description: description,
 		Configuration: &types.NetworkConfiguration{
 			FenceMode: types.FenceModeBridged,
 			ParentNetwork: &types.Reference{
@@ -285,7 +382,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	}
 	check.Assert(task.Task.HREF, Not(Equals), "")
 
-	AddToCleanupList(TestCreateOrgVdcNetworkDirect,
+	AddToCleanupList(networkName,
 		"network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
 		"Test_CreateOrgVdcNetworkDirect")
 
@@ -296,27 +393,60 @@ func (vcd *TestVCD) Test_CreateOrgVdcNetworkDirect(check *C) {
 	}
 	check.Assert(err, IsNil)
 
-	// Testing RemoveOrgVdcNetworkIfExists:
-	// (1) Make sure the network exists
-	newNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(TestCreateOrgVdcNetworkDirect, true)
+	// Retrieving the network
+	newNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
 	check.Assert(err, IsNil)
 	check.Assert(newNetwork, NotNil)
+	check.Assert(newNetwork.OrgVDCNetwork.Name, Equals, networkName)
+	check.Assert(newNetwork.OrgVDCNetwork.Description, Equals, description)
+	check.Assert(newNetwork.OrgVDCNetwork.Configuration, NotNil)
+	check.Assert(newNetwork.OrgVDCNetwork.Configuration.ParentNetwork, NotNil)
+	check.Assert(newNetwork.OrgVDCNetwork.Configuration.ParentNetwork.ID, Equals, externalNetwork.ExternalNetwork.ID)
+	check.Assert(newNetwork.OrgVDCNetwork.Configuration.ParentNetwork.Name, Equals, externalNetwork.ExternalNetwork.Name)
+
+	// Updating
+	updatedNetworkName := networkName + "-updated"
+	updatedDescription := "Updated by govcd tests"
+	newNetwork.OrgVDCNetwork.Description = updatedDescription
+	newNetwork.OrgVDCNetwork.Name = updatedNetworkName
+	err = newNetwork.Update()
+	check.Assert(err, IsNil)
+
+	AddToCleanupList(updatedNetworkName,
+		"network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name,
+		"Test_CreateOrgVdcNetworkDirect")
+
+	newNetwork, err = vcd.vdc.GetOrgVdcNetworkByName(updatedNetworkName, true)
+	check.Assert(err, IsNil)
+	check.Assert(newNetwork, NotNil)
+	check.Assert(newNetwork.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+	check.Assert(newNetwork.OrgVDCNetwork.Description, Equals, updatedDescription)
+
+	// restoring original name
+	newNetwork.OrgVDCNetwork.Name = networkName
+	err = newNetwork.Update()
+	check.Assert(err, IsNil)
+
+	// Testing RemoveOrgVdcNetworkIfExists:
+	// (1) Make sure the network exists
+	newNetwork, err = vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
+	check.Assert(err, IsNil)
 
 	// (2) Removing the network. It should return nil, as a successful deletion
-	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, TestCreateOrgVdcNetworkDirect)
+	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)
 	check.Assert(err, IsNil)
 
 	// (3) Look for the network again. It should be deleted
-	_, err = vcd.vdc.GetOrgVdcNetworkByName(TestCreateOrgVdcNetworkDirect, true)
+	_, err = vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 
 	// (4) Attempting a second conditional deletion. It should also return nil, as the network was not found
-	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, TestCreateOrgVdcNetworkDirect)
+	err = RemoveOrgVdcNetworkIfExists(*vcd.vdc, networkName)
 	check.Assert(err, IsNil)
 }
 
-func (vcd *TestVCD) Test_NetUpdate(check *C) {
+func (vcd *TestVCD) Test_NetworkUpdateRename(check *C) {
 	if vcd.config.VCD.Network.Net1 == "" {
 		check.Skip("Skipping test because no network was given")
 	}
@@ -328,17 +458,19 @@ func (vcd *TestVCD) Test_NetUpdate(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(network.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 	var saveNetwork = types.OrgVDCNetwork{
-		HREF:            network.OrgVDCNetwork.HREF,
-		Type:            network.OrgVDCNetwork.Type,
-		ID:              network.OrgVDCNetwork.ID,
-		Name:            network.OrgVDCNetwork.Name,
-		Status:          network.OrgVDCNetwork.Status,
-		Description:     network.OrgVDCNetwork.Description,
+		HREF:        network.OrgVDCNetwork.HREF,
+		Type:        network.OrgVDCNetwork.Type,
+		ID:          network.OrgVDCNetwork.ID,
+		Name:        network.OrgVDCNetwork.Name,
+		Status:      network.OrgVDCNetwork.Status,
+		Description: network.OrgVDCNetwork.Description,
 	}
 
 	// Change name and description
-	network.OrgVDCNetwork.Name = "UpdatedNetwork"
-	network.OrgVDCNetwork.Description = "updated description"
+	updatedNetworkName := "UpdatedNetwork"
+	updatedDescription := "Updated description"
+	network.OrgVDCNetwork.Description = updatedDescription
+	network.OrgVDCNetwork.Name = updatedNetworkName
 	err = network.Update()
 	check.Assert(err, IsNil)
 
@@ -346,8 +478,8 @@ func (vcd *TestVCD) Test_NetUpdate(check *C) {
 	network, err = vcd.vdc.GetOrgVdcNetworkById(saveNetwork.ID, false)
 	check.Assert(err, IsNil)
 
-	check.Assert(network.OrgVDCNetwork.Name, Equals, "UpdatedNetwork")
-	check.Assert(network.OrgVDCNetwork.Description, Equals, "updated description")
+	check.Assert(network.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, updatedDescription)
 	check.Assert(network.OrgVDCNetwork.HREF, Equals, saveNetwork.HREF)
 	check.Assert(network.OrgVDCNetwork.Type, Equals, saveNetwork.Type)
 	check.Assert(network.OrgVDCNetwork.ID, Equals, saveNetwork.ID)
@@ -364,4 +496,31 @@ func (vcd *TestVCD) Test_NetUpdate(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(network.OrgVDCNetwork.Description, Equals, saveNetwork.Description)
 	check.Assert(network.OrgVDCNetwork.Name, Equals, saveNetwork.Name)
+
+	// An update without any changes should run without producing side effects
+	err = network.Update()
+	check.Assert(err, IsNil)
+	network, err = vcd.vdc.GetOrgVdcNetworkById(saveNetwork.ID, false)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Description, Equals, saveNetwork.Description)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, saveNetwork.Name)
+
+	// We run some of the above operations using Rename instead of Update
+	err = network.Rename(updatedNetworkName)
+	check.Assert(err, IsNil)
+	network, err = vcd.vdc.GetOrgVdcNetworkById(saveNetwork.ID, false)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, updatedNetworkName)
+
+	// Trying to rename with the same name should give an error
+	err = network.Rename(updatedNetworkName)
+	check.Assert(err, NotNil)
+
+	// Setting the original name again
+	err = network.Rename(saveNetwork.Name)
+	check.Assert(err, IsNil)
+	network, err = vcd.vdc.GetOrgVdcNetworkById(saveNetwork.ID, false)
+	check.Assert(err, IsNil)
+	check.Assert(network.OrgVDCNetwork.Name, Equals, saveNetwork.Name)
+
 }

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -35,6 +35,8 @@ const (
 	MimeVDC = "application/vnd.vmware.vcloud.vdc+xml"
 	// MimeVDC mime for a admin VDC
 	MimeAdminVDC = "application/vnd.vmware.admin.vdc+xml"
+	// MimeEdgeGateway mime for an Edge Gateway
+	MimeEdgeGateway = "application/vnd.vmware.admin.edgeGateway+xml"
 	// MimeVAppTemplate mime for a vapp template
 	MimeVAppTemplate = "application/vnd.vmware.vcloud.vAppTemplate+xml"
 	// MimeVApp mime for a vApp
@@ -55,6 +57,8 @@ const (
 	MimeError = "application/vnd.vmware.vcloud.error+xml"
 	// MimeNetwork mime for a network
 	MimeNetwork = "application/vnd.vmware.vcloud.network+xml"
+	// MimeOrgVdcNetwork mime for an Org VDC network
+	MimeOrgVdcNetwork = "application/vnd.vmware.vcloud.orgVdcNetwork+xml"
 	//MimeDiskCreateParams mime for create independent disk
 	MimeDiskCreateParams = "application/vnd.vmware.vcloud.diskCreateParams+xml"
 	// Mime for VMs

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -219,7 +219,7 @@ type NetworkConfiguration struct {
 	// They cannot be both set (we'll get an API error if we do).
 	SubInterface         *bool `xml:"SubInterface,omitempty"`
 	DistributedInterface *bool `xml:"DistributedInterface,omitempty"`
-	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
+	GuestVlanAllowed     *bool `xml:"GuestVlanAllowed,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -212,7 +212,6 @@ type NetworkConfiguration struct {
 	FenceMode                      string           `xml:"FenceMode"`
 	RetainNetInfoAcrossDeployments bool             `xml:"RetainNetInfoAcrossDeployments,omitempty"`
 	Features                       *NetworkFeatures `xml:"Features,omitempty"`
-	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
 
 	// SubInterface and DistributedInterface are mutually exclusive
 	// When they are both nil, it means the "internal" interface (the default) will be used.
@@ -220,6 +219,7 @@ type NetworkConfiguration struct {
 	// They cannot be both set (we'll get an API error if we do).
 	SubInterface         *bool `xml:"SubInterface,omitempty"`
 	DistributedInterface *bool `xml:"DistributedInterface,omitempty"`
+	GuestVlanAllowed               *bool            `xml:"GuestVlanAllowed,omitempty"`
 	// TODO: Not Implemented
 	// RouterInfo                     RouterInfo           `xml:"RouterInfo,omitempty"`
 	// SyslogServerSettings           SyslogServerSettings `xml:"SyslogServerSettings,omitempty"`
@@ -339,13 +339,13 @@ type OrgVDCNetwork struct {
 	OperationKey    string                `xml:"operationKey,attr,omitempty"`
 	Name            string                `xml:"name,attr"`
 	Status          string                `xml:"status,attr,omitempty"`
+	Link            []Link                `xml:"Link,omitempty"`
 	Description     string                `xml:"Description,omitempty"`
 	Configuration   *NetworkConfiguration `xml:"Configuration,omitempty"`
 	EdgeGateway     *Reference            `xml:"EdgeGateway,omitempty"`
 	ServiceConfig   *GatewayFeatures      `xml:"ServiceConfig,omitempty"` // Specifies the service configuration for an isolated Org VDC networks
 	IsShared        bool                  `xml:"IsShared"`
 	VimPortGroupRef []*VimObjectRef       `xml:"VimPortGroupRef,omitempty"` // Needed to set up DHCP inside ServiceConfig
-	Link            []Link                `xml:"Link,omitempty"`
 	Tasks           *TasksInProgress      `xml:"Tasks,omitempty"`
 }
 


### PR DESCRIPTION
Adds the ability of updating Org VDC networks in place. Until now, we could only remove and re-create them.

Added methods `orgVdcNetwork.Update`, `orgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename`