### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.0 (unreleased)
+## 2.9.0 (October 15, 2020)
 
 * Improved testing tags isolation [#320](https://github.com/vmware/go-vcloud-director/pull/320)
 * Added command `make tagverify` to check tags isolation tests [#320](https://github.com/vmware/go-vcloud-director/pull/320)


### PR DESCRIPTION
This PR does nothing but adds release date to 2.9.0 in CHANGELOG.
Once it is merged - this will be tagged as `v2.9.0` (and will have the same codebase as `v2.9.0-rc.1`)