### PR TITLE
Introduce Org VDC network DHCP pool management methods using OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ for all networks types for NSX-V and NSX-T backed VDCs [#354](https://github.com
 lookup NSX-T segments for use in NSX-T Imported networks [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `vdc.IsNsxt` and `vdc.IsNsxv` methods to verify if VDC is backed by NSX-T or NSX-V [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`
-* Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, `CreateStandaloneVmAsync`
-* Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList`
-* Added VM methods `Delete`, `DeleteAsync`
+* Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
+`CreateStandaloneVmAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VM methods `Delete`, `DeleteAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added Vdc methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
+for OpenAPI management of Org Network DHCP configurations [#357](https://github.com/vmware/go-vcloud-director/pull/357)
 
 BREAKING CHANGES:
-* Renamed `types.VM` to `types.Vm` to facilitate implementation of standalone VM
+* Renamed `types.VM` to `types.Vm` to facilitate implementation of standalone VM 
+[#356](https://github.com/vmware/go-vcloud-director/pull/356)
 
 BUGS FIXED:
 * Made IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/vmware/go-vcloud-director/v2
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.0
 	github.com/peterhellberg/link v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/vmware/go-vcloud-director/v2
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
-	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.0
 	github.com/peterhellberg/link v1.1.0

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -23,6 +23,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks:             "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp:         "34.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcCapabilities:            "32.0",
 }
 

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -23,7 +23,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks:             "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp:         "34.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp:         "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcCapabilities:            "32.0",
 }
 

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -11,14 +11,14 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-// OpenApiOrgVdcNetwork uses OpenAPI endpoint to operate both - NSX-T and NSX-V Org VDC networks
+// OpenApiOrgVdcNetwork uses OpenAPI endpoint to operate both - NSX-T and NSX-V Org VDC network DHCP settings
 type OpenApiOrgVdcNetworkDhcp struct {
 	OpenApiOrgVdcNetworkDhcp *types.OpenApiOrgVdcNetworkDhcp
 	client                   *Client
 }
 
-// GetOpenApiOrgVdcNetworkDhcp allows to retrieve both DHCP configuration for specific Org VDC network
-// ID specified as orgNetworkId
+// GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
+// ID specified as orgNetworkId using OpenAPI
 func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdcNetworkDhcp, error) {
 
 	client := vdc.client
@@ -54,7 +54,8 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 	return orgNetDhcp, nil
 }
 
-// UpdateOpenApiOrgVdcNetworkDhcp allows to create NSX-T or NSX-V Org VDC network
+// UpdateOpenApiOrgVdcNetworkDhcp allows to update DHCP configuration for specific Org VDC network
+// ID specified as orgNetworkId using OpenAPI
 func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
 	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -74,13 +75,17 @@ func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetwor
 
 	err = vdc.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Org VDC network: %s", err)
+		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
 	}
 
 	return orgNetDhcpResponse, nil
 }
 
-// Delete allows to delete Org VDC network
+// DeleteOpenApiOrgVdcNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for specified Org VDC
+// Network ID
+//
+// Note. VCD Versions before 10.2 do not allow to perform "DELETE" on DHCP pool and will return error. The way to
+// remove DHCP configuration is to recreate Org VDC network itself.
 func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
 	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
