### PR TITLE
Enable usage of bearer tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added functions to retrieve and use VCD version `client.GetVcdVersion`, `client.GetVcdShortVersion`, `client.GetVcdFullVersion`, `client.VersionEqualOrGreater` [#339](https://github.com/vmware/go-vcloud-director/pull/339)
 * Added methods `VM.UpdateStorageProfile`, `VM.UpdateStorageProfileAsync` [#338](https://github.com/vmware/go-vcloud-director/pull/338)
+* Added support for bearer tokens [#341](https://github.com/vmware/go-vcloud-director/pull/341)
 
 ## 2.9.0 (October 15, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Added functions to retrieve and use VCD version `client.GetVcdVersion`, `client.GetVcdShortVersion`, `client.GetVcdFullVersion`, `client.VersionEqualOrGreater` [#339](https://github.com/vmware/go-vcloud-director/pull/339)
 * Added methods `VM.UpdateStorageProfile`, `VM.UpdateStorageProfileAsync` [#338](https://github.com/vmware/go-vcloud-director/pull/338)
 * Added methods `adminVdc.UpdateStorageProfile` [#340](https://github.com/vmware/go-vcloud-director/pull/340)
-* Added support for bearer tokens [#341](https://github.com/vmware/go-vcloud-director/pull/341)
+* Added transparent support for bearer tokens [#341](https://github.com/vmware/go-vcloud-director/pull/341)
 * Added transparent connection using `cloudapi/1.0.0/sessions` when access through `api/sessions` is disabled
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 BREAKING CHANGES:
 
 * type.VdcConfiguration (used for creation) changed the type for storage profile from `[]*VdcStorageProfile` to `[]*VdcStorageProfileConfiguration`
->>>>>>> master
 
 ## 2.9.0 (October 15, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 * Added functions to retrieve and use VCD version `client.GetVcdVersion`, `client.GetVcdShortVersion`, `client.GetVcdFullVersion`, `client.VersionEqualOrGreater` [#339](https://github.com/vmware/go-vcloud-director/pull/339)
 * Added methods `VM.UpdateStorageProfile`, `VM.UpdateStorageProfileAsync` [#338](https://github.com/vmware/go-vcloud-director/pull/338)
-* Added support for bearer tokens [#341](https://github.com/vmware/go-vcloud-director/pull/341)
 * Added methods `adminVdc.UpdateStorageProfile` [#340](https://github.com/vmware/go-vcloud-director/pull/340)
+* Added support for bearer tokens [#341](https://github.com/vmware/go-vcloud-director/pull/341)
+* Added transparent connection using `cloudapi/1.0.0/sessions` when access through `api/sessions` is disabled
 
 BREAKING CHANGES:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -11,7 +11,7 @@ If no environmental variable is set it will default to `govcd_test_config.yaml` 
 
 See `./govcd/sample_govcd_test_config.yaml`.
 
-Users must specify their username, password, API endpoint, vcd and org for any tests to run. Otherwise all tests get aborted. For more comprehensive testing the catalog, catalog item, storage profile, network, edge gateway, IP fields can be set using the format in the sample.
+Users must specify their username, password, API endpoint, vcd and org for any tests to run. Otherwise all tests get stopped. For more comprehensive testing the catalog, catalog item, storage profile, network, edge gateway, IP fields can be set using the format in the sample.
 Note that all the entities included in the configuration file must exist already and will not be removed or left altered during the tests. Leaving a field blank will skip one or more corresponding tests.
 
 If you are more comfortable with JSON, you can supply the configuration in that format. The field names are the same. See `./govcd/sample_govcd_test_config.json`.

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -57,6 +57,9 @@ type Client struct {
 // AuthorizationHeader header key used by default to set the authorization token.
 const AuthorizationHeader = "X-Vcloud-Authorization"
 
+// BearerTokenHeader is the header key containing a bearer token
+const BearerTokenHeader = "X-Vmware-Vcloud-Access-Token"
+
 // General purpose error to be used whenever an entity is not found from a "GET" request
 // Allows a simpler checking of the call result
 // such as
@@ -205,6 +208,12 @@ func (cli *Client) newRequest(params map[string]string, notEncodedParams map[str
 		(additionalHeader != nil && additionalHeader.Get("Authorization") != "") {
 		// Add the Accept header for VCD
 		req.Header.Add("Accept", "application/*+xml;version="+apiVersion)
+	}
+	// The deprecated authorization token is 32 characters long
+	// The bearer token is 612 characters long
+	if len(cli.VCDToken) > 32 {
+		req.Header.Add("X-Vmware-Vcloud-Token-Type", "Bearer")
+		req.Header.Add("Authorization", "bearer "+cli.VCDToken)
 	}
 
 	// Merge in additional headers before logging if any where specified in additionalHeader

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -74,8 +74,8 @@ func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, e
 	}
 	defer resp.Body.Close()
 	// Store the authorization header
-	vcdCli.Client.VCDToken = resp.Header.Get(AuthorizationHeader)
-	vcdCli.Client.VCDAuthHeader = AuthorizationHeader
+	vcdCli.Client.VCDToken = resp.Header.Get(BearerTokenHeader)
+	vcdCli.Client.VCDAuthHeader = BearerTokenHeader
 	vcdCli.Client.IsSysAdmin = strings.EqualFold(org, "system")
 	// Get query href
 	vcdCli.QueryHREF = vcdCli.Client.VCDHREF
@@ -160,7 +160,6 @@ func (vcdCli *VCDClient) GetAuthResponse(username, password, org string) (*http.
 // Up to version 29, token authorization uses the the header key x-vcloud-authorization
 // In version 30+ it also uses X-Vmware-Vcloud-Access-Token:TOKEN coupled with
 // X-Vmware-Vcloud-Token-Type:"bearer"
-// TODO: when enabling version 30+ for SDK, add ability of using bearer token
 func (vcdCli *VCDClient) SetToken(org, authHeader, token string) error {
 	vcdCli.Client.VCDAuthHeader = authHeader
 	vcdCli.Client.VCDToken = token

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // VCDClientOption defines signature for customizing VCDClient using
@@ -47,6 +48,31 @@ func (vcdCli *VCDClient) vcdloginurl() error {
 	return nil
 }
 
+// vcdCloudApiAuthorize performs the authorization to VCD using open API
+func (vcdCli *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.Response, error) {
+
+	util.Logger.Println("[TRACE] Connecting to VCD using cloudapi")
+	// This call can only be used by tenants
+	rawUrl := vcdCli.sessionHREF.Scheme + "://" + vcdCli.sessionHREF.Host + "/cloudapi/1.0.0/sessions"
+
+	// If we are connecting as provider, we need to qualify the request.
+	if strings.EqualFold(org, "system") {
+		rawUrl += "/provider"
+	}
+	util.Logger.Printf("[TRACE] URL %s\n", rawUrl)
+	loginUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing URL %s", rawUrl)
+	}
+	vcdCli.sessionHREF = *loginUrl
+	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodPost, *loginUrl, nil)
+	// Set Basic Authentication Header
+	req.SetBasicAuth(user+"@"+org, pass)
+	// Add the Accept header. The version must be at least 33.0 for cloudapi to work
+	req.Header.Add("Accept", "application/*;version=33.0")
+	return vcdCli.Client.Http.Do(req)
+}
+
 // vcdAuthorize authorizes the client and returns a http response
 func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, error) {
 	var missingItems []string
@@ -68,7 +94,21 @@ func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, e
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
 	req.Header.Add("Accept", "application/*+xml;version="+vcdCli.Client.APIVersion)
-	resp, err := checkResp(vcdCli.Client.Http.Do(req))
+	resp, err := vcdCli.Client.Http.Do(req)
+
+	// If the VCD has disabled the call to /api/sessions, the attempt will fail with error 401 (unauthorized)
+	// https://docs.vmware.com/en/VMware-Cloud-Director/10.0/com.vmware.vcloud.install.doc/GUID-84390C8F-E8C5-4137-A1A5-53EC27FE0024.html
+	// TODO: convert this method to main once we drop support for 9.7
+	if resp.StatusCode == 401 {
+		resp, err = vcdCli.vcdCloudApiAuthorize(user, pass, org)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = checkRespWithErrType(types.BodyTypeJSON, resp, err, &types.Error{})
+	} else {
+		resp, err = checkResp(resp, err)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -604,6 +604,12 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	if client.VCDAuthHeader != "" && client.VCDToken != "" {
 		// Add the authorization header
 		req.Header.Add(client.VCDAuthHeader, client.VCDToken)
+		// The deprecated authorization token is 32 characters long
+		// The bearer token is 612 characters long
+		if len(client.VCDToken) > 32 {
+			req.Header.Add("Authorization", "bearer "+client.VCDToken)
+			req.Header.Add("X-Vmware-Vcloud-Token-Type", "Bearer")
+		}
 		// Add the Accept header for VCD
 		acceptMime := types.JSONMime + ";version=" + apiVersion
 		req.Header.Add("Accept", acceptMime)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -417,7 +417,7 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 
 	// Check if VApp Children is populated
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	vu := &types.GuestCustomizationSection{
@@ -521,7 +521,7 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 
 	// Check if VApp Children is populated
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	newcpu := &types.OVFItem{
@@ -562,7 +562,7 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	}
 
 	if vapp.VApp.Children == nil || len(vapp.VApp.Children.VM) == 0 {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	vdc, err := vapp.getParentVDC()
@@ -593,7 +593,7 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 	}
 
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	newName := &types.VM{
@@ -616,11 +616,11 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	}
 
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	if vapp.VApp.Children.VM[0].ProductSection == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children with ProductSection, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children with ProductSection, interrupting customization")
 	}
 
 	for key, value := range parameters {
@@ -653,7 +653,7 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 	}
 
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	networksection, err := vapp.GetNetworkConnectionSection()
@@ -714,7 +714,7 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 
 	// Check if VApp Children is populated
 	if vapp.VApp.Children == nil {
-		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
+		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
 	newMem := &types.OVFItem{

--- a/samples/discover/discover.go
+++ b/samples/discover/discover.go
@@ -66,27 +66,27 @@ type Config struct {
 // Checks that a configuration structure is complete
 func check_configuration(conf Config) {
 	will_exit := false
-	abort := func(s string) {
+	exit := func(s string) {
 		fmt.Printf("configuration field '%s' empty or missing\n", s)
 		will_exit = true
 	}
 	if conf.Org == "" {
-		abort("org")
+		exit("org")
 	}
 	if conf.Href == "" || conf.Href == "https://YOUR_VCD_IP/api" {
-		abort("href")
+		exit("href")
 	}
 	if conf.VDC == "" {
-		abort("vdc")
+		exit("vdc")
 	}
 	if conf.Token != "" {
 		return
 	}
 	if conf.User == "" {
-		abort("user")
+		exit("user")
 	}
 	if conf.Password == "" {
-		abort("password")
+		exit("password")
 	}
 	if will_exit {
 		os.Exit(1)

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script will connect to the vCD using username and password,
-# and show the header that contains an authorization token.
+# and show the headers that contain a bearer or authorization token.
 #
 user=$1
 password=$2
@@ -21,8 +21,22 @@ curl -I -k --header "Accept: application/*;version=32.0" \
 
 # If successful, the output of this command will include lines like the following
 # X-VCLOUD-AUTHORIZATION: 08a321735de84f1d9ec80c3b3e18fa8b
-# X-VMWARE-VCLOUD-ACCESS-TOKEN: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbmlzdHJhdG9yIiwiaXNzIjoiYTkzYzlkYjktNzQ3MS0zMTkyLThkMDktYThmN2VlZGE4NWY5QGY5MDZlODE1LTM0NjgtNGQ0ZS04MmJlLTcyYzFjMmVkMTBiMyIsImV4cCI6MTYwNzUxMjgyOCwidmVyc2lvbiI6InZjbG91ZF8xLjAiLCJqdGkiOiJjY2IwZjIwN2JjY2Y0NmYwYmEwNTcyNzgxZDQyNDg2MyJ9.SMjp5wsSd7CXGMdlj-weeCRdr5AazA74pwwx2w3Eqh3RdzyiEMvQfWQAuPAQjM1oOsEUnFOg2u0gYsnIyQg_p7kzXKPQwPNz3BPi0tm2DxxQtQVhOBRXCqUJ9OmRlMVu7FZZ6gKD4GhpbTkZyKMN_IgOFkkt8iXs1-weNZw5TmyVHeWiJdV0JFM45CV47jQNdQMy4OSsU-CqE2VVLOK83oJhRnlnc3O4OAAIfuVZ4SLWqgi1lIoc2vbZv0HYeWO7L_2pGfmja8CVzVhPrgIGEoDhXnvO29z1ToEXRnyMKh9cisiRkhUISpsh4aHRGUUzaZYeOejVX3PAO9aCX3iYWA
+# X-VMWARE-VCLOUD-ACCESS-TOKEN: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbmlzdHJhdG9yI[562 more characters]
 #
 # The string after `X-VCLOUD-AUTHORIZATION:` is the old (deprecated) token.
-# The string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
+# The 612-character string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
+
+# For VCD version 10.0+, you can use one of the following commands instead.
+
+# PROVIDER:
+# curl -I -k --header "Accept: application/*;version=33.0" \
+#    --header "Authorization: Basic $auth" \
+#    --request POST https://$IP/cloudapi/1.0.0/sessions/provider
+
+# TENANT
+# curl -I -k --header "Accept: application/*;version=33.0" \
+#    --header "Authorization: Basic $auth" \
+#    --request POST https://$IP/cloudapi/1.0.0/sessions
+#
+# The cloudapi requests will only return the bearer token
 

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -15,11 +15,14 @@ fi
 
 auth=$(echo -n "$user@$org:$password" |base64)
 
-curl -I -k --header "Accept: application/*;version=29.0" \
+curl -I -k --header "Accept: application/*;version=32.0" \
     --header "Authorization: Basic $auth" \
     --request POST https://$IP/api/sessions
 
-# If successful, the output of this command will include a line like the following
-# x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
+# If successful, the output of this command will include lines like the following
+# X-VCLOUD-AUTHORIZATION: 08a321735de84f1d9ec80c3b3e18fa8b
+# X-VMWARE-VCLOUD-ACCESS-TOKEN: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbmlzdHJhdG9yIiwiaXNzIjoiYTkzYzlkYjktNzQ3MS0zMTkyLThkMDktYThmN2VlZGE4NWY5QGY5MDZlODE1LTM0NjgtNGQ0ZS04MmJlLTcyYzFjMmVkMTBiMyIsImV4cCI6MTYwNzUxMjgyOCwidmVyc2lvbiI6InZjbG91ZF8xLjAiLCJqdGkiOiJjY2IwZjIwN2JjY2Y0NmYwYmEwNTcyNzgxZDQyNDg2MyJ9.SMjp5wsSd7CXGMdlj-weeCRdr5AazA74pwwx2w3Eqh3RdzyiEMvQfWQAuPAQjM1oOsEUnFOg2u0gYsnIyQg_p7kzXKPQwPNz3BPi0tm2DxxQtQVhOBRXCqUJ9OmRlMVu7FZZ6gKD4GhpbTkZyKMN_IgOFkkt8iXs1-weNZw5TmyVHeWiJdV0JFM45CV47jQNdQMy4OSsU-CqE2VVLOK83oJhRnlnc3O4OAAIfuVZ4SLWqgi1lIoc2vbZv0HYeWO7L_2pGfmja8CVzVhPrgIGEoDhXnvO29z1ToEXRnyMKh9cisiRkhUISpsh4aHRGUUzaZYeOejVX3PAO9aCX3iYWA
 #
-# The string after `x-vcloud-authorization:` is the token.
+# The string after `X-VCLOUD-AUTHORIZATION:` is the old (deprecated) token.
+# The string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
+

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -6,18 +6,35 @@ user=$1
 password=$2
 org=$3
 IP=$4
+api_version=$5
 
 if [ -z "$IP" ]
 then
-    echo "Syntax $0 user password organization hostname_or_IP_address"
+    echo "Syntax $0 user password organization hostname_or_IP_address [API version]"
     exit 1
 fi
 
 auth=$(echo -n "$user@$org:$password" |base64)
 
-curl -I -k --header "Accept: application/*;version=32.0" \
+[ -z "$api_version" ] && api_version=32
+operation=api/sessions
+
+# if the requested version is greater than 32 (VCD 10.0+), we can use cloudapi
+if [[ $api_version -ge 33  ]]
+then
+    # endpoint for system administrator
+    operation=cloudapi/1.0.0/sessions/provider
+    if [ "$org" != "System" -a "$org" != "system" ]
+    then
+        # endpoint for org users
+        operation=cloudapi/1.0.0/sessions
+    fi
+fi
+
+set -x
+curl -I -k --header "Accept: application/*;version=${api_version}.0" \
     --header "Authorization: Basic $auth" \
-    --request POST https://$IP/api/sessions
+    --request POST https://$IP/$operation
 
 # If successful, the output of this command will include lines like the following
 # X-VCLOUD-AUTHORIZATION: 08a321735de84f1d9ec80c3b3e18fa8b
@@ -25,18 +42,5 @@ curl -I -k --header "Accept: application/*;version=32.0" \
 #
 # The string after `X-VCLOUD-AUTHORIZATION:` is the old (deprecated) token.
 # The 612-character string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
-
-# For VCD version 10.0+, you can use one of the following commands instead.
-
-# PROVIDER:
-# curl -I -k --header "Accept: application/*;version=33.0" \
-#    --header "Authorization: Basic $auth" \
-#    --request POST https://$IP/cloudapi/1.0.0/sessions/provider
-
-# TENANT
-# curl -I -k --header "Accept: application/*;version=33.0" \
-#    --header "Authorization: Basic $auth" \
-#    --request POST https://$IP/cloudapi/1.0.0/sessions
 #
-# The cloudapi requests will only return the bearer token
-
+# Note that using cloudapi we will only get the bearer token

--- a/support/run_in_docker.sh
+++ b/support/run_in_docker.sh
@@ -9,7 +9,7 @@ cd $SRCROOT
 DESTINATION_SRC=/go/src/github.com/vmware/go-vcloud-director
 
 # Build the Docker image using the current uid/gid so
-# repeat iterations of the Jenkins environment can 
+# repeat iterations of the Jenkins environment can
 # properly cleanup the workspace.
 DOCKER_BUILD=`docker build -q \
     --build-arg build_user=${USER} \
@@ -26,7 +26,7 @@ if [ "$GOVCD_CONFIG" != "" ]; then
     echo "$VCD_ARGS"
 else
     # If the GOVCD configuration is not set, we can't run the tests
-    # So we abort as early as possible and then investigate
+    # So we interrupt as early as possible and then investigate
     echo "$0: GOVCD_CONFIG not set"
     exit 1
 fi

--- a/types/v56/link.go
+++ b/types/v56/link.go
@@ -114,7 +114,6 @@ const (
 	RelVimServerDvSwitches = "vimServerDvSwitches"
 
 	RelCollaborationResume    = "resume"
-	RelCollaborationAbort     = "abort"
 	RelCollaborationFail      = "fail"
 	RelEnterMaintenanceMode   = "enterMaintenanceMode"
 	RelExitMaintenanceMode    = "exitMaintenanceMode"

--- a/util/logging.go
+++ b/util/logging.go
@@ -79,7 +79,7 @@ var (
 	LogHttpResponse bool = true
 
 	// List of tags to be excluded from logging
-	skipTags = []string{"SupportedVersions", "ovf:License"}
+	skipTags = []string{"ovf:License"}
 
 	// List of functions included in logging
 	// If this variable is filled, only operations from matching function names will be logged


### PR DESCRIPTION
The SDK now accepts both the old (deprecated) authorization token and the bearer token.
The usage is transparent: it doesn't require new options or configuration. If we enter a bearer token instead of an authorization token, it gets used.

How to test:
1. run `./scripts/get_token.sh`
2. Copy the bearer token
3. Paste the token into the configuration file
4. Set the environment variable `GOVCD_LOG_PASSWORDS=1`
5. Run a quick test (such as `Test_GetVcdVersion`)
6. Check the logs, making sure that the `Authorization` header now contains the bearer token and that the `X-Vmware-Vcloud-Token-Type` header contains "Bearer".
7. Change the token to the authorization token (also from step 1)
8. Run steps 4-6 (the token used is the short one)
9. Remove the token from the configuration file
10. Run steps 4-5
11. Check the logs, making sure that `Authorization` header contains the bearer token.

This PR also adds a transparent fallback connection using `cloudapi/1.0.0/sessions` when the call to `/api/session` has been disabled. No action is needed to activate it. When the fallback call happens, we'll find trace information in the logs:
```
2020/11/10 15:35:16 [TRACE] Connecting to VCD using cloudapi
2020/11/10 15:35:16 [TRACE] URL https://bos1-vcloud-static-xxx-xxx.eng.vmware.com/cloudapi/1.0.0/sessions/provider
```

To test the fallback functionality, disable access to `api/sessions` following the instructions in [this page](https://docs.vmware.com/en/VMware-Cloud-Director/10.0/com.vmware.vcloud.install.doc/GUID-84390C8F-E8C5-4137-A1A5-53EC27FE0024.html) and then run any test without token.