### PR TITLE
Update vapptemplate.go

### DIFF
--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -33,7 +33,7 @@ func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateP
 
 	vapptemplate := NewVAppTemplate(vdc.client)
 
-	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPut,
+	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPost,
 		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, vapptemplate)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Update InstantiateVAppTemplate to use http.MethodPost instead of incorrect http.MethodPut.

Related issue:  #309
