### PR TITLE
Do not overwrite log files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added `vdc.QueryVappVmTemplate` and changed `vapp.AddNewVMWithStorageProfile` to allow creating VM from VM template.
 * Enhanced tests command line with flags that can be used instead of environment variables. [#305](https://github.com/vmware/go-vcloud-director/pull/305)
 * Improve logging security of debug output for API requests and responses [#306](https://github.com/vmware/go-vcloud-director/pull/306)
+* Append log files by default instead of overwriting. `GOVCD_LOG_OVERWRITE=true` environment
+  variable can set to overwrite log file on every initialization
+  [#307](https://github.com/vmware/go-vcloud-director/pull/307)
 
 ## 2.7.0 (April 10,2020)
 

--- a/util/LOGGING.md
+++ b/util/LOGGING.md
@@ -3,7 +3,7 @@
 
 ## Defaults for logging
 
-Use of the standard Go `log` package is cwdeprecated and should be avoided. 
+Use of the standard Go `log` package is deprecated and should be avoided. 
 The recommended way of logging is through the logger `util.Logger`, which supports [all the functions normally available to `log`](https://golang.org/pkg/log/#Logger).
 
 
@@ -90,4 +90,4 @@ Variable                    | Corresponding environment var
 `LogHttpResponse`           | `GOVCD_LOG_SKIP_HTTP_RESP`
 `SetSkipTags`               | `GOVCD_LOG_SKIP_TAGS`
 `SetApiLogFunctions`        | `GOVCD_LOG_INCLUDE_FUNCTIONS`
-
+`OverwriteLog`              | `GOVCD_LOG_OVERWRITE`

--- a/util/logging.go
+++ b/util/logging.go
@@ -103,7 +103,7 @@ func newLogger(logpath string) *log.Logger {
 	var err error
 	var file *os.File
 	if OverwriteLog {
-		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE, 0640)
+		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
 	} else {
 		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0640)
 	}

--- a/util/logging.go
+++ b/util/logging.go
@@ -23,6 +23,9 @@ const (
 	// Name of the environment variable that enables logging
 	envUseLog = "GOVCD_LOG"
 
+	// envOverwriteLog allows to overwrite file on every initialization
+	envOverwriteLog = "GOVCD_LOG_OVERWRITE"
+
 	// Name of the environment variable with the log file name
 	envLogFileName = "GOVCD_LOG_FILE"
 
@@ -60,6 +63,9 @@ var (
 	// activated by GOVCD_LOG
 	EnableLogging bool = false
 
+	// OverwriteLog specifies if log file should be overwritten on every run
+	OverwriteLog bool = false
+
 	// Enable logging of passwords
 	// activated by GOVCD_LOG_PASSWORDS
 	LogPasswords bool = false
@@ -94,8 +100,14 @@ var (
 )
 
 func newLogger(logpath string) *log.Logger {
-	// println("LogFile: " + logpath)
-	file, err := os.Create(logpath)
+	var err error
+	var file *os.File
+	if OverwriteLog {
+		file, err = os.Create(logpath)
+	} else {
+		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0660)
+	}
+
 	if err != nil {
 		fmt.Printf("error opening log file %s : %v", logpath, err)
 		os.Exit(1)
@@ -338,6 +350,11 @@ func InitLogging() {
 	if EnableLogging || os.Getenv(envUseLog) != "" {
 		EnableLogging = true
 	}
+
+	if os.Getenv(envOverwriteLog) != "" {
+		OverwriteLog = true
+	}
+
 	SetLog()
 }
 

--- a/util/logging.go
+++ b/util/logging.go
@@ -103,9 +103,9 @@ func newLogger(logpath string) *log.Logger {
 	var err error
 	var file *os.File
 	if OverwriteLog {
-		file, err = os.Create(logpath)
+		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE, 0640)
 	} else {
-		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0660)
+		file, err = os.OpenFile(logpath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0640)
 	}
 
 	if err != nil {


### PR DESCRIPTION
By default `go-vcloud-director` always overwrites log files. This causes problems in some libraries if they instantiate `go-vcloud-director` multiple times during single operations run. One example of that being Terraform where it runs plugin 5 times during one `terraform apply` command and part of the logs are instantly overwritten.

This PR changes default to "append" instead of overwriting and introduces environment variable `GOVCD_LOG_OVERWRITE` to allow enabling old behavior.