@@ -100,7 +105,7 @@ func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 	err = vdc.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
 
 	if err != nil {
-		return fmt.Errorf("error deleting Org VDC network DHCP: %s", err)
+		return fmt.Errorf("error deleting Org VDC network DHCP configuration: %s", err)
 	}
 
 	return nil

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// OpenApiOrgVdcNetwork uses OpenAPI endpoint to operate both - NSX-T and NSX-V Org VDC networks
+type OpenApiOrgVdcNetworkDhcp struct {
+	OpenApiOrgVdcNetworkDhcp *types.OpenApiOrgVdcNetworkDhcp
+	client                   *Client
+}
+
+// GetOpenApiOrgVdcNetworkDhcp allows to retrieve both DHCP configuration for specific Org VDC network
+// ID specified as orgNetworkId
+func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdcNetworkDhcp, error) {
+
+	client := vdc.client
+	// Inject Vdc ID filter to perform filtering on server side
+	params := url.Values{}
+	queryParameters := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, params)
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if orgNetworkId == "" {
+		return nil, fmt.Errorf("empty Org VDC network ID")
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgNetworkId))
+	if err != nil {
+		return nil, err
+	}
+
+	orgNetDhcp := &OpenApiOrgVdcNetworkDhcp{
+		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
+		client:                   client,
+	}
+
+	err = client.OpenApiGetItem(minimumApiVersion, urlRef, queryParameters, orgNetDhcp.OpenApiOrgVdcNetworkDhcp)
+	if err != nil {
+		return nil, err
+	}
+
+	return orgNetDhcp, nil
+}
+
+// UpdateOpenApiOrgVdcNetworkDhcp allows to create NSX-T or NSX-V Org VDC network
+func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := vdc.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgNetworkId))
+	if err != nil {
+		return nil, err
+	}
+
+	orgNetDhcpResponse := &OpenApiOrgVdcNetworkDhcp{
+		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
+		client:                   vdc.client,
+	}
+
+	err = vdc.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Org VDC network: %s", err)
+	}
+
+	return orgNetDhcpResponse, nil
+}
+
+// Delete allows to delete Org VDC network
+func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	if orgNetworkId == "" {
+		return fmt.Errorf("cannot delete Org VDC network DHCP configuration without ID")
+	}
+
+	urlRef, err := vdc.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgNetworkId))
+	if err != nil {
+		return err
+	}
+
+	err = vdc.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting Org VDC network DHCP: %s", err)
+	}
+
+	return nil
+}

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -357,7 +357,7 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 
 	// Configure DHCP if specified
 	if dhcpFunc != nil {
-		nsxtRoutedDhcpConfig(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
+		dhcpFunc(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
 	}
 	// Delete
 	err = orgVdcNet.Delete()

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -51,7 +51,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, dhcpConfig)
+	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
 }
 
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
@@ -159,7 +159,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, dhcpConfig)
+	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, nil)
 
 }
 
@@ -205,7 +205,6 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
-	// skipNoNsxtConfiguration(vcd, check)
 
 	nsxvEdgeGateway, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, true)
 	check.Assert(err, IsNil)
@@ -383,24 +382,6 @@ func dhcpConfig(check *C, vdc *Vdc, orgNetId string) {
 		LeaseTime: 90000,
 		DhcpPools: []types.OpenApiOrgVdcNetworkDhcpPools{
 			{
-				Enabled: false,
-				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
-					StartAddress: "2.1.1.100",
-					EndAddress:   "2.1.1.101",
-				},
-				MaxLeaseTime:     0,
-				DefaultLeaseTime: 0,
-			},
-			{
-				Enabled: true,
-				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
-					StartAddress: "2.1.1.110",
-					EndAddress:   "2.1.1.111",
-				},
-				MaxLeaseTime:     0,
-				DefaultLeaseTime: 0,
-			},
-			{
 				Enabled: true,
 				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
 					StartAddress: "2.1.1.200",
@@ -410,8 +391,8 @@ func dhcpConfig(check *C, vdc *Vdc, orgNetId string) {
 				DefaultLeaseTime: 9000,
 			},
 		},
-		// Mode:      "",
-		// IPAddress: "",
+		// Mode:      "NETWORK",
+		// IPAddress: "2.1.1.199",
 	}
 	_, err := vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetId, t)
 	check.Assert(err, IsNil)

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -26,24 +26,24 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 		Subnets: types.OrgVdcNetworkSubnets{
 			Values: []types.OrgVdcNetworkSubnetValues{
 				{
-					Gateway:      "4.1.1.1",
-					PrefixLength: 25,
+					Gateway:      "2.1.1.1",
+					PrefixLength: 24,
 					DNSServer1:   "8.8.8.8",
 					DNSServer2:   "8.8.4.4",
 					DNSSuffix:    "bar.foo",
 					IPRanges: types.OrgVdcNetworkSubnetIPRanges{
 						Values: []types.OrgVdcNetworkSubnetIPRangeValues{
 							{
-								StartAddress: "4.1.1.20",
-								EndAddress:   "4.1.1.30",
+								StartAddress: "2.1.1.20",
+								EndAddress:   "2.1.1.30",
 							},
 							{
-								StartAddress: "4.1.1.40",
-								EndAddress:   "4.1.1.50",
+								StartAddress: "2.1.1.40",
+								EndAddress:   "2.1.1.50",
 							},
 							{
-								StartAddress: "4.1.1.88",
-								EndAddress:   "4.1.1.92",
+								StartAddress: "2.1.1.88",
+								EndAddress:   "2.1.1.92",
 							},
 						}},
 				},
@@ -51,7 +51,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated)
+	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, dhcpConfig)
 }
 
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
@@ -109,7 +109,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted)
+	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, dhcpConfig)
 }
 
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
@@ -138,7 +138,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 		Subnets: types.OrgVdcNetworkSubnets{
 			Values: []types.OrgVdcNetworkSubnetValues{
 				{
-					Gateway:      "3.1.1.1",
+					Gateway:      "2.1.1.1",
 					PrefixLength: 24,
 					DNSServer1:   "8.8.8.8",
 					DNSServer2:   "8.8.4.4",
@@ -146,12 +146,12 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 					IPRanges: types.OrgVdcNetworkSubnetIPRanges{
 						Values: []types.OrgVdcNetworkSubnetIPRangeValues{
 							{
-								StartAddress: "3.1.1.20",
-								EndAddress:   "3.1.1.30",
+								StartAddress: "2.1.1.20",
+								EndAddress:   "2.1.1.30",
 							},
 							{
-								StartAddress: "3.1.1.40",
-								EndAddress:   "3.1.1.50",
+								StartAddress: "2.1.1.40",
+								EndAddress:   "2.1.1.50",
 							},
 						}},
 				},
@@ -159,7 +159,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque)
+	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, dhcpConfig)
 
 }
 
