### PR TITLE
Update VDC dynamic func to handle API version 35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added command `make tagverify` to check tags isolation tests [#320](https://github.com/vmware/go-vcloud-director/pull/320)
 * Loosen up `Test_LBAppRule` for invalid application script check to work with different error engine in VCD 10.2
 [#326](https://github.com/vmware/go-vcloud-director/pull/326)
+* Update VDC dynamic func to handle API version 35.0 [#327](https://github.com/vmware/go-vcloud-director/pull/327)
 
 ## 2.8.0 (June 30, 2020)
 

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -56,19 +56,19 @@ var vdcVersionedFuncsV97 = vdcVersionedFuncs{
 var vdcVersionedFuncsByVcdVersion = map[string]vdcVersionedFuncs{
 	"vdc9.5":  vdcVersionedFuncsV95,
 	"vdc9.7":  vdcVersionedFuncsV97,
-	"vdc10.0": vdcVersionedFuncsV97,
-	"vdc10.1": vdcVersionedFuncsV97,
+
+	// If we add a new function to this list, we also need to update the "default" entry
+	"default": vdcVersionedFuncsV97,
 }
 
 // getVdcVersionedFuncsByVdcVersion is a wrapper function that retrieves the requested versioned VDC function
-// When the wanted version does not exist in the map, it returns the latest available one.
+// When the wanted version does not exist in the map, it returns the highest available one.
 func getVdcVersionedFuncsByVdcVersion(version string) vdcVersionedFuncs {
-	highest := vdcVersionedFuncsV97
 	f, ok := vdcVersionedFuncsByVcdVersion[version]
 	if ok {
 		return f
 	} else {
-		return highest
+		return vdcVersionedFuncsByVcdVersion["default"]
 	}
 }
 

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -61,6 +61,18 @@ var vdcVersionedFuncsByVcdVersion = map[string]vdcVersionedFuncs{
 	"vdc10.1": vdcVersionedFuncsV97,
 }
 
+// getVdcVersionedFuncsByVdcVersion is a wrapper function that retrieves the requested versioned VDC function
+// When the wanted version does not exist in the map, it returns the latest available one.
+func getVdcVersionedFuncsByVdcVersion(version string) vdcVersionedFuncs {
+	highest := vdcVersionedFuncsV97
+	f, ok := vdcVersionedFuncsByVcdVersion[version]
+	if ok {
+		return f
+	} else {
+		return highest
+	}
+}
+
 // GetAdminVdcByName function uses a valid VDC name and returns a admin VDC object.
 // If no VDC is found, then it returns an empty VDC and no error.
 // Otherwise it returns an empty VDC and an error.
@@ -231,10 +243,10 @@ func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
 	if err != nil {
 		return Task{}, err
 	}
-	vdcFunctions, ok := vdcVersionedFuncsByVcdVersion["vdc"+apiVersionToVcdVersion[apiVersion]]
-	if !ok {
-		return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	}
+	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
+	//if !ok {
+	//	return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
+	//}
 	if vdcFunctions.UpdateVdcAsync == nil {
 		return Task{}, fmt.Errorf("function UpdateVdcAsync is not defined for %s", "vdc"+apiVersion)
 	}
@@ -254,10 +266,10 @@ func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
 		return AdminVdc{}, err
 	}
 
-	vdcFunctions, ok := vdcVersionedFuncsByVcdVersion["vdc"+apiVersionToVcdVersion[apiVersion]]
-	if !ok {
-		return AdminVdc{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	}
+	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
+	//if !ok {
+	//	return AdminVdc{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
+	//}
 	if vdcFunctions.UpdateVdc == nil {
 		return AdminVdc{}, fmt.Errorf("function UpdateVdc is not defined for %s", "vdc"+apiVersion)
 	}
@@ -279,10 +291,10 @@ func (adminOrg *AdminOrg) CreateOrgVdc(vdcConfiguration *types.VdcConfiguration)
 	if err != nil {
 		return nil, err
 	}
-	vdcFunctions, ok := vdcVersionedFuncsByVcdVersion["vdc"+apiVersionToVcdVersion[apiVersion]]
-	if !ok {
-		return nil, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	}
+	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
+	//if !ok {
+	//	return nil, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
+	//}
 	if vdcFunctions.CreateVdc == nil {
 		return nil, fmt.Errorf("function CreateVdc is not defined for %s", "vdc"+apiVersion)
 	}
@@ -298,10 +310,10 @@ func (adminOrg *AdminOrg) CreateOrgVdcAsync(vdcConfiguration *types.VdcConfigura
 	if err != nil {
 		return Task{}, err
 	}
-	vdcFunctions, ok := vdcVersionedFuncsByVcdVersion["vdc"+apiVersionToVcdVersion[apiVersion]]
-	if !ok {
-		return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	}
+	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
+	//if !ok {
+	//	return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
+	//}
 	if vdcFunctions.CreateVdcAsync == nil {
 		return Task{}, fmt.Errorf("function CreateVdcAsync is not defined for %s", "vdc"+apiVersion)
 	}

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -54,10 +54,11 @@ var vdcVersionedFuncsV97 = vdcVersionedFuncs{
 
 // vdcVersionedFuncsByVcdVersion is a map of VDC functions by vCD version
 var vdcVersionedFuncsByVcdVersion = map[string]vdcVersionedFuncs{
-	"vdc9.5":  vdcVersionedFuncsV95,
-	"vdc9.7":  vdcVersionedFuncsV97,
+	"vdc9.5": vdcVersionedFuncsV95,
+	"vdc9.7": vdcVersionedFuncsV97,
 
 	// If we add a new function to this list, we also need to update the "default" entry
+	// The "default" entry will hold the highest currently available function
 	"default": vdcVersionedFuncsV97,
 }
 

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -244,9 +244,6 @@ func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
 		return Task{}, err
 	}
 	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
-	//if !ok {
-	//	return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	//}
 	if vdcFunctions.UpdateVdcAsync == nil {
 		return Task{}, fmt.Errorf("function UpdateVdcAsync is not defined for %s", "vdc"+apiVersion)
 	}
@@ -267,9 +264,6 @@ func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
 	}
 
 	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
-	//if !ok {
-	//	return AdminVdc{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	//}
 	if vdcFunctions.UpdateVdc == nil {
 		return AdminVdc{}, fmt.Errorf("function UpdateVdc is not defined for %s", "vdc"+apiVersion)
 	}
@@ -292,9 +286,6 @@ func (adminOrg *AdminOrg) CreateOrgVdc(vdcConfiguration *types.VdcConfiguration)
 		return nil, err
 	}
 	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
-	//if !ok {
-	//	return nil, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	//}
 	if vdcFunctions.CreateVdc == nil {
 		return nil, fmt.Errorf("function CreateVdc is not defined for %s", "vdc"+apiVersion)
 	}
@@ -311,9 +302,6 @@ func (adminOrg *AdminOrg) CreateOrgVdcAsync(vdcConfiguration *types.VdcConfigura
 		return Task{}, err
 	}
 	vdcFunctions := getVdcVersionedFuncsByVdcVersion("vdc" + apiVersionToVcdVersion[apiVersion])
-	//if !ok {
-	//	return Task{}, fmt.Errorf("no entity type found %s", "vdc"+apiVersion)
-	//}
 	if vdcFunctions.CreateVdcAsync == nil {
 		return Task{}, fmt.Errorf("function CreateVdcAsync is not defined for %s", "vdc"+apiVersion)
 	}

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -52,8 +52,7 @@ var vdcVersionedFuncsV97 = vdcVersionedFuncs{
 	UpdateVdcAsync:   updateVdcAsyncV97,
 }
 
-// TODO: add a wrapper function to use newest available method when version is higher than currently handled
-// VDC function mapping by vDC version
+// vdcVersionedFuncsByVcdVersion is a map of VDC functions by vCD version
 var vdcVersionedFuncsByVcdVersion = map[string]vdcVersionedFuncs{
 	"vdc9.5":  vdcVersionedFuncsV95,
 	"vdc9.7":  vdcVersionedFuncsV97,

--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -35,6 +35,7 @@ var apiVersionToVcdVersion = map[string]string{
 	"32.0": "9.7",
 	"33.0": "10.0",
 	"34.0": "10.1",
+	"35.0": "10.2", // Provisional version for non-GA release. It may change later
 }
 
 // vcdVersionToApiVersion gets the max supported API version from vCD version
@@ -45,6 +46,7 @@ var vcdVersionToApiVersion = map[string]string{
 	"9.7":  "32.0",
 	"10.0": "33.0",
 	"10.1": "34.0",
+	"10.2": "35.0", // Provisional version for non-GA release. It may change later
 }
 
 // to make vcdVersionToApiVersion used


### PR DESCRIPTION
Update recognized versions to handle 35.0 and (provisionally) 10.2.
Add a wrapper function to handle VDC creation when then highest version is not handled yet.