### PR TITLE
Introduce low level OpenAPI client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
 * Introduce low level OpenAPI client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
 `OpenApiPostItem`, `OpenApiGetItem`, `OpenApiPutItem`, `OpenApiPutItemSync`, `OpenApiPutItemAsync`,
-`OpenApiDeleteItem`, `OpenApiIsSupported`, `BuildOpenApiEndpoint`
+`OpenApiDeleteItem`, `OpenApiIsSupported`, `OpenApiBuildEndpoints`
 [#325](https://github.com/vmware/go-vcloud-director/pull/325)
 
 ## 2.8.0 (June 30, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
 [#326](https://github.com/vmware/go-vcloud-director/pull/326)
 * Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
-* Introduce low level OpenApi client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
+* Introduce low level OpenAPI client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
 `OpenApiPostItem`, `OpenApiGetItem`, `OpenApiPutItem`, `OpenApiPutItemSync`, `OpenApiPutItemAsync`,
 `OpenApiDeleteItem`, `OpenApiIsSupported`, `OpenApiBuildEndpoints`
 [#325](https://github.com/vmware/go-vcloud-director/pull/325)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 * Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
 [#326](https://github.com/vmware/go-vcloud-director/pull/326)
 * Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
-* Introduce low level OpenAPI client functions `OpenApiGetAllItems`, `OpenApiPostItem`, `OpenApiGetItem`,
- `OpenApiPutItem`, `OpenApiDeleteItem`, `OpenApiIsSupported`, `BuildOpenApiEndpoint`
- [#325](https://github.com/vmware/go-vcloud-director/pull/325)
+* Introduce low level OpenAPI client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
+`OpenApiPostItem`, `OpenApiGetItem`, `OpenApiPutItem`, `OpenApiPutItemSync`, `OpenApiPutItemAsync`,
+`OpenApiDeleteItem`, `OpenApiIsSupported`, `BuildOpenApiEndpoint`
+[#325](https://github.com/vmware/go-vcloud-director/pull/325)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Improved testing tags isolation [#320](https://github.com/vmware/go-vcloud-director/pull/320)
 * Added command `make tagverify` to check tags isolation tests [#320](https://github.com/vmware/go-vcloud-director/pull/320)
+* Introduce low level OpenAPI client functions `OpenApiGetAllItems`, `OpenApiPostItem`, `OpenApiGetItem`,
+ `OpenApiPutItem`, `OpenApiDeleteItem`, `OpenApiIsSupported`, `BuildOpenApiEndpoint`
+ [#325](https://github.com/vmware/go-vcloud-director/pull/325)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
 [#326](https://github.com/vmware/go-vcloud-director/pull/326)
 * Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
-* Introduce low level OpenAPI client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
+* Introduce low level OpenApi client functions `OpenApiGetAllItems`,`OpenApiPostItemSync`,`OpenApiPostItemAsync`,
 `OpenApiPostItem`, `OpenApiGetItem`, `OpenApiPutItem`, `OpenApiPutItemSync`, `OpenApiPutItemAsync`,
 `OpenApiDeleteItem`, `OpenApiIsSupported`, `OpenApiBuildEndpoints`
 [#325](https://github.com/vmware/go-vcloud-director/pull/325)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.0
+	github.com/peterhellberg/link v1.1.0
 	github.com/stretchr/testify v1.5.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu5kc=
+github.com/peterhellberg/link v1.1.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -92,7 +92,7 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	}
 
 	task := NewTask(adminOrg.client)
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 	return task.WaitTaskCompletion()
@@ -239,7 +239,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 			return fmt.Errorf("error deleting vdc: %s", err)
 		}
 		task := NewTask(adminOrg.client)
-		if err = decodeBody(resp, task.Task); err != nil {
+		if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 			return fmt.Errorf("error decoding task response: %s", err)
 		}
 		if task.Task.Status == "error" {

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -7,6 +7,7 @@ package govcd
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -238,9 +239,9 @@ func (cli *Client) NewRequestWithApiVersion(params map[string]string, method str
 
 // ParseErr takes an error XML resp, error interface for unmarshaling and returns a single string for
 // use in error messages.
-func ParseErr(resp *http.Response, errType error) error {
+func ParseErr(bodyType types.BodyType, resp *http.Response, errType error) error {
 	// if there was an error decoding the body, just return that
-	if err := decodeBody(resp, errType); err != nil {
+	if err := decodeBody(types.BodyTypeXML, resp, errType); err != nil {
 		util.Logger.Printf("[ParseErr]: unhandled response <--\n%+v\n-->\n", resp)
 		return fmt.Errorf("[ParseErr]: error parsing error body for non-200 request: %s (%+v)", err, resp)
 	}
@@ -248,9 +249,8 @@ func ParseErr(resp *http.Response, errType error) error {
 	return errType
 }
 
-// decodeBody is used to XML decode a response body
-func decodeBody(resp *http.Response, out interface{}) error {
-
+// decodeBody is used to decode a response body of types.BodyType
+func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) error {
 	body, err := ioutil.ReadAll(resp.Body)
 
 	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, fmt.Sprintf("%s", body))
@@ -260,11 +260,20 @@ func decodeBody(resp *http.Response, out interface{}) error {
 
 	debugShowResponse(resp, body)
 
-	// only attempty to unmarshal if body is not empty
+	// only attempt to unmarshal if body is not empty
 	if len(body) > 0 {
-		// Unmarshal the XML.
-		if err = xml.Unmarshal(body, &out); err != nil {
-			return err
+		switch bodyType {
+		case types.BodyTypeXML:
+			if err = xml.Unmarshal(body, &out); err != nil {
+				return err
+			}
+		case types.BodyTypeJSON:
+			if err = json.Unmarshal(body, &out); err != nil {
+				return err
+			}
+
+		default:
+			panic(fmt.Sprintf("unknown body type: %d", bodyType))
 		}
 	}
 
@@ -276,12 +285,12 @@ func decodeBody(resp *http.Response, out interface{}) error {
 // parses the resultant XML error and returns a descriptive error, if the
 // status code is not handled it returns a generic error with the status code.
 func checkResp(resp *http.Response, err error) (*http.Response, error) {
-	return checkRespWithErrType(resp, err, &types.Error{})
+	return checkRespWithErrType(types.BodyTypeXML, resp, err, &types.Error{})
 }
 
 // checkRespWithErrType allows to specify custom error errType for checkResp unmarshaling
 // the error.
-func checkRespWithErrType(resp *http.Response, err, errType error) (*http.Response, error) {
+func checkRespWithErrType(bodyType types.BodyType, resp *http.Response, err, errType error) (*http.Response, error) {
 	if err != nil {
 		return resp, err
 	}
@@ -322,7 +331,7 @@ func checkRespWithErrType(resp *http.Response, err, errType error) (*http.Respon
 		http.StatusInternalServerError,         // 500
 		http.StatusServiceUnavailable,          // 503
 		http.StatusGatewayTimeout:              // 504
-		return nil, ParseErr(resp, errType)
+		return nil, ParseErr(types.BodyTypeXML, resp, errType)
 	// Unhandled response.
 	default:
 		return nil, fmt.Errorf("unhandled API response, please report this issue, status code: %s", resp.Status)
@@ -373,7 +382,7 @@ func (client *Client) executeTaskRequest(pathURL, requestType, contentType, erro
 
 	task := NewTask(client)
 
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
 	}
 
@@ -489,7 +498,7 @@ func (client *Client) executeRequest(pathURL, requestType, contentType, errorMes
 		return resp, fmt.Errorf(errorMessage, err)
 	}
 
-	if err = decodeBody(resp, out); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, out); err != nil {
 		return resp, fmt.Errorf("error decoding response: %s", err)
 	}
 
@@ -575,7 +584,7 @@ func executeRequestCustomErr(pathURL string, params map[string]string, requestTy
 		return resp, err
 	}
 
-	return checkRespWithErrType(resp, err, errType)
+	return checkRespWithErrType(types.BodyTypeXML, resp, err, errType)
 }
 
 func isMessageWithPlaceHolder(message string) bool {

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -341,7 +341,7 @@ func checkRespWithErrType(bodyType types.BodyType, resp *http.Response, err, err
 		http.StatusInternalServerError,         // 500
 		http.StatusServiceUnavailable,          // 503
 		http.StatusGatewayTimeout:              // 504
-		return nil, ParseErr(types.BodyTypeXML, resp, errType)
+		return nil, ParseErr(bodyType, resp, errType)
 	// Unhandled response.
 	default:
 		return nil, fmt.Errorf("unhandled API response, please report this issue, status code: %s", resp.Status)

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -288,6 +288,7 @@ func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) e
 	return nil
 }
 
+// indentJsonBody indents raw JSON body for easier readability
 func indentJsonBody(body []byte) ([]byte, error) {
 	var prettyJSON bytes.Buffer
 	err := json.Indent(&prettyJSON, body, "", "  ")

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -255,12 +255,10 @@ func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) e
 
 	// In case of JSON, body does not have indents in response therefore it must be indented
 	if bodyType == types.BodyTypeJSON {
-		var prettyJSON bytes.Buffer
-		err := json.Indent(&prettyJSON, body, "", "  ")
+		body, err = indentJsonBody(body)
 		if err != nil {
-			return fmt.Errorf("error indenting response JSON: %s", err)
+			return err
 		}
-		body = prettyJSON.Bytes()
 	}
 
 	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, fmt.Sprintf("%s", body))
@@ -288,6 +286,16 @@ func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) e
 	}
 
 	return nil
+}
+
+func indentJsonBody(body []byte) ([]byte, error) {
+	var prettyJSON bytes.Buffer
+	err := json.Indent(&prettyJSON, body, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error indenting response JSON: %s", err)
+	}
+	body = prettyJSON.Bytes()
+	return body, nil
 }
 
 // checkResp wraps http.Client.Do() and verifies the request, if status code

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,4 +1,4 @@
-// +build api functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user search nsxv auth affinity ALL
+// +build api openapi functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user search nsxv auth affinity ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/api_vcd_test_unit.go
+++ b/govcd/api_vcd_test_unit.go
@@ -1,5 +1,9 @@
 // +build unit ALL
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -461,7 +461,7 @@ func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName st
 	defer response.Body.Close()
 
 	catalogItemParsed := &types.CatalogItem{}
-	if err = decodeBody(response, catalogItemParsed); err != nil {
+	if err = decodeBody(types.BodyTypeXML, response, catalogItemParsed); err != nil {
 		return nil, err
 	}
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -142,7 +142,7 @@ func (egw *EdgeGateway) AddDhcpPool(network *types.OrgVDCNetwork, dhcppool []int
 
 	task := NewTask(egw.client)
 
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
 	}
 
@@ -709,7 +709,7 @@ func (egw *EdgeGateway) CreateFirewallRules(defaultAction string, rules []*types
 
 	task := NewTask(egw.client)
 
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
 	}
 
@@ -997,7 +997,7 @@ func (egw *EdgeGateway) DeleteAsync(force bool, recursive bool) (Task, error) {
 		return Task{}, fmt.Errorf("error deleting edge gateway: %s", err)
 	}
 	task := NewTask(egw.client)
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding task response: %s", err)
 	}
 	return *task, err

--- a/govcd/filter_condition.go
+++ b/govcd/filter_condition.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"regexp"

--- a/govcd/filter_engine.go
+++ b/govcd/filter_engine.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"os"

--- a/govcd/filter_engine_unit_test.go
+++ b/govcd/filter_engine_unit_test.go
@@ -1,5 +1,9 @@
 // +build unit
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/filter_helpers.go
+++ b/govcd/filter_helpers.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"os"

--- a/govcd/filter_interface.go
+++ b/govcd/filter_interface.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 

--- a/govcd/filter_util.go
+++ b/govcd/filter_util.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"regexp"

--- a/govcd/filter_util_unit_test.go
+++ b/govcd/filter_util_unit_test.go
@@ -1,5 +1,9 @@
 // +build unit ALL
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -174,7 +174,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 	defer response.Body.Close()
 
 	mediaForUpload := &types.Media{}
-	if err = decodeBody(response, mediaForUpload); err != nil {
+	if err = decodeBody(types.BodyTypeXML, response, mediaForUpload); err != nil {
 		return nil, err
 	}
 

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/peterhellberg/link"
@@ -74,7 +73,7 @@ func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, que
 
 	// Perform API call to initial endpoint. The function call recursively follows pages using Link headers "nextPage"
 	// until it crawls all results
-	responses, err := client.openApiGetAllPages(apiVersion, nil, urlRef, queryParams, outType, nil)
+	responses, err := client.openApiGetAllPages(apiVersion, urlRef, queryParams, outType, nil)
 	if err != nil {
 		return fmt.Errorf("error getting all pages for endpoint %s: %s", urlRef.String(), err)
 	}
@@ -480,19 +479,9 @@ func (client *Client) openApiPerformPostPut(httpMethod string, apiVersion string
 // works by at first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is
 // no intermediate unmarshalling to exact `outType` for every page it can unmarshal into direct `outType` supplied.
 // outType must be a slice of object (e.g. []*types.OpenApiRole) because accumulated responses are in JSON list
-func (client *Client) openApiGetAllPages(apiVersion string, pageSize *int, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
+func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
 	if responses == nil {
 		responses = []json.RawMessage{}
-	}
-
-	// Reuse existing queryParams struct to fill in pages or create a new one if nil was passed
-	queryParameters := url.Values{}
-	if queryParams != nil {
-		queryParameters = queryParams
-	}
-
-	if pageSize != nil {
-		queryParameters.Set("pageSize", strconv.Itoa(*pageSize))
 	}
 
 	// Perform request

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"bytes"
 	"encoding/json"

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -166,7 +166,6 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 	}
 
 	req := client.newOpenApiRequest(apiVersion, params, http.MethodPost, urlRef, body)
-
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return err
@@ -237,7 +236,6 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 	}
 
 	req := client.newOpenApiRequest(apiVersion, params, http.MethodPut, urlRef, body)
-
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return err
@@ -269,7 +267,7 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 		}
 
 		// Synchronous task - new item body is returned in response of HTTP POST request
-	case http.StatusCreated:
+	case http.StatusOK:
 		if err = decodeBody(types.BodyTypeJSON, resp, outType); err != nil {
 			return fmt.Errorf("error decoding JSON response after POST: %s", err)
 		}
@@ -331,7 +329,7 @@ func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, para
 // openApiGetAllPages is a recursive function that helps to accumulate responses from multiple pages for GET query. It
 // works by at first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is
 // no intermediate unmarshalling to exact `outType` for every page it can unmarshal into direct `outType` supplied.
-// outType must be a slice of object (e.g. []*types.CloudAPIEdgeGateway) because accumulated responses are in JSON list
+// outType must be a slice of object (e.g. []*types.OpenApiRole) because accumulated responses are in JSON list
 func (client *Client) openApiGetAllPages(apiVersion string, pageSize *int, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
 	if responses == nil {
 		responses = []json.RawMessage{}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -419,8 +419,6 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	if client.VCDAuthHeader != "" && client.VCDToken != "" {
 		// Add the authorization header
 		req.Header.Add(client.VCDAuthHeader, client.VCDToken)
-	}
-	if client.VCDAuthHeader != "" && client.VCDToken != "" {
 		// Add the Accept header for VCD
 		acceptMime := types.JSONMime + ";version=" + apiVersion
 		req.Header.Add("Accept", acceptMime)

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -18,11 +18,11 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// This file contains generalised low level methods to interact with VCD OpenApi REST endpoints as documented in
-// https://{VCD_HOST}/docs. In addition to this there are OpenApi browser endpoints for tenant and provider
+// This file contains generalised low level methods to interact with VCD OpenAPI REST endpoints as documented in
+// https://{VCD_HOST}/docs. In addition to this there are OpenAPI browser endpoints for tenant and provider
 // respectively https://{VCD_HOST}/api-explorer/tenant/tenant-name and https://{VCD_HOST}/api-explorer/provider .
-// OpenApi has functions supporting below REST methods:
-// GET /items (gets a slice of types like `[]types.OpenApiEdgeGateway` or even `[]json.RawMessage` to process JSON as text.
+// OpenAPI has functions supporting below REST methods:
+// GET /items (gets a slice of types like `[]types.OpenAPIEdgeGateway` or even `[]json.RawMessage` to process JSON as text.
 // POST /items - creates an item
 // PUT /items/URN - updates an item with specified URN
 // GET /items/URN - retrieves an item with specified URN
@@ -32,22 +32,22 @@ import (
 // Not all API fields are supported for FIQL filtering and sometimes they return odd errors when filtering is
 // unsupported. No exact documentation exists so far.
 //
-// OpenApi versioning.
-// OpenApi was introduced in VCD 9.5 (with API version 31.0). Endpoints are being added with each VCD iteration.
+// OpenAPI versioning.
+// OpenAPI was introduced in VCD 9.5 (with API version 31.0). Endpoints are being added with each VCD iteration.
 // Internally hosted documentation (https://HOSTNAME/docs/) can be used to check which endpoints where introduced in
 // which VCD API version.
-// Additionally each OpenApi endpoint has a semantic version in its path (e.g.
+// Additionally each OpenAPI endpoint has a semantic version in its path (e.g.
 // https://HOSTNAME/cloudapi/1.0.0/auditTrail). This versioned endpoint should ensure compatibility as VCD evolves.
 
-// OpenApiIsSupported allows to check whether VCD supports OpenApi. Each OpenApi endpoint however is introduced with
-// different VCD API versions so this is just a general check if OpenApi is supported at all. Particular endpoint
+// OpenApiIsSupported allows to check whether VCD supports OpenAPI. Each OpenAPI endpoint however is introduced with
+// different VCD API versions so this is just a general check if OpenAPI is supported at all. Particular endpoint
 // introduction version can be checked in self hosted docs (https://HOSTNAME/docs/)
 func (client *Client) OpenApiIsSupported() bool {
-	// OpenApi was introduced in VCD 9.5+ (API version 31.0+)
+	// OpenAPI was introduced in VCD 9.5+ (API version 31.0+)
 	return client.APIVCDMaxVersionIs(">= 31")
 }
 
-// OpenApiBuildEndpoint helps to construct OpenApi endpoint by using already configured VCD HREF while requiring only
+// OpenApiBuildEndpoint helps to construct OpenAPI endpoint by using already configured VCD HREF while requiring only
 // the last bit for endpoint. This is a variadic function and multiple pieces can be supplied for convenience. Leading
 // '/' is added automatically.
 // Sample URL construct: https://HOST/cloudapi/endpoint
@@ -55,7 +55,7 @@ func (client *Client) OpenApiBuildEndpoint(endpoint ...string) (*url.URL, error)
 	endpointString := client.VCDHREF.Scheme + "://" + client.VCDHREF.Host + "/cloudapi/" + strings.Join(endpoint, "")
 	urlRef, err := url.ParseRequestURI(endpointString)
 	if err != nil {
-		return nil, fmt.Errorf("error formatting OpenApi endpoint: %s", err)
+		return nil, fmt.Errorf("error formatting OpenAPI endpoint: %s", err)
 	}
 	return urlRef, nil
 }
@@ -63,13 +63,13 @@ func (client *Client) OpenApiBuildEndpoint(endpoint ...string) (*url.URL, error)
 // OpenApiGetAllItems retrieves and accumulates all pages then parsing them to a single 'outType' object. It works by at
 // first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is no
 // intermediate unmarshalling to exact `outType` for every page it unmarshals into response struct in one go. 'outType'
-// must be a slice of object (e.g. []*types.OpenApiEdgeGateway) because this response contains slice of structs.
+// must be a slice of object (e.g. []*types.OpenAPIEdgeGateway) because this response contains slice of structs.
 func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}) error {
 	util.Logger.Printf("[TRACE] Getting all items from endpoint %s for parsing into %s type\n",
 		urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	// Perform API call to initial endpoint. The function call recursively follows pages using Link headers "nextPage"
@@ -98,7 +98,7 @@ func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, que
 	return nil
 }
 
-// OpenApiGetItem is a low level OpenApi client function to perform GET request for any item.
+// OpenApiGetItem is a low level OpenAPI client function to perform GET request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It responds with HTTP 403: Forbidden - If the user is not authorized or the entity does not exist. When HTTP 403 is
 // returned this function returns "ErrorEntityNotFound: API_ERROR" so that one can use ContainsNotFound(err) to
@@ -108,7 +108,7 @@ func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params 
 		urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	req := client.newOpenApiRequest(apiVersion, params, http.MethodGet, urlRef, nil)
@@ -145,7 +145,7 @@ func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params 
 	return nil
 }
 
-// OpenApiPostItemSync is a low level OpenApi client function to perform POST request for items that support synchronous
+// OpenApiPostItemSync is a low level OpenAPI client function to perform POST request for items that support synchronous
 // requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways') that supports synchronous requests. It
 // will return an error when endpoint does not support synchronous requests (HTTP response status code is not 201).
 // Response will be unmarshalled into outType.
@@ -157,7 +157,7 @@ func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, pa
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -182,7 +182,7 @@ func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, pa
 	return nil
 }
 
-// OpenApiPostItemAsync is a low level OpenApi client function to perform POST request for items that support
+// OpenApiPostItemAsync is a low level OpenAPI client function to perform POST request for items that support
 // asynchronous requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways') that supports asynchronous
 // requests. It will return an error if item does not support asynchronous request (does not respond with HTTP 202).
 //
@@ -193,7 +193,7 @@ func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, p
 		reflect.TypeOf(payload), urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return Task{}, fmt.Errorf("OpenApi is not supported on this VCD version")
+		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -221,7 +221,7 @@ func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, p
 	return *task, nil
 }
 
-// OpenApiPostItem is a low level OpenApi client function to perform POST request for item supporting synchronous or
+// OpenApiPostItem is a low level OpenAPI client function to perform POST request for item supporting synchronous or
 // asynchronous requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways'). When a task is
 // synchronous - it will track task until it is finished and pick reference to marshal outType.
 func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
@@ -229,7 +229,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -253,7 +253,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 
 		// Here we have to find the resource once more to return it populated.
 		// Task Owner ID is the ID of created object. ID must be used (although HREF exists in task) because HREF points to
-		// old XML API and here we need to pull data from OpenApi.
+		// old XML API and here we need to pull data from OpenAPI.
 
 		newObjectUrl, _ := url.ParseRequestURI(urlRef.String() + "/" + task.Task.Owner.ID)
 		err = client.OpenApiGetItem(apiVersion, newObjectUrl, nil, outType)
@@ -277,7 +277,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 	return nil
 }
 
-// OpenApiPutItemSync is a low level OpenApi client function to perform PUT request for items that support synchronous
+// OpenApiPutItemSync is a low level OpenAPI client function to perform PUT request for items that support synchronous
 // requests. The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}') and support synchronous
 // requests. It will return an error when endpoint does not support synchronous requests (HTTP response status code is not 201).
 // Response will be unmarshalled into outType.
@@ -289,7 +289,7 @@ func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, par
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
@@ -314,7 +314,7 @@ func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, par
 	return nil
 }
 
-// OpenApiPutItemAsync is a low level OpenApi client function to perform PUT request for items that support asynchronous
+// OpenApiPutItemAsync is a low level OpenAPI client function to perform PUT request for items that support asynchronous
 // requests. The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}') that supports asynchronous
 // requests. It will return an error if item does not support asynchronous request (does not respond with HTTP 202).
 //
@@ -325,7 +325,7 @@ func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, pa
 		reflect.TypeOf(payload), urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return Task{}, fmt.Errorf("OpenApi is not supported on this VCD version")
+		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
 	if err != nil {
@@ -352,7 +352,7 @@ func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, pa
 	return *task, nil
 }
 
-// OpenApiPutItem is a low level OpenApi client function to perform PUT request for any item.
+// OpenApiPutItem is a low level OpenAPI client function to perform PUT request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
 func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
@@ -360,7 +360,7 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
 
@@ -404,14 +404,14 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 	return nil
 }
 
-// OpenApiDeleteItem is a low level OpenApi client function to perform DELETE request for any item.
+// OpenApiDeleteItem is a low level OpenAPI client function to perform DELETE request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
 func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, params url.Values) error {
 	util.Logger.Printf("[TRACE] Deleting item at endpoint %s", urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenApi is not supported on this VCD version")
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	// Perform request
@@ -433,7 +433,7 @@ func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, para
 		return fmt.Errorf("error closing response body: %s", err)
 	}
 
-	// OpenApi may work synchronously or asynchronously. When working asynchronously - it will return HTTP 202 and
+	// OpenAPI may work synchronously or asynchronously. When working asynchronously - it will return HTTP 202 and
 	// `Location` header will contain reference to task so that it can be tracked. In DELETE case we do not care about any
 	// ID so if DELETE operation is synchronous (returns HTTP 201) - the request has already succeeded.
 	if resp.StatusCode == http.StatusAccepted {
@@ -546,7 +546,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, pageSize *int, urlRe
 	return responses, nil
 }
 
-// newOpenApiRequest is a low level function used in upstream OpenApi functions which handles logging and
+// newOpenApiRequest is a low level function used in upstream OpenAPI functions which handles logging and
 // authentication for each API request
 func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, method string, reqUrl *url.URL, body io.Reader) *http.Request {
 

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -1,0 +1,474 @@
+package govcd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/peterhellberg/link"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
+)
+
+// This file contains generalised low level methods to interact with VCD OpenAPI REST endpoints as documented in
+// https://{VCD_HOST}/api-explorer/tenant/tenant-name and https://{VCD_HOST}/api-explorer/provider documentation. It has
+// functions supporting below methods:
+// GET /items (gets a slice of types like `[]types.OpenAPIEdgeGateway` or even `[]json.RawMessage` to process JSON as text.
+// POST /items - creates an item
+// GET /items/URN - retrieves an item with specified URN
+// PUT /items/URN - updates an item with specified URN
+// DELETE /items/URN - deletes an item with specified URN
+//
+// GET endpoints support FIQL for filtering in field `filter`. (FIQL IETF doc - https://tools.ietf.org/html/draft-nottingham-atompub-fiql-00)
+// Not all API fields are supported for FIQL filtering and sometimes they return odd errors when filtering is unsupported.
+//
+// OpenAPI versioning.
+// Versions in path (e.g. 1.0.0) should guarantee behavior while header versions shouldn't matter in long term.
+
+// OpenApiIsSupported allows to check whether VCD supports OpenAPI
+func (client *Client) OpenApiIsSupported() bool {
+	return client.APIVCDMaxVersionIs(">= 33")
+}
+
+// BuildOpenApiEndpoint helps to construct OpenAPI endpoint by using already configured VCD HREF while requiring only
+// the last bit for endpoint.
+// Sample URL construct: https://HOST/cloudapi/endpoint
+func (client *Client) BuildOpenApiEndpoint(endpoint ...string) (*url.URL, error) {
+	endpointString := client.VCDHREF.Scheme + "://" + client.VCDHREF.Host + "/cloudapi/" + strings.Join(endpoint, "")
+	urlRef, err := url.ParseRequestURI(endpointString)
+	if err != nil {
+		return nil, fmt.Errorf("error formatting OpenAPI endpoint: %s", err)
+	}
+	return urlRef, nil
+}
+
+// OpenApiGetAllItems retrieves and accumulates all pages then parsing them to a single object. It works by at first
+// crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is no intermediate
+// unmarshalling to exact `outType` for every page it can actually unmarshal into response struct in one go. outType
+// must be a slice of object (e.g. []*types.OpenAPIEdgeGateway) because this response contains slice of structs
+func (client *Client) OpenApiGetAllItems(urlRef *url.URL, queryParams url.Values, outType interface{}) error {
+	util.Logger.Printf("[TRACE] Getting all items from endpoint %s for parsing into %s type\n",
+		urlRef.String(), reflect.TypeOf(outType))
+
+	if !client.OpenApiIsSupported() {
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+	}
+
+	// Perform API call to initial endpoint. The function call recursively follows pages using Link headers "nextPage"
+	// until it crawls all results
+	responses, err := client.openApiGetAllPages(nil, urlRef, queryParams, outType, nil)
+	if err != nil {
+		return fmt.Errorf("error getting all pages for endpoint %s: %s", urlRef.String(), err)
+	}
+
+	// Create a slice of raw JSON messages in text so that they can be unmarshalled to specified `outType` after multiple
+	// calls are executed
+	var rawJsonBodies []string
+	for _, singleObject := range responses {
+		rawJsonBodies = append(rawJsonBodies, string(singleObject))
+	}
+
+	// rawJsonBodies contains a slice of all response objects and they must be formatted as a JSON slice (wrapped
+	// into `[]`, separated with semicolons) so that unmarshalling to specified `outType` works in one go
+	allResponses := `[` + strings.Join(rawJsonBodies, ",") + `]`
+
+	// Unmarshal all accumulated responses into `outType`
+	if err = json.Unmarshal([]byte(allResponses), &outType); err != nil {
+		return fmt.Errorf("error decoding values into type: %s", err)
+	}
+
+	return nil
+}
+
+// OpenApiPostItem is a low level OpenAPI client function to perform any task.
+// The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways')
+func (client *Client) OpenApiPostItem(urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+	util.Logger.Printf("[TRACE] Posting %s item to endpoint %s with expected response of type %s",
+		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
+
+	if !client.OpenApiIsSupported() {
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+	}
+
+	// Marshal payload if we have one
+	var body *bytes.Buffer
+	if payload != nil {
+		marshaledJson, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error marshalling JSON data for POST request %s", err)
+		}
+		body = bytes.NewBuffer(marshaledJson)
+	}
+
+	req := client.newOpenApiRequest(params, http.MethodPost, urlRef, body, "34.0")
+
+	resp, err := client.Http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// resp is ignored below because it is the same the one above
+	_, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.OpenApiError{})
+	if err != nil {
+		return fmt.Errorf("error in HTTP POST request: %s", err)
+	}
+
+	// Handle two cases of API behaviour - synchronous (response status code is 201) and asynchronous (response status
+	// code 202)
+	switch resp.StatusCode {
+	// Asynchronous case - must track task and get item HREF from there
+	case http.StatusAccepted:
+		taskUrl := resp.Header.Get("Location")
+		task := NewTask(client)
+		task.Task.HREF = taskUrl
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
+		}
+
+		// Here we have to find the resource once more to return it populated.
+		// Task Owner ID is the ID of created object. ID must be used (although HREF exists in task) because HREF points to
+		// old XML API and here we need to pull data from CloudAPI.
+
+		newObjectUrl, _ := url.ParseRequestURI(urlRef.String() + "/" + task.Task.Owner.ID)
+		err = client.OpenApiGetItem(newObjectUrl, nil, outType)
+		if err != nil {
+			return fmt.Errorf("error retrieving item after creation: %s", err)
+		}
+
+		// Synchronous task - new item body is returned in response of HTTP POST request
+	case http.StatusCreated:
+		if err = decodeBody(types.BodyTypeJSON, resp, outType); err != nil {
+			return fmt.Errorf("error decoding JSON response after POST: %s", err)
+		}
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("error closing response body: %s", err)
+	}
+
+	return nil
+}
+
+// OpenApiGetItem
+// Responds with HTTP 403: Forbidden - If the user is not authorized or the entity does not exist. When HTTP 403 is
+// returned this function returns "ErrorEntityNotFound: API_ERROR" so that one can use ContainsNotFound(err) to validate
+// error
+func (client *Client) OpenApiGetItem(urlRef *url.URL, params url.Values, outType interface{}) error {
+	util.Logger.Printf("[TRACE] Getting item from endpoint %s with expected response of type %s", urlRef.String(), reflect.TypeOf(outType))
+
+	if !client.OpenApiIsSupported() {
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+	}
+
+	req := client.newOpenApiRequest(params, http.MethodGet, urlRef, nil, "34.0")
+	resp, err := client.Http.Do(req)
+	if err != nil {
+		return fmt.Errorf("error performing GET request to %s: %s", urlRef.String(), err)
+	}
+
+	// Bypassing the regular path using function checkRespWithErrType and returning parsed error directly
+	// HTTP 403: Forbidden - is returned if the user is not authorized or the entity does not exist.
+	if resp.StatusCode == http.StatusForbidden {
+		err := ParseErr(types.BodyTypeJSON, resp, &types.OpenApiError{})
+		resp.Body.Close()
+		return fmt.Errorf("%s: %s", ErrorEntityNotFound, err)
+	}
+
+	// resp is ignored below because it is the same as above
+	_, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.OpenApiError{})
+
+	// Any other error occured
+	if err != nil {
+		return fmt.Errorf("error in HTTP GET request: %s", err)
+	}
+
+	if err = decodeBody(types.BodyTypeJSON, resp, outType); err != nil {
+		return fmt.Errorf("error decoding JSON response after GET: %s", err)
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("error closing response body: %s", err)
+	}
+
+	return nil
+}
+
+// OpenApiPutItem handles the PUT method for CloudAPI and tracks the task before returning if the response is HTTP 202
+//
+func (client *Client) OpenApiPutItem(urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+	util.Logger.Printf("[TRACE] Performing HTTP PUT request for item of type %s at endpoint %s with expected response of type %s",
+		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
+
+	if !client.OpenApiIsSupported() {
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+	}
+
+	var body *bytes.Buffer
+	if payload != nil {
+		marshaledJson, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error marshalling JSON data for PUT request %s", err)
+		}
+		body = bytes.NewBuffer(marshaledJson)
+	}
+
+	req := client.newOpenApiRequest(params, http.MethodPut, urlRef, body, "34.0")
+
+	resp, err := client.Http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// resp is ignored below because it is the same as above
+	_, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.OpenApiError{})
+	if err != nil {
+		return fmt.Errorf("error in HTTP PUT request: %s", err)
+	}
+
+	// Handle two cases of API behaviour - synchronous (response status code is 201) and asynchronous (response status
+	// code 202)
+	switch resp.StatusCode {
+	// Asynchronous case - must track task and get item HREF from there
+	case http.StatusAccepted:
+		taskUrl := resp.Header.Get("Location")
+		task := NewTask(client)
+		task.Task.HREF = taskUrl
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
+		}
+
+		// Here we have to find the resource once more to return it populated. Provided params ir ignored for retrieval.
+		err = client.OpenApiGetItem(urlRef, nil, outType)
+		if err != nil {
+			return fmt.Errorf("error retrieving item after creation: %s", err)
+		}
+
+		// Synchronous task - new item body is returned in response of HTTP POST request
+	case http.StatusCreated:
+		if err = decodeBody(types.BodyTypeJSON, resp, outType); err != nil {
+			return fmt.Errorf("error decoding JSON response after POST: %s", err)
+		}
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("error closing HTTP PUT response body: %s", err)
+	}
+
+	return nil
+}
+
+// OpenApiDeleteItem performs HTTP DELETE request for a specified endpoint in given urlRef. If the task is asynchronous
+// - it will track the task until it is finished.
+func (client *Client) OpenApiDeleteItem(urlRef *url.URL, params url.Values) error {
+	util.Logger.Printf("[TRACE] Deleting item at endpoint %s", urlRef.String())
+
+	if !client.OpenApiIsSupported() {
+		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+	}
+
+	// Exec request
+	req := client.newOpenApiRequest(params, http.MethodDelete, urlRef, nil, "34.0")
+
+	resp, err := client.Http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// resp is ignored below because it would be the same as above
+	_, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.OpenApiError{})
+	if err != nil {
+		return fmt.Errorf("error in HTTP DELETE request: %s", err)
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("error closing response body: %s", err)
+	}
+
+	// CloudAPI may work synchronously or asynchronously. When working asynchronously - it will return HTTP 202 and
+	// `Location` header will contain reference to task so that it can be tracked. In DELETE case we do not care about any
+	// ID so if DELETE operation is synchronous (returns HTTP 201) - the request has already succeeded.
+	if resp.StatusCode == http.StatusAccepted {
+		taskUrl := resp.Header.Get("Location")
+		task := NewTask(client)
+		task.Task.HREF = taskUrl
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
+		}
+	}
+
+	return nil
+}
+
+// openApiGetAllPages is a recursive function that helps to accumulate responses from multiple pages for GET query. It
+// works by at first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is
+// no intermediate unmarshalling to exact `outType` for every page it can unmarshal into direct `outType` supplied.
+// outType must be a slice of object (e.g. []*types.CloudAPIEdgeGateway) because accumulated responses are in JSON list
+func (client *Client) openApiGetAllPages(pageSize *int, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
+	if responses == nil {
+		responses = []json.RawMessage{}
+	}
+
+	// Reuse existing queryParams struct to fill in pages or create a new one if nil was passed
+	queryParameters := url.Values{}
+	if queryParams != nil {
+		queryParameters = queryParams
+	}
+
+	if pageSize != nil {
+		queryParameters.Set("pageSize", strconv.Itoa(*pageSize))
+	}
+
+	// Perform request
+	req := client.newOpenApiRequest(queryParams, http.MethodGet, urlRef, nil, "34.0")
+
+	resp, err := client.Http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// resp is ignored below because it is the same as above
+	_, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.OpenApiError{})
+	if err != nil {
+		return nil, fmt.Errorf("error in HTTP GET request: %s", err)
+	}
+
+	// Pages will unwrap pagination and keep a slice of raw json message to marshal to specific types
+	pages := &types.CloudApiPages{}
+
+	if err = decodeBody(types.BodyTypeJSON, resp, pages); err != nil {
+		return nil, fmt.Errorf("error decoding JSON page response: %s", err)
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("error closing response body: %s", err)
+	}
+
+	// Accumulate all responses in a single page as JSON text using json.RawMessage
+	// After pages are unwrapped one can marshal response into specified type
+	// singleQueryResponses := &json.RawMessage{}
+	var singleQueryResponses []json.RawMessage
+	if err = json.Unmarshal(pages.Values, &singleQueryResponses); err != nil {
+		return nil, fmt.Errorf("error decoding values into accumulation type: %s", err)
+	}
+	responses = append(responses, singleQueryResponses...)
+
+	// Check if there is still 'nextPage' linked and continue accumulating responses if so
+	nextPageUrlRef, err := findRelLink("nextPage", resp.Header)
+	if err != nil && !IsNotFound(err) {
+		return nil, fmt.Errorf("error looking for 'nextPage' in 'Link' header: %s", err)
+	}
+
+	if nextPageUrlRef != nil {
+		responses, err = client.openApiGetAllPages(nil, nextPageUrlRef, url.Values{}, outType, responses)
+		if err != nil {
+			return nil, fmt.Errorf("got error on page %d: %s", pages.Page, err)
+		}
+	}
+
+	return responses, nil
+}
+
+// newOpenApiRequest is a low level function used in upstream CloudAPI functions which handles logging and
+// authentication for each API request
+func (client *Client) newOpenApiRequest(params url.Values, method string, reqUrl *url.URL, body io.Reader, apiVersion string) *http.Request {
+
+	// Add the params to our URL
+	reqUrl.RawQuery += params.Encode()
+
+	// If the body contains data - try to read all contents for logging and re-create another
+	// io.Reader with all contents to use it down the line
+	var readBody []byte
+	if body != nil {
+		readBody, _ = ioutil.ReadAll(body)
+		body = bytes.NewReader(readBody)
+	}
+
+	// Build the request, no point in checking for errors here as we're just
+	// passing a string version of an url.URL struct and http.NewRequest returns
+	// error only if can't process an url.ParseRequestURI().
+	req, _ := http.NewRequest(method, reqUrl.String(), body)
+
+	if client.VCDAuthHeader != "" && client.VCDToken != "" {
+		// Add the authorization header
+		req.Header.Add(client.VCDAuthHeader, client.VCDToken)
+	}
+	if client.VCDAuthHeader != "" && client.VCDToken != "" {
+		// Add the Accept header for VCD
+		acceptMime := types.JSONMime + ";version=" + apiVersion
+		req.Header.Add("Accept", acceptMime)
+	}
+
+	// Inject JSON mime type
+	req.Header.Add("Content-Type", types.JSONMime)
+
+	// Avoids passing data if the logging of requests is disabled
+	if util.LogHttpRequest {
+		payload := ""
+		if req.ContentLength > 0 {
+			payload = string(readBody)
+		}
+		util.ProcessRequestOutput(util.FuncNameCallStack(), method, reqUrl.String(), payload, req)
+		debugShowRequest(req, payload)
+	}
+
+	return req
+}
+
+// findRelLink looks for link to "nextPage" in "Link" header. It will return when first occurrence is found.
+// Sample Link header:
+// Link: [<https://HOSTNAME/cloudapi/1.0.0/auditTrail?sortAsc=&pageSize=25&sortDesc=&page=7>;rel="lastPage";type="application/json";model="AuditTrailEvents" <https://HOSTNAME/cloudapi/1.0.0/auditTrail?sortAsc=&pageSize=25&sortDesc=&page=2>;rel="nextPage";type="application/json";model="AuditTrailEvents"]
+// Returns *url.Url or ErrorEntityNotFound
+func findRelLink(relFieldName string, header http.Header) (*url.URL, error) {
+	headerLinks := link.ParseHeader(header)
+	var foundAddress *link.Link
+
+	for relKeyName, linkAddress := range headerLinks {
+		switch {
+		// When map key has more than one name (separated by space). In such cases it can have map key as
+		// "lastPage nextPage" when nextPage==lastPage or similar and one specific field needs to be matched.
+		case strings.Contains(relKeyName, " "):
+			relNameSlice := strings.Split(relKeyName, " ")
+			for _, oneRelName := range relNameSlice {
+				if oneRelName == relFieldName {
+					foundAddress = linkAddress
+				}
+			}
+			break
+		case relKeyName == relFieldName:
+			foundAddress = linkAddress
+			break
+		}
+	}
+
+	if foundAddress == nil {
+		return nil, ErrorEntityNotFound
+	}
+
+	return url.Parse(foundAddress.String())
+}
+
+// jsonRawMessagesToStrings converts []*json.RawMessage to []string
+func jsonRawMessagesToStrings(messages []json.RawMessage) []string {
+	resultString := make([]string, len(messages))
+	for index, message := range messages {
+		resultString[index] = string(message)
+	}
+
+	return resultString
+}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -526,7 +526,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, que
 	}
 
 	if nextPageUrlRef != nil {
-		responses, err = client.openApiGetAllPages(apiVersion, nil, nextPageUrlRef, url.Values{}, outType, responses)
+		responses, err = client.openApiGetAllPages(apiVersion,  nextPageUrlRef, url.Values{}, outType, responses)
 		if err != nil {
 			return nil, fmt.Errorf("got error on page %d: %s", pages.Page, err)
 		}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -530,7 +530,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, que
 	}
 
 	if nextPageUrlRef != nil {
-		responses, err = client.openApiGetAllPages(apiVersion,  nextPageUrlRef, url.Values{}, outType, responses)
+		responses, err = client.openApiGetAllPages(apiVersion, nextPageUrlRef, url.Values{}, outType, responses)
 		if err != nil {
 			return nil, fmt.Errorf("got error on page %d: %s", pages.Page, err)
 		}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -18,11 +18,11 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// This file contains generalised low level methods to interact with VCD OpenAPI REST endpoints as documented in
-// https://{VCD_HOST}/docs. In addition to this there are OpenAPI browser endpoints for tenant and provider
+// This file contains generalised low level methods to interact with VCD OpenApi REST endpoints as documented in
+// https://{VCD_HOST}/docs. In addition to this there are OpenApi browser endpoints for tenant and provider
 // respectively https://{VCD_HOST}/api-explorer/tenant/tenant-name and https://{VCD_HOST}/api-explorer/provider .
-// OpenAPI has functions supporting below REST methods:
-// GET /items (gets a slice of types like `[]types.OpenAPIEdgeGateway` or even `[]json.RawMessage` to process JSON as text.
+// OpenApi has functions supporting below REST methods:
+// GET /items (gets a slice of types like `[]types.OpenApiEdgeGateway` or even `[]json.RawMessage` to process JSON as text.
 // POST /items - creates an item
 // PUT /items/URN - updates an item with specified URN
 // GET /items/URN - retrieves an item with specified URN
@@ -32,22 +32,22 @@ import (
 // Not all API fields are supported for FIQL filtering and sometimes they return odd errors when filtering is
 // unsupported. No exact documentation exists so far.
 //
-// OpenAPI versioning.
-// OpenAPI was introduced in VCD 9.5 (with API version 31.0). Endpoints are being added with each VCD iteration.
+// OpenApi versioning.
+// OpenApi was introduced in VCD 9.5 (with API version 31.0). Endpoints are being added with each VCD iteration.
 // Internally hosted documentation (https://HOSTNAME/docs/) can be used to check which endpoints where introduced in
 // which VCD API version.
-// Additionally each OpenAPI endpoint has a semantic version in its path (e.g.
+// Additionally each OpenApi endpoint has a semantic version in its path (e.g.
 // https://HOSTNAME/cloudapi/1.0.0/auditTrail). This versioned endpoint should ensure compatibility as VCD evolves.
 
-// OpenApiIsSupported allows to check whether VCD supports OpenAPI. Each OpenAPI endpoint however is introduced with
-// different VCD API versions so this is just a general check if OpenAPI is supported at all. Particular endpoint
+// OpenApiIsSupported allows to check whether VCD supports OpenApi. Each OpenApi endpoint however is introduced with
+// different VCD API versions so this is just a general check if OpenApi is supported at all. Particular endpoint
 // introduction version can be checked in self hosted docs (https://HOSTNAME/docs/)
 func (client *Client) OpenApiIsSupported() bool {
-	// OpenAPI was introduced in VCD 9.5+ (API version 31.0+)
+	// OpenApi was introduced in VCD 9.5+ (API version 31.0+)
 	return client.APIVCDMaxVersionIs(">= 31")
 }
 
-// OpenApiBuildEndpoint helps to construct OpenAPI endpoint by using already configured VCD HREF while requiring only
+// OpenApiBuildEndpoint helps to construct OpenApi endpoint by using already configured VCD HREF while requiring only
 // the last bit for endpoint. This is a variadic function and multiple pieces can be supplied for convenience. Leading
 // '/' is added automatically.
 // Sample URL construct: https://HOST/cloudapi/endpoint
@@ -55,7 +55,7 @@ func (client *Client) OpenApiBuildEndpoint(endpoint ...string) (*url.URL, error)
 	endpointString := client.VCDHREF.Scheme + "://" + client.VCDHREF.Host + "/cloudapi/" + strings.Join(endpoint, "")
 	urlRef, err := url.ParseRequestURI(endpointString)
 	if err != nil {
-		return nil, fmt.Errorf("error formatting OpenAPI endpoint: %s", err)
+		return nil, fmt.Errorf("error formatting OpenApi endpoint: %s", err)
 	}
 	return urlRef, nil
 }
@@ -63,13 +63,13 @@ func (client *Client) OpenApiBuildEndpoint(endpoint ...string) (*url.URL, error)
 // OpenApiGetAllItems retrieves and accumulates all pages then parsing them to a single 'outType' object. It works by at
 // first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is no
 // intermediate unmarshalling to exact `outType` for every page it unmarshals into response struct in one go. 'outType'
-// must be a slice of object (e.g. []*types.OpenAPIEdgeGateway) because this response contains slice of structs.
+// must be a slice of object (e.g. []*types.OpenApiEdgeGateway) because this response contains slice of structs.
 func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}) error {
 	util.Logger.Printf("[TRACE] Getting all items from endpoint %s for parsing into %s type\n",
 		urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	// Perform API call to initial endpoint. The function call recursively follows pages using Link headers "nextPage"
@@ -98,7 +98,7 @@ func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, que
 	return nil
 }
 
-// OpenApiGetItem is a low level OpenAPI client function to perform GET request for any item.
+// OpenApiGetItem is a low level OpenApi client function to perform GET request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It responds with HTTP 403: Forbidden - If the user is not authorized or the entity does not exist. When HTTP 403 is
 // returned this function returns "ErrorEntityNotFound: API_ERROR" so that one can use ContainsNotFound(err) to
@@ -108,7 +108,7 @@ func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params 
 		urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	req := client.newOpenApiRequest(apiVersion, params, http.MethodGet, urlRef, nil)
@@ -145,7 +145,7 @@ func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params 
 	return nil
 }
 