@@ -200,7 +200,7 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated)
+	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
@@ -258,7 +258,7 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted)
+	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nil)
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
@@ -314,10 +314,10 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeDirect)
+	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeDirect, nil)
 }
 
-func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, extpectNetworkType string) {
+func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, extpectNetworkType string, dhcpFunc dhcpConfigFunc) {
 	orgVdcNet, err := vdc.CreateOpenApiOrgVdcNetwork(orgVdcNetworkConfig)
 	check.Assert(err, IsNil)
 
@@ -356,6 +356,13 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 	check.Assert(updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID, Equals, orgVdcNet.OpenApiOrgVdcNetwork.ID)
 	check.Assert(updatedOrgVdcNet.OpenApiOrgVdcNetwork.Description, Equals, orgVdcNet.OpenApiOrgVdcNetwork.Description)
 
+	// Configure DHCP if specified
+	if dhcpFunc != nil {
+		dhcpConfig(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
+	}
+	// fmt.Println("sleep")
+	// time.Sleep(3 * time.Minute)
+
 	// Delete
 	err = orgVdcNet.Delete()
 	check.Assert(err, IsNil)
@@ -366,4 +373,47 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 
 	_, err = vdc.GetOpenApiOrgVdcNetworkById(orgVdcNet.OpenApiOrgVdcNetwork.ID)
 	check.Assert(ContainsNotFound(err), Equals, true)
+}
+
+type dhcpConfigFunc func(check *C, vdc *Vdc, orgNetId string)
+
+func dhcpConfig(check *C, vdc *Vdc, orgNetId string) {
+	t := &types.OpenApiOrgVdcNetworkDhcp{
+		Enabled:   true,
+		LeaseTime: 90000,
+		DhcpPools: []types.OpenApiOrgVdcNetworkDhcpPools{
+			{
+				Enabled: false,
+				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
+					StartAddress: "2.1.1.100",
+					EndAddress:   "2.1.1.101",
+				},
+				MaxLeaseTime:     0,
+				DefaultLeaseTime: 0,
+			},
+			{
+				Enabled: true,
+				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
+					StartAddress: "2.1.1.110",
+					EndAddress:   "2.1.1.111",
+				},
+				MaxLeaseTime:     0,
+				DefaultLeaseTime: 0,
+			},
+			{
+				Enabled: true,
+				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
+					StartAddress: "2.1.1.200",
+					EndAddress:   "2.1.1.201",
+				},
+				MaxLeaseTime:     10000,
+				DefaultLeaseTime: 9000,
+			},
+		},
+		// Mode:      "",
+		// IPAddress: "",
+	}
+	_, err := vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetId, t)
+	check.Assert(err, IsNil)
+	// spew.Dump(updatedDhcpPools.OpenApiOrgVdcNetworkDhcp)
 }

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -987,9 +987,9 @@ func allNicsHaveIps(nicConfigs []nicDhcpConfig) bool {
 //
 // For this function to work - at least one the following must be true:
 // * VM has guest tools (vCD UI shows IP address). (Takes longer time)
-// * VM DHCP interface is connected to routed Org network and is using Edge Gateway DHCP. (Takes
+// * VM DHCP interface is connected to routed Org network and is using NSX-V Edge Gateway DHCP. (Takes
 // less time, but is more constrained)
-func (vm *VM) WaitForDhcpIpByNicIndexes(nicIndexes []int, maxWaitSeconds int, useDhcpLeaseCheck bool) ([]string, bool, error) {
+func (vm *VM) WaitForDhcpIpByNicIndexes(nicIndexes []int, maxWaitSeconds int, useNsxvDhcpLeaseCheck bool) ([]string, bool, error) {
 	util.Logger.Printf("[TRACE] [DHCP IP Lookup] VM '%s' attempting to lookup IP addresses for DHCP NICs %v\n",
 		vm.VM.Name, nicIndexes)
 	// validate NIC indexes
@@ -1010,7 +1010,7 @@ func (vm *VM) WaitForDhcpIpByNicIndexes(nicIndexes []int, maxWaitSeconds int, us
 		nicStates[index].vmNicIndex = nicIndex
 	}
 	var err error
-	if useDhcpLeaseCheck { // Edge gateways have to be looked up when DHCP lease checks are enabled
+	if useNsxvDhcpLeaseCheck { // Edge gateways have to be looked up when DHCP lease checks are enabled
 		// Lookup edge gateways for routed networks and store them
 		nicStates, err = vm.getEdgeGatewaysForRoutedNics(nicStates)
 		if err != nil {
@@ -1050,7 +1050,7 @@ func (vm *VM) WaitForDhcpIpByNicIndexes(nicIndexes []int, maxWaitSeconds int, us
 				vm.VM.Name, nicIndexes)
 
 			// Step 2 If enabled - check if DHCP leases in edge gateways can hint IP addresses
-			if useDhcpLeaseCheck {
+			if useNsxvDhcpLeaseCheck {
 				nicStates, err = vm.getIpsByDhcpLeaseMacs(nicStates)
 				if err != nil {
 					return []string{}, false, fmt.Errorf("could not check MAC leases for VM '%s': %s",

--- a/scripts/test-tags.sh
+++ b/scripts/test-tags.sh
@@ -23,7 +23,7 @@ echo "=== RUN TagsTest"
 for tag in $tags
 do
     
-    go test -tags $tag -timeout 0 -check.vv -vcd-help > /dev/null
+    go test -tags $tag -timeout 0 -count=0 -check.vv > /dev/null
 
     if [ "$?" == "0" ]
     then

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -341,6 +341,7 @@ const (
 	OpenApiEndpointVdcCapabilities            = "vdcs/%s/capabilities"
 	OpenApiEndpointEdgeGateways               = "edgeGateways/"
 	OpenApiEndpointOrgVdcNetworks             = "orgVdcNetworks/"
+	OpenApiEndpointOrgVdcNetworksDhcp         = "orgVdcNetworks/%s/dhcp"
 )
 
 // Header keys to run operations in tenant context

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -192,3 +192,20 @@ type Connection struct {
 // NsxtImportableSwitch is a type alias with better name for holding NSX-T Segments (Logical Switches) which can be used
 // to back NSX-T imported Org VDC network
 type NsxtImportableSwitch = OpenApiReference
+
+type OpenApiOrgVdcNetworkDhcp struct {
+	Enabled   bool                            `json:"enabled"`
+	LeaseTime int                             `json:"leaseTime"`
+	DhcpPools []OpenApiOrgVdcNetworkDhcpPools `json:"dhcpPools"`
+	Mode      string                          `json:"mode"`
+	IPAddress string                          `json:"ipAddress"`
+}
+
+type OpenApiOrgVdcNetworkDhcpIpRange = ExternalNetworkV2IPRange
+
+type OpenApiOrgVdcNetworkDhcpPools struct {
+	Enabled          bool                            `json:"enabled"`
+	IPRange          OpenApiOrgVdcNetworkDhcpIpRange `json:"ipRange"`
+	MaxLeaseTime     int                             `json:"maxLeaseTime"`
+	DefaultLeaseTime int                             `json:"defaultLeaseTime"`
+}

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -194,18 +194,37 @@ type Connection struct {
 type NsxtImportableSwitch = OpenApiReference
 
 type OpenApiOrgVdcNetworkDhcp struct {
-	Enabled   bool                            `json:"enabled"`
+	Enabled bool `json:"enabled"`
+	// LeaseTime applies for
 	LeaseTime int                             `json:"leaseTime"`
-	DhcpPools []OpenApiOrgVdcNetworkDhcpPools `json:"dhcpPools"`
-	Mode      string                          `json:"mode"`
-	IPAddress string                          `json:"ipAddress"`
+	DhcpPools []OpenApiOrgVdcNetworkDhcpPools `json:"dhcpPools,omitempty"`
+	// Mode describes how the DHCP service is configured for this network. Once a DHCP service has been created, the mode
+	// attribute cannot be changed. The mode field will default to 'EDGE' if it is not provided. This field only applies
+	// to networks backed by an NSX-T network provider.
+	//
+	// The supported values are EDGE (default) and NETWORK.
+	// * If EDGE is specified, the DHCP service of the edge is used to obtain DHCP IPs.
+	// * If NETWORK is specified, a DHCP server is created for use by this network. (To use NETWORK
+	//
+	// In order to use DHCP for IPV6, NETWORK mode must be used. Routed networks which are using NETWORK DHCP services can
+	// be disconnected from the edge gateway and still retain their DHCP configuration, however network using EDGE DHCP
+	// cannot be disconnected from the gateway until DHCP has been disabled.
+	Mode string `json:"mode,omitempty"`
+	// IPAddress is only applicable when mode=NETWORK. This will specify IP address of DHCP server in network.
+	IPAddress string `json:"ipAddress,omitempty"`
 }
 
 type OpenApiOrgVdcNetworkDhcpIpRange = ExternalNetworkV2IPRange
 
 type OpenApiOrgVdcNetworkDhcpPools struct {
-	Enabled          bool                            `json:"enabled"`
-	IPRange          OpenApiOrgVdcNetworkDhcpIpRange `json:"ipRange"`
-	MaxLeaseTime     int                             `json:"maxLeaseTime"`
-	DefaultLeaseTime int                             `json:"defaultLeaseTime"`
+	// Enabled defines if the DHCP pool is enabled or not
+	Enabled bool `json:"enabled"`
+	// IPRange holds IP ranges
+	IPRange OpenApiOrgVdcNetworkDhcpIpRange `json:"ipRange"`
+	// MaxLeaseTime is the maximum lease time that can be accepted on clients request
+	// This applies for NSX-V Isolated network
+	MaxLeaseTime int `json:"maxLeaseTime"`
+	// DefaultLeaseTime is the lease time that clients get if they do not specify particular lease time
+	// This applies for NSX-V Isolated network
+	DefaultLeaseTime int `json:"defaultLeaseTime"`
 }

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -193,10 +193,10 @@ type Connection struct {
 // to back NSX-T imported Org VDC network
 type NsxtImportableSwitch = OpenApiReference
 
+// OpenApiOrgVdcNetworkDhcp allows to manage DHCP configuration for Org VDC networks by using OpenAPI endpoint
 type OpenApiOrgVdcNetworkDhcp struct {
-	Enabled bool `json:"enabled"`
-	// LeaseTime applies for
-	LeaseTime int                             `json:"leaseTime"`
+	Enabled   *bool                           `json:"enabled,omitempty"`
+	LeaseTime *int                            `json:"leaseTime,omitempty"`
 	DhcpPools []OpenApiOrgVdcNetworkDhcpPools `json:"dhcpPools,omitempty"`
 	// Mode describes how the DHCP service is configured for this network. Once a DHCP service has been created, the mode
 	// attribute cannot be changed. The mode field will default to 'EDGE' if it is not provided. This field only applies
@@ -214,17 +214,18 @@ type OpenApiOrgVdcNetworkDhcp struct {
 	IPAddress string `json:"ipAddress,omitempty"`
 }
 
+// OpenApiOrgVdcNetworkDhcpIpRange is a type alias to fit naming
 type OpenApiOrgVdcNetworkDhcpIpRange = ExternalNetworkV2IPRange
 
 type OpenApiOrgVdcNetworkDhcpPools struct {
 	// Enabled defines if the DHCP pool is enabled or not
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 	// IPRange holds IP ranges
 	IPRange OpenApiOrgVdcNetworkDhcpIpRange `json:"ipRange"`
 	// MaxLeaseTime is the maximum lease time that can be accepted on clients request
 	// This applies for NSX-V Isolated network
-	MaxLeaseTime int `json:"maxLeaseTime"`
+	MaxLeaseTime *int `json:"maxLeaseTime,omitempty"`
 	// DefaultLeaseTime is the lease time that clients get if they do not specify particular lease time
 	// This applies for NSX-V Isolated network
-	DefaultLeaseTime int `json:"defaultLeaseTime"`
+	DefaultLeaseTime *int `json:"defaultLeaseTime,omitempty"`
 }


### PR DESCRIPTION
This PR introduces Org VDC network DHCP pool management methods using OpenAPI:
* vdc.GetOpenApiOrgVdcNetworkDhcp
* vdc.UpdateOpenApiOrgVdcNetworkDhcp
* vdc.DeleteOpenApiOrgVdcNetworkDhcp

It also adds additional step to test out DHCP settings in network `Test_NsxtOrgVdcNetworkRouted`

Additionally `scripts/test-tags.sh` is tuned to work with Go 1.16