### PR TITLE
Add functions to manage memory and vCPU hot add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
 [#326](https://github.com/vmware/go-vcloud-director/pull/326)
 * Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
-* Added methods `vm.UpdateVmCapabilities` and `vm.UpdateVmCapabilitiesAsyc` [#324](https://github.com/vmware/go-vcloud-director/pull/324)
+* Added methods `vm.UpdateVmCpuAndMemoryHotAdd` and `vm.UpdateVmCpuAndMemoryHotAddAsyc` [#324](https://github.com/vmware/go-vcloud-director/pull/324)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Improved testing tags isolation [#320](https://github.com/vmware/go-vcloud-director/pull/320)
 * Added command `make tagverify` to check tags isolation tests [#320](https://github.com/vmware/go-vcloud-director/pull/320)
+* Added methods `vm.UpdateVmCapabilities` and `vm.UpdateVmCapabilitiesAsyc` [#324](https://github.com/vmware/go-vcloud-director/pull/324)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -23,8 +23,8 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// createAngGetResourcesForVmCreation creates vAPP and two VM for the testing
-func (vcd *TestVCD) createAngGetResourcesForVmCreation(check *C, vmName string) (*Vdc, *EdgeGateway, VAppTemplate, *VApp, types.NetworkConnectionSection, error) {
+// createAndGetResourcesForVmCreation creates vAPP and two VM for the testing
+func (vcd *TestVCD) createAndGetResourcesForVmCreation(check *C, vmName string) (*Vdc, *EdgeGateway, VAppTemplate, *VApp, types.NetworkConnectionSection, error) {
 	if vcd.config.VCD.Catalog.Name == "" {
 		check.Skip("No Catalog name given for VDC tests")
 	}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -25,6 +25,13 @@ import (
 
 // createAngGetResourcesForVmCreation creates vAPP and two VM for the testing
 func (vcd *TestVCD) createAngGetResourcesForVmCreation(check *C, vmName string) (*Vdc, *EdgeGateway, VAppTemplate, *VApp, types.NetworkConnectionSection, error) {
+	if vcd.config.VCD.Catalog.Name == "" {
+		check.Skip("No Catalog name given for VDC tests")
+	}
+
+	if vcd.config.VCD.Catalog.CatalogItem == "" {
+		check.Skip("No Catalog item given for VDC tests")
+	}
 	// Get org and vdc
 	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -32,7 +32,7 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	// Validate prerequisites
 	validateTestLbPrerequisites(vcd, check)
 
-	vdc, edge, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, TestLb)
+	vdc, edge, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, TestLb)
 	check.Assert(err, IsNil)
 
 	// The script below creates a file /tmp/node/server with single value `name` being set in it.

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -332,3 +332,19 @@ func (org *Org) QueryCatalogList() ([]*types.CatalogRecord, error) {
 	util.Logger.Printf("[DEBUG] QueryCatalogList returned with : %#v and error: %s", catalogs, err)
 	return catalogs, nil
 }
+
+// GetTaskList returns Tasks for Organization and error.
+func (org *Org) GetTaskList() (types.TasksList, error) {
+
+	metrics := &types.TasksList{}
+	href := org.client.VCDHREF
+	href.Path = href.Path + "/tasksList/" + extractUuid(org.Org.ID)
+
+	_, err := org.client.ExecuteRequest(href.String(), http.MethodGet, "", "error refreshing vApp: %s", nil, metrics)
+	if err != nil {
+		return types.TasksList{}, err
+	}
+
+	// The request was successful
+	return *metrics, nil
+}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -334,7 +334,7 @@ func (org *Org) QueryCatalogList() ([]*types.CatalogRecord, error) {
 }
 
 // GetTaskList returns Tasks for Organization and error.
-func (org *Org) GetTaskList() (types.TasksList, error) {
+func (org *Org) GetTaskList() (*types.TasksList, error) {
 
 	for _, link := range org.Org.Link {
 		if link.Rel == "down" && link.Type == "application/vnd.vmware.vcloud.tasksList+xml" {
@@ -344,12 +344,12 @@ func (org *Org) GetTaskList() (types.TasksList, error) {
 			_, err := org.client.ExecuteRequest(link.HREF, http.MethodGet, "",
 				"error getting taskList: %s", nil, tasksList)
 			if err != nil {
-				return types.TasksList{}, err
+				return nil, err
 			}
 
-			return *tasksList, nil
+			return tasksList, nil
 		}
 	}
 
-	return types.TasksList{}, nil
+	return nil, fmt.Errorf("link not found")
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -903,9 +903,9 @@ func (vcd *TestVCD) Test_GetTaskList(check *C) {
 	check.Assert(len(taskList.Task), Not(Equals), 0)
 	check.Assert(taskList.Task[0], NotNil)
 	check.Assert(taskList.Task[0].ID, Not(Equals), "")
-	check.Assert(taskList.Task[0].ID, Not(Equals), "")
 	check.Assert(taskList.Task[0].Type, Not(Equals), "")
-	check.Assert(taskList.Task[0].Owner, Not(Equals), "")
+	check.Assert(taskList.Task[0].Owner, NotNil)
+	check.Assert(taskList.Task[0].Owner.Name, Not(Equals), "")
 	check.Assert(taskList.Task[0].Status, Not(Equals), "")
-	check.Assert(taskList.Task[0].Progress, Not(Equals), "")
+	check.Assert(taskList.Task[0].Progress, FitsTypeOf, 0)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -890,6 +890,10 @@ func (vcd *TestVCD) Test_GetTaskList(check *C) {
 		check.Skip("Test_GetTaskList: Org name not given.")
 		return
 	}
+	// we need to have Tasks
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vApp wasn't properly created")
+	}
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -882,3 +882,19 @@ func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
 	}
 	vcd.testFinderGetGenericEntity(def, check)
 }
+
+// Tests VDC retrieval by name, by ID, and by a combination of name and ID
+func (vcd *TestVCD) Test_GetTaskList(check *C) {
+
+	if vcd.config.VCD.Org == "" {
+		check.Skip("Test_GetTaskList: Org name not given.")
+		return
+	}
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	taskList, err := org.GetTaskList()
+	check.Assert(err, IsNil)
+	check.Assert(len(taskList.Task), Not(Equals), 0)
+}

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -905,7 +905,7 @@ func (vcd *TestVCD) Test_GetTaskList(check *C) {
 	check.Assert(taskList.Task[0].ID, Not(Equals), "")
 	check.Assert(taskList.Task[0].Type, Not(Equals), "")
 	check.Assert(taskList.Task[0].Owner, NotNil)
-	check.Assert(taskList.Task[0].Owner.Name, Not(Equals), "")
+	check.Assert(taskList.Task[0].Owner.HREF, Not(Equals), "")
 	check.Assert(taskList.Task[0].Status, Not(Equals), "")
 	check.Assert(taskList.Task[0].Progress, FitsTypeOf, 0)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -901,4 +901,11 @@ func (vcd *TestVCD) Test_GetTaskList(check *C) {
 	taskList, err := org.GetTaskList()
 	check.Assert(err, IsNil)
 	check.Assert(len(taskList.Task), Not(Equals), 0)
+	check.Assert(taskList.Task[0], NotNil)
+	check.Assert(taskList.Task[0].ID, Not(Equals), "")
+	check.Assert(taskList.Task[0].ID, Not(Equals), "")
+	check.Assert(taskList.Task[0].Type, Not(Equals), "")
+	check.Assert(taskList.Task[0].Owner, Not(Equals), "")
+	check.Assert(taskList.Task[0].Status, Not(Equals), "")
+	check.Assert(taskList.Task[0].Progress, Not(Equals), "")
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1452,7 +1452,7 @@ func (vm *VM) UpdateVmSpecSection(vmSettingsToUpdate *types.VmSpecSection, descr
 // UpdateVmSpecSectionAsync updates VM Spec section and returns Task and error.
 func (vm *VM) UpdateVmSpecSectionAsync(vmSettingsToUpdate *types.VmSpecSection, description string) (Task, error) {
 	if vm.VM.HREF == "" {
-		return Task{}, fmt.Errorf("cannot update disks, VM HREF is unset")
+		return Task{}, fmt.Errorf("cannot update VM spec section, VM HREF is unset")
 	}
 
 	vmSpecSectionModified := true
@@ -1500,4 +1500,39 @@ func (client *Client) QueryVmList(filter types.VmQueryFilter) ([]*types.QueryRes
 		vmList = vmResult.Results.AdminVMRecord
 	}
 	return vmList, nil
+}
+
+// UpdateVmCapabilities updates VM Capabilities and returns refreshed VM or error.
+func (vm *VM) UpdateVmCapabilities(cpuHot, memoryHot bool) (*VM, error) {
+	task, err := vm.UpdateVmCapabilitiesAsync(cpuHot, memoryHot)
+	if err != nil {
+		return nil, err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, err
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+
+}
+
+// UpdateVmCapabilitiesAsync updates VM Capabilities and returns Task and error.
+func (vm *VM) UpdateVmCapabilitiesAsync(cpuHot, memoryHot bool) (Task, error) {
+	if vm.VM.HREF == "" {
+		return Task{}, fmt.Errorf("cannot update VM capabilities, VM HREF is unset")
+	}
+
+	return vm.client.ExecuteTaskRequest(vm.VM.HREF+"/vmCapabilities", http.MethodPut,
+		types.MimeVmCapabilities, "error updating VM capabilities section: %s", &types.VmCapabilities{
+			Xmlns:               types.XMLNamespaceVCloud,
+			CPUHotAddEnabled:    cpuHot,
+			MemoryHotAddEnabled: memoryHot,
+		})
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1502,9 +1502,9 @@ func (client *Client) QueryVmList(filter types.VmQueryFilter) ([]*types.QueryRes
 	return vmList, nil
 }
 
-// UpdateVmCapabilities updates VM Capabilities and returns refreshed VM or error.
-func (vm *VM) UpdateVmCapabilities(cpuHot, memoryHot bool) (*VM, error) {
-	task, err := vm.UpdateVmCapabilitiesAsync(cpuHot, memoryHot)
+// UpdateVmCpuAndMemoryHotAdd updates VM Capabilities and returns refreshed VM or error.
+func (vm *VM) UpdateVmCpuAndMemoryHotAdd(cpuAdd, memoryAdd bool) (*VM, error) {
+	task, err := vm.UpdateVmCpuAndMemoryHotAddAsync(cpuAdd, memoryAdd)
 	if err != nil {
 		return nil, err
 	}
@@ -1523,8 +1523,8 @@ func (vm *VM) UpdateVmCapabilities(cpuHot, memoryHot bool) (*VM, error) {
 
 }
 
-// UpdateVmCapabilitiesAsync updates VM Capabilities and returns Task and error.
-func (vm *VM) UpdateVmCapabilitiesAsync(cpuHot, memoryHot bool) (Task, error) {
+// UpdateVmCpuAndMemoryHotAddAsync updates VM Capabilities and returns Task and error.
+func (vm *VM) UpdateVmCpuAndMemoryHotAddAsync(cpuHot, memoryAdd bool) (Task, error) {
 	if vm.VM.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update VM capabilities, VM HREF is unset")
 	}
@@ -1533,6 +1533,6 @@ func (vm *VM) UpdateVmCapabilitiesAsync(cpuHot, memoryHot bool) (Task, error) {
 		types.MimeVmCapabilities, "error updating VM capabilities section: %s", &types.VmCapabilities{
 			Xmlns:               types.XMLNamespaceVCloud,
 			CPUHotAddEnabled:    cpuHot,
-			MemoryHotAddEnabled: memoryHot,
+			MemoryHotAddEnabled: memoryAdd,
 		})
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1536,3 +1536,20 @@ func (vm *VM) UpdateVmCapabilitiesAsync(cpuHot, memoryHot bool) (Task, error) {
 			MemoryHotAddEnabled: memoryHot,
 		})
 }
+
+func (vm *VM) GetMetrics() (types.CurrentUsage, error) {
+	if vm.VM.HREF == "" {
+		return types.CurrentUsage{}, fmt.Errorf("cannot get VM metrics, VM HREF is unset")
+	}
+
+	// Empty struct before a new unmarshal, otherwise we end up with duplicate
+	// elements in slices.
+	metrics := &types.CurrentUsage{}
+
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/metrics/current", http.MethodGet, "", "error refreshing vApp: %s", nil, metrics)
+	if err != nil {
+		return types.CurrentUsage{}, err
+	}
+	// The request was successful
+	return *metrics, nil
+}

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1536,20 +1536,3 @@ func (vm *VM) UpdateVmCapabilitiesAsync(cpuHot, memoryHot bool) (Task, error) {
 			MemoryHotAddEnabled: memoryHot,
 		})
 }
-
-func (vm *VM) GetMetrics() (types.CurrentUsage, error) {
-	if vm.VM.HREF == "" {
-		return types.CurrentUsage{}, fmt.Errorf("cannot get VM metrics, VM HREF is unset")
-	}
-
-	// Empty struct before a new unmarshal, otherwise we end up with duplicate
-	// elements in slices.
-	metrics := &types.CurrentUsage{}
-
-	_, err := vm.client.ExecuteRequest(vm.VM.HREF+"/metrics/current", http.MethodGet, "", "error refreshing vApp: %s", nil, metrics)
-	if err != nil {
-		return types.CurrentUsage{}, err
-	}
-	// The request was successful
-	return *metrics, nil
-}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1457,3 +1457,28 @@ func (vcd *TestVCD) Test_UpdateVmCapabilities(check *C) {
 	// delete Vapp early to avoid env capacity issue
 	deleteVapp(vcd, vmName)
 }
+
+// Test update of VM Capabilities
+func (vcd *TestVCD) Test_GetMetrics(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vmName := "Test_GetMetrics"
+	if vcd.skipVappTests {
+		check.Skip("Skipping test because vApp wasn't properly created")
+	}
+
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, vmName)
+	check.Assert(err, IsNil)
+
+	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
+	check.Assert(err, IsNil)
+
+	metrics, err := vm.GetMetrics()
+	check.Assert(err, IsNil)
+	check.Assert(metrics, NotNil)
+
+	//verify
+
+	// delete Vapp early to avoid env capacity issue
+	deleteVapp(vcd, vmName)
+}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1457,28 +1457,3 @@ func (vcd *TestVCD) Test_UpdateVmCapabilities(check *C) {
 	// delete Vapp early to avoid env capacity issue
 	deleteVapp(vcd, vmName)
 }
-
-// Test update of VM Capabilities
-func (vcd *TestVCD) Test_GetMetrics(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-
-	vmName := "Test_GetMetrics"
-	if vcd.skipVappTests {
-		check.Skip("Skipping test because vApp wasn't properly created")
-	}
-
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, vmName)
-	check.Assert(err, IsNil)
-
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
-	check.Assert(err, IsNil)
-
-	metrics, err := vm.GetMetrics()
-	check.Assert(err, IsNil)
-	check.Assert(metrics, NotNil)
-
-	//verify
-
-	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
-}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -962,7 +962,7 @@ func (vcd *TestVCD) createInternalDisk(check *C, vmName string, busNumber int) (
 	previousVdcFastProvisioningValue := updateVdcFastProvisioning(vcd, check, "disable")
 	AddToCleanupList(previousVdcFastProvisioningValue, "fastProvisioning", vcd.config.VCD.Org+"|"+vcd.config.VCD.Vdc, "createInternalDisk")
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
 	check.Assert(err, IsNil)
 
 	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
@@ -1353,7 +1353,7 @@ func (vcd *TestVCD) Test_UpdateVmSpecSection(check *C) {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
 	check.Assert(err, IsNil)
 
 	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
@@ -1424,15 +1424,15 @@ func (vcd *TestVCD) Test_QueryVmList(check *C) {
 }
 
 // Test update of VM Capabilities
-func (vcd *TestVCD) Test_UpdateVmCapabilities(check *C) {
+func (vcd *TestVCD) Test_UpdateVmCpuAndMemoryHotAdd(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
-	vmName := "Test_UpdateVmCapabilities"
+	vmName := "Test_UpdateVmCpuAndMemoryHotAdd"
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAngGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
 	check.Assert(err, IsNil)
 
 	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
@@ -1446,7 +1446,7 @@ func (vcd *TestVCD) Test_UpdateVmCapabilities(check *C) {
 	check.Assert(vm.VM.VMCapabilities.MemoryHotAddEnabled, Equals, false)
 	check.Assert(vm.VM.VMCapabilities.CPUHotAddEnabled, Equals, false)
 
-	updatedVm, err := vm.UpdateVmCapabilities(true, true)
+	updatedVm, err := vm.UpdateVmCpuAndMemoryHotAdd(true, true)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVm, NotNil)
 

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -115,6 +115,8 @@ const (
 	MimeOrgLdapSettings = "application/vnd.vmware.admin.organizationldapsettings+xml"
 	// Mime of vApp network
 	MimeVappNetwork = "application/vnd.vmware.vcloud.vAppNetwork+xml"
+	// Mime of VM capabilities
+	MimeVmCapabilities = "application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"
 )
 
 const (

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1065,17 +1065,18 @@ type UndeployVAppParams struct {
 	UndeployPowerAction string `xml:"UndeployPowerAction,omitempty"`
 }
 
-// VMCapabilities allows you to specify certain capabilities of this virtual machine.
+// VmCapabilities allows you to specify certain capabilities of this virtual machine.
 // Type: VmCapabilitiesType
 // Namespace: http://www.vmware.com/vcloud/v1.5
 // Description: Allows you to specify certain capabilities of this virtual machine.
 // Since: 5.1
-type VMCapabilities struct {
+type VmCapabilities struct {
+	Xmlns               string   `xml:"xmlns,attr"`
 	HREF                string   `xml:"href,attr,omitempty"`
 	Type                string   `xml:"type,attr,omitempty"`
+	MemoryHotAddEnabled bool     `xml:"MemoryHotAddEnabled,omitempty"`
 	CPUHotAddEnabled    bool     `xml:"CpuHotAddEnabled,omitempty"`
 	Link                LinkList `xml:"Link,omitempty"`
-	MemoryHotAddEnabled bool     `xml:"MemoryHotAddEnabled,omitempty"`
 }
 
 // VMs represents a list of virtual machines.
@@ -1412,7 +1413,7 @@ type VM struct {
 	// changes, domain join configuration, etc
 	GuestCustomizationSection *GuestCustomizationSection `xml:"GuestCustomizationSection,omitempty"`
 
-	VMCapabilities *VMCapabilities `xml:"VmCapabilities,omitempty"` // Allows you to specify certain capabilities of this virtual machine.
+	VMCapabilities *VmCapabilities `xml:"VmCapabilities,omitempty"` // Allows you to specify certain capabilities of this virtual machine.
 	StorageProfile *Reference      `xml:"StorageProfile,omitempty"` // A reference to a storage profile to be used for this object. The specified storage profile must exist in the organization vDC that contains the object. If not specified, the default storage profile for the vDC is used.
 	ProductSection *ProductSection `xml:"ProductSection,omitempty"`
 	Media          *Reference      `xml:"Media,omitempty"` // Reference to the media object to insert in a new VM.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2390,6 +2390,13 @@ type Extension struct {
 	Link LinkList `xml:"Link,omitempty"` // A reference to an entity or operation associated with this object.
 }
 
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// Retrieve a list of tasks
+type TasksList struct {
+	XMLName xml.Name `xml:"TasksList"`
+	Task    []*Task  `xml:"Task,omitempty"`
+}
+
 type ExternalNetworkReferences struct {
 	ExternalNetworkReference []*ExternalNetworkReference `xml:"ExternalNetworkReference,omitempty"` // A reference to an entity or operation associated with this object.
 }

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -37,14 +37,3 @@ type CreateItem struct {
 	VmSpecSection             *VmSpecSection             `xml:"VmSpecSection,omitempty"`
 	BootImage                 *Media                     `xml:"Media,omitempty"` // boot image as vApp template. Href, Id and name needed.
 }
-
-type CurrentUsage struct {
-	Link    *Link     `xml:"Link,omitempty"`
-	Metrics []*Metric `xml:"Metric,omitempty"`
-}
-
-type Metric struct {
-	Name  string `xml:"name,attr,omitempty"`
-	Unit  string `xml:"unit,attr,omitempty"`
-	Value string `xml:"value,attr,omitempty"`
-}

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -37,3 +37,14 @@ type CreateItem struct {
 	VmSpecSection             *VmSpecSection             `xml:"VmSpecSection,omitempty"`
 	BootImage                 *Media                     `xml:"Media,omitempty"` // boot image as vApp template. Href, Id and name needed.
 }
+
+type CurrentUsage struct {
+	Link    *Link     `xml:"Link,omitempty"`
+	Metrics []*Metric `xml:"Metric,omitempty"`
+}
+
+type Metric struct {
+	Name  string `xml:"name,attr,omitempty"`
+	Unit  string `xml:"unit,attr,omitempty"`
+	Value string `xml:"value,attr,omitempty"`
+}


### PR DESCRIPTION
Ref: https://github.com/terraform-providers/terraform-provider-vcd/issues/452

Implemented needed functionality to handle toggling of hot cpu and memory property

Added:
* `vm.UpdateVmCapabilities` and `vm.UpdateVmCapabilitiesAsyc`
* `org.GetTaskList`