-// OpenApiPostItemSync is a low level OpenAPI client function to perform POST request for items that support synchronous
+// OpenApiPostItemSync is a low level OpenApi client function to perform POST request for items that support synchronous
 // requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways') that supports synchronous requests. It
 // will return an error when endpoint does not support synchronous requests (HTTP response status code is not 201).
 // Response will be unmarshalled into outType.
@@ -157,7 +157,7 @@ func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, pa
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -182,7 +182,7 @@ func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, pa
 	return nil
 }
 
-// OpenApiPostItemAsync is a low level OpenAPI client function to perform POST request for items that support
+// OpenApiPostItemAsync is a low level OpenApi client function to perform POST request for items that support
 // asynchronous requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways') that supports asynchronous
 // requests. It will return an error if item does not support asynchronous request (does not respond with HTTP 202).
 //
@@ -193,7 +193,7 @@ func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, p
 		reflect.TypeOf(payload), urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return Task{}, fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -221,7 +221,7 @@ func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, p
 	return *task, nil
 }
 
-// OpenApiPostItem is a low level OpenAPI client function to perform POST request for item supporting synchronous or
+// OpenApiPostItem is a low level OpenApi client function to perform POST request for item supporting synchronous or
 // asynchronous requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways'). When a task is
 // synchronous - it will track task until it is finished and pick reference to marshal outType.
 func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
