### PR TITLE
Adjust Test_LBAppRule to work with VCD 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Improved testing tags isolation [#320](https://github.com/vmware/go-vcloud-director/pull/320)
 * Added command `make tagverify` to check tags isolation tests [#320](https://github.com/vmware/go-vcloud-director/pull/320)
+* Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
+[#326](https://github.com/vmware/go-vcloud-director/pull/326)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/govcd/lbapprule_test.go
+++ b/govcd/lbapprule_test.go
@@ -74,7 +74,7 @@ func (vcd *TestVCD) Test_LBAppRule(check *C) {
 	lbAppRuleByID.Script = "invalid_script"
 	updatedAppProfile, err = edge.UpdateLbAppRule(lbAppRuleByID)
 	check.Assert(updatedAppProfile, IsNil)
-	check.Assert(err, ErrorMatches, ".*invalid applicationRule script.*")
+	check.Assert(err, NotNil)
 
 	// Update should fail without name
 	lbAppRuleByID.Name = ""


### PR DESCRIPTION
VCD 10.2 throws a bit different error when invalid application rule is being submitted and current test fails on it. This PR relieves invalid application rule check to fit older versions as well as 10.2.