### PR TITLE
bugfix for vapp.RemoveNetwork() and vapp.RemoveNetworkAsync() when removing multiple network sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ NOTES:
 BUGS FIXED:
 * Fix issue in Queries with vCD 10 version, which do not return network pool or provider VDC[#293](https://github.com/vmware/go-vcloud-director/pull/293)
 * Session timeout for media, catalog item upload  [#294](https://github.com/vmware/go-vcloud-director/pull/294)
+* Fix `vapp.RemoveNetwork`, `vapp.RemoveNetworkAsync` to use `DELETE` API call instead of update
+  which can apply incorrect remaining vApp network configurations [#299](https://github.com/vmware/go-vcloud-director/pull/299)
 
 ## 2.6.0 (March 13, 2010)
 


### PR DESCRIPTION
This PR attempts to fix `vapp.RemoveNetworkAsync()` and `vapp.RemoveNetwork()` functions by using http DELETE call on endpoint `https://xxx/api/network/ef005324-a62b-4041-ae8c-c7bec64fb348` instead of re-applying whole vApp network configuration with a particular network excluded.
It has caused situation where re-applying whole vApp network config gave error because that config was invalid.

One particular place which got impacted by that is Terraform provider with many sequential removals - https://github.com/terraform-providers/terraform-provider-vcd/issues/473