### PR TITLE
Add support for handling catalog storage profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added functions `edge.GetLbAppRules`, `edge.GetLbServerPools`, `edge.GetLbAppProfiles`, `edge.GetNsxvNatRules`, `client.GetOrgList`
 * Exported private function `client.maxSupportedVersion` to `client.MaxSupportedVersion`
 * Able to upload an OVF without ovf:size defined in File part. Some bug fix for uploading OVA/OVF. [#331](https://github.com/vmware/go-vcloud-director/pull/331)
-* Add support for handling catalog storage profiles (`adminOrg.CreateCatalogWithStorageProfile`,
+* Add support for handling catalog storage profile (`adminOrg.CreateCatalogWithStorageProfile`,
 `org.CreateCatalogWithStorageProfile`, `adminCatalog.Update`) [#345](https://github.com/vmware/go-vcloud-director/pull/345)
 * Add convenience functions `AdminOrg.GetAllStorageProfileReferences`, `AdminOrg.GetStorageProfileReferenceById`, `AdminOrg.GetAllVDCs`  [#345](https://github.com/vmware/go-vcloud-director/pull/345)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added functions `edge.GetLbAppRules`, `edge.GetLbServerPools`, `edge.GetLbAppProfiles`, `edge.GetNsxvNatRules`, `client.GetOrgList`
 * Exported private function `client.maxSupportedVersion` to `client.MaxSupportedVersion`
 * Able to upload an OVF without ovf:size defined in File part. Some bug fix for uploading OVA/OVF. [#331](https://github.com/vmware/go-vcloud-director/pull/331)
+* Add support for handling catalog storage profiles (`adminOrg.CreateCatalogWithStorageProfile`,
+`org.CreateCatalogWithStorageProfile`, `adminCatalog.Update`) [#345](https://github.com/vmware/go-vcloud-director/pull/345)
+* Add convenience functions `AdminOrg.GetAllStorageProfileReferences`, `AdminOrg.GetStorageProfileReferenceById`, `AdminOrg.GetAllVDCs`  [#345](https://github.com/vmware/go-vcloud-director/pull/345)
 
 BREAKING CHANGES:
 

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -47,9 +47,10 @@ func (adminCatalog *AdminCatalog) Update() error {
 		Description: adminCatalog.AdminCatalog.Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:       types.XMLNamespaceVCloud,
-		Catalog:     *reqCatalog,
-		IsPublished: adminCatalog.AdminCatalog.IsPublished,
+		Xmlns:                  types.XMLNamespaceVCloud,
+		Catalog:                *reqCatalog,
+		CatalogStorageProfiles: adminCatalog.AdminCatalog.CatalogStorageProfiles,
+		IsPublished:            adminCatalog.AdminCatalog.IsPublished,
 	}
 	catalog := &types.AdminCatalog{}
 	_, err := adminCatalog.client.ExecuteRequest(adminCatalog.AdminCatalog.HREF, http.MethodPut,

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -42,6 +42,57 @@ func (adminOrg *AdminOrg) CreateCatalog(name, description string) (AdminCatalog,
 	return CreateCatalog(adminOrg.client, adminOrg.AdminOrg.Link, name, description)
 }
 
+// CreateCatalogWithStorageProfile is like CreateCatalog, but allows to specify storage profile
+func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile(name, description string, storageProfiles *types.CatalogStorageProfiles) (AdminCatalog, error) {
+	return CreateCatalogWithStorageProfile(adminOrg.client, adminOrg.AdminOrg.Link, name, description, storageProfiles)
+}
+
+// GetAllVDCs returns all child VDCs
+func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	allVdcs := make([]*Vdc, len(adminOrg.AdminOrg.Vdcs.Vdcs))
+	for vdcIndex, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
+		vdc, err := adminOrg.GetVDCByHref(vdc.HREF)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving VDC '%s': %s", vdc.Vdc.Name, err)
+		}
+		allVdcs[vdcIndex] = vdc
+
+	}
+
+	return allVdcs, nil
+}
+
+// GetAllStorageProfileReferences traverses all child VDCs and returns a slice of storage profile references
+func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types.Reference, error) {
+	if refresh {
+		err := adminOrg.Refresh()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	allVdcs, err := adminOrg.GetAllVDCs(refresh)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve storage profile references: %s", err)
+	}
+
+	allStorageProfileReferences := make([]*types.Reference, 0)
+	for _, vdc := range allVdcs {
+		if len(vdc.Vdc.VdcStorageProfiles.VdcStorageProfile) > 0 {
+			allStorageProfileReferences = append(allStorageProfileReferences, vdc.Vdc.VdcStorageProfiles.VdcStorageProfile...)
+		}
+	}
+
+	return allStorageProfileReferences, nil
+}
+
 //   Deletes the org, returning an error if the vCD call fails.
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
 func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -47,7 +47,7 @@ func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile(name, description stri
 	return CreateCatalogWithStorageProfile(adminOrg.client, adminOrg.AdminOrg.Link, name, description, storageProfiles)
 }
 
-// GetAllVDCs returns all child VDCs
+// GetAllVDCs returns all depending VDCs for a particular Org
 func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
 	if refresh {
 		err := adminOrg.Refresh()
@@ -69,7 +69,8 @@ func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
 	return allVdcs, nil
 }
 
-// GetAllStorageProfileReferences traverses all child VDCs and returns a slice of storage profile references
+// GetAllStorageProfileReferences traverses all depending VDCs and returns a slice of storage profile references
+// available in those VDCs
 func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types.Reference, error) {
 	if refresh {
 		err := adminOrg.Refresh()
@@ -93,6 +94,7 @@ func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types
 	return allStorageProfileReferences, nil
 }
 
+// GetStorageProfileReferenceById finds storage profile reference by specified ID in Org or returns ErrorEntityNotFound
 func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool) (*types.Reference, error) {
 	allStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(refresh)
 	if err != nil {
@@ -107,7 +109,6 @@ func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool
 
 	return nil, fmt.Errorf("%s: storage profile with ID '%s' not found in Org '%s'",
 		ErrorEntityNotFound, id, adminOrg.AdminOrg.Name)
-
 }
 
 //   Deletes the org, returning an error if the vCD call fails.

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -43,7 +43,7 @@ func (adminOrg *AdminOrg) CreateCatalog(name, description string) (AdminCatalog,
 }
 
 // CreateCatalogWithStorageProfile is like CreateCatalog, but allows to specify storage profile
-func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile(name, description string, storageProfiles *types.CatalogStorageProfiles) (AdminCatalog, error) {
+func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile(name, description string, storageProfiles *types.CatalogStorageProfiles) (*AdminCatalog, error) {
 	return CreateCatalogWithStorageProfile(adminOrg.client, adminOrg.AdminOrg.Link, name, description, storageProfiles)
 }
 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -93,6 +93,23 @@ func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types
 	return allStorageProfileReferences, nil
 }
 
+func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool) (*types.Reference, error) {
+	allStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(refresh)
+	if err != nil {
+		return nil, fmt.Errorf("error getting all storage profiles: %s", err)
+	}
+
+	for _, storageProfileReference := range allStorageProfiles {
+		if storageProfileReference.ID == id {
+			return storageProfileReference, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s: storage profile with ID '%s' not found in Org '%s'",
+		ErrorEntityNotFound, id, adminOrg.AdminOrg.Name)
+
+}
+
 //   Deletes the org, returning an error if the vCD call fails.
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
 func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -225,3 +225,34 @@ func (vcd *TestVCD) TestOrg_AdminOrg_QueryCatalogList(check *C) {
 		check.Assert(foundInBoth, Equals, true)
 	}
 }
+
+// Test_GetAllVDCs checks that adminOrg.GetAllVDCs returns at least one VDC
+func (vcd *TestVCD) Test_GetAllVDCs(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	vdcs, err := adminOrg.GetAllVDCs(true)
+	check.Assert(err, IsNil)
+	check.Assert(len(vdcs) > 0, Equals, true)
+}
+
+// Test_GetAllStorageProfileReferences checks that adminOrg.GetAllStorageProfileReferences returns at least one storage
+// profile reference
+func (vcd *TestVCD) Test_GetAllStorageProfileReferences(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	storageProfileReferences, err := adminOrg.GetAllStorageProfileReferences(true)
+	check.Assert(err, IsNil)
+	check.Assert(len(storageProfileReferences) > 0, Equals, true)
+}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -91,13 +91,19 @@ func (org *Org) GetVdcByName(vdcname string) (Vdc, error) {
 }
 
 func CreateCatalog(client *Client, links types.LinkList, Name, Description string) (AdminCatalog, error) {
+	return CreateCatalogWithStorageProfile(client, links, Name, Description, nil)
+}
+
+// CreateCatalogWithStorageProfile is like CreateCatalog, but allows to specify storage profile
+func CreateCatalogWithStorageProfile(client *Client, links types.LinkList, Name, Description string, storageProfiles *types.CatalogStorageProfiles) (AdminCatalog, error) {
 	reqCatalog := &types.Catalog{
 		Name:        Name,
 		Description: Description,
 	}
 	vcomp := &types.AdminCatalog{
-		Xmlns:   types.XMLNamespaceVCloud,
-		Catalog: *reqCatalog,
+		Xmlns:                  types.XMLNamespaceVCloud,
+		Catalog:                *reqCatalog,
+		CatalogStorageProfiles: storageProfiles,
 	}
 
 	var createOrgLink *types.Link
@@ -125,8 +131,13 @@ func CreateCatalog(client *Client, links types.LinkList, Name, Description strin
 // task.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
 func (org *Org) CreateCatalog(name, description string) (Catalog, error) {
+	return org.CreateCatalogWithStorageProfile(name, description, nil)
+}
+
+// CreateCatalogWithStorageProfile is like CreateCatalog but additionally allows to specify storage profiles
+func (org *Org) CreateCatalogWithStorageProfile(name, description string, storageProfiles *types.CatalogStorageProfiles) (Catalog, error) {
 	catalog := NewCatalog(org.client)
-	adminCatalog, err := CreateCatalog(org.client, org.Org.Link, name, description)
+	adminCatalog, err := CreateCatalogWithStorageProfile(org.client, org.Org.Link, name, description, storageProfiles)
 	if err != nil {
 		return Catalog{}, err
 	}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -90,6 +90,7 @@ func (org *Org) GetVdcByName(vdcname string) (Vdc, error) {
 	return Vdc{}, nil
 }
 
+// CreateCatalog creates a catalog with specified name and description
 func CreateCatalog(client *Client, links types.LinkList, Name, Description string) (AdminCatalog, error) {
 	return CreateCatalogWithStorageProfile(client, links, Name, Description, nil)
 }

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -419,6 +419,58 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalog(check *C) {
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, copyAdminCatalog.AdminCatalog.Name)
 	check.Assert(adminCatalog.AdminCatalog.Description, Equals, copyAdminCatalog.AdminCatalog.Description)
 	check.Assert(adminCatalog.AdminCatalog.IsPublished, Equals, false)
+	check.Assert(adminCatalog.AdminCatalog.CatalogStorageProfiles, NotNil)
+	check.Assert(adminCatalog.AdminCatalog.CatalogStorageProfiles.VdcStorageProfile, IsNil)
+	err = adminCatalog.Delete(true, true)
+	check.Assert(err, IsNil)
+}
+
+func (vcd *TestVCD) Test_AdminOrgCreateCatalogWithStorageProfile(check *C) {
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+	oldAdminCatalog, _ := adminOrg.GetAdminCatalogByName(check.TestName(), false)
+	if oldAdminCatalog != nil {
+		err = oldAdminCatalog.Delete(true, true)
+		check.Assert(err, IsNil)
+	}
+
+	// Lookup storage profile to use in catalog
+	storageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	check.Assert(err, IsNil)
+	createStorageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&storageProfile}}
+
+	adminCatalog, err := adminOrg.CreateCatalogWithStorageProfile(check.TestName(), TestCreateCatalogDesc, createStorageProfiles)
+	check.Assert(err, IsNil)
+	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, check.TestName())
+	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
+	task := NewTask(&vcd.client.Client)
+	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	adminOrg, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(check.TestName(), false)
+	check.Assert(err, IsNil)
+	check.Assert(copyAdminCatalog, NotNil)
+	check.Assert(adminCatalog.AdminCatalog.Name, Equals, copyAdminCatalog.AdminCatalog.Name)
+	check.Assert(adminCatalog.AdminCatalog.Description, Equals, copyAdminCatalog.AdminCatalog.Description)
+	check.Assert(adminCatalog.AdminCatalog.IsPublished, Equals, false)
+
+	// Try to update storage profile for catalog if secondary profile is defined
+	if vcd.config.VCD.StorageProfile.SP2 != "" {
+		updateStorageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP2)
+		check.Assert(err, IsNil)
+		updateStorageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&updateStorageProfile}}
+		adminCatalog.AdminCatalog.CatalogStorageProfiles = updateStorageProfiles
+		err = adminCatalog.Update()
+		check.Assert(err, IsNil)
+	} else {
+		fmt.Printf("# Skipping storage profile update for %s because secondary storage profile is not provided",
+			adminCatalog.AdminCatalog.Name)
+	}
+
 	err = adminCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
 }
