### PR TITLE
VCD version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0 (Unreleased)
+
+* Added functions to retrieve and use VCD version `client.GetVcdVersion`, `client.GetVcdShortVersion`, `client.GetVcdFullVersion`, `client.VersionEqualOrGreater` [#339](https://github.com/vmware/go-vcloud-director/pull/339)
+
 ## 2.9.0 (October 15, 2020)
 
 * Improved testing tags isolation [#320](https://github.com/vmware/go-vcloud-director/pull/320)

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -499,7 +499,12 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Running on vCD %s\nas user %s@%s (using %s)\n", vcd.config.Provider.Url,
+	versionInfo := ""
+	version, versionTime, err := vcd.client.Client.GetVcdVersion()
+	if err == nil {
+		versionInfo = fmt.Sprintf("version %s built at %s", version, versionTime)
+	}
+	fmt.Printf("Running on vCD %s (%s)\nas user %s@%s (using %s)\n", vcd.config.Provider.Url, versionInfo,
 		vcd.config.Provider.User, vcd.config.Provider.SysOrg, authenticationMode)
 	if !vcd.client.Client.IsSysAdmin {
 		vcd.skipAdminTests = true

--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -289,9 +289,7 @@ func (cli *Client) GetVcdFullVersion() (VcdVersion, error) {
 	if err != nil {
 		return VcdVersion{}, err
 	}
-	// The version returned is in the format "10.2.0.17008054"
-	versionList := strings.Split(version, ".")
-	if len(versionList) < 4 {
+	if len(vcdVersion.Version.Segments()) < 4 {
 		return VcdVersion{}, fmt.Errorf("error getting version digits from version %s", version)
 	}
 	vcdVersion.Time = versionTime

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -9,8 +9,10 @@ package govcd
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
+	"github.com/kr/pretty"
 	. "gopkg.in/check.v1"
 )
 
@@ -137,6 +139,48 @@ func (vcd *TestVCD) Test_GetVcdVersion(check *C) {
 	reVersion := regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+`)
 	check.Assert(reVersion.MatchString(version), Equals, true)
 
-	fmt.Printf("VERSION %s\n",version)
-	fmt.Printf("DATE    %s\n",versionTime)
+	fmt.Printf("VERSION %s\n", version)
+	fmt.Printf("DATE    %s\n", versionTime)
+
+	shortVersion, err := vcd.client.Client.GetVcdShortVersion()
+	check.Assert(err, IsNil)
+	check.Assert(shortVersion, Not(Equals), "")
+	check.Assert(strings.HasPrefix(version, shortVersion), Equals, true)
+	if testVerbose {
+		fmt.Printf("SHORT VERSION %s\n", shortVersion)
+	}
+
+	fullVersion, err := vcd.client.Client.GetVcdFullVersion()
+	check.Assert(err, IsNil)
+	digits := fullVersion.Version.Segments()
+	check.Assert(len(digits), Not(Equals), 0)
+	check.Assert(shortVersion, Equals, fmt.Sprintf("%d.%d.%d", digits[0], digits[1], digits[2]))
+
+	if testVerbose {
+		fmt.Printf("FULL VERSION %# v\n", pretty.Formatter(fullVersion))
+	}
+
+	// Comparing the current version against itself, without build. Expected result: equal
+	result, err := vcd.client.Client.VersionEqualOrGreater(version, 3)
+	check.Assert(err, IsNil)
+	check.Assert(result, Equals, true)
+
+	// Comparing the current version against itself, with build. Expected result: equal
+	result, err = vcd.client.Client.VersionEqualOrGreater(version, 4)
+	check.Assert(err, IsNil)
+	check.Assert(result, Equals, true)
+
+	digits[3] -= 1
+	smallerBuild := intListToVersion(digits, 4)
+	// Comparing the current version against same version, with smaller build. Expected result: greater
+	result, err = vcd.client.Client.VersionEqualOrGreater(smallerBuild, 4)
+	check.Assert(err, IsNil)
+	check.Assert(result, Equals, true)
+
+	// Comparing the current version against same version, with bigger build. Expected result: less
+	digits[3] += 2
+	biggerBuild := intListToVersion(digits, 4)
+	result, err = vcd.client.Client.VersionEqualOrGreater(biggerBuild, 4)
+	check.Assert(err, IsNil)
+	check.Assert(result, Equals, false)
 }

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -8,6 +8,8 @@ package govcd
 
 import (
 	"fmt"
+	"regexp"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -124,4 +126,17 @@ func getMockVcdWithAPIVersion(version string) *VCDClient {
 			},
 		},
 	}
+}
+
+func (vcd *TestVCD) Test_GetVcdVersion(check *C) {
+
+	version, versionTime, err := vcd.client.Client.GetVcdVersion()
+	check.Assert(err, IsNil)
+	check.Assert(version, Not(Equals), "")
+	check.Assert(versionTime, Not(Equals), time.Time{})
+	reVersion := regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+`)
+	check.Assert(reVersion.MatchString(version), Equals, true)
+
+	fmt.Printf("VERSION %s\n",version)
+	fmt.Printf("DATE    %s\n",versionTime)
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2823,3 +2823,20 @@ type VdcComputePolicyReferences struct {
 	Link                      *Link        `xml:"Link,omitempty"`
 	VdcComputePolicyReference []*Reference `xml:"VdcComputePolicyReference,omitempty"`
 }
+
+// Structure returned by /api/admin call
+type VCloud struct {
+	XMLName     xml.Name `xml:"VCloud"`
+	Xmlns       string   `xml:"xmlns,attr,omitempty"`
+	Name        string   `xml:"name,attr"`
+	HREF        string   `xml:"href,attr"`
+	Type        string   `xml:"type,attr,omitempty"`
+	Description string   `xml:"Description"` // Contains VCD version, build number and build timestamp
+	Link        *Link    `xml:"Link,omitempty"`
+	// TODO: Add other fields if needed
+	// OrganizationReferences
+	// ProviderVdcReferences
+	// RightReferences
+	// RoleReferences
+	// Networks
+}


### PR DESCRIPTION
Add functions to retrieve and compare VCD version
`client.GetVcdVersion`
`client.GetVcdShortVersion`
`client.GetVcdFullVersion`
`client.VersionEqualOrGreater`

This Code does not replace the functions used to compare API versions, which continue having its use.
The main uses of these functions are:

* Accessing the VCD version through API, and displaying it in logs, test output, diagnostics.
* Comparing the current version with a given (precise) version, in cases when the API version proves to be too broad (e.g. when a bug fix is introduced in a minor or revision version, and we want to change behavior based on such fix)