### PR TITLE
Improve deleteVapp() testing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 * Added methods `OrgVdcNetwork.Update`, `OrgVdcNetwork.UpdateAsync`, and `OrgVdcNetwork.Rename` [#292](https://github.com/vmware/go-vcloud-director/pull/292)
 * Added methods `EdgeGateway.Update` and `EdgeGateway.UpdateAsync` [#292](https://github.com/vmware/go-vcloud-director/pull/292)
 
+NOTES:
+
+* Improved testinf function `deleteVapp()` to avoid deletion errors during test suite run
+  [#297](https://github.com/vmware/go-vcloud-director/pull/297)
+
+
 ## 2.6.0 (March 13, 2010)
 
 * Moved `VCDClient.supportedVersions` to `VCDClient.Client.supportedVersions` [#274](https://github.com/vmware/go-vcloud-director/pull/274)    

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -87,7 +87,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 	return *task, nil
 }
 
-// Looks for an Org Vdc network and, if found, will delete it.
+// RemoveOrgVdcNetworkIfExists looks for an Org Vdc network and, if found, will delete it.
 func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
 	network, err := vdc.GetOrgVdcNetworkByName(networkName, true)
 
@@ -102,11 +102,11 @@ func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
 	// The network was found. We attempt deletion
 	task, err := network.Delete()
 	if err != nil {
-		return fmt.Errorf("error deleting network [phase 1] %s", networkName)
+		return fmt.Errorf("error deleting network '%s' [phase 1]: %s", networkName, err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf("error deleting network [task] %s", networkName)
+		return fmt.Errorf("error deleting network '%s' [task]: %s", networkName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
In some cases vApp deletion in tests could stumble on still running task of vApp deletion and fail like that:
```shell
....
# 2 removeLeftoverEntries: [INFO] Attempting cleanup of network 'TestCreateOrgVdcNetworkDhcp' instantiated by TestCreateOrgVdcNetworkDhcp
removeLeftoverEntries: [ERROR] Error deleting network 'TestCreateOrgVdcNetworkDhcp': error deleting network [phase 1] TestCreateOrgVdcNetworkDhcp
```

This PR adds network detachment and deletion task tracking output. It also improves error reporting in `RemoveOrgVdcNetworkIfExists` function


So far I have tested 
* ```go test -tags functional -check.vv -timeout 0 -check.f Test_VMGetDhcpAddress``` 7+ times.
* Full suite run on vCD 10.0.0.1