### PR TITLE
Update types.go

### DIFF
--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -136,17 +136,17 @@ const (
 // https://blogs.vmware.com/vapp/2009/11/virtual-hardware-in-ovf-part-1.html
 
 const (
-	ResourceTypeOther     int = 0
+	ResourceTypeOther     int   = 0
 	ResourceTypeProcessor int64 = 3
-	ResourceTypeMemory    int = 4
-	ResourceTypeIDE       int = 5
-	ResourceTypeSCSI      int = 6
-	ResourceTypeEthernet  int = 10
-	ResourceTypeFloppy    int = 14
-	ResourceTypeCD        int = 15
-	ResourceTypeDVD       int = 16
-	ResourceTypeDisk      int = 17
-	ResourceTypeUSB       int = 23
+	ResourceTypeMemory    int   = 4
+	ResourceTypeIDE       int   = 5
+	ResourceTypeSCSI      int   = 6
+	ResourceTypeEthernet  int   = 10
+	ResourceTypeFloppy    int   = 14
+	ResourceTypeCD        int   = 15
+	ResourceTypeDVD       int   = 16
+	ResourceTypeDisk      int   = 17
+	ResourceTypeUSB       int   = 23
 )
 
 const (
@@ -287,7 +287,7 @@ func (qf VmQueryFilter) String() string {
 		return ""
 	}
 	return [...]string{
-		"",                      // No filter: will not remove any items
+		"", // No filter: will not remove any items
 		"isVAppTemplate==false", // Will find only the deployed VMs
 		"isVAppTemplate==true",  // Will find only those VM that are inside a template
 	}[qf]

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -137,7 +137,7 @@ const (
 
 const (
 	ResourceTypeOther     int = 0
-	ResourceTypeProcessor int = 3
+	ResourceTypeProcessor int64 = 3
 	ResourceTypeMemory    int = 4
 	ResourceTypeIDE       int = 5
 	ResourceTypeSCSI      int = 6

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1505,7 +1505,7 @@ type VirtualHardwareSection struct {
 // Each ovf:Item parsed from the ovf:VirtualHardwareSection
 type VirtualHardwareItem struct {
 	XMLName             xml.Name                       `xml:"Item"`
-	ResourceType        int                            `xml:"ResourceType,omitempty"`
+	ResourceType        int64                          `xml:"ResourceType,omitempty"`
 	ResourceSubType     string                         `xml:"ResourceSubType,omitempty"`
 	ElementName         string                         `xml:"ElementName,omitempty"`
 	Description         string                         `xml:"Description,omitempty"`


### PR DESCRIPTION
Changing type of VirtualHardwareItem from int to int64

## Description

Super simple type change to fix https://github.com/vmware/terraform-provider-vcd/issues/626

Tested after these changes and it fixes the above issue as pointed out by @dataclouder 