@@ -229,7 +229,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRef, params, payload)
@@ -253,7 +253,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 
 		// Here we have to find the resource once more to return it populated.
 		// Task Owner ID is the ID of created object. ID must be used (although HREF exists in task) because HREF points to
-		// old XML API and here we need to pull data from OpenAPI.
+		// old XML API and here we need to pull data from OpenApi.
 
 		newObjectUrl, _ := url.ParseRequestURI(urlRef.String() + "/" + task.Task.Owner.ID)
 		err = client.OpenApiGetItem(apiVersion, newObjectUrl, nil, outType)
@@ -277,7 +277,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 	return nil
 }
 
-// OpenApiPutItemSync is a low level OpenAPI client function to perform PUT request for items that support synchronous
+// OpenApiPutItemSync is a low level OpenApi client function to perform PUT request for items that support synchronous
 // requests. The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}') and support synchronous
 // requests. It will return an error when endpoint does not support synchronous requests (HTTP response status code is not 201).
 // Response will be unmarshalled into outType.
@@ -289,7 +289,7 @@ func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, par
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
@@ -314,7 +314,7 @@ func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, par
 	return nil
 }
 
-// OpenApiPutItemAsync is a low level OpenAPI client function to perform PUT request for items that support asynchronous
+// OpenApiPutItemAsync is a low level OpenApi client function to perform PUT request for items that support asynchronous
 // requests. The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}') that supports asynchronous
 // requests. It will return an error if item does not support asynchronous request (does not respond with HTTP 202).
 //
