### PR TITLE
Improve debug output security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Removed code that handled specific cases for API 29.0 and 30.0. This library now supports VCD versions from 9.5 to 10.1 included.
 * Added `vdc.QueryVappVmTemplate` and changed `vapp.AddNewVMWithStorageProfile` to allow creating VM from VM template.
+* Improve logging security of debug output for API requests and responses [#306](https://github.com/vmware/go-vcloud-director/pull/306)
 
 ## 2.7.0 (April 10, 2020)
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -86,16 +87,18 @@ func disableDebugShowResponse() {
 func debugShowRequest(req *http.Request, payload string) {
 	if debugShowRequestEnabled {
 		header := "[\n"
-		for key, value := range req.Header {
+		for key, value := range util.SanitizedHeader(req.Header) {
 			header += fmt.Sprintf("\t%s => %s\n", key, value)
 		}
 		header += "]\n"
+		fmt.Printf("time:    %s\n", time.Now().Format("2006-01-02T15:04:05.000Z"))
 		fmt.Printf("method:  %s\n", req.Method)
 		fmt.Printf("host:    %s\n", req.Host)
 		fmt.Printf("length:  %d\n", req.ContentLength)
 		fmt.Printf("URL:     %s\n", req.URL.String())
 		fmt.Printf("header:  %s\n", header)
 		fmt.Printf("payload: %s\n", payload)
+		fmt.Println()
 	}
 }
 
@@ -104,10 +107,12 @@ func debugShowRequest(req *http.Request, payload string) {
 // of the response as it is being processed.
 func debugShowResponse(resp *http.Response, body []byte) {
 	if debugShowResponseEnabled {
+		fmt.Printf("time:   %s\n", time.Now().Format("2006-01-02T15:04:05.000Z"))
 		fmt.Printf("status: %d - %s \n", resp.StatusCode, resp.Status)
 		fmt.Printf("length: %d\n", resp.ContentLength)
-		fmt.Printf("header: %v\n", resp.Header)
-		fmt.Printf("body: %s\n", body)
+		fmt.Printf("header: %v\n", util.SanitizedHeader(resp.Header))
+		fmt.Printf("body:   %s\n", body)
+		fmt.Println()
 	}
 }
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -91,6 +91,7 @@ func debugShowRequest(req *http.Request, payload string) {
 			header += fmt.Sprintf("\t%s => %s\n", key, value)
 		}
 		header += "]\n"
+		fmt.Println("** REQUEST **")
 		fmt.Printf("time:    %s\n", time.Now().Format("2006-01-02T15:04:05.000Z"))
 		fmt.Printf("method:  %s\n", req.Method)
 		fmt.Printf("host:    %s\n", req.Host)
@@ -107,6 +108,7 @@ func debugShowRequest(req *http.Request, payload string) {
 // of the response as it is being processed.
 func debugShowResponse(resp *http.Response, body []byte) {
 	if debugShowResponseEnabled {
+		fmt.Println("## RESPONSE ##")
 		fmt.Printf("time:   %s\n", time.Now().Format("2006-01-02T15:04:05.000Z"))
 		fmt.Printf("status: %d - %s \n", resp.StatusCode, resp.Status)
 		fmt.Printf("length: %d\n", resp.ContentLength)

--- a/util/logging.go
+++ b/util/logging.go
@@ -168,14 +168,22 @@ func isBinary(data string, req *http.Request) bool {
 	return false
 }
 
-// Scans the header for known keys that contain authentication tokens
-// and hide the contents
-func logSanitizedHeader(input_header http.Header) {
-	for key, value := range input_header {
-		if (key == "Config-Secret" || key == "authorization" || key == "Authorization" || key == "X-Vcloud-Authorization") &&
+// SanitizedHeader returns a http.Header with sensitive fields masked
+func SanitizedHeader(inputHeader http.Header) http.Header {
+	var sanitizedHeader = make(http.Header)
+	for key, value := range inputHeader {
+		if (key == "Config-Secret" || key == "authorization" || key == "Authorization" || key == "X-Vcloud-Authorization" || key == "X-Vmware-Vcloud-Access-Token") &&
 			!LogPasswords {
 			value = []string{"********"}
 		}
+		sanitizedHeader[key] = value
+	}
+	return sanitizedHeader
+}
+
+// logSanitizedHeader logs the contents of the header after sanitizing
+func logSanitizedHeader(inputHeader http.Header) {
+	for key, value := range SanitizedHeader(inputHeader) {
 		Logger.Printf("\t%s: %s\n", key, value)
 	}
 }

--- a/util/logging.go
+++ b/util/logging.go
@@ -170,11 +170,22 @@ func isBinary(data string, req *http.Request) bool {
 
 // SanitizedHeader returns a http.Header with sensitive fields masked
 func SanitizedHeader(inputHeader http.Header) http.Header {
+	if LogPasswords {
+		return inputHeader
+	}
+	var sensitiveKeys = []string{
+		"Config-Secret",
+		"Authorization",
+		"X-Vcloud-Authorization",
+		"X-Vmware-Vcloud-Access-Token",
+	}
 	var sanitizedHeader = make(http.Header)
 	for key, value := range inputHeader {
-		if (key == "Config-Secret" || key == "authorization" || key == "Authorization" || key == "X-Vcloud-Authorization" || key == "X-Vmware-Vcloud-Access-Token") &&
-			!LogPasswords {
-			value = []string{"********"}
+		for _, sk := range sensitiveKeys {
+			if strings.EqualFold(sk, key) {
+				value = []string{"********"}
+				break
+			}
 		}
 		sanitizedHeader[key] = value
 	}


### PR DESCRIPTION
Remove default showing of security headers when asking for API requests and responses for debug.

See the issue by running:
```
GOVCD_SKIP_VAPP_CREATION=1 \
  GOVCD_SHOW_REQ=1 \
  GOVCD_SHOW_RESP=1 \
  go test -tags functional -check.vv   -check.f Test_GetUserByNameOrId | less
```

The fields `X-Vcloud-Authorization` and `X-Vmware-Vcloud-Access-Token` were reported without masking.

This change removes such exposure.

Additionally, we now show a time stamp with the debug listing.