### PR TITLE
New functionality for handlig vapp network firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.8.0 (Unreleased)
 
-*  Removed code that handled specific cases for API 29.0 and 30.0. This library now supports VCD versions from 9.5 to 10.1 included.
+* Removed code that handled specific cases for API 29.0 and 30.0. This library now supports VCD versions from 9.5 to 10.1 included.
+* Added methods `vapp.UpdateNetworkFirewallRules`, `vapp.UpdateNetworkFirewallRulesAsync`, `vapp.GetVappNetworkById`, `vapp.GetVappNetworkByName` and `vapp.GetVappNetworkByNameOrId` [#308](https://github.com/vmware/go-vcloud-director/pull/308)
 
 ## 2.7.0 (April 10, 2020)
 

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -234,9 +234,11 @@ func (vapp *VApp) RemoveVM(vm VM) error {
 	if vapp.VApp.Tasks != nil {
 		for _, taskItem := range vapp.VApp.Tasks.Task {
 			task.Task = taskItem
-			err := task.WaitTaskCompletion()
-			if err != nil {
-				return fmt.Errorf("error performing task: %s", err)
+			if task.Task.Status != "error" && task.Task.Status != "success" {
+				err := task.WaitTaskCompletion()
+				if err != nil {
+					return fmt.Errorf("error performing task: %s", err)
+				}
 			}
 		}
 	}

--- a/govcd/vapp_network.go
+++ b/govcd/vapp_network.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
+	"net/http"
+)
+
+// UpdateNetworkFirewallRules updates vApp networks firewall rules.
+// Returns pointer to types.VAppNetwork or error
+func (vapp *VApp) UpdateNetworkFirewallRules(networkId string, firewallRules []*types.FirewallRule, defaultAction string, logDefaultAction bool) (*types.VAppNetwork, error) {
+	task, err := vapp.UpdateNetworkFirewallRulesAsync(networkId, firewallRules, defaultAction, logDefaultAction)
+	if err != nil {
+		return nil, err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
+	}
+
+	return vapp.GetVappNetworkById(networkId, false)
+}
+
+// UpdateNetworkFirewallRulesAsync asynchronously updates vApp networks firewall rules.
+// Returns task or error
+func (vapp *VApp) UpdateNetworkFirewallRulesAsync(networkId string, firewallRules []*types.FirewallRule, defaultAction string, logDefaultAction bool) (Task, error) {
+	util.Logger.Printf("[TRACE] UpdateNetworkFirewallRulesAsync with values: id: %s and firewallServiceConfiguration: %#v", networkId, firewallRules)
+	uuid := extractUuid(networkId)
+	networkToUpdate, err := vapp.GetVappNetworkById(uuid, true)
+	if err != nil {
+		return Task{}, err
+	}
+
+	if networkToUpdate.Configuration.Features == nil {
+		networkToUpdate.Configuration.Features = &types.NetworkFeatures{}
+	}
+	networkToUpdate.Xmlns = types.XMLNamespaceVCloud
+
+	if networkToUpdate.Configuration.Features.FirewallService == nil {
+		return Task{}, fmt.Errorf("provided network isn't connecd to org network or isn't fenced")
+	}
+	networkToUpdate.Configuration.Features.FirewallService.LogDefaultAction = logDefaultAction
+	networkToUpdate.Configuration.Features.FirewallService.DefaultAction = defaultAction
+	networkToUpdate.Configuration.Features.FirewallService.FirewallRule = firewallRules
+
+	apiEndpoint := vapp.client.VCDHREF
+	apiEndpoint.Path += "/network/" + uuid
+
+	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeVappNetwork, "error updating vApp Network firewall rules: %s", networkToUpdate)
+}
+
+// GetVappNetworkById returns a VApp network reference if the vApp network ID matches an existing one.
+// If no valid VApp network is found, it returns a nil VApp network reference and an error
+func (vapp *VApp) GetVappNetworkById(id string, refresh bool) (*types.VAppNetwork, error) {
+	util.Logger.Printf("[TRACE] [GetVappNetworkById] getting vApp Network: %s", id)
+
+	if refresh {
+		err := vapp.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vapp: %s", err)
+		}
+	}
+
+	//vApp Might Not Have Any networks
+	if vapp.VApp.NetworkConfigSection == nil || len(vapp.VApp.NetworkConfigSection.NetworkConfig) == 0 {
+		return nil, ErrorEntityNotFound
+	}
+
+	util.Logger.Printf("[TRACE] Looking for networks: %s --- %d", id, len(vapp.VApp.NetworkConfigSection.NetworkConfig))
+	for _, vappNetwork := range vapp.VApp.NetworkConfigSection.NetworkConfig {
+		util.Logger.Printf("[TRACE] Looking at: %s", vappNetwork.Link.HREF)
+		if equalIds(id, vappNetwork.ID, vappNetwork.Link.HREF) {
+			vappNetwork := &types.VAppNetwork{}
+
+			apiEndpoint := vapp.client.VCDHREF
+			apiEndpoint.Path += "/network/" + extractUuid(id)
+
+			_, err := vapp.client.ExecuteRequest(apiEndpoint.String(), http.MethodGet,
+				types.MimeVappNetwork, "error getting vApp network: %s", nil, vappNetwork)
+			if err != nil {
+				return nil, err
+			}
+			return vappNetwork, nil
+		}
+	}
+	util.Logger.Printf("[TRACE] GetVappNetworkById returns not found entity")
+	return nil, ErrorEntityNotFound
+}
+
+// GetVMByName returns a VM reference if the VM name matches an existing one.
+// If no valid VM is found, it returns a nil VM reference and an error
+func (vapp *VApp) GetVappNetworkByName(vappNetworkName string, refresh bool) (*types.VAppNetwork, error) {
+	if refresh {
+		err := vapp.Refresh()
+		if err != nil {
+			return nil, fmt.Errorf("error refreshing vapp: %s", err)
+		}
+	}
+
+	//vApp Might Not Have Any networks
+	if vapp.VApp.NetworkConfigSection == nil || len(vapp.VApp.NetworkConfigSection.NetworkConfig) == 0 {
+		return nil, ErrorEntityNotFound
+	}
+
+	util.Logger.Printf("[TRACE] Looking for networks: %s", vappNetworkName)
+	for _, vappNetwork := range vapp.VApp.NetworkConfigSection.NetworkConfig {
+
+		util.Logger.Printf("[TRACE] Looking at: %s", vappNetwork.NetworkName)
+		if vappNetwork.NetworkName == vappNetworkName {
+			return vapp.GetVappNetworkById(extractUuid(vappNetwork.Link.HREF), refresh)
+		}
+
+	}
+	util.Logger.Printf("[TRACE] Couldn't find vApp network: %s", vappNetworkName)
+	return nil, ErrorEntityNotFound
+}
+
+// GetVappNetworkByNameOrId returns a types.VAppNetwork reference if either the vApp network name or ID matches an existing one.
+// If no valid vApp network is found, it returns a nil types.VAppNetwork reference and an error
+func (vapp *VApp) GetVappNetworkByNameOrId(identifier string, refresh bool) (*types.VAppNetwork, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vapp.GetVappNetworkByName(name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vapp.GetVappNetworkById(id, refresh) }
+	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
+	if entity == nil {
+		return nil, err
+	}
+	return entity.(*types.VAppNetwork), err
+}

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -1,0 +1,148 @@
+// +build vapp functional ALL
+
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func (vcd *TestVCD) Test_UpdateNetworkFirewallRules(check *C) {
+	vapp, err, networkName, vappNetworkConfig := vcd.prepareVappWithVppNetwork(check, "Test_UpdateNetworkFirewallRulesVapp")
+
+	networkFound := types.VAppNetworkConfiguration{}
+	for _, networkConfig := range vappNetworkConfig.NetworkConfig {
+		if networkConfig.NetworkName == networkName {
+			networkFound = networkConfig
+		}
+	}
+	check.Assert(networkFound, Not(Equals), types.VAppNetworkConfiguration{})
+
+	uuid, err := GetUuidFromHref(networkFound.Link.HREF, false)
+	check.Assert(err, IsNil)
+
+	result, err := vapp.UpdateNetworkFirewallRules(uuid, []*types.FirewallRule{&types.FirewallRule{Description: "myFirstRule1", IsEnabled: true, Policy: "allow",
+		DestinationPortRange: "Any", DestinationIP: "Any", SourcePortRange: "Any", SourceIP: "Any", Protocols: &types.FirewallRuleProtocols{TCP: true}},
+		&types.FirewallRule{Description: "myFirstRule2", IsEnabled: false, Policy: "drop", DestinationPortRange: "Any",
+			DestinationIP: "Any", SourcePortRange: "Any", SourceIP: "Any", Protocols: &types.FirewallRuleProtocols{Any: true}}}, "drop", true)
+	check.Assert(err, IsNil)
+	check.Assert(result, NotNil)
+
+	// verify
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].Description, Equals, "myFirstRule1")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].IsEnabled, Equals, true)
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].Policy, Equals, "allow")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].DestinationPortRange, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].DestinationIP, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].SourcePortRange, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].SourceIP, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].Protocols.TCP, Equals, true)
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[0].Protocols.TCP, Equals, true)
+
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].Description, Equals, "myFirstRule2")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].IsEnabled, Equals, false)
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].Policy, Equals, "drop")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].DestinationPortRange, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].DestinationIP, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].SourcePortRange, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].SourceIP, Equals, "Any")
+	check.Assert(result.Configuration.Features.FirewallService.FirewallRule[1].Protocols.Any, Equals, true)
+
+	check.Assert(result.Configuration.Features.FirewallService.DefaultAction, Equals, "drop")
+	check.Assert(result.Configuration.Features.FirewallService.LogDefaultAction, Equals, true)
+
+	//cleanup
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
+func (vcd *TestVCD) prepareVappWithVppNetwork(check *C, vappName string) (*VApp, error, string, *types.NetworkConfigSection) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vapp, err := createVappForTest(vcd, vappName)
+	check.Assert(err, IsNil)
+	check.Assert(vapp, NotNil)
+
+	networkName := "Test_UpdateNetworkFirewallRules"
+	description := "Created in test"
+	const gateway = "192.168.0.1"
+	const netmask = "255.255.255.0"
+	const dns1 = "8.8.8.8"
+	const dns2 = "1.1.1.1"
+	const dnsSuffix = "biz.biz"
+	const startAddress = "192.168.0.10"
+	const endAddress = "192.168.0.20"
+	const dhcpStartAddress = "192.168.0.30"
+	const dhcpEndAddress = "192.168.0.40"
+	const maxLeaseTime = 3500
+	const defaultLeaseTime = 2400
+	var guestVlanAllowed = true
+	var fwEnabled = false
+	var natEnabled = false
+	var retainIpMacEnabled = true
+
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	check.Assert(err, IsNil)
+	check.Assert(orgVdcNetwork, NotNil)
+
+	vappNetworkSettings := &VappNetworkSettings{
+		Name:               networkName,
+		Gateway:            gateway,
+		NetMask:            netmask,
+		DNS1:               dns1,
+		DNS2:               dns2,
+		DNSSuffix:          dnsSuffix,
+		StaticIPRanges:     []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
+		DhcpSettings:       &DhcpSettings{IsEnabled: true, MaxLeaseTime: maxLeaseTime, DefaultLeaseTime: defaultLeaseTime, IPRange: &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress}},
+		GuestVLANAllowed:   &guestVlanAllowed,
+		Description:        description,
+		FirewallEnabled:    &fwEnabled,
+		NatEnabled:         &natEnabled,
+		RetainIpMacEnabled: &retainIpMacEnabled,
+	}
+
+	vappNetworkConfig, err := vapp.CreateVappNetwork(vappNetworkSettings, orgVdcNetwork.OrgVDCNetwork)
+	check.Assert(err, IsNil)
+	check.Assert(vappNetworkConfig, NotNil)
+	return vapp, err, networkName, vappNetworkConfig
+}
+
+func (vcd *TestVCD) Test_GetVappNetworkByNameOrId(check *C) {
+	vapp, err, networkName, vappNetworkConfig := vcd.prepareVappWithVppNetwork(check, "Test_GetVappNetworkByNameOrId")
+
+	networkFound := types.VAppNetworkConfiguration{}
+	for _, networkConfig := range vappNetworkConfig.NetworkConfig {
+		if networkConfig.NetworkName == networkName {
+			networkFound = networkConfig
+		}
+	}
+	check.Assert(networkFound, Not(Equals), types.VAppNetworkConfiguration{})
+
+	uuid, err := GetUuidFromHref(networkFound.Link.HREF, false)
+	check.Assert(err, IsNil)
+
+	vappNetwork, err := vapp.GetVappNetworkById(uuid, true)
+	check.Assert(err, IsNil)
+	check.Assert(vappNetwork, NotNil)
+
+	vappNetwork, err = vapp.GetVappNetworkByName(networkName, false)
+	check.Assert(err, IsNil)
+	check.Assert(vappNetwork, NotNil)
+
+	//cleanup
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -107,6 +107,8 @@ const (
 	MimeExternalNetwork = "application/vnd.vmware.admin.vmwexternalnet+xml"
 	// Mime of an Org User
 	MimeAdminUser = "application/vnd.vmware.admin.user+xml"
+	// Mime of vApp network
+	MimeVappNetwork = "application/vnd.vmware.vcloud.vAppNetwork+xml"
 )
 
 const (

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -233,12 +233,32 @@ type NetworkConfiguration struct {
 type VAppNetworkConfiguration struct {
 	HREF        string `xml:"href,attr,omitempty"`
 	Type        string `xml:"type,attr,omitempty"`
+	ID          string `xml:"id,attr,omitempty"`
 	NetworkName string `xml:"networkName,attr"`
 
 	Link          *Link                 `xml:"Link,omitempty"`
 	Description   string                `xml:"Description,omitempty"`
 	Configuration *NetworkConfiguration `xml:"Configuration"`
 	IsDeployed    bool                  `xml:"IsDeployed"`
+}
+
+// VAppNetworkType represents a vApp network configuration
+// Type: VAppNetworkType
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// Description: Represents a vApp network configuration.
+// Since: 0.9
+type VAppNetwork struct {
+	Xmlns    string `xml:"xmlns,attr,omitempty"`
+	HREF     string `xml:"href,attr,omitempty"`
+	Type     string `xml:"type,attr,omitempty"`
+	ID       string `xml:"id,attr,omitempty"`
+	Name     string `xml:"name,attr"`
+	Deployed bool   `xml:"deployed,attr"`
+
+	Link          *Link                 `xml:"Link,omitempty"`
+	Description   string                `xml:"Description,omitempty"`
+	Tasks         *TasksInProgress      `xml:"Tasks,omitempty"`
+	Configuration *NetworkConfiguration `xml:"Configuration"`
 }
 
 // NetworkConfigSection is container for vApp networks.


### PR DESCRIPTION
* Added methods needed for implementing vapp network firewall rules resource
* `vapp.UpdateNetworkFirewallRules`
* `vapp.UpdateNetworkFirewallRulesAsync`
* `vapp.GetVappNetworkById`
* `vapp.GetVappNetworkByName`
* `vapp.GetVappNetworkByNameOrId`