@@ -325,7 +325,7 @@ func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, pa
 		reflect.TypeOf(payload), urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return Task{}, fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
 	if err != nil {
@@ -352,7 +352,7 @@ func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, pa
 	return *task, nil
 }
 
-// OpenApiPutItem is a low level OpenAPI client function to perform PUT request for any item.
+// OpenApiPutItem is a low level OpenApi client function to perform PUT request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
 func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
@@ -360,7 +360,7 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 		reflect.TypeOf(payload), urlRef.String(), reflect.TypeOf(outType))
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRef, params, payload)
 
@@ -404,14 +404,14 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 	return nil
 }
 
-// OpenApiDeleteItem is a low level OpenAPI client function to perform DELETE request for any item.
+// OpenApiDeleteItem is a low level OpenApi client function to perform DELETE request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
 func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, params url.Values) error {
 	util.Logger.Printf("[TRACE] Deleting item at endpoint %s", urlRef.String())
 
 	if !client.OpenApiIsSupported() {
-		return fmt.Errorf("OpenAPI is not supported on this VCD version")
+		return fmt.Errorf("OpenApi is not supported on this VCD version")
 	}
 
 	// Perform request
@@ -433,7 +433,7 @@ func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, para
 		return fmt.Errorf("error closing response body: %s", err)
 	}
 
-	// OpenAPI may work synchronously or asynchronously. When working asynchronously - it will return HTTP 202 and
+	// OpenApi may work synchronously or asynchronously. When working asynchronously - it will return HTTP 202 and
 	// `Location` header will contain reference to task so that it can be tracked. In DELETE case we do not care about any
 	// ID so if DELETE operation is synchronous (returns HTTP 201) - the request has already succeeded.
 	if resp.StatusCode == http.StatusAccepted {
@@ -546,7 +546,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, pageSize *int, urlRe
 	return responses, nil
 }
 
