### PR TITLE
fix InstantiateVappTemplate not working

### DIFF
--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -31,16 +31,16 @@ func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateP
 	}
 	vdcHref.Path += "/action/instantiateVAppTemplate"
 
-	vapptemplate := NewVAppTemplate(vdc.client)
+	var vapp types.VApp
 
-	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPut,
-		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, vapptemplate)
+	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPost,
+		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, &vapp)
 	if err != nil {
 		return err
 	}
 
 	task := NewTask(vdc.client)
-	for _, taskItem := range vapptemplate.VAppTemplate.Tasks.Task {
+	for _, taskItem := range vapp.Tasks.Task {
 		task.Task = taskItem
 		err = task.WaitTaskCompletion()
 		if err != nil {


### PR DESCRIPTION
This was a trivial fix so there is no related Issue.

According to [the documentation](https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/operations/POST-InstantiateVAppTemplate.html) this endpoint takes a POST and returns a VApp record, so I made those changes and it works now.
