### PR TITLE
Cleanup CHANGELOG and set 2.11 release date before tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ for all networks types for NSX-V and NSX-T backed VDCs [#354](https://github.com
 * Added `NsxtImportableSwitch` structure with `GetNsxtImportableSwitchByName` and `GetAllNsxtImportableSwitches` to 
 lookup NSX-T segments for use in NSX-T Imported networks [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `vdc.IsNsxt` and `vdc.IsNsxv` methods to verify if VDC is backed by NSX-T or NSX-V [#354](https://github.com/vmware/go-vcloud-director/pull/354)
-* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`
-* Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
+* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`  [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
 `CreateStandaloneVmAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 * Added VM methods `Delete`, `DeleteAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
+* Added VDC methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
 for OpenAPI management of Org Network DHCP configurations [#357](https://github.com/vmware/go-vcloud-director/pull/357)
 
 BREAKING CHANGES:
@@ -18,10 +18,10 @@ BREAKING CHANGES:
 [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 
 BUGS FIXED:
-* Made IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
+* Converted IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
 
 IMPROVEMENTS:
-* Introduce generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
+* Added generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
 
 ## 2.10.0 (December 18, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.11.0 (Unreleased)
+## 2.11.0 (March 10, 2021)
 
 * Added structure and methods to handle Org VDC networks using OpenAPI - `OpenApiOrgVdcNetwork`. It supports VCD 9.7+
 for all networks types for NSX-V and NSX-T backed VDCs [#354](https://github.com/vmware/go-vcloud-director/pull/354)


### PR DESCRIPTION
This PR cleans up CHANGELOG.md and sets a 2.11.0 release date.

Note. Best to read it in "file" view (which reenders markdown) - https://github.com/vmware/go-vcloud-director/blob/0f49d1e848f16c53b8477c10d923d0b4e48b6814/CHANGELOG.md