-// newOpenApiRequest is a low level function used in upstream OpenAPI functions which handles logging and
+// newOpenApiRequest is a low level function used in upstream OpenApi functions which handles logging and
 // authentication for each API request
 func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, method string, reqUrl *url.URL, body io.Reader) *http.Request {
 

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -437,7 +437,6 @@ func (client *Client) newOpenApiRequest(params url.Values, method string, reqUrl
 // Returns *url.Url or ErrorEntityNotFound
 func findRelLink(relFieldName string, header http.Header) (*url.URL, error) {
 	headerLinks := link.ParseHeader(header)
-	var foundAddress *link.Link
 
 	for relKeyName, linkAddress := range headerLinks {
 		switch {
@@ -447,21 +446,15 @@ func findRelLink(relFieldName string, header http.Header) (*url.URL, error) {
 			relNameSlice := strings.Split(relKeyName, " ")
 			for _, oneRelName := range relNameSlice {
 				if oneRelName == relFieldName {
-					foundAddress = linkAddress
+					return url.Parse(linkAddress.String())
 				}
 			}
-			break
 		case relKeyName == relFieldName:
-			foundAddress = linkAddress
-			break
+			return url.Parse(linkAddress.String())
 		}
 	}
 
-	if foundAddress == nil {
-		return nil, ErrorEntityNotFound
-	}
-
-	return url.Parse(foundAddress.String())
+	return nil, ErrorEntityNotFound
 }
 
 // jsonRawMessagesToStrings converts []*json.RawMessage to []string

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -35,7 +35,8 @@ import (
 
 // OpenApiIsSupported allows to check whether VCD supports OpenAPI
 func (client *Client) OpenApiIsSupported() bool {
-	return client.APIVCDMaxVersionIs(">= 33")
+	// OpenAPI was introduced in VCD 9.5+ (API version 31.0+)
+	return client.APIVCDMaxVersionIs(">= 31")
 }
 
 // BuildOpenApiEndpoint helps to construct OpenAPI endpoint by using already configured VCD HREF while requiring only

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -1,0 +1,27 @@
+package govcd
+
+import "fmt"
+
+var endpointMinApiVersions = map[string]string{
+	"1.0.0/roles/": "31.0",
+}
+
+// checkOpenApiEndpointCompatibility checks if required VCD version is sufficient to work with this endpoint and returns
+// either error, either version
+func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string, error) {
+	minimumApiVersion, ok := endpointMinApiVersions[endpoint]
+	if !ok {
+		return "", fmt.Errorf("minimum API version for endopoint '%s' is not defined", endpoint)
+	}
+
+	if client.APIVCDMaxVersionIs("< " + minimumApiVersion) {
+		maxSupportedVersion, err := client.maxSupportedVersion()
+		if err != nil {
+			return "", fmt.Errorf("error reading maximum supported API version: %s", err)
+		}
+		return "", fmt.Errorf("endpoint '%s' requires API version to support at least '%s'. Maximum supported version in this instance: '%s'",
+			endpoint, minimumApiVersion, maxSupportedVersion)
+	}
+
+	return minimumApiVersion, nil
+}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -2,14 +2,14 @@ package govcd
 
 import "fmt"
 
-// endpointMinApiVersions holds mapping of OpenApi endpoints and API versions they were introduced in.
+// endpointMinApiVersions holds mapping of OpenAPI endpoints and API versions they were introduced in.
 var endpointMinApiVersions = map[string]string{
 	"1.0.0/roles/": "31.0",
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with
-// specified OpenApi endpoint and returns either error, either Api version to use for calling that endpoint. This Api
-// version can then be supplied to low level OpenApi client functions.
+// specified OpenAPI endpoint and returns either error, either Api version to use for calling that endpoint. This Api
+// version can then be supplied to low level OpenAPI client functions.
 func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string, error) {
 	minimumApiVersion, ok := endpointMinApiVersions[endpoint]
 	if !ok {

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -2,12 +2,14 @@ package govcd
 
 import "fmt"
 
+// endpointMinApiVersions holds mapping of OpenApi endpoints and API versions they were introduced in.
 var endpointMinApiVersions = map[string]string{
 	"1.0.0/roles/": "31.0",
 }
 
-// checkOpenApiEndpointCompatibility checks if required VCD version is sufficient to work with this endpoint and returns
-// either error, either version
+// checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with
+// specified OpenApi endpoint and returns either error, either Api version to use for calling that endpoint. This Api
+// version can then be supplied to low level OpenApi client functions.
 func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string, error) {
 	minimumApiVersion, ok := endpointMinApiVersions[endpoint]
 	if !ok {

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import "fmt"
 
 // endpointMinApiVersions holds mapping of OpenAPI endpoints and API versions they were introduced in.

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -4,11 +4,14 @@ package govcd
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
 
 // endpointMinApiVersions holds mapping of OpenAPI endpoints and API versions they were introduced in.
 var endpointMinApiVersions = map[string]string{
-	"1.0.0/roles/": "31.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles: "31.0",
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -15,9 +15,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Test_OpenApiRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
+// Test_OpenAPIRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
 // how to fetch response from multiple pages in RAW json messages without having defined as struct.
-func (vcd *TestVCD) Test_OpenApiRawJsonAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
@@ -46,9 +46,9 @@ func (vcd *TestVCD) Test_OpenApiRawJsonAudiTrail(check *C) {
 	check.Assert(len(matches), Equals, len(allResponses))
 }
 
-// Test_OpenApiInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
+// Test_OpenAPIInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
 // to user defined inline type
-func (vcd *TestVCD) Test_OpenApiInlineStructAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
@@ -105,9 +105,9 @@ func (vcd *TestVCD) Test_OpenApiInlineStructAudiTrail(check *C) {
 	}
 }
 
-// Test_OpenApiInlineStructCRUDRoles test aims to test out low level OpenApi functions to check if all of them work as
+// Test_OpenApiInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
 // expected. It uses a very simple "InlineRoles" endpoint which does not have bigger prerequisites and therefore is not
-// dependent one more deployment specific features. It also supports all of the OpenApi CRUD endpoints so is a good
+// dependent one more deployment specific features. It also supports all of the OpenAPI CRUD endpoints so is a good
 // endpoint to test on
 // This test performs the following:
 // 1. Gets all available roles using "Get all endpoint"
@@ -216,7 +216,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	err = vcd.client.Client.OpenApiGetItem(minimumRequiredApiVersion, deleteUrlRef, nil, lostRole)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
-	// Step 7 - test synchronous POST and PUT functions (because Roles is a synchronous OpenApi endpoint)
+	// Step 7 - test synchronous POST and PUT functions (because Roles is a synchronous OpenAPI endpoint)
 	newRole.ID = "" // unset ID as it cannot be set for creation
 	err = vcd.client.Client.OpenApiPostItemSync(minimumRequiredApiVersion, createUrl, nil, newRole, newRoleResponse)
 	check.Assert(err, IsNil)
@@ -246,7 +246,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 
 }
 
-// skipOpenApiEndpointTest is a helper to skip tests for particular unsupported OpenApi endpoints
+// skipOpenApiEndpointTest is a helper to skip tests for particular unsupported OpenAPI endpoints
 func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint, requiredVersion string) {
 	constraint := ">= " + requiredVersion
 	if !vcd.client.Client.APIVCDMaxVersionIs(constraint) {
@@ -254,7 +254,7 @@ func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint, requiredVersion s
 		if err != nil {
 			panic(fmt.Sprintf("Could not get maximum supported version: %s", err))
 		}
-		skipText := fmt.Sprintf("Skipping test because OpenApi endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
+		skipText := fmt.Sprintf("Skipping test because OpenAPI endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
 			endpoint, constraint, maxSupportedVersion)
 		check.Skip(skipText)
 	}

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,4 +1,4 @@
-// +build openapi ALL
+// +build functional openapi ALL
 
 package govcd
 
@@ -125,6 +125,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 
 	allExistingRoles := []*Roles{{}}
 	err = vcd.vdc.client.OpenApiGetAllItems(urlRef, nil, &allExistingRoles)
+	check.Assert(err, IsNil)
 
 	// Step 2 - Get all roles using query filters
 	for _, oneRole := range allExistingRoles {
@@ -143,6 +144,8 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 
 		// Step 2.2 - retrieve specific role by using endpoint
 		singleRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/" + oneRole.ID)
+		check.Assert(err, IsNil)
+
 		oneRole := &Roles{}
 		err = vcd.vdc.client.OpenApiGetItem(singleRef, nil, oneRole)
 		check.Assert(err, IsNil)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,5 +1,9 @@
 // +build functional openapi ALL
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -19,7 +19,7 @@ import (
 // how to fetch response from multiple pages in RAW json messages without having defined as struct.
 func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
+	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
@@ -50,7 +50,7 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 // to user defined inline type
 func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
+	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
@@ -106,7 +106,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 }
 
 // Test_OpenAPIInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
-// expected. It uses a very simple "Roles" endpoint which does not have bigger prerequisites and therefore is not
+// expected. It uses a very simple "InlineRoles" endpoint which does not have bigger prerequisites and therefore is not
 // dependent one more deployment specific features. It also supports all of the OpenAPI CRUD endpoints so is a good
 // endpoint to test on
 // This test performs the following:
@@ -120,13 +120,13 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 // 5. Tests read for deleted item
 func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	minimumRequiredApiVersion := "31.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
+	skipOpenApiEndpointTest(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
 
 	// Step 1 - Get all roles
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
 	check.Assert(err, IsNil)
 
-	type Roles struct {
+	type InlineRoles struct {
 		ID          string `json:"id,omitempty"`
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -134,7 +134,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 		ReadOnly    bool   `json:"readOnly"`
 	}
 
-	allExistingRoles := []*Roles{{}}
+	allExistingRoles := []*InlineRoles{{}}
 	err = vcd.vdc.client.OpenApiGetAllItems(minimumRequiredApiVersion, urlRef, nil, &allExistingRoles)
 	check.Assert(err, IsNil)
 
@@ -147,7 +147,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 		queryParams := url.Values{}
 		queryParams.Add("filter", "id=="+oneRole.ID)
 
-		expectOneRoleResultById := []*Roles{{}}
+		expectOneRoleResultById := []*InlineRoles{{}}
 
 		err = vcd.vdc.client.OpenApiGetAllItems(minimumRequiredApiVersion, urlRef2, queryParams, &expectOneRoleResultById)
 		check.Assert(err, IsNil)
@@ -157,7 +157,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 		singleRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/" + oneRole.ID)
 		check.Assert(err, IsNil)
 
-		oneRole := &Roles{}
+		oneRole := &InlineRoles{}
 		err = vcd.vdc.client.OpenApiGetItem(minimumRequiredApiVersion, singleRef, nil, oneRole)
 		check.Assert(err, IsNil)
 		check.Assert(oneRole, NotNil)
@@ -171,14 +171,14 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	createUrl, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
 	check.Assert(err, IsNil)
 
-	newRole := &Roles{
+	newRole := &InlineRoles{
 		Name:        check.TestName(),
 		Description: "Role created by test",
 		// This BundleKey is being set by VCD even if it is not sent
 		BundleKey: "com.vmware.vcloud.undefined.key",
 		ReadOnly:  false,
 	}
-	newRoleResponse := &Roles{}
+	newRoleResponse := &InlineRoles{}
 	err = vcd.client.Client.OpenApiPostItem(minimumRequiredApiVersion, createUrl, nil, newRole, newRoleResponse)
 	check.Assert(err, IsNil)
 
@@ -196,13 +196,13 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	// Step 5 - try to read deleted role and expect error to contain 'ErrorEntityNotFound'
 	// Read is tricky - it throws an error ACCESS_TO_RESOURCE_IS_FORBIDDEN when the resource with ID does not
 	// exist therefore one cannot know what kind of error occurred.
-	lostRole := &Roles{}
+	lostRole := &InlineRoles{}
 	err = vcd.client.Client.OpenApiGetItem(minimumRequiredApiVersion, deleteUrlRef, nil, lostRole)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
-// skipOpenApiEndpoint is a helper to skip tests for particular unsupported OpenAPI endpoints
-func skipOpenApiEndpoint(vcd *TestVCD, check *C, endpoint, requiredVersion string) {
+// skipOpenApiEndpointTest is a helper to skip tests for particular unsupported OpenAPI endpoints
+func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint, requiredVersion string) {
 	constraint := ">= " + requiredVersion
 	if !vcd.client.Client.APIVCDMaxVersionIs(constraint) {
 		maxSupportedVersion, err := vcd.client.Client.maxSupportedVersion()

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -15,9 +15,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Test_OpenAPIRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
+// Test_OpenApiRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
 // how to fetch response from multiple pages in RAW json messages without having defined as struct.
-func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenApiRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
@@ -46,9 +46,9 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	check.Assert(len(matches), Equals, len(allResponses))
 }
 
-// Test_OpenAPIInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
+// Test_OpenApiInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
 // to user defined inline type
-func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenApiInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
@@ -105,9 +105,9 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	}
 }
 
-// Test_OpenApiInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
+// Test_OpenApiInlineStructCRUDRoles test aims to test out low level OpenApi functions to check if all of them work as
 // expected. It uses a very simple "InlineRoles" endpoint which does not have bigger prerequisites and therefore is not
-// dependent one more deployment specific features. It also supports all of the OpenAPI CRUD endpoints so is a good
+// dependent one more deployment specific features. It also supports all of the OpenApi CRUD endpoints so is a good
 // endpoint to test on
 // This test performs the following:
 // 1. Gets all available roles using "Get all endpoint"
@@ -216,7 +216,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	err = vcd.client.Client.OpenApiGetItem(minimumRequiredApiVersion, deleteUrlRef, nil, lostRole)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
-	// Step 7 - test synchronous POST and PUT functions (because Roles is a synchronous OpenAPI endpoint)
+	// Step 7 - test synchronous POST and PUT functions (because Roles is a synchronous OpenApi endpoint)
 	newRole.ID = "" // unset ID as it cannot be set for creation
 	err = vcd.client.Client.OpenApiPostItemSync(minimumRequiredApiVersion, createUrl, nil, newRole, newRoleResponse)
 	check.Assert(err, IsNil)
@@ -246,7 +246,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 
 }
 
-// skipOpenApiEndpointTest is a helper to skip tests for particular unsupported OpenAPI endpoints
+// skipOpenApiEndpointTest is a helper to skip tests for particular unsupported OpenApi endpoints
 func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint, requiredVersion string) {
 	constraint := ">= " + requiredVersion
 	if !vcd.client.Client.APIVCDMaxVersionIs(constraint) {
@@ -254,7 +254,7 @@ func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint, requiredVersion s
 		if err != nil {
 			panic(fmt.Sprintf("Could not get maximum supported version: %s", err))
 		}
-		skipText := fmt.Sprintf("Skipping test because OpenAPI endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
+		skipText := fmt.Sprintf("Skipping test because OpenApi endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
 			endpoint, constraint, maxSupportedVersion)
 		check.Skip(skipText)
 	}

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,3 +1,5 @@
+// +build openapi ALL
+
 package govcd
 
 import (
@@ -107,6 +109,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 // 2.3 Compare struct retrieved by using "Get all" endpoint and FIQL filter with struct retrieved by using "Get By ID"
 // 3. Create a new role and verify it is created as specified by using deep equality
 // 4. Delete created role
+// 5. Test read for deleted item
 func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	// Step 1 - Get all roles
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -21,7 +21,7 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
-	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
 
 	// Limit search of audits trails to the last 12 hours so that it doesn't take too long and set pageSize to be 1 result
@@ -52,7 +52,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
-	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
 
 	// Inline type
@@ -123,7 +123,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
 
 	// Step 1 - Get all roles
-	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
 	check.Assert(err, IsNil)
 
 	type InlineRoles struct {
@@ -141,7 +141,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	// Step 2 - Get all roles using query filters
 	for _, oneRole := range allExistingRoles {
 		// Step 2.1 - retrieve specific role by using FIQL filter
-		urlRef2, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+		urlRef2, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
 		check.Assert(err, IsNil)
 
 		queryParams := url.Values{}
@@ -154,7 +154,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
 
 		// Step 2.2 - retrieve specific role by using endpoint
-		singleRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/" + oneRole.ID)
+		singleRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/" + oneRole.ID)
 		check.Assert(err, IsNil)
 
 		oneRole := &InlineRoles{}
@@ -168,7 +168,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	}
 
 	// Step 3 - Create a new role and ensure it is created as specified by doing deep comparison
-	createUrl, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+	createUrl, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
 	check.Assert(err, IsNil)
 
 	newRole := &InlineRoles{
@@ -187,7 +187,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	check.Assert(newRoleResponse, DeepEquals, newRole)
 
 	// Step 4 - delete created role
-	deleteUrlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	deleteUrlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
 	err = vcd.client.Client.OpenApiDeleteItem(minimumRequiredApiVersion, deleteUrlRef, nil)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -193,6 +193,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	// Step 4 - update created role (change description)
 	newRoleResponse.Description = "Updated description created by test"
 	updateUrl, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	check.Assert(err, IsNil)
 
 	updatedRoleResponse := &InlineRoles{}
 	err = vcd.client.Client.OpenApiPutItem(minimumRequiredApiVersion, updateUrl, nil, newRoleResponse, updatedRoleResponse)
@@ -227,6 +228,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	// Step 8 - update role using synchronous PUT function
 	newRoleResponse.Description = "Updated description created by sync test"
 	updateUrl2, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	check.Assert(err, IsNil)
 
 	updatedRoleResponse2 := &InlineRoles{}
 	err = vcd.client.Client.OpenApiPutItem(minimumRequiredApiVersion, updateUrl2, nil, newRoleResponse, updatedRoleResponse2)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -200,14 +200,15 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 }
 
 // skipOpenApiEndpoint is a helper to skip tests for particular unsupported OpenAPI endpoints
-func skipOpenApiEndpoint(vcd *TestVCD, check *C, endpoint, requiredVersionConstraint string) {
-	if !vcd.client.Client.APIVCDMaxVersionIs(">= " + requiredVersionConstraint) {
+func skipOpenApiEndpoint(vcd *TestVCD, check *C, endpoint, requiredVersion string) {
+	constraint := ">= " + requiredVersion
+	if !vcd.client.Client.APIVCDMaxVersionIs(constraint) {
 		maxSupportedVersion, err := vcd.client.Client.maxSupportedVersion()
 		if err != nil {
 			panic(fmt.Sprintf("Could not get maximum supported version: %s", err))
 		}
 		skipText := fmt.Sprintf("Skipping test because OpenAPI endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
-			endpoint, requiredVersionConstraint, maxSupportedVersion)
+			endpoint, constraint, maxSupportedVersion)
 		check.Skip(skipText)
 	}
 }

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,0 +1,184 @@
+package govcd
+
+import (
+	"encoding/json"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	. "gopkg.in/check.v1"
+)
+
+// Test_CloudAPIAudiTrail uses low level GET function to test out that pagination really works. It is an example how to
+// fetch response from multiple pages in RAW json messages without having defined a clear struct.
+func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
+	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	check.Assert(err, IsNil)
+
+	// Limit search of audi trails to the last 12 hours so that it doesn't take too long and set pageSize to be 1 result to
+	// force following pages
+	queryParams := url.Values{}
+	filterTime := time.Now().Add(-12 * time.Hour).Format(types.FiqlQueryTimestampFormat)
+	queryParams.Add("filter", "timestamp=gt="+filterTime)
+	queryParams.Add("pageSize", "1")
+
+	allResponses := []json.RawMessage{{}}
+	err = vcd.vdc.client.OpenApiGetAllItems(urlRef, queryParams, &allResponses)
+
+	check.Assert(err, IsNil)
+	check.Assert(len(allResponses) > 1, Equals, true)
+
+	// Build a regex ant match it internally so that we are sure auditTrail events are returned in RAW json message. There
+	// should be the same amount of audit event IDs as total responses
+	auditLogUrn := regexp.MustCompile("urn:vcloud:audit:")
+	responseStrings := jsonRawMessagesToStrings(allResponses)
+	allStringResponses := `[` + strings.Join(responseStrings, ",") + `]`
+	matches := auditLogUrn.FindAllStringIndex(allStringResponses, -1)
+	check.Assert(len(matches), Equals, len(allResponses))
+}
+
+// Test_OpenAPIInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
+// to user defined inline type
+func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
+	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	check.Assert(err, IsNil)
+
+	// Inline type
+	type AudiTrail struct {
+		EventID      string `json:"eventId"`
+		Description  string `json:"description"`
+		OperatingOrg struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"operatingOrg"`
+		User struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"user"`
+		EventEntity struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"eventEntity"`
+		TaskID               interface{} `json:"taskId"`
+		TaskCellID           string      `json:"taskCellId"`
+		CellID               string      `json:"cellId"`
+		EventType            string      `json:"eventType"`
+		ServiceNamespace     string      `json:"serviceNamespace"`
+		EventStatus          string      `json:"eventStatus"`
+		Timestamp            string      `json:"timestamp"`
+		External             bool        `json:"external"`
+		AdditionalProperties struct {
+			UserRoles                         string `json:"user.roles"`
+			UserSessionID                     string `json:"user.session.id"`
+			CurrentContextUserProxyAddress    string `json:"currentContext.user.proxyAddress"`
+			CurrentContextUserClientIPAddress string `json:"currentContext.user.clientIpAddress"`
+		} `json:"additionalProperties"`
+	}
+
+	allResponses := []*AudiTrail{{}}
+
+	// Define FIQL query to find events for the last 24 hours
+	queryParams := url.Values{}
+	filterTime := time.Now().Add(-24 * time.Hour).Format(types.FiqlQueryTimestampFormat)
+	queryParams.Add("filter", "timestamp=gt="+filterTime)
+
+	err = vcd.vdc.client.OpenApiGetAllItems(urlRef, queryParams, &allResponses)
+
+	check.Assert(err, IsNil)
+	check.Assert(len(allResponses) > 1, Equals, true)
+
+	// Check that all responses have IDs populated
+	for _, v := range allResponses {
+		check.Assert(v.EventID, NotNil)
+	}
+}
+
+// Test_OpenAPIInlineStructCRUDRoles test aims to test out low level CloudAPI functions to check if all of them work as
+// expected. It uses a very simple "Roles" endpoint which does not have bigger prerequisites and therefore is not
+// dependent one more deployment specific features. It also supports all of the CloudAPI CRUD endpoints so is a good
+// endpoint to test on
+// Actions of the test:
+// 1. Get all available roles using "Get all endpoint"
+// 2.1 Use FIQL query filtering to retrieve specific item by ID on "Get All" endpoint
+// 2.2 Use GET by ID endpoint to check that each of roles retrieved by get all can be found individually
+// 2.3 Compare struct retrieved by using "Get all" endpoint and FIQL filter with struct retrieved by using "Get By ID"
+// 3. Create a new role and verify it is created as specified by using deep equality
+// 4. Delete created role
+func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
+	// Step 1 - Get all roles
+	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+	check.Assert(err, IsNil)
+
+	type Roles struct {
+		ID          string `json:"id,omitempty"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		BundleKey   string `json:"bundleKey"`
+		ReadOnly    bool   `json:"readOnly"`
+	}
+
+	allExistingRoles := []*Roles{{}}
+	err = vcd.vdc.client.OpenApiGetAllItems(urlRef, nil, &allExistingRoles)
+
+	// Step 2 - Get all roles using query filters
+	for _, oneRole := range allExistingRoles {
+		// Step 2.1 - retrieve specific role by using FIQL filter
+		urlRef2, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+		check.Assert(err, IsNil)
+
+		queryParams := url.Values{}
+		queryParams.Add("filter", "id=="+oneRole.ID)
+
+		expectOneRoleResultById := []*Roles{{}}
+
+		err = vcd.vdc.client.OpenApiGetAllItems(urlRef2, queryParams, &expectOneRoleResultById)
+		check.Assert(err, IsNil)
+		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
+
+		// Step 2.2 - retrieve specific role by using endpoint
+		singleRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/" + oneRole.ID)
+		oneRole := &Roles{}
+		err = vcd.vdc.client.OpenApiGetItem(singleRef, nil, oneRole)
+		check.Assert(err, IsNil)
+		check.Assert(oneRole, NotNil)
+
+		// Step 2.3 - compare struct retrieve by using filter and the one retrieve by exact endpoint ID
+		check.Assert(oneRole, DeepEquals, expectOneRoleResultById[0])
+
+	}
+
+	// Step 3 - Create a new role and ensure it is created as specified by doing deep comparison
+	createUrl, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+	check.Assert(err, IsNil)
+
+	newRole := &Roles{
+		Name:        check.TestName(),
+		Description: "Role created by test",
+		BundleKey:   "com.vmware.vcloud.undefined.key",
+		ReadOnly:    false,
+	}
+	newRoleResponse := &Roles{}
+	err = vcd.client.Client.OpenApiPostItem(createUrl, nil, newRole, newRoleResponse)
+	check.Assert(err, IsNil)
+
+	// Ensure supplied and created structs differ only by ID
+	newRole.ID = newRoleResponse.ID
+	check.Assert(newRoleResponse, DeepEquals, newRole)
+
+	// Step 4 - delete created role
+	deleteUrlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	check.Assert(err, IsNil)
+
+	err = vcd.client.Client.OpenApiDeleteItem(deleteUrlRef, nil)
+	check.Assert(err, IsNil)
+
+	// Step 5 - try to read deleted role and expect error to contain 'ErrorEntityNotFound'
+	// Read is tricky - it throws an error ACCESS_TO_RESOURCE_IS_FORBIDDEN when the resource with ID does not
+	// exist therefore one cannot know what kind of error occurred.
+	lostRole := &Roles{}
+	err = vcd.client.Client.OpenApiGetItem(deleteUrlRef, nil, lostRole)
+	check.Assert(ContainsNotFound(err), Equals, true)
+}

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -105,7 +105,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	}
 }
 
-// Test_OpenAPIInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
+// Test_OpenApiInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
 // expected. It uses a very simple "InlineRoles" endpoint which does not have bigger prerequisites and therefore is not
 // dependent one more deployment specific features. It also supports all of the OpenAPI CRUD endpoints so is a good
 // endpoint to test on
@@ -118,7 +118,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 // 3. Creates a new role and verifies it is created as specified by using deep equality
 // 4. Deletes created role
 // 5. Tests read for deleted item
-func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
+func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	minimumRequiredApiVersion := "31.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
 

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -128,10 +128,11 @@ func (vcd *TestVCD) Test_OpenApiInlineStructAudiTrail(check *C) {
 // 9. Delete role once again
 func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	minimumRequiredApiVersion := "31.0"
-	skipOpenApiEndpointTest(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
+	skipOpenApiEndpointTest(vcd, check, endpoint, minimumRequiredApiVersion)
 
 	// Step 1 - Get all roles
-	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
+	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
 	check.Assert(err, IsNil)
 
 	type InlineRoles struct {
@@ -149,7 +150,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	// Step 2 - Get all roles using query filters
 	for _, oneRole := range allExistingRoles {
 		// Step 2.1 - retrieve specific role by using FIQL filter
-		urlRef2, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
+		urlRef2, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
 		check.Assert(err, IsNil)
 
 		queryParams := url.Values{}
@@ -162,7 +163,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
 
 		// Step 2.2 - retrieve specific role by using endpoint
-		singleRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/" + oneRole.ID)
+		singleRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint + oneRole.ID)
 		check.Assert(err, IsNil)
 
 		oneRole := &InlineRoles{}
@@ -176,7 +177,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	}
 
 	// Step 3 - Create a new role and ensure it is created as specified by doing deep comparison
-	createUrl, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles")
+	createUrl, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
 	check.Assert(err, IsNil)
 
 	newRole := &InlineRoles{
@@ -196,7 +197,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 
 	// Step 4 - update created role (change description)
 	newRoleResponse.Description = "Updated description created by test"
-	updateUrl, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	updateUrl, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
 	updatedRoleResponse := &InlineRoles{}
@@ -207,7 +208,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	check.Assert(updatedRoleResponse, DeepEquals, newRoleResponse)
 
 	// Step 5 - delete created role
-	deleteUrlRef, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	deleteUrlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
 	err = vcd.client.Client.OpenApiDeleteItem(minimumRequiredApiVersion, deleteUrlRef, nil)
@@ -231,7 +232,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 
 	// Step 8 - update role using synchronous PUT function
 	newRoleResponse.Description = "Updated description created by sync test"
-	updateUrl2, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	updateUrl2, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
 	updatedRoleResponse2 := &InlineRoles{}
@@ -242,7 +243,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	check.Assert(updatedRoleResponse2, DeepEquals, newRoleResponse)
 
 	// Step 9 - delete role once again
-	deleteUrlRef2, err := vcd.client.Client.OpenApiBuildEndpoint("1.0.0/roles/", newRoleResponse.ID)
+	deleteUrlRef2, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
 	err = vcd.client.Client.OpenApiDeleteItem(minimumRequiredApiVersion, deleteUrlRef2, nil)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -15,9 +15,9 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Test_OpenAPIRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
+// Test_OpenApiRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
 // how to fetch response from multiple pages in RAW json messages without having defined as struct.
-func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenApiRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
@@ -46,9 +46,9 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	check.Assert(len(matches), Equals, len(allResponses))
 }
 
-// Test_OpenAPIInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
+// Test_OpenApiInlineStructAudiTrail uses low level GET function to test out that get function can unmarshal directly
 // to user defined inline type
-func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
+func (vcd *TestVCD) Test_OpenApiInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpointTest(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -15,8 +15,8 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Test_CloudAPIAudiTrail uses low level GET function to test out that pagination really works. It is an example how to
-// fetch response from multiple pages in RAW json messages without having defined a clear struct.
+// Test_OpenAPIRawJsonAudiTrail uses low level GET function to test out that pagination really works. It is an example
+// how to fetch response from multiple pages in RAW json messages without having defined as struct.
 func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
 	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
@@ -24,8 +24,8 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
 
-	// Limit search of audi trails to the last 12 hours so that it doesn't take too long and set pageSize to be 1 result to
-	// force following pages
+	// Limit search of audits trails to the last 12 hours so that it doesn't take too long and set pageSize to be 1 result
+	// to force following pages
 	queryParams := url.Values{}
 	filterTime := time.Now().Add(-12 * time.Hour).Format(types.FiqlQueryTimestampFormat)
 	queryParams.Add("filter", "timestamp=gt="+filterTime)
@@ -105,18 +105,19 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	}
 }
 
-// Test_OpenAPIInlineStructCRUDRoles test aims to test out low level CloudAPI functions to check if all of them work as
+// Test_OpenAPIInlineStructCRUDRoles test aims to test out low level OpenAPI functions to check if all of them work as
 // expected. It uses a very simple "Roles" endpoint which does not have bigger prerequisites and therefore is not
-// dependent one more deployment specific features. It also supports all of the CloudAPI CRUD endpoints so is a good
+// dependent one more deployment specific features. It also supports all of the OpenAPI CRUD endpoints so is a good
 // endpoint to test on
-// Actions of the test:
-// 1. Get all available roles using "Get all endpoint"
-// 2.1 Use FIQL query filtering to retrieve specific item by ID on "Get All" endpoint
+// This test performs the following:
+// 1. Gets all available roles using "Get all endpoint"
+// 2.1 Uses FIQL query filtering to retrieve specific item by ID on "Get All" endpoint
 // 2.2 Use GET by ID endpoint to check that each of roles retrieved by get all can be found individually
-// 2.3 Compare struct retrieved by using "Get all" endpoint and FIQL filter with struct retrieved by using "Get By ID"
-// 3. Create a new role and verify it is created as specified by using deep equality
-// 4. Delete created role
-// 5. Test read for deleted item
+// 2.3 Compares retrieved struct by using "Get all" endpoint and FIQL filter with struct retrieved by using "Get By ID"
+// endpoint
+// 3. Creates a new role and verifies it is created as specified by using deep equality
+// 4. Deletes created role
+// 5. Tests read for deleted item
 func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	minimumRequiredApiVersion := "31.0"
 	skipOpenApiEndpoint(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
@@ -161,7 +162,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 		check.Assert(err, IsNil)
 		check.Assert(oneRole, NotNil)
 
-		// Step 2.3 - compare struct retrieve by using filter and the one retrieve by exact endpoint ID
+		// Step 2.3 - compare struct retrieved by using filter and the one retrieved by exact endpoint ID
 		check.Assert(oneRole, DeepEquals, expectOneRoleResultById[0])
 
 	}
@@ -173,8 +174,9 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	newRole := &Roles{
 		Name:        check.TestName(),
 		Description: "Role created by test",
-		BundleKey:   "com.vmware.vcloud.undefined.key",
-		ReadOnly:    false,
+		// This BundleKey is being set by VCD even if it is not sent
+		BundleKey: "com.vmware.vcloud.undefined.key",
+		ReadOnly:  false,
 	}
 	newRoleResponse := &Roles{}
 	err = vcd.client.Client.OpenApiPostItem(minimumRequiredApiVersion, createUrl, nil, newRole, newRoleResponse)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -19,7 +19,7 @@ import (
 // fetch response from multiple pages in RAW json messages without having defined a clear struct.
 func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", "< "+minimumRequiredApiVersion)
+	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
@@ -50,7 +50,7 @@ func (vcd *TestVCD) Test_OpenAPIRawJsonAudiTrail(check *C) {
 // to user defined inline type
 func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 	minimumRequiredApiVersion := "33.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", "< "+minimumRequiredApiVersion)
+	skipOpenApiEndpoint(vcd, check, "1.0.0/auditTrail", minimumRequiredApiVersion)
 
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
 	check.Assert(err, IsNil)
@@ -119,7 +119,7 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructAudiTrail(check *C) {
 // 5. Test read for deleted item
 func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 	minimumRequiredApiVersion := "31.0"
-	skipOpenApiEndpoint(vcd, check, "1.0.0/roles", "< "+minimumRequiredApiVersion)
+	skipOpenApiEndpoint(vcd, check, "1.0.0/roles", minimumRequiredApiVersion)
 
 	// Step 1 - Get all roles
 	urlRef, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
@@ -200,14 +200,14 @@ func (vcd *TestVCD) Test_OpenAPIInlineStructCRUDRoles(check *C) {
 }
 
 // skipOpenApiEndpoint is a helper to skip tests for particular unsupported OpenAPI endpoints
-func skipOpenApiEndpoint(vcd *TestVCD, check *C, endpoint, skipWhenMaxVersion string) {
-	if vcd.client.Client.APIVCDMaxVersionIs(skipWhenMaxVersion) {
+func skipOpenApiEndpoint(vcd *TestVCD, check *C, endpoint, requiredVersionConstraint string) {
+	if !vcd.client.Client.APIVCDMaxVersionIs(">= " + requiredVersionConstraint) {
 		maxSupportedVersion, err := vcd.client.Client.maxSupportedVersion()
 		if err != nil {
 			panic(fmt.Sprintf("Could not get maximum supported version: %s", err))
 		}
-		skipText := fmt.Sprintf("Skipping test because OpenAPI endpoint '%s' must satisfy version constraint '%s'. Maximum supported version is %s",
-			endpoint, skipWhenMaxVersion, maxSupportedVersion)
+		skipText := fmt.Sprintf("Skipping test because OpenAPI endpoint '%s' must satisfy API version constraint '%s'. Maximum supported version is %s",
+			endpoint, requiredVersionConstraint, maxSupportedVersion)
 		check.Skip(skipText)
 	}
 }

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -79,7 +79,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 
 	task := NewTask(orgVdcNet.client)
 
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
 	}
 
@@ -169,7 +169,7 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 				break
 			}
 			orgVDCNetwork := NewOrgVDCNetwork(vdc.client)
-			if err = decodeBody(resp, orgVDCNetwork.OrgVDCNetwork); err != nil {
+			if err = decodeBody(types.BodyTypeXML, resp, orgVDCNetwork.OrgVDCNetwork); err != nil {
 				return Task{}, fmt.Errorf("error decoding orgvdcnetwork response: %s", err)
 			}
 			activeTasks := 0

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -80,7 +80,7 @@ func getResult(client *Client, request *http.Request) (Results, error) {
 
 	results := NewResults(client)
 
-	if err = decodeBody(resp, results.Results); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, results.Results); err != nil {
 		return Results{}, fmt.Errorf("error decoding query results: %s", err)
 	}
 

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -1,0 +1,149 @@
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type OpenApiRole struct {
+	Role   *types.Role
+	client *Client
+}
+
+// GetOpenApiRoleById retrieves role by given ID
+func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
+	endpoint := "1.0.0/roles/"
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if id == "" {
+		return nil, fmt.Errorf("empty role id")
+	}
+
+	urlRef, err := adminOrg.client.BuildOpenApiEndpoint(endpoint, id)
+	if err != nil {
+		return nil, err
+	}
+
+	role := &OpenApiRole{
+		Role:   &types.Role{},
+		client: adminOrg.client,
+	}
+
+	err = adminOrg.client.OpenApiGetItem(minimumApiVersion, urlRef, nil, role.Role)
+	if err != nil {
+		return nil, err
+	}
+
+	return role, nil
+}
+
+// GetAllOpenApiRoles retrieves all roles using OpenAPI endpoint. Query parameters can be supplied to perform additional
+// filtering
+func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*types.Role, error) {
+	endpoint := "1.0.0/roles/"
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := adminOrg.client.BuildOpenApiEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := []*types.Role{{}}
+
+	err = adminOrg.client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &responses)
+	if err != nil {
+		return nil, err
+	}
+
+	return responses, nil
+}
+
+// Create creates a new role using OpenAPI endpoint
+func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
+	endpoint := "1.0.0/roles/"
+	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	returnRole := &OpenApiRole{
+		Role:   &types.Role{},
+		client: role.client,
+	}
+
+	err = role.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newRole, returnRole.Role)
+	if err != nil {
+		return nil, fmt.Errorf("error creating role: %s", err)
+	}
+
+	return returnRole, nil
+}
+
+// Update updates existing OpenAPI role
+func (role *OpenApiRole) Update() (*OpenApiRole, error) {
+	endpoint := "1.0.0/roles/"
+	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if role.Role.ID == "" {
+		return nil, fmt.Errorf("cannot update role without id")
+	}
+
+	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint, role.Role.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	returnRole := &OpenApiRole{
+		Role:   &types.Role{},
+		client: role.client,
+	}
+
+	err = role.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, role.Role, returnRole.Role)
+	if err != nil {
+		return nil, fmt.Errorf("error updating role: %s", err)
+	}
+
+	return returnRole, nil
+}
+
+// Delete deletes OpenAPI role
+func (role *OpenApiRole) Delete() error {
+	endpoint := "1.0.0/roles/"
+	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	if role.Role.ID == "" {
+		return fmt.Errorf("cannot delete role without id")
+	}
+
+	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint, role.Role.ID)
+	if err != nil {
+		return err
+	}
+
+	err = role.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting role: %s", err)
+	}
+
+	return nil
+}

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -42,7 +42,7 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
 	return role, nil
 }
 
-// GetAllOpenApiRoles retrieves all roles using OpenAPI endpoint. Query parameters can be supplied to perform additional
+// GetAllOpenApiRoles retrieves all roles using OpenApi endpoint. Query parameters can be supplied to perform additional
 // filtering
 func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*types.Role, error) {
 	endpoint := "1.0.0/roles/"
@@ -66,7 +66,7 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*typ
 	return responses, nil
 }
 
-// Create creates a new role using OpenAPI endpoint
+// Create creates a new role using OpenApi endpoint
 func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -92,7 +92,7 @@ func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 	return returnRole, nil
 }
 
-// Update updates existing OpenAPI role
+// Update updates existing OpenApi role
 func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -122,7 +122,7 @@ func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 	return returnRole, nil
 }
 