@@ -447,6 +499,42 @@ func (vcd *TestVCD) Test_OrgCreateCatalog(check *C) {
 	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	copyCatalog, err := org.GetCatalogByName(TestCreateCatalog, false)
+	check.Assert(err, IsNil)
+	check.Assert(copyCatalog, NotNil)
+	check.Assert(catalog.Catalog.Name, Equals, copyCatalog.Catalog.Name)
+	check.Assert(catalog.Catalog.Description, Equals, copyCatalog.Catalog.Description)
+	check.Assert(catalog.Catalog.IsPublished, Equals, false)
+	err = catalog.Delete(true, true)
+	check.Assert(err, IsNil)
+}
+
+func (vcd *TestVCD) Test_OrgCreateCatalogWithStorageProfile(check *C) {
+	org, err := vcd.client.GetOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+	oldCatalog, _ := org.GetCatalogByName(check.TestName(), false)
+	if oldCatalog != nil {
+		err = oldCatalog.Delete(true, true)
+		check.Assert(err, IsNil)
+	}
+
+	// Lookup storage profile to use in catalog
+	storageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	check.Assert(err, IsNil)
+	storageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&storageProfile}}
+
+	catalog, err := org.CreateCatalogWithStorageProfile(check.TestName(), TestCreateCatalogDesc, storageProfiles)
+	check.Assert(err, IsNil)
+	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
+	check.Assert(catalog.Catalog.Name, Equals, check.TestName())
+	check.Assert(catalog.Catalog.Description, Equals, TestCreateCatalogDesc)
+	task := NewTask(&vcd.client.Client)
+	task.Task = catalog.Catalog.Tasks.Task[0]
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	copyCatalog, err := org.GetCatalogByName(check.TestName(), false)
 	check.Assert(err, IsNil)
 	check.Assert(copyCatalog, NotNil)
 	check.Assert(catalog.Catalog.Name, Equals, copyCatalog.Catalog.Name)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -603,7 +603,7 @@ type ComputeCapacity struct {
 // Description: A reference to a resource. Contains an href attribute and optional name and type attributes.
 // Since: 0.9
 type Reference struct {
-	HREF string `xml:"href,attr"`
+	HREF string `xml:"href,attr,omitempty"`
 	ID   string `xml:"id,attr,omitempty"`
 	Type string `xml:"type,attr,omitempty"`
 	Name string `xml:"name,attr,omitempty"`


### PR DESCRIPTION
It can be tricky to use catalogs while working with multiple VDCs without specifying particular storage profile  (https://github.com/vmware/terraform-provider-vcd/issues/598)

This PR adds functions to SDK so that one can handle Storage profiles for catalog during creation and update phases.

It improves functions `func (adminCatalog *AdminCatalog) Update()` and adds 
* `func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile`
* `func (org *Org) CreateCatalogWithStorageProfile`

Additionally these functions are added for convenience:
* `func (adminOrg *AdminOrg) GetAllStorageProfileReferences`
* `func (adminOrg *AdminOrg) GetStorageProfileReferenceById`
* `func (adminOrg *AdminOrg) GetAllVDCs`

**Note**. Test suite passed on at least one env.