### PR TITLE
2.10.0 pre-release PR 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.10.0 (Unreleased)
+## 2.10.0 (December 18, 2020)
 
 * Added functions to retrieve and use VCD version `client.GetVcdVersion`, `client.GetVcdShortVersion`, `client.GetVcdFullVersion`, `client.VersionEqualOrGreater` [#339](https://github.com/vmware/go-vcloud-director/pull/339)
 * Added methods `VM.UpdateStorageProfile`, `VM.UpdateStorageProfileAsync` [#338](https://github.com/vmware/go-vcloud-director/pull/338)

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -294,6 +294,9 @@ func getAuditTrailTimestampWithElements(elementCount int, check *C, vcd *TestVCD
 	} else {
 		singleElement = onePageAuditTrail[(elementCount - 1)]
 	}
-	return singleElement.Timestamp
 
+	timeFormat, err := time.Parse("2006-01-02T15:04:05.000+0000", singleElement.Timestamp)
+	check.Assert(err, IsNil)
+
+	return timeFormat.Format(types.FiqlQueryTimestampFormat)
 }


### PR DESCRIPTION
This PR improves Test_OpenApiRawJsonAuditTrail on VCD 10 where the API does not accept datetime format which it returns. 
Also adds a release date for govcd library.