-// Delete deletes OpenAPI role
+// Delete deletes OpenApi role
 func (role *OpenApiRole) Delete() error {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -42,7 +42,7 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
 	return role, nil
 }
 
-// GetAllOpenApiRoles retrieves all roles using OpenApi endpoint. Query parameters can be supplied to perform additional
+// GetAllOpenApiRoles retrieves all roles using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
 func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*types.Role, error) {
 	endpoint := "1.0.0/roles/"
@@ -66,7 +66,7 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*typ
 	return responses, nil
 }
 
-// Create creates a new role using OpenApi endpoint
+// Create creates a new role using OpenAPI endpoint
 func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -92,7 +92,7 @@ func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 	return returnRole, nil
 }
 
-// Update updates existing OpenApi role
+// Update updates existing OpenAPI role
 func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -122,7 +122,7 @@ func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 	return returnRole, nil
 }
 
-// Delete deletes OpenApi role
+// Delete deletes OpenAPI role
 func (role *OpenApiRole) Delete() error {
 	endpoint := "1.0.0/roles/"
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -18,7 +18,7 @@ type OpenApiRole struct {
 
 // GetOpenApiRoleById retrieves role by given ID
 func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
-	endpoint := "1.0.0/roles/"
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
 	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
 // GetAllOpenApiRoles retrieves all roles using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
 func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*types.Role, error) {
-	endpoint := "1.0.0/roles/"
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
 	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*typ
 
 // Create creates a new role using OpenAPI endpoint
 func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
-	endpoint := "1.0.0/roles/"
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 
 // Update updates existing OpenAPI role
 func (role *OpenApiRole) Update() (*OpenApiRole, error) {
-	endpoint := "1.0.0/roles/"
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 
 // Delete deletes OpenAPI role
 func (role *OpenApiRole) Delete() error {
-	endpoint := "1.0.0/roles/"
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
 	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return err

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"net/url"

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -24,7 +24,7 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*OpenApiRole, error) {
 		return nil, fmt.Errorf("empty role id")
 	}
 
-	urlRef, err := adminOrg.client.BuildOpenApiEndpoint(endpoint, id)
+	urlRef, err := adminOrg.client.OpenApiBuildEndpoint(endpoint, id)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*typ
 		return nil, err
 	}
 
-	urlRef, err := adminOrg.client.BuildOpenApiEndpoint(endpoint)
+	urlRef, err := adminOrg.client.OpenApiBuildEndpoint(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (role *OpenApiRole) Create(newRole *types.Role) (*OpenApiRole, error) {
 		return nil, err
 	}
 
-	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint)
+	urlRef, err := role.client.OpenApiBuildEndpoint(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (role *OpenApiRole) Update() (*OpenApiRole, error) {
 		return nil, fmt.Errorf("cannot update role without id")
 	}
 
-	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint, role.Role.ID)
+	urlRef, err := role.client.OpenApiBuildEndpoint(endpoint, role.Role.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (role *OpenApiRole) Delete() error {
 		return fmt.Errorf("cannot delete role without id")
 	}
 
-	urlRef, err := role.client.BuildOpenApiEndpoint(endpoint, role.Role.ID)
+	urlRef, err := role.client.OpenApiBuildEndpoint(endpoint, role.Role.ID)
 	if err != nil {
 		return err
 	}

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -1,0 +1,83 @@
+// +build functional openapi ALL
+
+package govcd
+
+import (
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_Roles(check *C) {
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	allExistingRoles, err := adminOrg.GetAllOpenApiRoles(nil)
+	check.Assert(err, IsNil)
+	check.Assert(allExistingRoles, NotNil)
+
+	// Step 2 - Get all roles using query filters
+	for _, oneRole := range allExistingRoles {
+
+		// Step 2.1 - retrieve specific role by using FIQL filter
+		// urlRef2, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
+		// check.Assert(err, IsNil)
+
+		queryParams := url.Values{}
+		queryParams.Add("filter", "id=="+oneRole.ID)
+
+		// expectOneRoleResultById := []*InlineRoles{{}}
+		expectOneRoleResultById, err := adminOrg.GetAllOpenApiRoles(queryParams)
+		check.Assert(err, IsNil)
+		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
+
+		// Step 2.2 - retrieve specific role by using endpoint
+		exactItem, err := adminOrg.GetOpenApiRoleById(oneRole.ID)
+		check.Assert(err, IsNil)
+
+		check.Assert(err, IsNil)
+		check.Assert(exactItem, NotNil)
+
+		// Step 2.3 - compare struct retrieved by using filter and the one retrieved by exact endpoint ID
+		check.Assert(oneRole, DeepEquals, expectOneRoleResultById[0])
+
+	}
+
+	// Step 3 - Create a new role and ensure it is created as specified by doing deep comparison
+
+	newR := &OpenApiRole{
+		client: adminOrg.client,
+		Role: &types.Role{
+			Name:        check.TestName(),
+			Description: "Role created by test",
+			// This BundleKey is being set by VCD even if it is not sent
+			BundleKey: "com.vmware.vcloud.undefined.key",
+			ReadOnly:  false,
+		},
+	}
+
+	createdRole, err := newR.Create(newR.Role)
+	check.Assert(err, IsNil)
+
+	// Ensure supplied and created structs differ only by ID
+	newR.Role.ID = createdRole.Role.ID
+	check.Assert(createdRole.Role, DeepEquals, newR.Role)
+
+	// Step 4 - updated created role
+	newR.Role.Description = "Updated description"
+	updatedRole, err := newR.Update()
+	check.Assert(err, IsNil)
+	check.Assert(updatedRole.Role, DeepEquals, newR.Role)
+
+	// Step 5 - delete created role
+	err = updatedRole.Delete()
+	check.Assert(err, IsNil)
+	// Step 5 - try to read deleted role and expect error to contain 'ErrorEntityNotFound'
+	// Read is tricky - it throws an error ACCESS_TO_RESOURCE_IS_FORBIDDEN when the resource with ID does not
+	// exist therefore one cannot know what kind of error occurred.
+	deletedRole, err := adminOrg.GetOpenApiRoleById(createdRole.Role.ID)
+	check.Assert(ContainsNotFound(err), Equals, true)
+	check.Assert(deletedRole, IsNil)
+}

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -1,5 +1,9 @@
 // +build functional openapi ALL
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -14,6 +14,7 @@ func (vcd *TestVCD) Test_Roles(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
+	// Step 1 - Get all roles
 	allExistingRoles, err := adminOrg.GetAllOpenApiRoles(nil)
 	check.Assert(err, IsNil)
 	check.Assert(allExistingRoles, NotNil)
@@ -22,13 +23,9 @@ func (vcd *TestVCD) Test_Roles(check *C) {
 	for _, oneRole := range allExistingRoles {
 
 		// Step 2.1 - retrieve specific role by using FIQL filter
-		// urlRef2, err := vcd.client.Client.BuildOpenApiEndpoint("1.0.0/roles")
-		// check.Assert(err, IsNil)
-
 		queryParams := url.Values{}
 		queryParams.Add("filter", "id=="+oneRole.ID)
 
-		// expectOneRoleResultById := []*InlineRoles{{}}
 		expectOneRoleResultById, err := adminOrg.GetAllOpenApiRoles(queryParams)
 		check.Assert(err, IsNil)
 		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)

--- a/govcd/saml_auth.go
+++ b/govcd/saml_auth.go
@@ -266,8 +266,8 @@ func authorizeSignToken(vcdCli *VCDClient, base64GzippedSignToken, org string) (
 // The payload is not configured as a struct and unmarshalled because Go's unmarshalling changes
 // structure so that ADFS does not accept the payload
 func getSamlTokenRequestBody(user, password, samlEntityIdReference, adfsAuthEndpoint string) string {
-	return `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
-	xmlns:a="http://www.w3.org/2005/08/addressing"
+	return `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" 
+	xmlns:a="http://www.w3.org/2005/08/addressing" 
 	xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
 	<s:Header>
 		<a:Action s:mustUnderstand="1">http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue</a:Action>
@@ -275,7 +275,7 @@ func getSamlTokenRequestBody(user, password, samlEntityIdReference, adfsAuthEndp
 			<a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
 		</a:ReplyTo>
 		<a:To s:mustUnderstand="1">` + adfsAuthEndpoint + `</a:To>
-		<o:Security s:mustUnderstand="1"
+		<o:Security s:mustUnderstand="1" 
 			xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 			<u:Timestamp u:Id="_0">
 				<u:Created>` + time.Now().Format(time.RFC3339) + `</u:Created>
@@ -296,7 +296,7 @@ func getSamlTokenRequestBody(user, password, samlEntityIdReference, adfsAuthEndp
 			</wsp:AppliesTo>
 			<trust:KeySize>0</trust:KeySize>
 			<trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</trust:KeyType>
-			<i:RequestDisplayToken xml:lang="en"
+			<i:RequestDisplayToken xml:lang="en" 
 				xmlns:i="http://schemas.xmlsoap.org/ws/2005/05/identity" />
 			<trust:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</trust:RequestType>
 			<trust:TokenType>http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0</trust:TokenType>

--- a/govcd/saml_auth_unit_test.go
+++ b/govcd/saml_auth_unit_test.go
@@ -1,5 +1,9 @@
 // +build unit ALL
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -67,7 +67,7 @@ func (task *Task) Refresh() error {
 	// elements in slices.
 	task.Task = &types.Task{}
 
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return fmt.Errorf("error decoding task response: %s", task.getErrorMessage(err))
 	}
 

--- a/govcd/upload.go
+++ b/govcd/upload.go
@@ -221,7 +221,7 @@ func createTaskForVcdImport(client *Client, taskHREF string) (Task, error) {
 
 	task := NewTask(client)
 
-	if err = decodeBody(response, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, response, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding Task response: %s", err)
 	}
 

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -1,5 +1,9 @@
 // +build concurrent
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -149,7 +149,7 @@ func (vdc *Vdc) Delete(force bool, recursive bool) (Task, error) {
 		return Task{}, fmt.Errorf("error deleting vdc: %s", err)
 	}
 	task := NewTask(vdc.client)
-	if err = decodeBody(resp, task.Task); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return Task{}, fmt.Errorf("error decoding task response: %s", err)
 	}
 	if task.Task.Status == "error" {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -734,12 +734,12 @@ func (vm *VM) GetQuestion() (types.VmPendingQuestion, error) {
 	}
 
 	if http.StatusOK != resp.StatusCode {
-		return types.VmPendingQuestion{}, fmt.Errorf("error getting question: %s", ParseErr(resp, &types.Error{}))
+		return types.VmPendingQuestion{}, fmt.Errorf("error getting question: %s", ParseErr(types.BodyTypeXML, resp, &types.Error{}))
 	}
 
 	question := &types.VmPendingQuestion{}
 
-	if err = decodeBody(resp, question); err != nil {
+	if err = decodeBody(types.BodyTypeXML, resp, question); err != nil {
 		return types.VmPendingQuestion{}, fmt.Errorf("error decoding question response: %s", err)
 	}
 

--- a/govcd/vm_affinity_rule.go
+++ b/govcd/vm_affinity_rule.go
@@ -1,5 +1,9 @@
 package govcd
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 import (
 	"fmt"
 	"net/http"

--- a/govcd/vm_concurrent_test.go
+++ b/govcd/vm_concurrent_test.go
@@ -1,5 +1,9 @@
 // +build concurrent
 
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
 package govcd
 
 import (

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -9,7 +9,7 @@ OpenAPI low level functions consist of the following to match REST API:
 * OpenApiPutItem
 * OpenApiDeleteItem
 * OpenApiIsSupported
-* BuildOpenApiEndpoint
+* OpenApiBuildEndpoint
 
 **Note** The endpoint `1.0.0/auditTrail` requires VCD API to support version 33.0 or higher. Version 33.0 was introduced
 with VCD 10.0.

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -11,12 +11,12 @@ OpenAPI low level functions consist of the following to match REST API:
 * OpenApiIsSupported
 * BuildOpenApiEndpoint
 
-**Note** The endpoint `1.0.0/auditTrail` requires VCD API to support version 33.0 or bigger. Version 33.0 was introduced
+**Note** The endpoint `1.0.0/auditTrail` requires VCD API to support version 33.0 or higher. Version 33.0 was introduced
 with VCD 10.0.
 
-## Using mode 1 (Dump raw JSON message as strings)
-This command will dump JSON for audiTrail endpoint as strings allowing to pipe it and process using
-external tools like jq
+## Using mode 1 (Dump raw JSON message as string)
+This command will dump JSON for audiTrail endpoint as string allowing to pipe it and process using
+external tools like `jq`
 ```
 ./openapi --username my_user --password my_secret_password --org my-org --endpoint https://192.168.1.160/api --mode 1 | jq
 ```

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -1,0 +1,73 @@
+# Open API consumption using low level functions and RAW JSON structures
+
+This example demonstrates how to consume new [OpenAPI](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) in VMware Cloud Director. 
+
+OpenAPI low level functions consist of the following to match REST API:
+* OpenApiGetAllItems (FIQL filtering can be applied to narrow down results)
+* OpenApiPostItem
+* OpenApiGetItem
+* OpenApiPutItem
+* OpenApiDeleteItem
+* OpenApiIsSupported
+* BuildOpenApiEndpoint
+
+
+## Using mode 1 (Dump raw JSON message as strings)
+This command will dump JSON for audiTrail endpoint as strings allowing to pipe it and process using
+external tools like jq
+```
+./openapi --username my_user --password my_secret_password --org my-org --endpoint https://192.168.1.160/api --mode 1 | jq
+```
+
+Sample output:
+```
+[
+  {
+    "eventId": "urn:vcloud:audit:1df68f82-8e75-4bf9-94ce-c06e1cec66bc",
+    "description": "User 'administrator' login failed",
+    "operatingOrg": {
+      "name": "username-custom",
+      "id": "urn:vcloud:org:534625ff-7399-4368-8313-0b75d66bbb6e"
+    },
+    "user": {
+      "name": "administrator",
+      "id": "urn:vcloud:user:522d756c-ad00-3b4f-ae6a-6d241437b471"
+    },
+    "eventEntity": {
+      "name": "administrator",
+      "id": "urn:vcloud:user:522d756c-ad00-3b4f-ae6a-6d241437b471"
+    },
+    "taskId": null,
+...
+```
+
+## Using mode 2 (Define custom struct with JSON tags and access fields)
+This mode allows to use OpenAPI in regular Go way (by defining a struct with JSON field tags)
+
+```
+./openapi --username my_user --password my_secret_password --org my-org --endpoint https://192.168.1.160/api --mode 2
+```
+
+Sample output:
+
+```
+Got 30 results
+2020-07-19T18:57:34.398+0000 - administrator, -com/vmware/vcloud/event/session/login
+2020-07-19T18:58:04.211+0000 - administrator, -com/vmware/vcloud/event/user/create
+2020-07-19T18:58:13.904+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T18:58:14.026+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+2020-07-19T18:58:18.256+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T18:58:18.353+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+2020-07-19T18:58:23.841+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T18:58:23.934+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+2020-07-19T19:01:22.513+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T19:01:22.619+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+2020-07-19T19:04:54.392+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T19:04:54.517+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+2020-07-19T19:04:59.648+0000 - dainius, -com/vmware/vcloud/event/session/login
+2020-07-19T19:04:59.758+0000 - dainius, -com/vmware/vcloud/event/session/authorize
+```
+
+## Troubleshooting
+Environment variable `GOVCD_LOG=1` can be used to enable API call logging. It should log all API
+calls with obfuscated credentials to aid troubleshooting.

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -1,8 +1,8 @@
 # Open API consumption using low level functions and RAW JSON structures
 
-This example demonstrates how to consume new [OpenAPI](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) in VMware Cloud Director. 
+This example demonstrates how to consume new [OpenApi](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) in VMware Cloud Director. 
 
-OpenAPI low level functions consist of the following to match REST API:
+OpenApi low level functions consist of the following to match REST API:
 * OpenApiGetAllItems (FIQL filtering can be applied to narrow down results)
 * OpenApiPostItem
 * OpenApiGetItem
@@ -44,7 +44,7 @@ Sample output:
 ```
 
 ## Using mode 2 (Define custom struct with JSON tags and access fields)
-This mode allows to use OpenAPI in regular Go way (by defining a struct with JSON field tags)
+This mode allows to use OpenApi in regular Go way (by defining a struct with JSON field tags)
 
 ```
 ./openapi --username my_user --password my_secret_password --org my-org --endpoint https://192.168.1.160/api --mode 2

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -1,8 +1,8 @@
 # Open API consumption using low level functions and RAW JSON structures
 
-This example demonstrates how to consume new [OpenApi](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) in VMware Cloud Director. 
+This example demonstrates how to consume new [OpenAPI](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) in VMware Cloud Director. 
 
-OpenApi low level functions consist of the following to match REST API:
+OpenAPI low level functions consist of the following to match REST API:
 * OpenApiGetAllItems (FIQL filtering can be applied to narrow down results)
 * OpenApiPostItem
 * OpenApiGetItem
@@ -44,7 +44,7 @@ Sample output:
 ```
 
 ## Using mode 2 (Define custom struct with JSON tags and access fields)
-This mode allows to use OpenApi in regular Go way (by defining a struct with JSON field tags)
+This mode allows to use OpenAPI in regular Go way (by defining a struct with JSON field tags)
 
 ```
 ./openapi --username my_user --password my_secret_password --org my-org --endpoint https://192.168.1.160/api --mode 2

--- a/samples/openapi/README.md
+++ b/samples/openapi/README.md
@@ -11,6 +11,8 @@ OpenAPI low level functions consist of the following to match REST API:
 * OpenApiIsSupported
 * BuildOpenApiEndpoint
 
+**Note** The endpoint `1.0.0/auditTrail` requires VCD API to support version 33.0 or bigger. Version 33.0 was introduced
+with VCD 10.0.
 
 ## Using mode 1 (Dump raw JSON message as strings)
 This command will dump JSON for audiTrail endpoint as strings allowing to pipe it and process using

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&password, "password", "", "Password")
 	flag.StringVar(&org, "org", "System", "Org name. Default is 'System'")
 	flag.StringVar(&apiEndpoint, "endpoint", "", "API endpoint (e.g. 'https://hostname/api')")
-	flag.StringVar(&mode, "mode", "", "OpenAPI query mode: 1 - RAW json, 2 - inline type")
+	flag.StringVar(&mode, "mode", "", "OpenApi query mode: 1 - RAW json, 2 - inline type")
 }
 
 // Usage:
@@ -73,7 +73,7 @@ func main() {
 }
 
 // openAPIGetRawJsonAuditTrail is an example function how to use low level function to interact
-// with OpenAPI in VCD. This examples dumps to screen valid JSON which can then be processed using
+// with OpenApi in VCD. This examples dumps to screen valid JSON which can then be processed using
 // other tools (for example 'jq' in shell)
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
@@ -99,7 +99,7 @@ func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
 }
 
 // openAPIGetStructAuditTrail is an example function how to use low level function to interact with
-// OpenAPI in VCD and marshal responses into custom defined struct with tags.
+// OpenApi in VCD and marshal responses into custom defined struct with tags.
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetStructAuditTrail(vcdClient *govcd.VCDClient) {
 	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+var (
+	username    string
+	password    string
+	org         string
+	apiEndpoint string
+	mode        string
+)
+
+func init() {
+	flag.StringVar(&username, "username", "", "Username")
+	flag.StringVar(&password, "password", "", "Password")
+	flag.StringVar(&org, "org", "System", "Org name. Default is 'System'")
+	flag.StringVar(&apiEndpoint, "endpoint", "", "API endpoint (e.g. 'https://hostname/api')")
+	flag.StringVar(&mode, "mode", "", "OpenAPI query mode: 1 - RAW json, 2 - inline type")
+}
+
+// Usage:
+// # go build -o openapi
+// # ./openapi --username my_user --password my_secret_password --org my-org --endpoint
+// https://192.168.1.160/api  --mode 1
+func main() {
+	flag.Parse()
+
+	if username == "" || password == "" || org == "" || apiEndpoint == "" || mode == "" {
+		fmt.Printf("'username', 'password', 'org', 'endpoint' and 'mode' must be specified\n")
+		os.Exit(1)
+	}
+
+	vcdURL, err := url.Parse(apiEndpoint)
+	if err != nil {
+		fmt.Printf("Error parsing supplied endpoint %s: %s", apiEndpoint, err)
+		os.Exit(2)
+	}
+
+	vcdCli := govcd.NewVCDClient(*vcdURL, true)
+	err = vcdCli.Authenticate(username, password, org)
+	if err != nil {
+
+		fmt.Println(err)
+		os.Exit(3)
+	}
+
+	switch mode {
+	case "1":
+		openAPIGetRawJsonAuditTrail(vcdCli)
+	case "2":
+		openAPIGetStructAuditTrail(vcdCli)
+	}
+
+}
+
+// openAPIGetRawJsonAuditTrail is an example function how to use low level function to interact
+// with OpenAPI in VCD. This examples dumps to screen valid JSON which can then be processed using
+// other tools (for example 'jq' in shell)
+// It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
+func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
+	urlRef, err := vcdClient.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	if err != nil {
+		panic(err)
+	}
+
+	queryParams := url.Values{}
+	filterTime := time.Now().Add(-12 * time.Hour).Format(types.FiqlQueryTimestampFormat)
+	queryParams.Add("filter", "timestamp=gt="+filterTime)
+
+	allResponses := []json.RawMessage{{}}
+	err = vcdClient.Client.OpenApiGetAllItems(urlRef, queryParams, &allResponses)
+	if err != nil {
+		panic(err)
+	}
+
+	// Wrap slice of response objects into JSON list so that it is correct JSON
+	responseStrings := jsonRawMessagesToStrings(allResponses)
+	allStringResponses := `[` + strings.Join(responseStrings, ",") + `]`
+	fmt.Println(allStringResponses)
+}
+
+// openAPIGetStructAuditTrail is an example function how to use low level function to interact with
+// OpenAPI in VCD and marshal responses into custom defined struct with tags.
+// It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
+func openAPIGetStructAuditTrail(vcdClient *govcd.VCDClient) {
+	urlRef, err := vcdClient.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	if err != nil {
+		panic(err)
+	}
+
+	// Inline type
+	type AudiTrail struct {
+		EventID      string `json:"eventId"`
+		Description  string `json:"description"`
+		OperatingOrg struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"operatingOrg"`
+		User struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"user"`
+		EventEntity struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+		} `json:"eventEntity"`
+		TaskID               interface{} `json:"taskId"`
+		TaskCellID           string      `json:"taskCellId"`
+		CellID               string      `json:"cellId"`
+		EventType            string      `json:"eventType"`
+		ServiceNamespace     string      `json:"serviceNamespace"`
+		EventStatus          string      `json:"eventStatus"`
+		Timestamp            string      `json:"timestamp"`
+		External             bool        `json:"external"`
+		AdditionalProperties struct {
+			UserRoles                         string `json:"user.roles"`
+			UserSessionID                     string `json:"user.session.id"`
+			CurrentContextUserProxyAddress    string `json:"currentContext.user.proxyAddress"`
+			CurrentContextUserClientIPAddress string `json:"currentContext.user.clientIpAddress"`
+		} `json:"additionalProperties"`
+	}
+
+	response := []*AudiTrail{{}}
+
+	queryParams := url.Values{}
+	filterTime := time.Now().Add(-12 * time.Hour).Format(types.FiqlQueryTimestampFormat)
+	queryParams.Add("filter", "timestamp=gt="+filterTime)
+
+	err = vcdClient.Client.OpenApiGetAllItems(urlRef, queryParams, &response)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Got %d results\n", len(response))
+
+	for _, value := range response {
+		fmt.Printf("%s - %s, -%s\n", value.Timestamp, value.User.Name, value.EventType)
+	}
+}
+
+// jsonRawMessagesToStrings converts []*json.RawMessage to []string
+func jsonRawMessagesToStrings(messages []json.RawMessage) []string {
+	resultString := make([]string, len(messages))
+	for index, message := range messages {
+		resultString[index] = string(message)
+	}
+	return resultString
+}

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	if vcdCli.Client.APIVCDMaxVersionIs("< 33.0") {
-		fmt.Println("This example requires VCD API to support at least version 33.0 to use '1.0.0/auditTrail' endpoint")
+		fmt.Println("This example requires VCD API to support at least version 33.0 (VCD 10.0) to use '1.0.0/auditTrail' endpoint")
 		os.Exit(4)
 	}
 

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&password, "password", "", "Password")
 	flag.StringVar(&org, "org", "System", "Org name. Default is 'System'")
 	flag.StringVar(&apiEndpoint, "endpoint", "", "API endpoint (e.g. 'https://hostname/api')")
-	flag.StringVar(&mode, "mode", "", "OpenApi query mode: 1 - RAW json, 2 - inline type")
+	flag.StringVar(&mode, "mode", "", "OpenAPI query mode: 1 - RAW json, 2 - inline type")
 }
 
 // Usage:
@@ -73,7 +73,7 @@ func main() {
 }
 
 // openAPIGetRawJsonAuditTrail is an example function how to use low level function to interact
-// with OpenApi in VCD. This examples dumps to screen valid JSON which can then be processed using
+// with OpenAPI in VCD. This examples dumps to screen valid JSON which can then be processed using
 // other tools (for example 'jq' in shell)
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
@@ -99,7 +99,7 @@ func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
 }
 
 // openAPIGetStructAuditTrail is an example function how to use low level function to interact with
-// OpenApi in VCD and marshal responses into custom defined struct with tags.
+// OpenAPI in VCD and marshal responses into custom defined struct with tags.
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetStructAuditTrail(vcdClient *govcd.VCDClient) {
 	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -77,7 +77,7 @@ func main() {
 // other tools (for example 'jq' in shell)
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
-	urlRef, err := vcdClient.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")
 	if err != nil {
 		panic(err)
 	}
@@ -102,7 +102,7 @@ func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
 // OpenAPI in VCD and marshal responses into custom defined struct with tags.
 // It also uses FIQL query filter to retrieve auditTrail items only for the last 12 hours
 func openAPIGetStructAuditTrail(vcdClient *govcd.VCDClient) {
-	urlRef, err := vcdClient.Client.BuildOpenApiEndpoint("1.0.0/auditTrail")
+	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint("1.0.0/auditTrail")
 	if err != nil {
 		panic(err)
 	}

--- a/samples/openapi/main.go
+++ b/samples/openapi/main.go
@@ -58,6 +58,11 @@ func main() {
 		os.Exit(3)
 	}
 
+	if vcdCli.Client.APIVCDMaxVersionIs("< 33.0") {
+		fmt.Println("This example requires VCD API to support at least version 33.0 to use '1.0.0/auditTrail' endpoint")
+		os.Exit(4)
+	}
+
 	switch mode {
 	case "1":
 		openAPIGetRawJsonAuditTrail(vcdCli)
@@ -82,7 +87,7 @@ func openAPIGetRawJsonAuditTrail(vcdClient *govcd.VCDClient) {
 	queryParams.Add("filter", "timestamp=gt="+filterTime)
 
 	allResponses := []json.RawMessage{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(urlRef, queryParams, &allResponses)
+	err = vcdClient.Client.OpenApiGetAllItems("33.0", urlRef, queryParams, &allResponses)
 	if err != nil {
 		panic(err)
 	}
@@ -140,7 +145,7 @@ func openAPIGetStructAuditTrail(vcdClient *govcd.VCDClient) {
 	filterTime := time.Now().Add(-12 * time.Hour).Format(types.FiqlQueryTimestampFormat)
 	queryParams.Add("filter", "timestamp=gt="+filterTime)
 
-	err = vcdClient.Client.OpenApiGetAllItems(urlRef, queryParams, &response)
+	err = vcdClient.Client.OpenApiGetAllItems("33.0", urlRef, queryParams, &response)
 	if err != nil {
 		panic(err)
 	}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -22,6 +22,8 @@ const (
 	Version = Version511
 	// SoapXML mime type
 	SoapXML = "application/soap+xml"
+	// JSONMime
+	JSONMime = "application/json"
 )
 
 const (
@@ -272,4 +274,20 @@ const (
 	LdapModeNone   = "NONE"
 	LdapModeSystem = "SYSTEM"
 	LdapModeCustom = "CUSTOM"
+)
+
+// BodyType allows to define API body types where applicable
+type BodyType int
+
+const (
+	// BodyTypeXML
+	BodyTypeXML BodyType = iota
+
+	// BodyTypeJSON
+	BodyTypeJSON
+)
+
+const (
+	// FiqlQueryTimestampFormat is the format accepted by Cloud API time comparison operator in FIQL query filters
+	FiqlQueryTimestampFormat = "2006-01-02T15:04:05.000Z"
 )

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -293,3 +293,9 @@ const (
 	// FiqlQueryTimestampFormat is the format accepted by Cloud API time comparison operator in FIQL query filters
 	FiqlQueryTimestampFormat = "2006-01-02T15:04:05.000Z"
 )
+
+// These constants allow to construct OpenAPI endpoint paths and avoid strings in code for easy replacement in future.
+const (
+	OpenApiPathVersion1_0_0 = "1.0.0/"
+	OpenApiEndpointRoles    = "roles/"
+)

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CloudApiPageValues is a slice of json.RawMessage. json.RawMessage itself allows to partially marshal responses and is
+// used to decouple API paging handling from particular returned types.
+type CloudApiPageValues []json.RawMessage
+
+// CloudApiPages unwraps pagination for "Get All" endpoints in CloudAPI. It uses a type "CloudApiPageValues" for values
+// which are kept int []json.RawMessage. json.RawMessage helps to decouple marshalling paging related information from
+// exact type related information. Paging can be handled dynamically this way while values can be marshaled into exact
+// types.
+type CloudApiPages struct {
+	// ResultTotal reports total results available
+	ResultTotal int `json:"resultTotal,omitempty"`
+	// PageCount reports total result pages available
+	PageCount int `json:"pageCount,omitempty"`
+	// Page reports current page of result
+	Page int `json:"page,omitempty"`
+	// PageSize reports pagesize
+	PageSize int `json:"pageSize,omitempty"`
+	// Associations ...
+	Associations interface{} `json:"associations,omitempty"`
+	// Values holds types depending on the endpoint therefore `json.RawMessage` is used to dynamically unmarshal into
+	// specific type as required
+	Values json.RawMessage `json:"values,omitempty"`
+}
+
+// AccumulatePageResponses helps to accumulate Raw JSON objects during a pagination query
+type AccumulatePageResponses []json.RawMessage
+
+// OpenApiError helpes to marshal and provider meaningful `Error` for
+type OpenApiError struct {
+	MinorErrorCode string `json:"minorErrorCode"`
+	Message        string `json:"message"`
+	StackTrace     string `json:"stackTrace"`
+}
+
+// Error method implements Go's default `error` interface for CloudAPI errors formats them for human readable output.
+func (openApiError OpenApiError) Error() string {
+	return fmt.Sprintf("%s - %s", openApiError.MinorErrorCode, openApiError.Message)
+}
+
+// ErrorWithStack is the same as `Error()`, but also includes stack trace returned by API which is usually lengthy.
+func (openApiError OpenApiError) ErrorWithStack() string {
+	return fmt.Sprintf("%s - %s. Stack: %s", openApiError.MinorErrorCode, openApiError.Message,
+		openApiError.StackTrace)
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// OpenApiPages unwraps pagination for "Get All" endpoints in OpenAPI. Values kept in json.RawMessage helps to decouple
+// OpenApiPages unwraps pagination for "Get All" endpoints in OpenApi. Values kept in json.RawMessage helps to decouple
 // marshalling paging related information from exact type related information. Paging can be handled dynamically this
 // way while values can be marshaled into exact types.
 type OpenApiPages struct {

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -41,3 +41,12 @@ func (openApiError OpenApiError) ErrorWithStack() string {
 	return fmt.Sprintf("%s - %s. Stack: %s", openApiError.MinorErrorCode, openApiError.Message,
 		openApiError.StackTrace)
 }
+
+// Role defines access roles in VCD
+type Role struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	BundleKey   string `json:"bundleKey"`
+	ReadOnly    bool   `json:"readOnly"`
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -5,10 +5,6 @@ import (
 	"fmt"
 )
 
-// CloudApiPageValues is a slice of json.RawMessage. json.RawMessage itself allows to partially marshal responses and is
-// used to decouple API paging handling from particular returned types.
-type CloudApiPageValues []json.RawMessage
-
 // CloudApiPages unwraps pagination for "Get All" endpoints in CloudAPI. It uses a type "CloudApiPageValues" for values
 // which are kept int []json.RawMessage. json.RawMessage helps to decouple marshalling paging related information from
 // exact type related information. Paging can be handled dynamically this way while values can be marshaled into exact
@@ -28,9 +24,6 @@ type CloudApiPages struct {
 	// specific type as required
 	Values json.RawMessage `json:"values,omitempty"`
 }
-
-// AccumulatePageResponses helps to accumulate Raw JSON objects during a pagination query
-type AccumulatePageResponses []json.RawMessage
 
 // OpenApiError helpes to marshal and provider meaningful `Error` for
 type OpenApiError struct {

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// OpenApiPages unwraps pagination for "Get All" endpoints in OpenApi. Values kept in json.RawMessage helps to decouple
+// OpenApiPages unwraps pagination for "Get All" endpoints in OpenAPI. Values kept in json.RawMessage helps to decouple
 // marshalling paging related information from exact type related information. Paging can be handled dynamically this
 // way while values can be marshaled into exact types.
 type OpenApiPages struct {

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 )
 
-// CloudApiPages unwraps pagination for "Get All" endpoints in CloudAPI. It uses a type "CloudApiPageValues" for values
-// which are kept int []json.RawMessage. json.RawMessage helps to decouple marshalling paging related information from
-// exact type related information. Paging can be handled dynamically this way while values can be marshaled into exact
-// types.
-type CloudApiPages struct {
+// OpenApiPages unwraps pagination for "Get All" endpoints in OpenAPI. Values kept in json.RawMessage helps to decouple
+// marshalling paging related information from exact type related information. Paging can be handled dynamically this
+// way while values can be marshaled into exact types.
+type OpenApiPages struct {
 	// ResultTotal reports total results available
 	ResultTotal int `json:"resultTotal,omitempty"`
 	// PageCount reports total result pages available

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -16,7 +16,7 @@ type CloudApiPages struct {
 	PageCount int `json:"pageCount,omitempty"`
 	// Page reports current page of result
 	Page int `json:"page,omitempty"`
-	// PageSize reports pagesize
+	// PageSize reports page size
 	PageSize int `json:"pageSize,omitempty"`
 	// Associations ...
 	Associations interface{} `json:"associations,omitempty"`
@@ -25,7 +25,7 @@ type CloudApiPages struct {
 	Values json.RawMessage `json:"values,omitempty"`
 }
 
-// OpenApiError helpes to marshal and provider meaningful `Error` for
+// OpenApiError helps to marshal and provider meaningful `Error` for
 type OpenApiError struct {
 	MinorErrorCode string `json:"minorErrorCode"`
 	Message        string `json:"message"`

--- a/util/logging.go
+++ b/util/logging.go
@@ -335,7 +335,7 @@ func ProcessResponseOutput(caller string, resp *http.Response, result string) {
 	}
 }
 
-// Sets the list of tahs to skip
+// Sets the list of tags to skip
 func SetSkipTags(tags string) {
 	if tags != "" {
 		skipTags = strings.Split(tags, ",")


### PR DESCRIPTION
This PR lays some groundwork towards supporting NSX-T (and other future features) by implementing support for new OpenAPI standard in VMware Cloud Director. OpenAPI support was introduced with VCD 9.5 (which coincides with currently minimum supported VCD version by this library). [This guide ](https://vdc-download.vmware.com/vmwb-repository/dcr-public/71f952e6-c14b-417d-8749-dbb5ff2dd48a/9b26a7c0-0cee-40a2-8c01-2f15472324cf/com.vmware.vmware_cloud_director.openapi_34_0.pdf) has some guidelines about how this API works.

Each OpenAPI endpoint is introduced with different API versions so one must always supply apiVersion to use in the low level API. Best place to check when a specific endpoint was introduced could be in https://HOSTNAME/docs/ or a publicly hosted [docs page](https://vdc-download.vmware.com/vmwb-repository/dcr-public/772aa4c5-7e61-4d80-8432-b8e0d821c969/2747ec83-6aef-4560-b1d1-55ed9adc4e73/vcd-openapi-docs.html#api-AuditTrail-queryAuditTrail) 


In short - OpenAPI endpoints support CRUD endpoints (JSON format):
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/15804230/87866521-7479d500-c98b-11ea-8102-13f95663e3fd.png">
This PR introduces low level functions to interact directly with these endpoints (one function for each) where one can supply either his own types for marshaling/unmarshaling or the ones which are to be provided in the system. In addition - there will be higher level structures built for each type just as this library has it for existing XML API.
Such public functions are introduced:
* `OpenApiGetAllItems` ([FIQL](https://tools.ietf.org/html/draft-nottingham-atompub-fiql-00) filtering can be applied to narrow down results)
* `OpenApiPostItem` (automatically handles Sync and Async endpoints)
* `OpenApiPostItemSync` (for endpoints which work in Sync way)
* `OpenApiPostItemAsync` (for endpoints which work in Async way)
* `OpenApiGetItem`
* `OpenApiPutItem` (automatically handles Sync and Async endpoints)
* `OpenApiPutItemSync` (for endpoints which work in Sync way)
* `OpenApiPutItemAsync` (for endpoints which work in Async way)
* `OpenApiDeleteItem`

Additionally helper functions are introduced as well:
* `OpenApiIsSupported`
* `OpenApiBuildEndpoint`


**Important** These functions __are not__ guaranteed to stay unchanged until `go-vcloud-director` reaches v2.9.0 and will most probably change as we are working it through. It means that functions and signatures are subject to change during `alpha` and `beta` stages with hope that actually using these functions in real life in the upcoming PRs during this release cycle will uncover some problems.

## High level functions with `OpenApiRole` type
To demonstrate usage of low level functions there is an `OpenApiRole` type created as an example with below functions:
* `adminOrg.GetOpenApiRoleById`
* `adminOrg.GetAllOpenApiRoles`
* `OpenApiRole.Create`
* `OpenApiRole.Update`
* `OpenApiRole.Delete`

## Testing
3 tests are bundled with this PR which aim to demonstrate and test capabilities of above defined functions:
* Test_OpenAPIRawJsonAudiTrail (demonstrates how one can get RAW JSON string using `json.RawMessage` type
* Test_OpenAPIInlineStructAudiTrail (demonstrates how one can define his own type to use with low level functions)
* Test_OpenAPIInlineStructCRUDRoles (aims to test CRUD features using `1.0.0/roles` endpoint. This endpoint has no specific meaning in this PR, but it was chosen as then one which has all CRUD endpoints and can be manipulated quickly)
 
There is potential to generalize testing suite for each endpoint we have however I have left it so far to be tackled when I actually open PR with implementation for specific resources and that should give better perspective.

### Testing output
#### VCD 9.5 (`1.0.0/auditTrail` endpoint was still not available, `1.0.0/roles` endpoint was available)
```
go test -timeout=1h -tags openapi -check.vv -check.f "Test_OpenApi"
START: api_vcd_test.go:420: TestVCD.SetUpSuite
Running on vCD https://{HOST}/api
as user administrator@System (using password)
Skipping all vapp tests because one of the following wasn't given: Network, StorageProfile, Catalog, Catalogitem
PASS: api_vcd_test.go:420: TestVCD.SetUpSuite   3.608s

START: openapi_test.go:51: TestVCD.Test_OpenAPIInlineStructAudiTrail
SKIP: openapi_test.go:51: TestVCD.Test_OpenAPIInlineStructAudiTrail (Skipping test because OpenAPI endpoint '1.0.0/auditTrail' must satisfy API version constraint '33.0'. Maximum supported version is 31.0)

START: openapi_test.go:120: TestVCD.Test_OpenAPIInlineStructCRUDRoles
PASS: openapi_test.go:120: TestVCD.Test_OpenAPIInlineStructCRUDRoles    2.399s

START: openapi_test.go:20: TestVCD.Test_OpenAPIRawJsonAudiTrail
SKIP: openapi_test.go:20: TestVCD.Test_OpenAPIRawJsonAudiTrail (Skipping test because OpenAPI endpoint '1.0.0/auditTrail' must satisfy API version constraint '33.0'. Maximum supported version is 31.0)

START: api_vcd_test.go:1314: TestVCD.TearDownSuite
PASS: api_vcd_test.go:1314: TestVCD.TearDownSuite       0.000s

OK: 1 passed, 2 skipped
PASS
ok      github.com/vmware/go-vcloud-director/v2/govcd   8.235s
```

#### VCD 10.0 and 10.1 ('1.0.0/auditTrail'  and `1.0.0/roles` endpoints are available)
```
go test -timeout=1h -tags openapi -check.vv -check.f "Test_OpenApi"
START: api_vcd_test.go:420: TestVCD.SetUpSuite
Running on vCD https://{HOST}/api
as user administrator@System (using password)
Skipping all vapp tests because one of the following wasn't given: Network, StorageProfile, Catalog, Catalogitem
PASS: api_vcd_test.go:420: TestVCD.SetUpSuite   6.635s

START: openapi_test.go:51: TestVCD.Test_OpenAPIInlineStructAudiTrail
PASS: openapi_test.go:51: TestVCD.Test_OpenAPIInlineStructAudiTrail     6.867s

START: openapi_test.go:120: TestVCD.Test_OpenAPIInlineStructCRUDRoles
PASS: openapi_test.go:120: TestVCD.Test_OpenAPIInlineStructCRUDRoles    5.576s

START: openapi_test.go:20: TestVCD.Test_OpenAPIRawJsonAudiTrail
PASS: openapi_test.go:20: TestVCD.Test_OpenAPIRawJsonAudiTrail  75.286s

START: api_vcd_test.go:1314: TestVCD.TearDownSuite
PASS: api_vcd_test.go:1314: TestVCD.TearDownSuite       0.000s

OK: 3 passed
PASS
ok      github.com/vmware/go-vcloud-director/v2/govcd   97.297s
```

## Code Samples
`samples/openapi` directory contains a few examples how one could use low level functions directly for any endpoint by defining struct or even using RAW JSON.