### PR TITLE
Add functions for NSX-V advanced edge gateway DHCP pool handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ lookup NSX-T segments for use in NSX-T Imported networks [#354](https://github.c
 * Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, `CreateStandaloneVmAsync`
 * Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList`
 * Added VM methods `Delete`, `DeleteAsync`
+* Added NSX-V DHCP pool management functions `UpdateDhcpPools`, `GetDhcpPools`, `RemoveDhcpPools`,
+ `ResetDhcpPoolsAndBindings` [#XXX]
 
 BREAKING CHANGES:
 * Renamed `types.VM` to `types.Vm` to facilitate implementation of standalone VM

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/vmware/go-vcloud-director/v2
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
+	github.com/davecgh/go-spew v1.1.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.0
 	github.com/peterhellberg/link v1.1.0

--- a/govcd/nsxv_dhcp.go
+++ b/govcd/nsxv_dhcp.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// GetDhcpPoolsAndBindings retrieves a structure of *types.EdgeDhcp with all DHCP pool and binding settings present on a
+// particular edge gateway.
+func (egw *EdgeGateway) GetDhcpPoolsAndBindings() (*types.EdgeDhcp, error) {
+	if !egw.HasAdvancedNetworking() {
+		return nil, fmt.Errorf("only advanced edge gateways support DHCP pools")
+	}
+	response := &types.EdgeDhcp{}
+
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeDhcpPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+
+	// This query Edge gateway DHCP pool using proxied NSX-V API
+	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
+		"unable to read edge gateway DHCP pool configuration: %s", nil, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// UpdateDhcpPoolsAndBindings allows to update DHCP pool and binding settings for a particular edge gateway
+//
+// Note. Update must contain all settings to avoid removing previously set settings
+func (egw *EdgeGateway) UpdateDhcpPoolsAndBindings(dhcpPoolConfig *types.EdgeDhcp) (*types.EdgeDhcp, error) {
+	if !egw.HasAdvancedNetworking() {
+		return nil, fmt.Errorf("only advanced edge gateways support DHCP pools")
+	}
+
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeDhcpPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+	// We expect to get http.StatusNoContent or if not an error of type types.NSXError
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPut, types.AnyXMLMime,
+		"error setting DHCP pool settings: %s", dhcpPoolConfig, &types.NSXError{})
+	if err != nil {
+		return nil, err
+	}
+
+	return egw.GetDhcpPoolsAndBindings()
+}
+
+// UpdateDhcpPools allows to update DHCP pool settings for a particular edge gateway
+//
+// Note. There is no endpoint to update DHCP pools only as static DHCP bindings must go together always. This function
+// retrieves latest static DHCP bindings and feeds them back into dhcpPoolConfig to avoid overwriting/removing existing
+// static DHCP bindings
+func (egw *EdgeGateway) UpdateDhcpPools(dhcpPoolConfig *types.EdgeDhcp) (*types.EdgeDhcp, error) {
+	if !egw.HasAdvancedNetworking() {
+		return nil, fmt.Errorf("only advanced edge gateways support DHCP pools")
+	}
+
+	// To allow updating DHCP pools only
+	currentDhcpSettings, err := egw.GetDhcpPoolsAndBindings()
+	if err != nil {
+		return nil, fmt.Errorf("error reading existing DHCP pools and bindings: %s", err)
+	}
+	dhcpPoolConfig.StaticBindings = currentDhcpSettings.StaticBindings
+
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeDhcpPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+	// We expect to get http.StatusNoContent or if not an error of type types.NSXError
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPut, types.AnyXMLMime,
+		"error setting DHCP pool settings: %s", dhcpPoolConfig, &types.NSXError{})
+	if err != nil {
+		return nil, err
+	}
+
+	return egw.GetDhcpPoolsAndBindings()
+}
+
+// RemoveDhcpPools internally performs an update with empty DHCP pool definition while persisting DHCP bindings
+//
+// Note. It will disable DHCP service as well because that is how native ResetDhcpPoolsAndBindings() works
+func (egw *EdgeGateway) RemoveDhcpPools() error {
+	dhcpConfig, err := egw.GetDhcpPoolsAndBindings()
+	if err != nil {
+		return fmt.Errorf("error getting DHCP pools: %s", err)
+	}
+
+	dhcpPoolConfig := &types.EdgeDhcp{
+		Enabled: false,
+		// Feed in the same static bindings to not override existing customer settings
+		StaticBindings: dhcpConfig.StaticBindings,
+	}
+
+	_, err = egw.UpdateDhcpPoolsAndBindings(dhcpPoolConfig)
+	return err
+}
+
+// ResetDhcpPoolsAndBindings removes all configuration for DHCP Pools and Bindings by sending a DELETE request for DHCP
+// pool and binding configuration endpoint
+func (egw *EdgeGateway) ResetDhcpPoolsAndBindings() error {
+	if !egw.HasAdvancedNetworking() {
+		return fmt.Errorf("only advanced edge gateways support DHCP pools")
+	}
+	httpPath, err := egw.buildProxiedEdgeEndpointURL(types.EdgeDhcpPath)
+	if err != nil {
+		return fmt.Errorf("could not get Edge Gateway API endpoint: %s", err)
+	}
+
+	// Send a DELETE request to DHCP pool configuration endpoint
+	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+		"unable to reset edge gateway DHCP pool configuration: %s", nil, &types.NSXError{})
+	return err
+}

--- a/govcd/nsxv_dhcp_test.go
+++ b/govcd/nsxv_dhcp_test.go
@@ -1,0 +1,157 @@
+// +build nsxv functional ALL
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+// Test_NsxvDhcp does the following:
+// 1. pre-creates Org VDC routed network using Openapi
+// 2. Creates 3 DHCP pools in the scope of this Org VDC Routed network by using UpdateDhcpPoolsAndBindings()
+// 3. Updates 3 DHCP pools  in the scope of this Org VDC Routed network by using UpdateDhcpPools()
+// 4. Removes DHCP pools
+func (vcd *TestVCD) Test_NsxvDhcp(check *C) {
+	if vcd.config.VCD.EdgeGateway == "" {
+		check.Skip("Skipping test because no edge gateway given")
+	}
+
+	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	check.Assert(err, IsNil)
+	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
+
+	// Pre-create Org VDC routed network using OpenAPI to try and attach DHCP pools to it in this test
+	orgVdcNet := createOrgVdcRoutedNet(check, edge.EdgeGateway.ID, vcd.vdc)
+	defer func() {
+		orgVdcNet.Delete()
+	}()
+
+	// Retrieve any binding to store them internally
+	currentDhcpPool, err := edge.GetDhcpPoolsAndBindings()
+	check.Assert(err, IsNil)
+
+	poolDef1 := types.EdgeDhcpIpPool{
+		AutoConfigureDNS:    false,
+		DefaultGateway:      "22.1.1.1",
+		DomainName:          "asd.hostname",
+		LeaseTime:           "2000",
+		SubnetMask:          "255.255.255.0",
+		IpRange:             "22.1.1.242-22.1.1.243",
+		PrimaryNameServer:   "8.8.8.8",
+		SecondaryNameServer: "8.8.4.4",
+	}
+
+	poolDef2 := types.EdgeDhcpIpPool{
+		AutoConfigureDNS: true,
+		DefaultGateway:   "22.1.1.1",
+		LeaseTime:        "infinite",
+		SubnetMask:       "255.255.255.0",
+		IpRange:          "22.1.1.244-22.1.1.245",
+	}
+
+	poolDef3 := types.EdgeDhcpIpPool{
+		AutoConfigureDNS: false,
+		DefaultGateway:   "22.1.1.1",
+		SubnetMask:       "255.255.255.0",
+		IpRange:          "22.1.1.200-22.1.1.201",
+	}
+
+	dhcpPoolConfig := &types.EdgeDhcp{
+		Enabled: true,
+		// Feed in the same static bindings to not override existing customer settings
+		StaticBindings: currentDhcpPool.StaticBindings,
+		EdgeDhcpIpPools: &types.EdgeDhcpIpPools{
+			EdgeDhcpIpPool: []types.EdgeDhcpIpPool{
+				poolDef1,
+				poolDef2,
+				poolDef3,
+			},
+		},
+	}
+
+	returnedDhcpPool, err := edge.UpdateDhcpPoolsAndBindings(dhcpPoolConfig)
+	check.Assert(err, IsNil)
+
+	check.Assert(len(returnedDhcpPool.EdgeDhcpIpPools.EdgeDhcpIpPool) > 0, Equals, true)
+	check.Assert(returnedDhcpPool.Enabled, Equals, true)
+	check.Assert(findDhcpPoolByIpRange(returnedDhcpPool.EdgeDhcpIpPools.EdgeDhcpIpPool, poolDef1.IpRange), Equals, poolDef1)
+	check.Assert(findDhcpPoolByIpRange(returnedDhcpPool.EdgeDhcpIpPools.EdgeDhcpIpPool, poolDef2.IpRange), Equals, poolDef2)
+
+	// poolDef3 definition did not specify lease time, but VCD returns 864000 by default therefore it must be injected
+	// before comparison
+	poolDef3.LeaseTime = "86400"
+	check.Assert(findDhcpPoolByIpRange(returnedDhcpPool.EdgeDhcpIpPools.EdgeDhcpIpPool, poolDef3.IpRange), Equals, poolDef3)
+
+	// Update by using only UpdateDhcpPools and see if the settings are the same
+	returnedDhcpPool2, err := edge.UpdateDhcpPools(dhcpPoolConfig)
+	check.Assert(err, IsNil)
+
+	check.Assert(len(returnedDhcpPool2.EdgeDhcpIpPools.EdgeDhcpIpPool) > 0, Equals, true)
+	check.Assert(returnedDhcpPool.Enabled, Equals, true)
+	check.Assert(findDhcpPoolByIpRange(returnedDhcpPool2.EdgeDhcpIpPools.EdgeDhcpIpPool, poolDef1.IpRange), Equals, poolDef1)
+	check.Assert(findDhcpPoolByIpRange(returnedDhcpPool2.EdgeDhcpIpPools.EdgeDhcpIpPool, poolDef2.IpRange), Equals, poolDef2)
+
+	err = edge.RemoveDhcpPools()
+	check.Assert(err, IsNil)
+}
+
+// findDhcpPoolByIpRange helps to find particular DHCP pool in unordered list by ipRange (which does not allow
+// duplicates)
+func findDhcpPoolByIpRange(sliceOfPools []types.EdgeDhcpIpPool, ipRange string) types.EdgeDhcpIpPool {
+	for index := range sliceOfPools {
+		if sliceOfPools[index].IpRange == ipRange {
+			return sliceOfPools[index]
+		}
+	}
+	return types.EdgeDhcpIpPool{}
+}
+
+func createOrgVdcRoutedNet(check *C, edgeGatewayId string, vdc *Vdc) *OpenApiOrgVdcNetwork {
+	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
+		Name:        check.TestName(),
+		Description: check.TestName() + "-description",
+		OrgVdc:      &types.OpenApiReference{ID: vdc.Vdc.ID},
+
+		NetworkType: types.OrgVdcNetworkTypeRouted,
+
+		// Connection is used for "routed" network
+		Connection: &types.Connection{
+			RouterRef: types.OpenApiReference{
+				ID: edgeGatewayId,
+			},
+			ConnectionType: "INTERNAL",
+		},
+		Subnets: types.OrgVdcNetworkSubnets{
+			Values: []types.OrgVdcNetworkSubnetValues{
+				{
+					Gateway:      "22.1.1.1",
+					PrefixLength: 24,
+					DNSServer1:   "8.8.8.8",
+					DNSServer2:   "8.8.4.4",
+					DNSSuffix:    "foo.bar",
+					IPRanges: types.OrgVdcNetworkSubnetIPRanges{
+						Values: []types.OrgVdcNetworkSubnetIPRangeValues{
+							{
+								StartAddress: "22.1.1.20",
+								EndAddress:   "22.1.1.30",
+							},
+						}},
+				},
+			},
+		},
+	}
+
+	orgVdcNet, err := vdc.CreateOpenApiOrgVdcNetwork(orgVdcNetworkConfig)
+	check.Assert(err, IsNil)
+
+	// Use generic "OpenApiEntity" resource cleanup type
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks + orgVdcNet.OpenApiOrgVdcNetwork.ID
+	AddToCleanupListOpenApi(orgVdcNet.OpenApiOrgVdcNetwork.Name, check.TestName(), openApiEndpoint)
+
+	return orgVdcNet
+}

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -205,7 +205,6 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
-	// skipNoNsxtConfiguration(vcd, check)
 
 	nsxvEdgeGateway, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, true)
 	check.Assert(err, IsNil)

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -191,6 +191,7 @@ const (
 	EdgeVnicConfig         = "/vnics"
 	EdgeVdcVnicConfig      = "/vdcNetworks"
 	EdgeDhcpRelayPath      = "/dhcp/config/relay"
+	EdgeDhcpPath           = "/dhcp/config"
 	EdgeDhcpLeasePath      = "/dhcp/leaseInfo"
 	LbConfigPath           = "/loadbalancer/config/"
 	LbMonitorPath          = "/loadbalancer/config/monitors/"

--- a/types/v56/nsxv_types.go
+++ b/types/v56/nsxv_types.go
@@ -448,3 +448,46 @@ type EdgeDhcpLeaseInfo struct {
 	// HardwareType holds type of hardware, usually "ethernet"
 	HardwareType string `xml:"hardwareType"`
 }
+
+// EdgeDhcp allows to manage advanced NSX-V Edge Gateway DHCP pools and static bindings by using proxied NSX-V API.
+// The endpoint does not allow to handle DHCP pools and static bindings separately (which are two tabs in UI). This
+// struct is created for handling DHCP pools therefore StaticBindings are kept as
+type EdgeDhcp struct {
+	XMLName xml.Name `xml:"dhcp"`
+	// Enabled specifies if the DHCP service is enabled or disabled on Edge Gateway.
+	// Note. If there are no DHCP pools defined on Edge Gateway - even after enabling it will report the service as
+	// disabled
+	Enabled bool `xml:"enabled"`
+	// StaticBindings have `innerxml` tag so that they are not processed but instead
+	// sent/received verbatim to avoid overriding it while
+	StaticBindings InnerXML `xml:"staticBindings"`
+	// EdgeDhcpIpPools contains a slice of EdgeDhcpIpPool definitions
+	EdgeDhcpIpPools *EdgeDhcpIpPools `xml:"ipPools"`
+	// Logging allows to set logging settings
+	Logging *LbLogging `xml:"logging"`
+}
+
+// EdgeDhcpIpPools unwraps many EdgeDhcpIpPool in API structure
+type EdgeDhcpIpPools struct {
+	EdgeDhcpIpPool []EdgeDhcpIpPool `xml:"ipPool"`
+}
+
+// EdgeDhcpIpPool is one definition of DHCP pool
+type EdgeDhcpIpPool struct {
+	// AutoConfigureDNS allows to inherit DNS settings from Edge Gateway
+	AutoConfigureDNS bool `xml:"autoConfigureDNS"`
+	// DefaultGateway must contain IP address to be set for DHCP clients
+	DefaultGateway string `xml:"defaultGateway"`
+	// LeaseTime can be set to 'infinite' or time in seconds. If it is left empty - default is set 86400 and reported back
+	LeaseTime string `xml:"leaseTime,omitempty"`
+	// Subnet mask of the network
+	SubnetMask string `xml:"subnetMask"`
+	// IpRange
+	IpRange string `xml:"ipRange"`
+	// DomainName allows to set domain name for DHCP clients
+	DomainName string `xml:"domainName,omitempty"`
+	// PrimaryNameServer allows to set primary DNS server for DHCP clients
+	PrimaryNameServer string `xml:"primaryNameServer,omitempty"`
+	// SecondaryNameServer allows to set primary DNS server for DHCP clients
+	SecondaryNameServer string `xml:"secondaryNameServer,omitempty"`
+}


### PR DESCRIPTION
This PR introduces a few new functions to manage DHCP pools on NSX-V advanced edge gateway using proxied API. All of them operate on new introduced type `types.EdgeDhcp`
* `edgegateway.GetDhcpPoolsAndBindings` retrieves `types.EdgeDhcp`
* `edgegateway.UpdateDhcpPoolsAndBindings` - updates by using `types.EdgeDhcp`
* `edgegateway.UpdateDhcpPools` - updates by using `types.EdgeDhcp`, but automatically persists `StaticBindings` as they are updated on the same API call and must be sent in order to avoid removing them at all
* `edgegateway.ResetDhcpPools` - clears all DHCP pools and disables DHCP service
* `edgegateway.ResetDhcpPoolsAndBindings` - executes a DELETE API method which removes all `StaticBindings` and DHCP pools + disables DHCP service.

It also adds tests to create a routed network using OpenAPI and attach

**Note.** While DHCP pools serve specific Org VDC networks, there is no direct relationship (network ID or something). The only real relationship are routed network subnets and DHCP pool IP ranges. If a DHCP pool is defined for a non existing IP range - it will throw error.
