### PR TITLE
Add command-line flags to replace env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removed code that handled specific cases for API 29.0 and 30.0. This library now supports VCD versions from 9.5 to 10.1 included.
 * Added `vdc.QueryVappVmTemplate` and changed `vapp.AddNewVMWithStorageProfile` to allow creating VM from VM template.
+* Enhanced tests command line with flags that can be used instead of environment variables. [#305](https://github.com/vmware/go-vcloud-director/pull/305)
 
 ## 2.7.0 (April 10, 2020)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -332,8 +332,7 @@ While running tests, the following environment variables can be used:
 * `VCD_TOKEN` : specifies the authorization token to use instead of username/password
    (Use `./scripts/get_token.sh` to retrieve one)
 
-When both the environment variable and the command line option are possible, the environment variable gets evaluated first: is it is set,
-also the flag becomes true.
+When both the environment variable and the command line option are possible, the environment variable gets evaluated first.
 
 # Final Words
 Be careful about using our tests as these tests run on a real vcd. If you don't have 1 gb of ram and 2 vcpus available then you should not be running tests that deploy your vm/change memory and cpu. However everything created will be removed at the end of testing.

--- a/TESTING.md
+++ b/TESTING.md
@@ -309,24 +309,26 @@ func (vcd *TestVCD) Test_ComposeVApp(check *checks.C) {
 }
 ```
 
-# Environment variables
+# Environment variables and corresponding flags
 
 While running tests, the following environment variables can be used:
 
 * `GOVCD_CONFIG=/path/file`: sets an alternative configuration file for the tests.
    e.g.:  `GOVCD_CONFIG=/some/path/govcd_test_config.yaml go test -tags functional -timeout 0 .`
-* `GOVCD_DEBUG=1`: enable debug output on screen.
-* `GOVCD_TEST_VERBOSE=1`: shows execution details in some tests.
-* `GOVCD_SKIP_VAPP_CREATION=1`: will not create the initial vApp. All tests that
+* `GOVCD_DEBUG=1` (`-vcd-debug`): enable debug output on screen.
+* `GOVCD_TEST_VERBOSE=1` (`-vcd-verbose`): shows execution details in some tests.
+* `GOVCD_SKIP_VAPP_CREATION=1` (`-vcd-skip-vapp-creation`): will not create the initial vApp. All tests that
    depend on a vApp availability will be skipped.
 * `GOVCD_TASK_MONITOR=show|log|simple_show|simple|log`: sets a task monitor function when running `task.WaitCompletion`
     * `show` : displays full task details on screen
     * `log` : writes full task details in the log
     * `simple_show` : displays a summary line for the task on screen
     * `simple_log` : writes a summary line for the task in the log
-* `GOVCD_IGNORE_CLEANUP_FILE` Ignore the cleanup file if it is left behind after a test failure.
+* `GOVCD_IGNORE_CLEANUP_FILE` (`-vcd-ignore-cleanup-file`): Ignore the cleanup file if it is left behind after a test failure.
     This could be useful after running a single test, when we need to check how the test behaves with the resource still
     in place.
+* `GOVCD_SHOW_REQ` (`-vcd-show-request`): shows the API request on standard output
+* `GOVCD_SHOW_RESP` (`-vcd-show-response`): shows the API response on standard output
 * `VCD_TOKEN` : specifies the authorization token to use instead of username/password
    (Use `./scripts/get_token.sh` to retrieve one)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -332,6 +332,9 @@ While running tests, the following environment variables can be used:
 * `VCD_TOKEN` : specifies the authorization token to use instead of username/password
    (Use `./scripts/get_token.sh` to retrieve one)
 
+When both the environment variable and the command line option are possible, the environment variable gets evaluated first: is it is set,
+also the flag becomes true.
+
 # Final Words
 Be careful about using our tests as these tests run on a real vcd. If you don't have 1 gb of ram and 2 vcpus available then you should not be running tests that deploy your vm/change memory and cpu. However everything created will be removed at the end of testing.
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1450,7 +1450,6 @@ func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
 func setBoolFlag(variable *bool, name, envVar, help string) {
 	if envVar != "" && os.Getenv(envVar) != "" {
 		*variable = true
-		return
 	}
 	flag.BoolVar(variable, name, *variable, help)
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1447,11 +1447,14 @@ func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
 	fmt.Printf("Test: %s run with api Version: %s\n", check.TestName(), apiVersion)
 }
 
-func setBoolFlag(variable *bool, name, envVar, help string) {
+// setBoolFlag binds a flag to a boolean variable (passed as pointer)
+// it also uses an optional environment variable that, if set, will
+// update the variable before binding it to the flag.
+func setBoolFlag(varPointer *bool, name, envVar, help string) {
 	if envVar != "" && os.Getenv(envVar) != "" {
-		*variable = true
+		*varPointer = true
 	}
-	flag.BoolVar(variable, name, *variable, help)
+	flag.BoolVar(varPointer, name, *varPointer, help)
 }
 
 // setTestEnv enables environment variables that are also used in non-test code

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1471,7 +1471,7 @@ func setTestEnv() {
 func init() {
 	testingTags["api"] = "api_vcd_test.go"
 
-	// To list the flags when we run "go test -vcd-help", the flag name must start with "vcd"
+	// To list the flags when we run "go test -tags functional -vcd-help", the flag name must start with "vcd"
 	// They will all appear alongside the native flags when we use an invalid one
 	setBoolFlag(&vcdHelp, "vcd-help", "VCD_HELP", "Show vcd flags")
 	setBoolFlag(&enableDebug, "vcd-debug", "GOVCD_DEBUG", "enables debug output")


### PR DESCRIPTION
Same as the equivalent PR in terraform-provider-vcd, this change enables command line flags that
can be used instead of environment variables.

Use "go test -tags functional -vcd-help" for a list of flags


