### PR TITLE
adding context to allow timeout/cancellation of http request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-## 2.11.0 (Unreleased)
+## 2.11.0 (March 10, 2021)
 
 * Added structure and methods to handle Org VDC networks using OpenAPI - `OpenApiOrgVdcNetwork`. It supports VCD 9.7+
 for all networks types for NSX-V and NSX-T backed VDCs [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `NsxtImportableSwitch` structure with `GetNsxtImportableSwitchByName` and `GetAllNsxtImportableSwitches` to 
 lookup NSX-T segments for use in NSX-T Imported networks [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `vdc.IsNsxt` and `vdc.IsNsxv` methods to verify if VDC is backed by NSX-T or NSX-V [#354](https://github.com/vmware/go-vcloud-director/pull/354)
-* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`
-* Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
+* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`  [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
 `CreateStandaloneVmAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 * Added VM methods `Delete`, `DeleteAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
+* Added VDC methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
 for OpenAPI management of Org Network DHCP configurations [#357](https://github.com/vmware/go-vcloud-director/pull/357)
 
 BREAKING CHANGES:
@@ -18,10 +18,10 @@ BREAKING CHANGES:
 [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 
 BUGS FIXED:
-* Made IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
+* Converted IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
 
 IMPROVEMENTS:
-* Introduce generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
+* Added generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
 
 ## 2.10.0 (December 18, 2020)
 

--- a/govcd/access_control.go
+++ b/govcd/access_control.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -26,7 +27,7 @@ type orgInfoType struct {
 var orgInfoCache = make(map[string]orgInfoType)
 
 // GetAccessControl retrieves the access control information for the requested entity
-func (client Client) GetAccessControl(href, entityType, entityName string, headerValues map[string]string) (*types.ControlAccessParams, error) {
+func (client Client) GetAccessControl(ctx context.Context, href, entityType, entityName string, headerValues map[string]string) (*types.ControlAccessParams, error) {
 
 	href += "/controlAccess"
 	var controlAccess types.ControlAccessParams
@@ -43,6 +44,7 @@ func (client Client) GetAccessControl(href, entityType, entityName string, heade
 		}
 	}
 	req := client.newRequest(
+		ctx,
 		nil,               // params
 		nil,               // notEncodedParams
 		http.MethodGet,    // method
@@ -73,7 +75,7 @@ func (client Client) GetAccessControl(href, entityType, entityName string, heade
 // For each setting we must provide:
 // * The subject (HREF and Type are mandatory)
 // * The access level (one of ReadOnly, Change, FullControl)
-func (client *Client) SetAccessControl(accessControl *types.ControlAccessParams, href, entityType, entityName string, headerValues map[string]string) error {
+func (client *Client) SetAccessControl(ctx context.Context, accessControl *types.ControlAccessParams, href, entityType, entityName string, headerValues map[string]string) error {
 
 	href += "/action/controlAccess"
 	// Make sure that subjects in the setting list are used only once
@@ -114,6 +116,7 @@ func (client *Client) SetAccessControl(accessControl *types.ControlAccessParams,
 	body := bytes.NewBufferString(xml.Header + string(marshaledXml))
 
 	req := client.newRequest(
+		ctx,
 		nil,               // params
 		nil,               // notEncodedParams
 		http.MethodPost,   // method
@@ -136,7 +139,7 @@ func (client *Client) SetAccessControl(accessControl *types.ControlAccessParams,
 }
 
 // GetAccessControl retrieves the access control information for this vApp
-func (vapp VApp) GetAccessControl(useTenantContext bool) (*types.ControlAccessParams, error) {
+func (vapp VApp) GetAccessControl(ctx context.Context, useTenantContext bool) (*types.ControlAccessParams, error) {
 
 	if vapp.VApp.HREF == "" {
 		return nil, fmt.Errorf("vApp HREF is empty")
@@ -147,11 +150,11 @@ func (vapp VApp) GetAccessControl(useTenantContext bool) (*types.ControlAccessPa
 	if err != nil {
 		return nil, err
 	}
-	return vapp.client.GetAccessControl(vapp.VApp.HREF, "vApp", vapp.VApp.Name, accessControlHeader)
+	return vapp.client.GetAccessControl(ctx, vapp.VApp.HREF, "vApp", vapp.VApp.Name, accessControlHeader)
 }
 
 // SetAccessControl changes the access control information for this vApp
-func (vapp VApp) SetAccessControl(accessControl *types.ControlAccessParams, useTenantContext bool) error {
+func (vapp VApp) SetAccessControl(ctx context.Context, accessControl *types.ControlAccessParams, useTenantContext bool) error {
 
 	if vapp.VApp.HREF == "" {
 		return fmt.Errorf("vApp HREF is empty")
@@ -163,18 +166,18 @@ func (vapp VApp) SetAccessControl(accessControl *types.ControlAccessParams, useT
 	if err != nil {
 		return err
 	}
-	return vapp.client.SetAccessControl(accessControl, vapp.VApp.HREF, "vApp", vapp.VApp.Name, accessControlHeader)
+	return vapp.client.SetAccessControl(ctx, accessControl, vapp.VApp.HREF, "vApp", vapp.VApp.Name, accessControlHeader)
 
 }
 
 // RemoveAccessControl is a shortcut to SetAccessControl with all access disabled
-func (vapp VApp) RemoveAccessControl(useTenantContext bool) error {
-	return vapp.SetAccessControl(&types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
+func (vapp VApp) RemoveAccessControl(ctx context.Context, useTenantContext bool) error {
+	return vapp.SetAccessControl(ctx, &types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
 }
 
 // IsShared shows whether a vApp is shared or not, regardless of the number of subjects sharing it
-func (vapp VApp) IsShared(useTenantContext bool) (bool, error) {
-	settings, err := vapp.GetAccessControl(useTenantContext)
+func (vapp VApp) IsShared(ctx context.Context, useTenantContext bool) (bool, error) {
+	settings, err := vapp.GetAccessControl(ctx, useTenantContext)
 	if err != nil {
 		return false, err
 	}
@@ -185,7 +188,7 @@ func (vapp VApp) IsShared(useTenantContext bool) (bool, error) {
 }
 
 // GetAccessControl retrieves the access control information for this catalog
-func (adminCatalog AdminCatalog) GetAccessControl(useTenantContext bool) (*types.ControlAccessParams, error) {
+func (adminCatalog AdminCatalog) GetAccessControl(ctx context.Context, useTenantContext bool) (*types.ControlAccessParams, error) {
 
 	if adminCatalog.AdminCatalog.HREF == "" {
 		return nil, fmt.Errorf("catalog HREF is empty")
@@ -198,11 +201,11 @@ func (adminCatalog AdminCatalog) GetAccessControl(useTenantContext bool) (*types
 	if err != nil {
 		return nil, err
 	}
-	return adminCatalog.client.GetAccessControl(href, "catalog", adminCatalog.AdminCatalog.Name, accessControlHeader)
+	return adminCatalog.client.GetAccessControl(ctx, href, "catalog", adminCatalog.AdminCatalog.Name, accessControlHeader)
 }
 
 // SetAccessControl changes the access control information for this catalog
-func (adminCatalog AdminCatalog) SetAccessControl(accessControl *types.ControlAccessParams, useTenantContext bool) error {
+func (adminCatalog AdminCatalog) SetAccessControl(ctx context.Context, accessControl *types.ControlAccessParams, useTenantContext bool) error {
 
 	if adminCatalog.AdminCatalog.HREF == "" {
 		return fmt.Errorf("catalog HREF is empty")
@@ -215,17 +218,17 @@ func (adminCatalog AdminCatalog) SetAccessControl(accessControl *types.ControlAc
 	if err != nil {
 		return err
 	}
-	return adminCatalog.client.SetAccessControl(accessControl, href, "catalog", adminCatalog.AdminCatalog.Name, accessControlHeader)
+	return adminCatalog.client.SetAccessControl(ctx, accessControl, href, "catalog", adminCatalog.AdminCatalog.Name, accessControlHeader)
 }
 
 // RemoveAccessControl is a shortcut to SetAccessControl with all access disabled
-func (adminCatalog AdminCatalog) RemoveAccessControl(useTenantContext bool) error {
-	return adminCatalog.SetAccessControl(&types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
+func (adminCatalog AdminCatalog) RemoveAccessControl(ctx context.Context, useTenantContext bool) error {
+	return adminCatalog.SetAccessControl(ctx, &types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
 }
 
 // IsShared shows whether a catalog is shared or not, regardless of the number of subjects sharing it
-func (adminCatalog AdminCatalog) IsShared(useTenantContext bool) (bool, error) {
-	settings, err := adminCatalog.GetAccessControl(useTenantContext)
+func (adminCatalog AdminCatalog) IsShared(ctx context.Context, useTenantContext bool) (bool, error) {
+	settings, err := adminCatalog.GetAccessControl(ctx, useTenantContext)
 	if err != nil {
 		return false, err
 	}
@@ -238,52 +241,52 @@ func (adminCatalog AdminCatalog) IsShared(useTenantContext bool) (bool, error) {
 // GetVappAccessControl is a convenience method to retrieve access control for a vApp
 // from a VDC.
 // The input variable vappIdentifier can be either the vApp name or its ID
-func (vdc *Vdc) GetVappAccessControl(vappIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
+func (vdc *Vdc) GetVappAccessControl(ctx context.Context, vappIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
 	vapp, err := vdc.GetVAppByNameOrId(vappIdentifier, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving vApp %s: %s", vappIdentifier, err)
 	}
-	return vapp.GetAccessControl(useTenantContext)
+	return vapp.GetAccessControl(ctx, useTenantContext)
 }
 
 // GetCatalogAccessControl is a convenience method to retrieve access control for a catalog
 // from an organization.
 // The input variable catalogIdentifier can be either the catalog name or its ID
-func (org *AdminOrg) GetCatalogAccessControl(catalogIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
-	catalog, err := org.GetAdminCatalogByNameOrId(catalogIdentifier, true)
+func (org *AdminOrg) GetCatalogAccessControl(ctx context.Context, catalogIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
+	catalog, err := org.GetAdminCatalogByNameOrId(ctx, catalogIdentifier, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving catalog %s: %s", catalogIdentifier, err)
 	}
-	return catalog.GetAccessControl(useTenantContext)
+	return catalog.GetAccessControl(ctx, useTenantContext)
 }
 
 // GetCatalogAccessControl is a convenience method to retrieve access control for a catalog
 // from an organization.
 // The input variable catalogIdentifier can be either the catalog name or its ID
-func (org *Org) GetCatalogAccessControl(catalogIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
+func (org *Org) GetCatalogAccessControl(ctx context.Context, catalogIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
 	catalog, err := org.GetCatalogByNameOrId(catalogIdentifier, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving catalog %s: %s", catalogIdentifier, err)
 	}
-	return catalog.GetAccessControl(useTenantContext)
+	return catalog.GetAccessControl(ctx, useTenantContext)
 }
 
 // GetAccessControl retrieves the access control information for this catalog
-func (catalog Catalog) GetAccessControl(useTenantContext bool) (*types.ControlAccessParams, error) {
+func (catalog Catalog) GetAccessControl(ctx context.Context, useTenantContext bool) (*types.ControlAccessParams, error) {
 
 	if catalog.Catalog.HREF == "" {
 		return nil, fmt.Errorf("catalog HREF is empty")
 	}
 	href := strings.Replace(catalog.Catalog.HREF, "/admin/", "/", 1)
-	accessControlHeader, err := catalog.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := catalog.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return nil, err
 	}
-	return catalog.client.GetAccessControl(href, "catalog", catalog.Catalog.Name, accessControlHeader)
+	return catalog.client.GetAccessControl(ctx, href, "catalog", catalog.Catalog.Name, accessControlHeader)
 }
 
 // SetAccessControl changes the access control information for this catalog
-func (catalog Catalog) SetAccessControl(accessControl *types.ControlAccessParams, useTenantContext bool) error {
+func (catalog Catalog) SetAccessControl(ctx context.Context, accessControl *types.ControlAccessParams, useTenantContext bool) error {
 
 	if catalog.Catalog.HREF == "" {
 		return fmt.Errorf("catalog HREF is empty")
@@ -293,21 +296,21 @@ func (catalog Catalog) SetAccessControl(accessControl *types.ControlAccessParams
 
 	// if useTenantContext is false, we use an empty header (= default behavior)
 	// if it is true, we use a header populated with tenant context values
-	accessControlHeader, err := catalog.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := catalog.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return err
 	}
-	return catalog.client.SetAccessControl(accessControl, href, "catalog", catalog.Catalog.Name, accessControlHeader)
+	return catalog.client.SetAccessControl(ctx, accessControl, href, "catalog", catalog.Catalog.Name, accessControlHeader)
 }
 
 // RemoveAccessControl is a shortcut to SetAccessControl with all access disabled
-func (catalog Catalog) RemoveAccessControl(useTenantContext bool) error {
-	return catalog.SetAccessControl(&types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
+func (catalog Catalog) RemoveAccessControl(ctx context.Context, useTenantContext bool) error {
+	return catalog.SetAccessControl(ctx, &types.ControlAccessParams{IsSharedToEveryone: false}, useTenantContext)
 }
 
 // IsShared shows whether a catalog is shared or not, regardless of the number of subjects sharing it
-func (catalog Catalog) IsShared(useTenantContext bool) (bool, error) {
-	settings, err := catalog.GetAccessControl(useTenantContext)
+func (catalog Catalog) IsShared(ctx context.Context, useTenantContext bool) (bool, error) {
+	settings, err := catalog.GetAccessControl(ctx, useTenantContext)
 	if err != nil {
 		return false, err
 	}
@@ -335,11 +338,11 @@ func (vapp *VApp) getAccessControlHeader(useTenantContext bool) (map[string]stri
 // getAccessControlHeader builds the data needed to set the header when tenant context is required.
 // If useTenantContext is false, it returns an empty map.
 // Otherwise, it finds the Org ID and name and creates the header data
-func (catalog *Catalog) getAccessControlHeader(useTenantContext bool) (map[string]string, error) {
+func (catalog *Catalog) getAccessControlHeader(ctx context.Context, useTenantContext bool) (map[string]string, error) {
 	if !useTenantContext {
 		return map[string]string{}, nil
 	}
-	orgInfo, err := catalog.getOrgInfo()
+	orgInfo, err := catalog.getOrgInfo(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/access_control.go
+++ b/govcd/access_control.go
@@ -146,7 +146,7 @@ func (vapp VApp) GetAccessControl(ctx context.Context, useTenantContext bool) (*
 	}
 	// if useTenantContext is false, we use an empty header (= default behavior)
 	// if it is true, we use a header populated with tenant context values
-	accessControlHeader, err := vapp.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := vapp.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (vapp VApp) SetAccessControl(ctx context.Context, accessControl *types.Cont
 
 	// if useTenantContext is false, we use an empty header (= default behavior)
 	// if it is true, we use a header populated with tenant context values
-	accessControlHeader, err := vapp.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := vapp.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (adminCatalog AdminCatalog) GetAccessControl(ctx context.Context, useTenant
 
 	// if useTenantContext is false, we use an empty header (= default behavior)
 	// if it is true, we use a header populated with tenant context values
-	accessControlHeader, err := adminCatalog.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := adminCatalog.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (adminCatalog AdminCatalog) SetAccessControl(ctx context.Context, accessCon
 
 	// if useTenantContext is false, we use an empty header (= default behavior)
 	// if it is true, we use a header populated with tenant context values
-	accessControlHeader, err := adminCatalog.getAccessControlHeader(useTenantContext)
+	accessControlHeader, err := adminCatalog.getAccessControlHeader(ctx, useTenantContext)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (adminCatalog AdminCatalog) IsShared(ctx context.Context, useTenantContext 
 // from a VDC.
 // The input variable vappIdentifier can be either the vApp name or its ID
 func (vdc *Vdc) GetVappAccessControl(ctx context.Context, vappIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
-	vapp, err := vdc.GetVAppByNameOrId(vappIdentifier, true)
+	vapp, err := vdc.GetVAppByNameOrId(ctx, vappIdentifier, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving vApp %s: %s", vappIdentifier, err)
 	}
@@ -264,7 +264,7 @@ func (org *AdminOrg) GetCatalogAccessControl(ctx context.Context, catalogIdentif
 // from an organization.
 // The input variable catalogIdentifier can be either the catalog name or its ID
 func (org *Org) GetCatalogAccessControl(ctx context.Context, catalogIdentifier string, useTenantContext bool) (*types.ControlAccessParams, error) {
-	catalog, err := org.GetCatalogByNameOrId(catalogIdentifier, true)
+	catalog, err := org.GetCatalogByNameOrId(ctx, catalogIdentifier, true)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving catalog %s: %s", catalogIdentifier, err)
 	}
@@ -324,11 +324,11 @@ func (catalog Catalog) IsShared(ctx context.Context, useTenantContext bool) (boo
 // If useTenantContext is false, it returns an empty map.
 // Otherwise, it finds the Org ID and name (going up in the hierarchy through the VDC)
 // and creates the header data
-func (vapp *VApp) getAccessControlHeader(useTenantContext bool) (map[string]string, error) {
+func (vapp *VApp) getAccessControlHeader(ctx context.Context, useTenantContext bool) (map[string]string, error) {
 	if !useTenantContext {
 		return map[string]string{}, nil
 	}
-	orgInfo, err := vapp.getOrgInfo()
+	orgInfo, err := vapp.getOrgInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -352,11 +352,11 @@ func (catalog *Catalog) getAccessControlHeader(ctx context.Context, useTenantCon
 // getAccessControlHeader builds the data needed to set the header when tenant context is required.
 // If useTenantContext is false, it returns an empty map.
 // Otherwise, it finds the Org ID and name and creates the header data
-func (adminCatalog *AdminCatalog) getAccessControlHeader(useTenantContext bool) (map[string]string, error) {
+func (adminCatalog *AdminCatalog) getAccessControlHeader(ctx context.Context, useTenantContext bool) (map[string]string, error) {
 	if !useTenantContext {
 		return map[string]string{}, nil
 	}
-	orgInfo, err := adminCatalog.getOrgInfo()
+	orgInfo, err := adminCatalog.getOrgInfo(ctx)
 
 	if err != nil {
 		return nil, err

--- a/govcd/access_control_test.go
+++ b/govcd/access_control_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -18,10 +19,10 @@ import (
 
 // accessControlType is an interface used to test access control for all entities that support it
 type accessControlType interface {
-	GetAccessControl(useTenantContext bool) (*types.ControlAccessParams, error)
-	SetAccessControl(params *types.ControlAccessParams, useTenantContext bool) error
-	RemoveAccessControl(useTenantContext bool) error
-	IsShared(useTenantContext bool) (bool, error)
+	GetAccessControl(ctx context.Context, useTenantContext bool) (*types.ControlAccessParams, error)
+	SetAccessControl(ctx context.Context, params *types.ControlAccessParams, useTenantContext bool) error
+	RemoveAccessControl(ctx context.Context, useTenantContext bool) error
+	IsShared(ctx context.Context, useTenantContext bool) (bool, error)
 	GetId() string
 }
 
@@ -47,17 +48,17 @@ func accessSettingsToMap(params types.ControlAccessParams) accessSettingMap {
 // * params are the access control parameters to be set
 // * expected are the result parameters that we should find in the end result
 // * wantShared is whether the final settings should result in the entity being shared
-func testAccessControl(label string, accessible accessControlType, params types.ControlAccessParams, expected types.ControlAccessParams, wantShared bool, useTenantContext bool, check *C) error {
+func testAccessControl(ctx context.Context, label string, accessible accessControlType, params types.ControlAccessParams, expected types.ControlAccessParams, wantShared bool, useTenantContext bool, check *C) error {
 
 	if testVerbose {
 		fmt.Printf("-- %s\n", label)
 	}
-	err := accessible.SetAccessControl(&params, useTenantContext)
+	err := accessible.SetAccessControl(ctx, &params, useTenantContext)
 	if err != nil {
 		return err
 	}
 
-	foundParams, err := accessible.GetAccessControl(useTenantContext)
+	foundParams, err := accessible.GetAccessControl(ctx, useTenantContext)
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func testAccessControl(label string, accessible accessControlType, params types.
 		}
 	}
 
-	shared, err := accessible.IsShared(useTenantContext)
+	shared, err := accessible.IsShared(ctx, useTenantContext)
 	if err != nil {
 		return err
 	}

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,9 +49,9 @@ func (adminOrg *AdminOrg) CreateCatalogWithStorageProfile(name, description stri
 }
 
 // GetAllVDCs returns all depending VDCs for a particular Org
-func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
+func (adminOrg *AdminOrg) GetAllVDCs(ctx context.Context, refresh bool) ([]*Vdc, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +59,7 @@ func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
 
 	allVdcs := make([]*Vdc, len(adminOrg.AdminOrg.Vdcs.Vdcs))
 	for vdcIndex, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
-		vdc, err := adminOrg.GetVDCByHref(vdc.HREF)
+		vdc, err := adminOrg.GetVDCByHref(ctx, vdc.HREF)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving VDC '%s': %s", vdc.Vdc.Name, err)
 		}
@@ -71,15 +72,15 @@ func (adminOrg *AdminOrg) GetAllVDCs(refresh bool) ([]*Vdc, error) {
 
 // GetAllStorageProfileReferences traverses all depending VDCs and returns a slice of storage profile references
 // available in those VDCs
-func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types.Reference, error) {
+func (adminOrg *AdminOrg) GetAllStorageProfileReferences(ctx context.Context, refresh bool) ([]*types.Reference, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	allVdcs, err := adminOrg.GetAllVDCs(refresh)
+	allVdcs, err := adminOrg.GetAllVDCs(ctx, refresh)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve storage profile references: %s", err)
 	}
@@ -95,8 +96,8 @@ func (adminOrg *AdminOrg) GetAllStorageProfileReferences(refresh bool) ([]*types
 }
 
 // GetStorageProfileReferenceById finds storage profile reference by specified ID in Org or returns ErrorEntityNotFound
-func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool) (*types.Reference, error) {
-	allStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(refresh)
+func (adminOrg *AdminOrg) GetStorageProfileReferenceById(ctx context.Context, id string, refresh bool) (*types.Reference, error) {
+	allStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(ctx, refresh)
 	if err != nil {
 		return nil, fmt.Errorf("error getting all storage profiles: %s", err)
 	}
@@ -113,36 +114,36 @@ func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool
 
 //   Deletes the org, returning an error if the vCD call fails.
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
-func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
+func (adminOrg *AdminOrg) Delete(ctx context.Context, force bool, recursive bool) error {
 	if force && recursive {
 		//undeploys vapps
-		err := adminOrg.undeployAllVApps()
+		err := adminOrg.undeployAllVApps(ctx)
 		if err != nil {
 			return fmt.Errorf("error could not undeploy: %s", err)
 		}
 		//removes vapps
-		err = adminOrg.removeAllVApps()
+		err = adminOrg.removeAllVApps(ctx)
 		if err != nil {
 			return fmt.Errorf("error could not remove vapp: %s", err)
 		}
 		//removes catalogs
-		err = adminOrg.removeCatalogs()
+		err = adminOrg.removeCatalogs(ctx)
 		if err != nil {
 			return fmt.Errorf("error could not remove all catalogs: %s", err)
 		}
 		//removes networks
-		err = adminOrg.removeAllOrgNetworks()
+		err = adminOrg.removeAllOrgNetworks(ctx)
 		if err != nil {
 			return fmt.Errorf("error could not remove all networks: %s", err)
 		}
 		//removes org vdcs
-		err = adminOrg.removeAllOrgVDCs()
+		err = adminOrg.removeAllOrgVDCs(ctx)
 		if err != nil {
 			return fmt.Errorf("error could not remove all vdcs: %s", err)
 		}
 	}
 	// Disable org
-	err := adminOrg.Disable()
+	err := adminOrg.Disable(ctx)
 	if err != nil {
 		return fmt.Errorf("error disabling Org %s: %s", adminOrg.AdminOrg.Name, err)
 	}
@@ -151,7 +152,7 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	if err != nil {
 		return fmt.Errorf("error getting AdminOrg HREF %s : %s", adminOrg.AdminOrg.HREF, err)
 	}
-	req := adminOrg.client.NewRequest(map[string]string{
+	req := adminOrg.client.NewRequest(ctx, map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
 	}, http.MethodDelete, *orgHREF, nil)
@@ -164,26 +165,26 @@ func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
-	return task.WaitTaskCompletion()
+	return task.WaitTaskCompletion(ctx)
 }
 
 // Disables the org. Returns an error if the call to vCD fails.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-DisableOrg.html
-func (adminOrg *AdminOrg) Disable() error {
+func (adminOrg *AdminOrg) Disable(ctx context.Context) error {
 	orgHREF, err := url.ParseRequestURI(adminOrg.AdminOrg.HREF)
 	if err != nil {
 		return fmt.Errorf("error getting AdminOrg HREF %s : %s", adminOrg.AdminOrg.HREF, err)
 	}
 	orgHREF.Path += "/action/disable"
 
-	return adminOrg.client.ExecuteRequestWithoutResponse(orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
+	return adminOrg.client.ExecuteRequestWithoutResponse(ctx, orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
 }
 
 //   Updates the Org definition from current org struct contents.
 //   Any differences that may be legally applied will be updated.
 //   Returns an error if the call to vCD fails.
 //   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
-func (adminOrg *AdminOrg) Update() (Task, error) {
+func (adminOrg *AdminOrg) Update(ctx context.Context) (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        adminOrg.AdminOrg.Name,
@@ -200,18 +201,18 @@ func (adminOrg *AdminOrg) Update() (Task, error) {
 	}
 
 	// Return the task
-	return adminOrg.client.ExecuteTaskRequest(adminOrg.AdminOrg.HREF, http.MethodPut,
+	return adminOrg.client.ExecuteTaskRequest(ctx, adminOrg.AdminOrg.HREF, http.MethodPut,
 		"application/vnd.vmware.admin.organization+xml", "error updating Org: %s", vcomp)
 }
 
 // Undeploys every vapp within an organization
-func (adminOrg *AdminOrg) undeployAllVApps() error {
+func (adminOrg *AdminOrg) undeployAllVApps(ctx context.Context) error {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		adminVdcHREF, err := url.Parse(vdcs.HREF)
 		if err != nil {
 			return err
 		}
-		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
+		vdc, err := adminOrg.getVdcByAdminHREF(ctx, adminVdcHREF)
 		if err != nil {
 			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
 		}
@@ -224,13 +225,13 @@ func (adminOrg *AdminOrg) undeployAllVApps() error {
 }
 
 // Deletes every vapp within an organization
-func (adminOrg *AdminOrg) removeAllVApps() error {
+func (adminOrg *AdminOrg) removeAllVApps(ctx context.Context) error {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		adminVdcHREF, err := url.Parse(vdcs.HREF)
 		if err != nil {
 			return err
 		}
-		vdc, err := adminOrg.getVdcByAdminHREF(adminVdcHREF)
+		vdc, err := adminOrg.getVdcByAdminHREF(ctx, adminVdcHREF)
 		if err != nil {
 			return fmt.Errorf("error retrieving vapp with url: %s and with error %s", adminVdcHREF.Path, err)
 		}
@@ -247,7 +248,7 @@ func (adminOrg *AdminOrg) removeAllVApps() error {
 // it returns an error.  Users should use refresh whenever they have
 // a stale org due to the creation/update/deletion of a resource
 // within the org or the org itself.
-func (adminOrg *AdminOrg) Refresh() error {
+func (adminOrg *AdminOrg) Refresh(ctx context.Context) error {
 	if *adminOrg == (AdminOrg{}) {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
@@ -256,7 +257,7 @@ func (adminOrg *AdminOrg) Refresh() error {
 	// elements in slices.
 	unmarshalledAdminOrg := &types.AdminOrg{}
 
-	_, err := adminOrg.client.ExecuteRequest(adminOrg.AdminOrg.HREF, http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, adminOrg.AdminOrg.HREF, http.MethodGet,
 		"", "error refreshing organization: %s", nil, unmarshalledAdminOrg)
 	if err != nil {
 		return err
@@ -267,21 +268,21 @@ func (adminOrg *AdminOrg) Refresh() error {
 }
 
 // Gets a vdc within org associated with an admin vdc url
-func (adminOrg *AdminOrg) getVdcByAdminHREF(adminVdcUrl *url.URL) (*Vdc, error) {
+func (adminOrg *AdminOrg) getVdcByAdminHREF(ctx context.Context, adminVdcUrl *url.URL) (*Vdc, error) {
 	// get non admin vdc path
 	vdcURL := adminOrg.client.VCDHREF
 	vdcURL.Path += strings.Split(adminVdcUrl.Path, "/api/admin")[1] //gets id
 
 	vdc := NewVdc(adminOrg.client)
 
-	_, err := adminOrg.client.ExecuteRequest(vdcURL.String(), http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, vdcURL.String(), http.MethodGet,
 		"", "error retrieving vdc: %s", nil, vdc.Vdc)
 
 	return vdc, err
 }
 
 // Removes all vdcs in a org
-func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
+func (adminOrg *AdminOrg) removeAllOrgVDCs(ctx context.Context) error {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 
 		adminVdcUrl := adminOrg.client.VCDHREF
@@ -292,14 +293,14 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 			adminVdcUrl.Path += "/admin/vdc/" + splitVdcId[1] + "/action/disable"
 		}
 
-		req := adminOrg.client.NewRequest(map[string]string{}, http.MethodPost, adminVdcUrl, nil)
+		req := adminOrg.client.NewRequest(ctx, map[string]string{}, http.MethodPost, adminVdcUrl, nil)
 		_, err := checkResp(adminOrg.client.Http.Do(req))
 		if err != nil {
 			return fmt.Errorf("error disabling vdc: %s", err)
 		}
 		// Get admin vdc HREF for normal deletion
 		adminVdcUrl.Path = strings.Split(adminVdcUrl.Path, "/action/disable")[0]
-		req = adminOrg.client.NewRequest(map[string]string{
+		req = adminOrg.client.NewRequest(ctx, map[string]string{
 			"recursive": "true",
 			"force":     "true",
 		}, http.MethodDelete, adminVdcUrl, nil)
@@ -314,7 +315,7 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 		if task.Task.Status == "error" {
 			return fmt.Errorf("vdc not properly destroyed")
 		}
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("couldn't finish removing vdc %s", err)
 		}
@@ -325,13 +326,13 @@ func (adminOrg *AdminOrg) removeAllOrgVDCs() error {
 }
 
 // Removes All networks in the org
-func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
+func (adminOrg *AdminOrg) removeAllOrgNetworks(ctx context.Context) error {
 	for _, networks := range adminOrg.AdminOrg.Networks.Networks {
 		// Get Network HREF
 		networkHREF := adminOrg.client.VCDHREF
 		networkHREF.Path += "/admin/network/" + strings.Split(networks.HREF, "/api/admin/network/")[1] //gets id
 
-		task, err := adminOrg.client.ExecuteTaskRequest(networkHREF.String(), http.MethodDelete,
+		task, err := adminOrg.client.ExecuteTaskRequest(ctx, networkHREF.String(), http.MethodDelete,
 			"", "error deleting network: %s", nil)
 		if err != nil {
 			return err
@@ -340,7 +341,7 @@ func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
 		if task.Task.Status == "error" {
 			return fmt.Errorf("network not properly destroyed")
 		}
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("couldn't finish removing network %s", err)
 		}
@@ -349,7 +350,7 @@ func (adminOrg *AdminOrg) removeAllOrgNetworks() error {
 }
 
 // removeCatalogs force removal of all organization catalogs
-func (adminOrg *AdminOrg) removeCatalogs() error {
+func (adminOrg *AdminOrg) removeCatalogs(ctx context.Context) error {
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		isCatalogFromSameOrg, err := isCatalogFromSameOrg(adminOrg, catalog.Name)
 		if err != nil {
@@ -359,7 +360,7 @@ func (adminOrg *AdminOrg) removeCatalogs() error {
 			// Get Catalog HREF
 			catalogHREF := adminOrg.client.VCDHREF
 			catalogHREF.Path += "/admin/catalog/" + strings.Split(catalog.HREF, "/api/admin/catalog/")[1] //gets id
-			req := adminOrg.client.NewRequest(map[string]string{
+			req := adminOrg.client.NewRequest(ctx, map[string]string{
 				"force":     "true",
 				"recursive": "true",
 			}, http.MethodDelete, catalogHREF, nil)
@@ -410,12 +411,12 @@ func (adminOrg *AdminOrg) FindAdminCatalogRecords(name string) ([]*types.Catalog
 // perform administrator tasks then function returns an error.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/GET-Catalog-AdminView.html
 // Deprecated: Use adminOrg.GetAdminCatalog instead
-func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, error) {
+func (adminOrg *AdminOrg) FindAdminCatalog(ctx context.Context, catalogName string) (AdminCatalog, error) {
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
 		if catalog.Name == catalogName {
 			adminCatalog := NewAdminCatalog(adminOrg.client)
-			_, err := adminOrg.client.ExecuteRequest(catalog.HREF, http.MethodGet,
+			_, err := adminOrg.client.ExecuteRequest(ctx, catalog.HREF, http.MethodGet,
 				"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
 			// The request was successful
 			return *adminCatalog, err
@@ -429,7 +430,7 @@ func (adminOrg *AdminOrg) FindAdminCatalog(catalogName string) (AdminCatalog, er
 // Otherwise it returns an error. Function allows user to use an AdminOrg
 // to also fetch a Catalog.
 // Deprecated: Use adminOrg.GetCatalogByName instead
-func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
+func (adminOrg *AdminOrg) FindCatalog(ctx context.Context, catalogName string) (Catalog, error) {
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
 		if catalog.Name == catalogName {
@@ -438,7 +439,7 @@ func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
 
 			cat := NewCatalog(adminOrg.client)
 
-			_, err := adminOrg.client.ExecuteRequest(catalogURL.String(), http.MethodGet,
+			_, err := adminOrg.client.ExecuteRequest(ctx, catalogURL.String(), http.MethodGet,
 				"", "error retrieving catalog: %s", nil, cat.Catalog)
 
 			// The request was successful
@@ -451,7 +452,7 @@ func (adminOrg *AdminOrg) FindCatalog(catalogName string) (Catalog, error) {
 // GetCatalogByHref  finds a Catalog by HREF
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetCatalogByHref(catalogHref string) (*Catalog, error) {
+func (adminOrg *AdminOrg) GetCatalogByHref(ctx context.Context, catalogHref string) (*Catalog, error) {
 	splitByAdminHREF := strings.Split(catalogHref, "/api/admin")
 
 	// admin user and normal user will have different urls
@@ -464,7 +465,7 @@ func (adminOrg *AdminOrg) GetCatalogByHref(catalogHref string) (*Catalog, error)
 
 	cat := NewCatalog(adminOrg.client)
 
-	_, err := adminOrg.client.ExecuteRequest(catalogHREF, http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, catalogHREF, http.MethodGet,
 		"", "error retrieving catalog: %s", nil, cat.Catalog)
 
 	if err != nil {
@@ -477,10 +478,10 @@ func (adminOrg *AdminOrg) GetCatalogByHref(catalogHref string) (*Catalog, error)
 // GetCatalogByName  finds a Catalog by Name
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetCatalogByName(catalogName string, refresh bool) (*Catalog, error) {
+func (adminOrg *AdminOrg) GetCatalogByName(ctx context.Context, catalogName string, refresh bool) (*Catalog, error) {
 
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +489,7 @@ func (adminOrg *AdminOrg) GetCatalogByName(catalogName string, refresh bool) (*C
 
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		if catalog.Name == catalogName {
-			return adminOrg.GetCatalogByHref(catalog.HREF)
+			return adminOrg.GetCatalogByHref(ctx, catalog.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -536,16 +537,16 @@ func equalIds(wantedId, foundId, foundHref string) bool {
 // GetCatalogById finds a Catalog by ID
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetCatalogById(catalogId string, refresh bool) (*Catalog, error) {
+func (adminOrg *AdminOrg) GetCatalogById(ctx context.Context, catalogId string, refresh bool) (*Catalog, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		if equalIds(catalogId, catalog.ID, catalog.HREF) {
-			return adminOrg.GetCatalogByHref(catalog.HREF)
+			return adminOrg.GetCatalogByHref(ctx, catalog.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -554,9 +555,11 @@ func (adminOrg *AdminOrg) GetCatalogById(catalogId string, refresh bool) (*Catal
 // GetCatalogByNameOrId finds a Catalog by name or ID
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(id, refresh) }
+func (adminOrg *AdminOrg) GetCatalogByNameOrId(ctx context.Context, identifier string, refresh bool) (*Catalog, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
+		return adminOrg.GetCatalogByName(ctx, name, refresh)
+	}
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetCatalogById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
 		return nil, err
@@ -567,10 +570,10 @@ func (adminOrg *AdminOrg) GetCatalogByNameOrId(identifier string, refresh bool) 
 // GetAdminCatalogByHref  finds an AdminCatalog by HREF
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminCatalogByHref(catalogHref string) (*AdminCatalog, error) {
+func (adminOrg *AdminOrg) GetAdminCatalogByHref(ctx context.Context, catalogHref string) (*AdminCatalog, error) {
 	adminCatalog := NewAdminCatalog(adminOrg.client)
 
-	_, err := adminOrg.client.ExecuteRequest(catalogHref, http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, catalogHref, http.MethodGet,
 		"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
 
 	if err != nil {
@@ -584,9 +587,9 @@ func (adminOrg *AdminOrg) GetAdminCatalogByHref(catalogHref string) (*AdminCatal
 // GetCatalogByName finds an AdminCatalog by Name
 // On success, returns a pointer to the AdminCatalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminCatalogByName(catalogName string, refresh bool) (*AdminCatalog, error) {
+func (adminOrg *AdminOrg) GetAdminCatalogByName(ctx context.Context, catalogName string, refresh bool) (*AdminCatalog, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -594,7 +597,7 @@ func (adminOrg *AdminOrg) GetAdminCatalogByName(catalogName string, refresh bool
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
 		if catalog.Name == catalogName {
-			return adminOrg.GetAdminCatalogByHref(catalog.HREF)
+			return adminOrg.GetAdminCatalogByHref(ctx, catalog.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -603,9 +606,9 @@ func (adminOrg *AdminOrg) GetAdminCatalogByName(catalogName string, refresh bool
 // GetCatalogById finds an AdminCatalog by ID
 // On success, returns a pointer to the AdminCatalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminCatalogById(catalogId string, refresh bool) (*AdminCatalog, error) {
+func (adminOrg *AdminOrg) GetAdminCatalogById(ctx context.Context, catalogId string, refresh bool) (*AdminCatalog, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -613,7 +616,7 @@ func (adminOrg *AdminOrg) GetAdminCatalogById(catalogId string, refresh bool) (*
 	for _, catalog := range adminOrg.AdminOrg.Catalogs.Catalog {
 		// Get Catalog HREF
 		if equalIds(catalogId, catalog.ID, catalog.HREF) {
-			return adminOrg.GetAdminCatalogByHref(catalog.HREF)
+			return adminOrg.GetAdminCatalogByHref(ctx, catalog.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -622,12 +625,12 @@ func (adminOrg *AdminOrg) GetAdminCatalogById(catalogId string, refresh bool) (*
 // GetAdminCatalogByNameOrId finds an AdminCatalog by name or ID
 // On success, returns a pointer to the AdminCatalog structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(identifier string, refresh bool) (*AdminCatalog, error) {
+func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(ctx context.Context, identifier string, refresh bool) (*AdminCatalog, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) {
-		return adminOrg.GetAdminCatalogByName(name, refresh)
+		return adminOrg.GetAdminCatalogByName(ctx, name, refresh)
 	}
 	getById := func(id string, refresh bool) (interface{}, error) {
-		return adminOrg.GetAdminCatalogById(id, refresh)
+		return adminOrg.GetAdminCatalogById(ctx, id, refresh)
 	}
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
@@ -637,7 +640,7 @@ func (adminOrg *AdminOrg) GetAdminCatalogByNameOrId(identifier string, refresh b
 }
 
 // GetVDCByHref retrieves a VDC using a direct call with the HREF
-func (adminOrg *AdminOrg) GetVDCByHref(vdcHref string) (*Vdc, error) {
+func (adminOrg *AdminOrg) GetVDCByHref(ctx context.Context, vdcHref string) (*Vdc, error) {
 	splitByAdminHREF := strings.Split(vdcHref, "/api/admin")
 
 	// admin user and normal user will have different urls
@@ -650,7 +653,7 @@ func (adminOrg *AdminOrg) GetVDCByHref(vdcHref string) (*Vdc, error) {
 
 	vdc := NewVdc(adminOrg.client)
 
-	_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, vdcHREF, http.MethodGet,
 		"", "error getting vdc: %s", nil, vdc.Vdc)
 
 	if err != nil {
@@ -663,16 +666,16 @@ func (adminOrg *AdminOrg) GetVDCByHref(vdcHref string) (*Vdc, error) {
 // GetVDCByName finds a VDC by Name
 // On success, returns a pointer to the Vdc structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetVDCByName(vdcName string, refresh bool) (*Vdc, error) {
+func (adminOrg *AdminOrg) GetVDCByName(ctx context.Context, vdcName string, refresh bool) (*Vdc, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if vdc.Name == vdcName {
-			return adminOrg.GetVDCByHref(vdc.HREF)
+			return adminOrg.GetVDCByHref(ctx, vdc.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -681,16 +684,16 @@ func (adminOrg *AdminOrg) GetVDCByName(vdcName string, refresh bool) (*Vdc, erro
 // GetVDCById finds a VDC by ID
 // On success, returns a pointer to the Vdc structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
+func (adminOrg *AdminOrg) GetVDCById(ctx context.Context, vdcId string, refresh bool) (*Vdc, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if equalIds(vdcId, vdc.ID, vdc.HREF) {
-			return adminOrg.GetVDCByHref(vdc.HREF)
+			return adminOrg.GetVDCByHref(ctx, vdc.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -699,9 +702,9 @@ func (adminOrg *AdminOrg) GetVDCById(vdcId string, refresh bool) (*Vdc, error) {
 // GetVDCByNameOrId finds a VDC by name or ID
 // On success, returns a pointer to the VDC structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetVDCByNameOrId(identifier string, refresh bool) (*Vdc, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(id, refresh) }
+func (adminOrg *AdminOrg) GetVDCByNameOrId(ctx context.Context, identifier string, refresh bool) (*Vdc, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return adminOrg.GetVDCByName(ctx, name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetVDCById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
 		return nil, err
@@ -714,7 +717,7 @@ func (adminOrg *AdminOrg) GetVDCByNameOrId(identifier string, refresh bool) (*Vd
 // Otherwise it returns an empty vdc and an error. This function
 // allows users to use an AdminOrg to fetch a vdc as well.
 // Deprecated: Use adminOrg.GetVDCByName instead
-func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
+func (adminOrg *AdminOrg) GetVdcByName(ctx context.Context, vdcname string) (Vdc, error) {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if vdcs.Name == vdcname {
 			splitByAdminHREF := strings.Split(vdcs.HREF, "/api/admin")
@@ -729,7 +732,7 @@ func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
 
 			vdc := NewVdc(adminOrg.client)
 
-			_, err := adminOrg.client.ExecuteRequest(vdcHREF, http.MethodGet,
+			_, err := adminOrg.client.ExecuteRequest(ctx, vdcHREF, http.MethodGet,
 				"", "error getting vdc: %s", nil, vdc.Vdc)
 
 			return *vdc, err

--- a/govcd/adminorg_administration_test.go
+++ b/govcd/adminorg_administration_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -19,7 +20,9 @@ func (vcd *TestVCD) Test_LDAP_Configuration(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	ctx := context.Background()
+
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 
 	ldapSettings := &types.OrgLdapSettingsType{
@@ -52,7 +55,7 @@ func (vcd *TestVCD) Test_LDAP_Configuration(check *C) {
 			},
 		},
 	}
-	gotSettings, err := org.LdapConfigure(ldapSettings)
+	gotSettings, err := org.LdapConfigure(ctx, ldapSettings)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList("LDAP-configuration", "orgLdapSettings", org.AdminOrg.Name, check.TestName())
@@ -64,10 +67,10 @@ func (vcd *TestVCD) Test_LDAP_Configuration(check *C) {
 	check.Assert(ldapSettings.CustomOrgLdapSettings.AuthenticationMechanism, DeepEquals, gotSettings.CustomOrgLdapSettings.AuthenticationMechanism)
 	check.Assert(ldapSettings.CustomOrgLdapSettings.ConnectorType, DeepEquals, gotSettings.CustomOrgLdapSettings.ConnectorType)
 
-	err = org.LdapDisable()
+	err = org.LdapDisable(ctx)
 	check.Assert(err, IsNil)
 
-	ldapConfig, err := org.GetLdapConfiguration()
+	ldapConfig, err := org.GetLdapConfiguration(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(ldapConfig.OrgLdapMode, Equals, types.LdapModeNone)

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -28,10 +29,10 @@ func NewAdminVdc(cli *Client) *AdminVdc {
 // vdcVersionedFuncs is a generic representation of VDC CRUD operations across multiple versions
 type vdcVersionedFuncs struct {
 	SupportedVersion string
-	CreateVdc        func(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (*Vdc, error)
-	CreateVdcAsync   func(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (Task, error)
-	UpdateVdc        func(adminVdc *AdminVdc) (*AdminVdc, error)
-	UpdateVdcAsync   func(adminVdc *AdminVdc) (Task, error)
+	CreateVdc        func(ctx context.Context, adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (*Vdc, error)
+	CreateVdcAsync   func(ctx context.Context, adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (Task, error)
+	UpdateVdc        func(ctx context.Context, adminVdc *AdminVdc) (*AdminVdc, error)
+	UpdateVdcAsync   func(ctx context.Context, adminVdc *AdminVdc) (Task, error)
 }
 
 // VDC function mapping for API version 32.0 (from vCD 9.7)
@@ -67,11 +68,11 @@ func getVdcVersionedFuncsByVdcVersion(version string) vdcVersionedFuncs {
 // If no VDC is found, then it returns an empty VDC and no error.
 // Otherwise it returns an empty VDC and an error.
 // Deprecated: Use adminOrg.GetAdminVDCByName
-func (adminOrg *AdminOrg) GetAdminVdcByName(vdcname string) (AdminVdc, error) {
+func (adminOrg *AdminOrg) GetAdminVdcByName(ctx context.Context, vdcname string) (AdminVdc, error) {
 	for _, vdcs := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if vdcs.Name == vdcname {
 			adminVdc := NewAdminVdc(adminOrg.client)
-			_, err := adminOrg.client.ExecuteRequest(vdcs.HREF, http.MethodGet,
+			_, err := adminOrg.client.ExecuteRequest(ctx, vdcs.HREF, http.MethodGet,
 				"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
 			return *adminVdc, err
 		}
@@ -80,9 +81,9 @@ func (adminOrg *AdminOrg) GetAdminVdcByName(vdcname string) (AdminVdc, error) {
 }
 
 // GetAdminVDCByHref retrieves a VDC using a direct call with the HREF
-func (adminOrg *AdminOrg) GetAdminVDCByHref(vdcHref string) (*AdminVdc, error) {
+func (adminOrg *AdminOrg) GetAdminVDCByHref(ctx context.Context, vdcHref string) (*AdminVdc, error) {
 	adminVdc := NewAdminVdc(adminOrg.client)
-	_, err := adminOrg.client.ExecuteRequest(vdcHref, http.MethodGet,
+	_, err := adminOrg.client.ExecuteRequest(ctx, vdcHref, http.MethodGet,
 		"", "error getting vdc: %s", nil, adminVdc.AdminVdc)
 
 	if err != nil {
@@ -94,16 +95,16 @@ func (adminOrg *AdminOrg) GetAdminVDCByHref(vdcHref string) (*AdminVdc, error) {
 // GetAdminVDCByName finds an Admin VDC by Name
 // On success, returns a pointer to the AdminVdc structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminVDCByName(vdcName string, refresh bool) (*AdminVdc, error) {
+func (adminOrg *AdminOrg) GetAdminVDCByName(ctx context.Context, vdcName string, refresh bool) (*AdminVdc, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if vdc.Name == vdcName {
-			return adminOrg.GetAdminVDCByHref(vdc.HREF)
+			return adminOrg.GetAdminVDCByHref(ctx, vdc.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -112,16 +113,16 @@ func (adminOrg *AdminOrg) GetAdminVDCByName(vdcName string, refresh bool) (*Admi
 // GetAdminVDCById finds an Admin VDC by ID
 // On success, returns a pointer to the AdminVdc structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminVDCById(vdcId string, refresh bool) (*AdminVdc, error) {
+func (adminOrg *AdminOrg) GetAdminVDCById(ctx context.Context, vdcId string, refresh bool) (*AdminVdc, error) {
 	if refresh {
-		err := adminOrg.Refresh()
+		err := adminOrg.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for _, vdc := range adminOrg.AdminOrg.Vdcs.Vdcs {
 		if equalIds(vdcId, vdc.ID, vdc.HREF) {
-			return adminOrg.GetAdminVDCByHref(vdc.HREF)
+			return adminOrg.GetAdminVDCByHref(ctx, vdc.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -130,11 +131,11 @@ func (adminOrg *AdminOrg) GetAdminVDCById(vdcId string, refresh bool) (*AdminVdc
 // GetAdminVDCByNameOrId finds an Admin VDC by Name Or ID
 // On success, returns a pointer to the AdminVdc structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(identifier string, refresh bool) (*AdminVdc, error) {
+func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(ctx context.Context, identifier string, refresh bool) (*AdminVdc, error) {
 	getByName := func(name string, refresh bool) (interface{}, error) {
-		return adminOrg.GetAdminVDCByName(name, refresh)
+		return adminOrg.GetAdminVDCByName(ctx, name, refresh)
 	}
-	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return adminOrg.GetAdminVDCById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
 		return nil, err
@@ -146,7 +147,7 @@ func (adminOrg *AdminOrg) GetAdminVDCByNameOrId(identifier string, refresh bool)
 // Returns an AdminVdc.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-VdcConfiguration.html
 // Deprecated in favor of adminOrg.CreateOrgVdcAsync
-func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (Task, error) {
+func (adminOrg *AdminOrg) CreateVdc(ctx context.Context, vdcConfiguration *types.VdcConfiguration) (Task, error) {
 	err := validateVdcConfiguration(vdcConfiguration)
 	if err != nil {
 		return Task{}, err
@@ -162,7 +163,7 @@ func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (T
 
 	adminVdc := NewAdminVdc(adminOrg.client)
 
-	_, err = adminOrg.client.ExecuteRequest(vdcCreateHREF.String(), http.MethodPost,
+	_, err = adminOrg.client.ExecuteRequest(ctx, vdcCreateHREF.String(), http.MethodPost,
 		"application/vnd.vmware.admin.createVdcParams+xml", "error creating VDC: %s", vdcConfiguration, adminVdc.AdminVdc)
 	if err != nil {
 		return Task{}, err
@@ -176,12 +177,12 @@ func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (T
 
 // Creates the VDC and waits for the asynchronous task to complete.
 // Deprecated in favor of adminOrg.CreateOrgVdc
-func (adminOrg *AdminOrg) CreateVdcWait(vdcDefinition *types.VdcConfiguration) error {
-	task, err := adminOrg.CreateVdc(vdcDefinition)
+func (adminOrg *AdminOrg) CreateVdcWait(ctx context.Context, vdcDefinition *types.VdcConfiguration) error {
+	task, err := adminOrg.CreateVdc(ctx, vdcDefinition)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't finish creating VDC %s", err)
 	}
@@ -193,7 +194,7 @@ func (adminOrg *AdminOrg) CreateVdcWait(vdcDefinition *types.VdcConfiguration) e
 // Users should use refresh whenever they suspect
 // a stale VDC due to the creation/update/deletion of a resource
 // within the the VDC itself.
-func (adminVdc *AdminVdc) Refresh() error {
+func (adminVdc *AdminVdc) Refresh(ctx context.Context) error {
 	if *adminVdc == (AdminVdc{}) || adminVdc.AdminVdc.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
 	}
@@ -202,7 +203,7 @@ func (adminVdc *AdminVdc) Refresh() error {
 	// elements in slices.
 	unmarshalledAdminVdc := &types.AdminVdc{}
 
-	_, err := adminVdc.client.ExecuteRequest(adminVdc.AdminVdc.HREF, http.MethodGet,
+	_, err := adminVdc.client.ExecuteRequest(ctx, adminVdc.AdminVdc.HREF, http.MethodGet,
 		"", "error refreshing VDC: %s", nil, unmarshalledAdminVdc)
 	if err != nil {
 		return err
@@ -216,7 +217,7 @@ func (adminVdc *AdminVdc) Refresh() error {
 // Any differences that may be legally applied will be updated.
 // Returns an error if the call to vCD fails.
 // API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
-func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
+func (adminVdc *AdminVdc) UpdateAsync(ctx context.Context) (Task, error) {
 	apiVersion, err := adminVdc.client.MaxSupportedVersion()
 	if err != nil {
 		return Task{}, err
@@ -227,7 +228,7 @@ func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
 	}
 	util.Logger.Printf("[DEBUG] UpdateAsync call function for version %s", vdcFunctions.SupportedVersion)
 
-	return vdcFunctions.UpdateVdcAsync(adminVdc)
+	return vdcFunctions.UpdateVdcAsync(ctx, adminVdc)
 
 }
 
@@ -235,7 +236,7 @@ func (adminVdc *AdminVdc) UpdateAsync() (Task, error) {
 // Any differences that may be legally applied will be updated.
 // Returns an empty AdminVdc struct and error if the call to vCD fails.
 // API Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/7a028e78-bd37-4a6a-8298-9c26c7eeb9aa/09142237-dd46-4dee-8326-e07212fb63a8/doc/doc/operations/PUT-Vdc.html
-func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
+func (adminVdc *AdminVdc) Update(ctx context.Context) (AdminVdc, error) {
 	apiVersion, err := adminVdc.client.MaxSupportedVersion()
 	if err != nil {
 		return AdminVdc{}, err
@@ -248,7 +249,7 @@ func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
 
 	util.Logger.Printf("[DEBUG] Update call function for version %s", vdcFunctions.SupportedVersion)
 
-	updatedAdminVdc, err := vdcFunctions.UpdateVdc(adminVdc)
+	updatedAdminVdc, err := vdcFunctions.UpdateVdc(ctx, adminVdc)
 	if err != nil {
 		return AdminVdc{}, err
 	}
@@ -258,7 +259,7 @@ func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
 // CreateOrgVdc creates a VDC with the given params under the given organization
 // and waits for the asynchronous task to complete.
 // Returns an AdminVdc pointer and an error.
-func (adminOrg *AdminOrg) CreateOrgVdc(vdcConfiguration *types.VdcConfiguration) (*Vdc, error) {
+func (adminOrg *AdminOrg) CreateOrgVdc(ctx context.Context, vdcConfiguration *types.VdcConfiguration) (*Vdc, error) {
 	apiVersion, err := adminOrg.client.MaxSupportedVersion()
 	if err != nil {
 		return nil, err
@@ -269,12 +270,12 @@ func (adminOrg *AdminOrg) CreateOrgVdc(vdcConfiguration *types.VdcConfiguration)
 	}
 
 	util.Logger.Printf("[DEBUG] CreateOrgVdc call function for version %s", vdcFunctions.SupportedVersion)
-	return vdcFunctions.CreateVdc(adminOrg, vdcConfiguration)
+	return vdcFunctions.CreateVdc(ctx, adminOrg, vdcConfiguration)
 }
 
 // CreateOrgVdcAsync creates a VDC with the given params under the given organization.
 // Returns a Task and an error.
-func (adminOrg *AdminOrg) CreateOrgVdcAsync(vdcConfiguration *types.VdcConfiguration) (Task, error) {
+func (adminOrg *AdminOrg) CreateOrgVdcAsync(ctx context.Context, vdcConfiguration *types.VdcConfiguration) (Task, error) {
 	apiVersion, err := adminOrg.client.MaxSupportedVersion()
 	if err != nil {
 		return Task{}, err
@@ -286,34 +287,34 @@ func (adminOrg *AdminOrg) CreateOrgVdcAsync(vdcConfiguration *types.VdcConfigura
 
 	util.Logger.Printf("[DEBUG] CreateOrgVdcAsync call function for version %s", vdcFunctions.SupportedVersion)
 
-	return vdcFunctions.CreateVdcAsync(adminOrg, vdcConfiguration)
+	return vdcFunctions.CreateVdcAsync(ctx, adminOrg, vdcConfiguration)
 }
 
 // updateVdcAsyncV97 updates a VDC with the given params. Supports Flex type allocation.
 // Needs vCD 9.7+ to work. Returns a Task and an error.
-func updateVdcAsyncV97(adminVdc *AdminVdc) (Task, error) {
+func updateVdcAsyncV97(ctx context.Context, adminVdc *AdminVdc) (Task, error) {
 	util.Logger.Printf("[TRACE] updateVdcAsyncV97 called %#v", *adminVdc)
 	adminVdc.AdminVdc.Xmlns = types.XMLNamespaceVCloud
 
 	// Return the task
-	return adminVdc.client.ExecuteTaskRequest(adminVdc.AdminVdc.HREF, http.MethodPut,
+	return adminVdc.client.ExecuteTaskRequest(ctx, adminVdc.AdminVdc.HREF, http.MethodPut,
 		types.MimeAdminVDC, "error updating VDC: %s", adminVdc.AdminVdc)
 }
 
 // updateVdcV97 updates a VDC with the given params
 // and waits for the asynchronous task to complete. Supports Flex type allocation.
 // Needs vCD 9.7+ to work. Returns an AdminVdc pointer and an error.
-func updateVdcV97(adminVdc *AdminVdc) (*AdminVdc, error) {
+func updateVdcV97(ctx context.Context, adminVdc *AdminVdc) (*AdminVdc, error) {
 	util.Logger.Printf("[TRACE] updateVdcV97 called %#v", *adminVdc)
-	task, err := updateVdcAsyncV97(adminVdc)
+	task, err := updateVdcAsyncV97(ctx, adminVdc)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, err
 	}
-	err = adminVdc.Refresh()
+	err = adminVdc.Refresh(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -323,18 +324,18 @@ func updateVdcV97(adminVdc *AdminVdc) (*AdminVdc, error) {
 // createVdcV97 creates a VDC with the given params under the given organization
 // and waits for the asynchronous task to complete. Supports Flex type allocation.
 // Needs vCD 9.7+ to work. Returns a Vdc pointer and error.
-func createVdcV97(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (*Vdc, error) {
+func createVdcV97(ctx context.Context, adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (*Vdc, error) {
 	util.Logger.Printf("[TRACE] createVdcV97 called %#v", *vdcConfiguration)
-	task, err := createVdcAsyncV97(adminOrg, vdcConfiguration)
+	task, err := createVdcAsyncV97(ctx, adminOrg, vdcConfiguration)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't finish creating VDC %s", err)
 	}
 
-	vdc, err := adminOrg.GetVDCByName(vdcConfiguration.Name, true)
+	vdc, err := adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, true)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +344,7 @@ func createVdcV97(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) 
 
 // createVdcAsyncV97 creates a VDC with the given params under the given organization. Supports Flex type allocation.
 // Needs vCD 9.7+ to work. Returns a Task and an error
-func createVdcAsyncV97(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (Task, error) {
+func createVdcAsyncV97(ctx context.Context, adminOrg *AdminOrg, vdcConfiguration *types.VdcConfiguration) (Task, error) {
 	util.Logger.Printf("[TRACE] createVdcAsyncV97 called %#v", *vdcConfiguration)
 	err := validateVdcConfigurationV97(*vdcConfiguration)
 	if err != nil {
@@ -360,7 +361,7 @@ func createVdcAsyncV97(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfigurat
 
 	adminVdc := NewAdminVdc(adminOrg.client)
 
-	_, err = adminOrg.client.ExecuteRequest(vdcCreateHREF.String(), http.MethodPost,
+	_, err = adminOrg.client.ExecuteRequest(ctx, vdcCreateHREF.String(), http.MethodPost,
 		"application/vnd.vmware.admin.createVdcParams+xml", "error creating VDC: %s",
 		vdcConfiguration, adminVdc.AdminVdc)
 	if err != nil {
@@ -402,7 +403,7 @@ func (vdc *AdminVdc) GetVappList() []*types.ResourceReference {
 }
 
 // UpdateStorageProfile updates VDC storage profile and returns refreshed VDC or error.
-func (vdc *AdminVdc) UpdateStorageProfile(storageProfileId string, storageProfile *types.AdminVdcStorageProfile) (*types.AdminVdcStorageProfile, error) {
+func (vdc *AdminVdc) UpdateStorageProfile(ctx context.Context, storageProfileId string, storageProfile *types.AdminVdcStorageProfile) (*types.AdminVdcStorageProfile, error) {
 	if vdc.client.VCDHREF.String() == "" {
 		return nil, fmt.Errorf("cannot update VDC storage profile, VCD HREF is unset")
 	}
@@ -413,7 +414,7 @@ func (vdc *AdminVdc) UpdateStorageProfile(storageProfileId string, storageProfil
 	storageProfile.Xmlns = types.XMLNamespaceVCloud
 	updateAdminVdcStorageProfile := &types.AdminVdcStorageProfile{}
 
-	_, err := vdc.client.ExecuteRequest(queryUrl.String(), http.MethodPut,
+	_, err := vdc.client.ExecuteRequest(ctx, queryUrl.String(), http.MethodPut,
 		types.MimeStorageProfile, "error updating VDC storage profile: %s", storageProfile, updateAdminVdcStorageProfile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot update VDC storage profile, error: %s", err)

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -26,8 +27,8 @@ type VCDClient struct {
 	QueryHREF   url.URL // HREF for the query API
 }
 
-func (vcdCli *VCDClient) vcdloginurl() error {
-	if err := vcdCli.Client.validateAPIVersion(); err != nil {
+func (vcdCli *VCDClient) vcdloginurl(ctx context.Context) error {
+	if err := vcdCli.Client.validateAPIVersion(ctx); err != nil {
 		return fmt.Errorf("could not find valid version for login: %s", err)
 	}
 
@@ -49,7 +50,7 @@ func (vcdCli *VCDClient) vcdloginurl() error {
 }
 
 // vcdCloudApiAuthorize performs the authorization to VCD using open API
-func (vcdCli *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.Response, error) {
+func (vcdCli *VCDClient) vcdCloudApiAuthorize(ctx context.Context, user, pass, org string) (*http.Response, error) {
 
 	util.Logger.Println("[TRACE] Connecting to VCD using cloudapi")
 	// This call can only be used by tenants
@@ -65,7 +66,7 @@ func (vcdCli *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.Res
 		return nil, fmt.Errorf("error parsing URL %s", rawUrl)
 	}
 	vcdCli.sessionHREF = *loginUrl
-	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodPost, *loginUrl, nil)
+	req := vcdCli.Client.NewRequest(ctx, map[string]string{}, http.MethodPost, *loginUrl, nil)
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header. The version must be at least 33.0 for cloudapi to work
@@ -74,7 +75,7 @@ func (vcdCli *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.Res
 }
 
 // vcdAuthorize authorizes the client and returns a http response
-func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, error) {
+func (vcdCli *VCDClient) vcdAuthorize(ctx context.Context, user, pass, org string) (*http.Response, error) {
 	var missingItems []string
 	if user == "" {
 		missingItems = append(missingItems, "user")
@@ -89,7 +90,7 @@ func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, e
 		return nil, fmt.Errorf("authorization is not possible because of these missing items: %v", missingItems)
 	}
 	// No point in checking for errors here
-	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodPost, vcdCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(ctx, map[string]string{}, http.MethodPost, vcdCli.sessionHREF, nil)
 	// Set Basic Authentication Header
 	req.SetBasicAuth(user+"@"+org, pass)
 	// Add the Accept header for vCA
@@ -100,7 +101,7 @@ func (vcdCli *VCDClient) vcdAuthorize(user, pass, org string) (*http.Response, e
 	// https://docs.vmware.com/en/VMware-Cloud-Director/10.0/com.vmware.vcloud.install.doc/GUID-84390C8F-E8C5-4137-A1A5-53EC27FE0024.html
 	// TODO: convert this method to main once we drop support for 9.7
 	if resp.StatusCode == 401 {
-		resp, err = vcdCli.vcdCloudApiAuthorize(user, pass, org)
+		resp, err = vcdCli.vcdCloudApiAuthorize(ctx, user, pass, org)
 		if err != nil {
 			return nil, err
 		}
@@ -161,17 +162,17 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 }
 
 // Authenticate is a helper function that performs a login in vCloud Director.
-func (vcdCli *VCDClient) Authenticate(username, password, org string) error {
-	_, err := vcdCli.GetAuthResponse(username, password, org)
+func (vcdCli *VCDClient) Authenticate(ctx context.Context, username, password, org string) error {
+	_, err := vcdCli.GetAuthResponse(ctx, username, password, org)
 	return err
 }
 
 // GetAuthResponse performs authentication and returns the full HTTP response
 // The purpose of this function is to preserve information that is useful
 // for token-based authentication
-func (vcdCli *VCDClient) GetAuthResponse(username, password, org string) (*http.Response, error) {
+func (vcdCli *VCDClient) GetAuthResponse(ctx context.Context, username, password, org string) (*http.Response, error) {
 	// LoginUrl
-	err := vcdCli.vcdloginurl()
+	err := vcdCli.vcdloginurl(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error finding LoginUrl: %s", err)
 	}
@@ -187,7 +188,7 @@ func (vcdCli *VCDClient) GetAuthResponse(username, password, org string) (*http.
 		}
 	default:
 		// Authorize
-		resp, err = vcdCli.vcdAuthorize(username, password, org)
+		resp, err = vcdCli.vcdAuthorize(ctx, username, password, org)
 		if err != nil {
 			return nil, fmt.Errorf("error authorizing: %s", err)
 		}
@@ -200,11 +201,11 @@ func (vcdCli *VCDClient) GetAuthResponse(username, password, org string) (*http.
 // Up to version 29, token authorization uses the the header key x-vcloud-authorization
 // In version 30+ it also uses X-Vmware-Vcloud-Access-Token:TOKEN coupled with
 // X-Vmware-Vcloud-Token-Type:"bearer"
-func (vcdCli *VCDClient) SetToken(org, authHeader, token string) error {
+func (vcdCli *VCDClient) SetToken(ctx context.Context, org, authHeader, token string) error {
 	vcdCli.Client.VCDAuthHeader = authHeader
 	vcdCli.Client.VCDToken = token
 
-	err := vcdCli.vcdloginurl()
+	err := vcdCli.vcdloginurl(ctx)
 	if err != nil {
 		return fmt.Errorf("error finding LoginUrl: %s", err)
 	}
@@ -224,7 +225,7 @@ func (vcdCli *VCDClient) SetToken(org, authHeader, token string) error {
 
 	orgList := new(types.OrgList)
 
-	_, err = vcdCli.Client.ExecuteRequest(orgListHREF.String(), http.MethodGet,
+	_, err = vcdCli.Client.ExecuteRequest(ctx, orgListHREF.String(), http.MethodGet,
 		"", "error connecting to vCD using token: %s", nil, orgList)
 	if err != nil {
 		return err
@@ -233,11 +234,11 @@ func (vcdCli *VCDClient) SetToken(org, authHeader, token string) error {
 }
 
 // Disconnect performs a disconnection from the vCloud Director API endpoint.
-func (vcdCli *VCDClient) Disconnect() error {
+func (vcdCli *VCDClient) Disconnect(ctx context.Context) error {
 	if vcdCli.Client.VCDToken == "" && vcdCli.Client.VCDAuthHeader == "" {
 		return fmt.Errorf("cannot disconnect, client is not authenticated")
 	}
-	req := vcdCli.Client.NewRequest(map[string]string{}, http.MethodDelete, vcdCli.sessionHREF, nil)
+	req := vcdCli.Client.NewRequest(ctx, map[string]string{}, http.MethodDelete, vcdCli.sessionHREF, nil)
 	// Add the Accept header for vCA
 	req.Header.Add("Accept", "application/xml;version="+vcdCli.Client.APIVersion)
 	// Set Authorization Header

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -182,7 +182,7 @@ func (vcdCli *VCDClient) GetAuthResponse(ctx context.Context, username, password
 	var resp *http.Response
 	switch {
 	case vcdCli.Client.UseSamlAdfs:
-		err = vcdCli.authorizeSamlAdfs(username, password, org, vcdCli.Client.CustomAdfsRptId)
+		err = vcdCli.authorizeSamlAdfs(ctx, username, password, org, vcdCli.Client.CustomAdfsRptId)
 		if err != nil {
 			return nil, fmt.Errorf("error authorizing SAML: %s", err)
 		}

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -43,7 +44,7 @@ func NewCatalog(client *Client) *Catalog {
 
 // Deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
-func (catalog *Catalog) Delete(force, recursive bool) error {
+func (catalog *Catalog) Delete(ctx context.Context, force, recursive bool) error {
 
 	adminCatalogHREF := catalog.client.VCDHREF
 	catalogID, err := getBareEntityUuid(catalog.Catalog.ID)
@@ -55,7 +56,7 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 	}
 	adminCatalogHREF.Path += "/admin/catalog/" + catalogID
 
-	req := catalog.client.NewRequest(map[string]string{
+	req := catalog.client.NewRequest(ctx, map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
 	}, http.MethodDelete, adminCatalogHREF, nil)
@@ -86,14 +87,14 @@ type Envelope struct {
 // exist, then it returns an empty CatalogItem. If the call fails
 // at any point, it returns an error.
 // Deprecated: use GetCatalogItemByName instead
-func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error) {
+func (cat *Catalog) FindCatalogItem(ctx context.Context, catalogItemName string) (CatalogItem, error) {
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
 			if catalogItem.Name == catalogItemName && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
 
 				cat := NewCatalogItem(cat.client)
 
-				_, err := cat.client.ExecuteRequest(catalogItem.HREF, http.MethodGet,
+				_, err := cat.client.ExecuteRequest(ctx, catalogItem.HREF, http.MethodGet,
 					"", "error retrieving catalog: %s", nil, cat.CatalogItem)
 				return *cat, err
 			}
@@ -109,7 +110,7 @@ func (cat *Catalog) FindCatalogItem(catalogItemName string) (CatalogItem, error)
 // Returns errors if any occur during upload from vCD or upload process. On upload fail client may need to
 // remove vCD catalog item which waits for files to be uploaded. Files from ova are extracted to system
 // temp folder "govcd+random number" and left for inspection on error.
-func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadPieceSize int64) (UploadTask, error) {
+func (cat *Catalog) UploadOvf(ctx context.Context, ovaFileName, itemName, description string, uploadPieceSize int64) (UploadTask, error) {
 
 	//	On a very high level the flow is as follows
 	//	1. Makes a POST call to vCD to create the catalog item (also creates a transfer folder in the spool area and as result will give a sparse catalog item resource XML).
@@ -181,12 +182,12 @@ func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadP
 		return UploadTask{}, err
 	}
 
-	vappTemplateUrl, err := createItemForUpload(cat.client, catalogItemUploadURL, itemName, description)
+	vappTemplateUrl, err := createItemForUpload(ctx, cat.client, catalogItemUploadURL, itemName, description)
 	if err != nil {
 		return UploadTask{}, err
 	}
 
-	vappTemplate, err := queryVappTemplate(cat.client, vappTemplateUrl, itemName)
+	vappTemplate, err := queryVappTemplate(ctx, cat.client, vappTemplateUrl, itemName)
 	if err != nil {
 		return UploadTask{}, err
 	}
@@ -196,15 +197,15 @@ func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadP
 		return UploadTask{}, err
 	}
 
-	err = uploadOvfDescription(cat.client, ovfFilePath, ovfUploadHref)
+	err = uploadOvfDescription(ctx, cat.client, ovfFilePath, ovfUploadHref)
 	if err != nil {
-		removeCatalogItemOnError(cat.client, vappTemplateUrl, itemName)
+		removeCatalogItemOnError(ctx, cat.client, vappTemplateUrl, itemName)
 		return UploadTask{}, err
 	}
 
-	vappTemplate, err = waitForTempUploadLinks(cat.client, vappTemplateUrl, itemName)
+	vappTemplate, err = waitForTempUploadLinks(ctx, cat.client, vappTemplateUrl, itemName)
 	if err != nil {
-		removeCatalogItemOnError(cat.client, vappTemplateUrl, itemName)
+		removeCatalogItemOnError(ctx, cat.client, vappTemplateUrl, itemName)
 		return UploadTask{}, err
 	}
 
@@ -213,17 +214,17 @@ func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadP
 	uploadError := *new(error)
 
 	//sending upload process to background, this allows no to lock and return task to client
-	go uploadFiles(cat.client, vappTemplate, &ovfFileDesc, tmpDir, filesAbsPaths, uploadPieceSize, progressCallBack, &uploadError, isOvf)
+	go uploadFiles(ctx, cat.client, vappTemplate, &ovfFileDesc, tmpDir, filesAbsPaths, uploadPieceSize, progressCallBack, &uploadError, isOvf)
 
 	var task Task
 	for _, item := range vappTemplate.Tasks.Task {
-		task, err = createTaskForVcdImport(cat.client, item.HREF)
+		task, err = createTaskForVcdImport(ctx, cat.client, item.HREF)
 		if err != nil {
-			removeCatalogItemOnError(cat.client, vappTemplateUrl, itemName)
+			removeCatalogItemOnError(ctx, cat.client, vappTemplateUrl, itemName)
 			return UploadTask{}, err
 		}
 		if task.Task.Status == "error" {
-			removeCatalogItemOnError(cat.client, vappTemplateUrl, itemName)
+			removeCatalogItemOnError(ctx, cat.client, vappTemplateUrl, itemName)
 			return UploadTask{}, fmt.Errorf("task did not complete succesfully: %s", task.Task.Description)
 		}
 	}
@@ -247,7 +248,7 @@ func (cat *Catalog) UploadOvf(ovaFileName, itemName, description string, uploadP
 // uploadPieceSize - size of chunks in which the file will be uploaded to the catalog.
 // callBack a function with signature //function(bytesUpload, totalSize) to let the caller monitor progress of the upload operation.
 // uploadError - error to be ready be task
-func uploadFiles(client *Client, vappTemplate *types.VAppTemplate, ovfFileDesc *Envelope, tempPath string, filesAbsPaths []string, uploadPieceSize int64, progressCallBack func(bytesUpload, totalSize int64), uploadError *error, isOvf bool) error {
+func uploadFiles(ctx context.Context, client *Client, vappTemplate *types.VAppTemplate, ovfFileDesc *Envelope, tempPath string, filesAbsPaths []string, uploadPieceSize int64, progressCallBack func(bytesUpload, totalSize int64), uploadError *error, isOvf bool) error {
 	var uploadedBytes int64
 	for _, item := range vappTemplate.Files.File {
 		if item.BytesTransferred == 0 {
@@ -287,7 +288,7 @@ func uploadFiles(client *Client, vappTemplate *types.VAppTemplate, ovfFileDesc *
 					callBack:                 progressCallBack,
 					uploadError:              uploadError,
 				}
-				tempVar, err := uploadFile(client, findFilePath(filesAbsPaths, item.Name), details)
+				tempVar, err := uploadFile(ctx, client, findFilePath(filesAbsPaths, item.Name), details)
 				if err != nil {
 					util.Logger.Printf("[Error] Error uploading files: %#v", err)
 					*uploadError = err
@@ -335,7 +336,7 @@ func getAllFileSizeSum(ovfFileDesc *Envelope) (sizeSum int64) {
 // vappTemplate - parsed from response vApp template
 // filePaths - all chunked vmdk file paths
 // uploadDetails - file upload settings and data
-func uploadMultiPartFile(client *Client, filePaths []string, uDetails uploadDetails) (int64, error) {
+func uploadMultiPartFile(ctx context.Context, client *Client, filePaths []string, uDetails uploadDetails) (int64, error) {
 	util.Logger.Printf("[TRACE] Upload multi part file: %v\n, href: %s, size: %v", filePaths, uDetails.uploadLink, uDetails.fileSizeToUpload)
 
 	var uploadedBytes int64
@@ -344,7 +345,7 @@ func uploadMultiPartFile(client *Client, filePaths []string, uDetails uploadDeta
 		util.Logger.Printf("[TRACE] Uploading file: %v\n", i+1)
 		uDetails.uploadedBytesForCallback += uploadedBytes // previous files uploaded size plus current upload size
 		uDetails.uploadedBytes = uploadedBytes
-		tempVar, err := uploadFile(client, filePath, uDetails)
+		tempVar, err := uploadFile(ctx, client, filePath, uDetails)
 		if err != nil {
 			return uploadedBytes, err
 		}
@@ -354,13 +355,13 @@ func uploadMultiPartFile(client *Client, filePaths []string, uDetails uploadDeta
 }
 
 // Function waits until vCD provides temporary file upload links.
-func waitForTempUploadLinks(client *Client, vappTemplateUrl *url.URL, newItemName string) (*types.VAppTemplate, error) {
+func waitForTempUploadLinks(ctx context.Context, client *Client, vappTemplateUrl *url.URL, newItemName string) (*types.VAppTemplate, error) {
 	var vAppTemplate *types.VAppTemplate
 	var err error
 	for {
 		util.Logger.Printf("[TRACE] Sleep... for 5 seconds.\n")
 		time.Sleep(time.Second * 5)
-		vAppTemplate, err = queryVappTemplate(client, vappTemplateUrl, newItemName)
+		vAppTemplate, err = queryVappTemplate(ctx, client, vappTemplateUrl, newItemName)
 		if err != nil {
 			return nil, err
 		}
@@ -372,12 +373,12 @@ func waitForTempUploadLinks(client *Client, vappTemplateUrl *url.URL, newItemNam
 	return vAppTemplate, nil
 }
 
-func queryVappTemplate(client *Client, vappTemplateUrl *url.URL, newItemName string) (*types.VAppTemplate, error) {
+func queryVappTemplate(ctx context.Context, client *Client, vappTemplateUrl *url.URL, newItemName string) (*types.VAppTemplate, error) {
 	util.Logger.Printf("[TRACE] Querying vapp template: %s\n", vappTemplateUrl)
 
 	vappTemplateParsed := &types.VAppTemplate{}
 
-	_, err := client.ExecuteRequest(vappTemplateUrl.String(), http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, vappTemplateUrl.String(), http.MethodGet,
 		"", "error querying vApp template: %s", nil, vappTemplateParsed)
 	if err != nil {
 		return nil, err
@@ -395,7 +396,7 @@ func queryVappTemplate(client *Client, vappTemplateUrl *url.URL, newItemName str
 
 // Uploads ovf description file from unarchived provided ova file. As a result vCD will generate temporary upload links which has to be queried later.
 // Function will return parsed part for upload files from description xml.
-func uploadOvfDescription(client *Client, ovfFile string, ovfUploadUrl *url.URL) error {
+func uploadOvfDescription(ctx context.Context, client *Client, ovfFile string, ovfUploadUrl *url.URL) error {
 	util.Logger.Printf("[TRACE] Uploding ovf description with file: %s and url: %s\n", ovfFile, ovfUploadUrl)
 	// #nosec G304 - linter does not like 'filePath' to be a variable. However this is necessary for file uploads.
 	openedFile, err := os.Open(ovfFile)
@@ -406,7 +407,7 @@ func uploadOvfDescription(client *Client, ovfFile string, ovfUploadUrl *url.URL)
 	var buf bytes.Buffer
 	ovfReader := io.TeeReader(openedFile, &buf)
 
-	request := client.NewRequest(map[string]string{}, http.MethodPut, *ovfUploadUrl, ovfReader)
+	request := client.NewRequest(ctx, map[string]string{}, http.MethodPut, *ovfUploadUrl, ovfReader)
 	request.Header.Add("Content-Type", "text/xml")
 
 	_, err = checkResp(client.Http.Do(request))
@@ -473,14 +474,14 @@ func findFilePath(filesAbsPaths []string, fileName string) string {
 }
 
 // Initiates creation of item and returns ovf upload url for created item.
-func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName string, itemDescription string) (*url.URL, error) {
+func createItemForUpload(ctx context.Context, client *Client, createHREF *url.URL, catalogItemName string, itemDescription string) (*url.URL, error) {
 	util.Logger.Printf("[TRACE] createItemForUpload: %s, item name: %v, description: %v \n", createHREF, catalogItemName, itemDescription)
 	reqBody := bytes.NewBufferString(
 		"<UploadVAppTemplateParams xmlns=\"" + types.XMLNamespaceVCloud + "\" name=\"" + catalogItemName + "\" >" +
 			"<Description>" + itemDescription + "</Description>" +
 			"</UploadVAppTemplateParams>")
 
-	request := client.NewRequest(map[string]string{}, http.MethodPost, *createHREF, reqBody)
+	request := client.NewRequest(ctx, map[string]string{}, http.MethodPost, *createHREF, reqBody)
 	request.Header.Add("Content-Type", "application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml")
 
 	response, err := checkResp(client.Http.Do(request))
@@ -609,7 +610,7 @@ func checkIfFileMatchesDescription(filesAbsPaths []string, fileDescription struc
 	return nil
 }
 
-func removeCatalogItemOnError(client *Client, vappTemplateLink *url.URL, itemName string) {
+func removeCatalogItemOnError(ctx context.Context, client *Client, vappTemplateLink *url.URL, itemName string) {
 	if vappTemplateLink != nil {
 		util.Logger.Printf("[TRACE] Deleting Catalog item %v", vappTemplateLink)
 
@@ -619,7 +620,7 @@ func removeCatalogItemOnError(client *Client, vappTemplateLink *url.URL, itemNam
 		for {
 			util.Logger.Printf("[TRACE] Sleep... for 5 seconds.\n")
 			time.Sleep(time.Second * 5)
-			vAppTemplate, err = queryVappTemplate(client, vappTemplateLink, itemName)
+			vAppTemplate, err = queryVappTemplate(ctx, client, vappTemplateLink, itemName)
 			if err != nil {
 				util.Logger.Printf("[Error] Error deleting Catalog item %s: %s", vappTemplateLink, err)
 			}
@@ -633,7 +634,7 @@ func removeCatalogItemOnError(client *Client, vappTemplateLink *url.URL, itemNam
 			if itemName == taskItem.Owner.Name {
 				task := NewTask(client)
 				task.Task = taskItem
-				err = task.CancelTask()
+				err = task.CancelTask(ctx)
 				if err != nil {
 					util.Logger.Printf("[ERROR] Error canceling task for catalog item upload %#v", err)
 				}
@@ -644,7 +645,7 @@ func removeCatalogItemOnError(client *Client, vappTemplateLink *url.URL, itemNam
 	}
 }
 
-func (cat *Catalog) UploadMediaImage(mediaName, mediaDescription, filePath string, uploadPieceSize int64) (UploadTask, error) {
+func (cat *Catalog) UploadMediaImage(ctx context.Context, mediaName, mediaDescription, filePath string, uploadPieceSize int64) (UploadTask, error) {
 
 	if *cat == (Catalog{}) {
 		return UploadTask{}, errors.New("catalog can not be empty or nil")
@@ -677,28 +678,28 @@ func (cat *Catalog) UploadMediaImage(mediaName, mediaDescription, filePath strin
 		return UploadTask{}, err
 	}
 
-	media, err := createMedia(cat.client, catalogItemUploadURL.String(), mediaName, mediaDescription, fileSize)
+	media, err := createMedia(ctx, cat.client, catalogItemUploadURL.String(), mediaName, mediaDescription, fileSize)
 	if err != nil {
 		return UploadTask{}, fmt.Errorf("[ERROR] Issue creating media: %#v", err)
 	}
 
-	createdMedia, err := queryMedia(cat.client, media.Entity.HREF, mediaName)
+	createdMedia, err := queryMedia(ctx, cat.client, media.Entity.HREF, mediaName)
 	if err != nil {
 		return UploadTask{}, err
 	}
 
-	return executeUpload(cat.client, createdMedia, mediaFilePath, mediaName, fileSize, uploadPieceSize)
+	return executeUpload(ctx, cat.client, createdMedia, mediaFilePath, mediaName, fileSize, uploadPieceSize)
 }
 
 // Refresh gets a fresh copy of the catalog from vCD
-func (cat *Catalog) Refresh() error {
+func (cat *Catalog) Refresh(ctx context.Context) error {
 	if cat == nil || *cat == (Catalog{}) || cat.Catalog.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty or HREF is empty")
 	}
 
 	refreshedCatalog := &types.Catalog{}
 
-	_, err := cat.client.ExecuteRequest(cat.Catalog.HREF, http.MethodGet,
+	_, err := cat.client.ExecuteRequest(ctx, cat.Catalog.HREF, http.MethodGet,
 		"", "error refreshing VDC: %s", nil, refreshedCatalog)
 	if err != nil {
 		return err
@@ -711,11 +712,11 @@ func (cat *Catalog) Refresh() error {
 // GetCatalogItemByHref finds a CatalogItem by HREF
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetCatalogItemByHref(catalogItemHref string) (*CatalogItem, error) {
+func (cat *Catalog) GetCatalogItemByHref(ctx context.Context, catalogItemHref string) (*CatalogItem, error) {
 
 	catItem := NewCatalogItem(cat.client)
 
-	_, err := cat.client.ExecuteRequest(catalogItemHref, http.MethodGet,
+	_, err := cat.client.ExecuteRequest(ctx, catalogItemHref, http.MethodGet,
 		"", "error retrieving catalog item: %s", nil, catItem.CatalogItem)
 	if err != nil {
 		return nil, err
@@ -726,11 +727,11 @@ func (cat *Catalog) GetCatalogItemByHref(catalogItemHref string) (*CatalogItem, 
 // GetVappTemplateByHref finds a vApp template by HREF
 // On success, returns a pointer to the vApp template structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetVappTemplateByHref(href string) (*VAppTemplate, error) {
+func (cat *Catalog) GetVappTemplateByHref(ctx context.Context, href string) (*VAppTemplate, error) {
 
 	vappTemplate := NewVAppTemplate(cat.client)
 
-	_, err := cat.client.ExecuteRequest(href, http.MethodGet,
+	_, err := cat.client.ExecuteRequest(ctx, href, http.MethodGet,
 		"", "error retrieving catalog item: %s", nil, vappTemplate.VAppTemplate)
 	if err != nil {
 		return nil, err
@@ -741,9 +742,9 @@ func (cat *Catalog) GetVappTemplateByHref(href string) (*VAppTemplate, error) {
 // GetCatalogItemByName finds a CatalogItem by Name
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetCatalogItemByName(catalogItemName string, refresh bool) (*CatalogItem, error) {
+func (cat *Catalog) GetCatalogItemByName(ctx context.Context, catalogItemName string, refresh bool) (*CatalogItem, error) {
 	if refresh {
-		err := cat.Refresh()
+		err := cat.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -751,7 +752,7 @@ func (cat *Catalog) GetCatalogItemByName(catalogItemName string, refresh bool) (
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
 			if catalogItem.Name == catalogItemName && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
-				return cat.GetCatalogItemByHref(catalogItem.HREF)
+				return cat.GetCatalogItemByHref(ctx, catalogItem.HREF)
 			}
 		}
 	}
@@ -761,9 +762,9 @@ func (cat *Catalog) GetCatalogItemByName(catalogItemName string, refresh bool) (
 // GetCatalogItemById finds a Catalog Item by ID
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*CatalogItem, error) {
+func (cat *Catalog) GetCatalogItemById(ctx context.Context, catalogItemId string, refresh bool) (*CatalogItem, error) {
 	if refresh {
-		err := cat.Refresh()
+		err := cat.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -771,7 +772,7 @@ func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*Cat
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
 			if equalIds(catalogItemId, catalogItem.ID, catalogItem.HREF) && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
-				return cat.GetCatalogItemByHref(catalogItem.HREF)
+				return cat.GetCatalogItemByHref(ctx, catalogItem.HREF)
 			}
 		}
 	}
@@ -781,9 +782,11 @@ func (cat *Catalog) GetCatalogItemById(catalogItemId string, refresh bool) (*Cat
 // GetCatalogItemByNameOrId finds a Catalog Item by Name or ID
 // On success, returns a pointer to the CatalogItem structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetCatalogItemByNameOrId(identifier string, refresh bool) (*CatalogItem, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return cat.GetCatalogItemByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(id, refresh) }
+func (cat *Catalog) GetCatalogItemByNameOrId(ctx context.Context, identifier string, refresh bool) (*CatalogItem, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
+		return cat.GetCatalogItemByName(ctx, name, refresh)
+	}
+	getById := func(id string, refresh bool) (interface{}, error) { return cat.GetCatalogItemById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
 		return nil, err
@@ -792,14 +795,14 @@ func (cat *Catalog) GetCatalogItemByNameOrId(identifier string, refresh bool) (*
 }
 
 // QueryMediaList retrieves a list of media items for the catalog
-func (catalog *Catalog) QueryMediaList() ([]*types.MediaRecordType, error) {
+func (catalog *Catalog) QueryMediaList(ctx context.Context) ([]*types.MediaRecordType, error) {
 	typeMedia := "media"
 	if catalog.client.IsSysAdmin {
 		typeMedia = "adminMedia"
 	}
 
 	filter := fmt.Sprintf("catalog==" + url.QueryEscape(catalog.Catalog.HREF))
-	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": filter, "filterEncoded": "true"})
+	results, err := catalog.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia, "filter": filter, "filterEncoded": "true"})
 	if err != nil {
 		return nil, fmt.Errorf("error querying medias %s", err)
 	}
@@ -812,7 +815,7 @@ func (catalog *Catalog) QueryMediaList() ([]*types.MediaRecordType, error) {
 }
 
 // getOrgInfo finds the organization to which the entity belongs, and returns its name and ID
-func getOrgInfo(client *Client, links types.LinkList, id, name, entityType string) (orgInfoType, error) {
+func getOrgInfo(ctx context.Context, client *Client, links types.LinkList, id, name, entityType string) (orgInfoType, error) {
 	previous, exists := orgInfoCache[id]
 	if exists {
 		return previous, nil
@@ -834,7 +837,7 @@ func getOrgInfo(client *Client, links types.LinkList, id, name, entityType strin
 		return orgInfoType{}, fmt.Errorf("error retrieving org info for %s %s", entityType, name)
 	}
 	var org types.Org
-	_, err = client.ExecuteRequest(orgHref, http.MethodGet,
+	_, err = client.ExecuteRequest(ctx, orgHref, http.MethodGet,
 		"", "error retrieving org: %s", nil, &org)
 	if err != nil {
 		return orgInfoType{}, err
@@ -848,6 +851,6 @@ func getOrgInfo(client *Client, links types.LinkList, id, name, entityType strin
 }
 
 // getOrgInfo finds the organization to which the catalog belongs, and returns its name and ID
-func (catalog *Catalog) getOrgInfo() (orgInfoType, error) {
-	return getOrgInfo(catalog.client, catalog.Catalog.Link, catalog.Catalog.ID, catalog.Catalog.Name, "Catalog")
+func (catalog *Catalog) getOrgInfo(ctx context.Context) (orgInfoType, error) {
+	return getOrgInfo(ctx, catalog.client, catalog.Catalog.Link, catalog.Catalog.ID, catalog.Catalog.Name, "Catalog")
 }

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -270,7 +270,7 @@ func uploadFiles(ctx context.Context, client *Client, vappTemplate *types.VAppTe
 					callBack:                 progressCallBack,
 					uploadError:              uploadError,
 				}
-				tempVar, err := uploadMultiPartFile(client, chunkFilePaths, details)
+				tempVar, err := uploadMultiPartFile(ctx, client, chunkFilePaths, details)
 				if err != nil {
 					util.Logger.Printf("[Error] Error uploading files: %#v", err)
 					*uploadError = err

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,11 +26,11 @@ func NewCatalogItem(cli *Client) *CatalogItem {
 	}
 }
 
-func (catalogItem *CatalogItem) GetVAppTemplate() (VAppTemplate, error) {
+func (catalogItem *CatalogItem) GetVAppTemplate(ctx context.Context) (VAppTemplate, error) {
 
 	cat := NewVAppTemplate(catalogItem.client)
 
-	_, err := catalogItem.client.ExecuteRequest(catalogItem.CatalogItem.Entity.HREF, http.MethodGet,
+	_, err := catalogItem.client.ExecuteRequest(ctx, catalogItem.CatalogItem.Entity.HREF, http.MethodGet,
 		"", "error retrieving vApp template: %s", nil, cat.VAppTemplate)
 
 	// The request was successful
@@ -39,19 +40,19 @@ func (catalogItem *CatalogItem) GetVAppTemplate() (VAppTemplate, error) {
 
 // Deletes the Catalog Item, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-CatalogItem.html
-func (catalogItem *CatalogItem) Delete() error {
+func (catalogItem *CatalogItem) Delete(ctx context.Context) error {
 	util.Logger.Printf("[TRACE] Deleting catalog item: %#v", catalogItem.CatalogItem)
 	catalogItemHREF := catalogItem.client.VCDHREF
 	catalogItemHREF.Path += "/catalogItem/" + catalogItem.CatalogItem.ID[23:]
 
 	util.Logger.Printf("[TRACE] Url for deleting catalog item: %#v and name: %s", catalogItemHREF, catalogItem.CatalogItem.Name)
 
-	return catalogItem.client.ExecuteRequestWithoutResponse(catalogItemHREF.String(), http.MethodDelete,
+	return catalogItem.client.ExecuteRequestWithoutResponse(ctx, catalogItemHREF.String(), http.MethodDelete,
 		"", "error deleting Catalog item: %s", nil)
 }
 
 // queryCatalogItemList returns a list of Catalog Item for the given parent
-func queryCatalogItemList(client *Client, parentField, parentValue string) ([]*types.QueryResultCatalogItemType, error) {
+func queryCatalogItemList(ctx context.Context, client *Client, parentField, parentValue string) ([]*types.QueryResultCatalogItemType, error) {
 
 	catalogItemType := types.QtCatalogItem
 	if client.IsSysAdmin {
@@ -60,7 +61,7 @@ func queryCatalogItemList(client *Client, parentField, parentValue string) ([]*t
 
 	filterText := fmt.Sprintf("%s==%s", parentField, url.QueryEscape(parentValue))
 
-	results, err := client.cumulativeQuery(catalogItemType, nil, map[string]string{
+	results, err := client.cumulativeQuery(ctx, catalogItemType, nil, map[string]string{
 		"type":   catalogItemType,
 		"filter": filterText,
 	})
@@ -76,28 +77,28 @@ func queryCatalogItemList(client *Client, parentField, parentValue string) ([]*t
 }
 
 // QueryCatalogItemList returns a list of Catalog Item for the given catalog
-func (catalog *Catalog) QueryCatalogItemList() ([]*types.QueryResultCatalogItemType, error) {
-	return queryCatalogItemList(catalog.client, "catalog", catalog.Catalog.ID)
+func (catalog *Catalog) QueryCatalogItemList(ctx context.Context) ([]*types.QueryResultCatalogItemType, error) {
+	return queryCatalogItemList(ctx, catalog.client, "catalog", catalog.Catalog.ID)
 }
 
 // QueryCatalogItemList returns a list of Catalog Item for the given VDC
-func (vdc *Vdc) QueryCatalogItemList() ([]*types.QueryResultCatalogItemType, error) {
-	return queryCatalogItemList(vdc.client, "vdc", vdc.Vdc.ID)
+func (vdc *Vdc) QueryCatalogItemList(ctx context.Context) ([]*types.QueryResultCatalogItemType, error) {
+	return queryCatalogItemList(ctx, vdc.client, "vdc", vdc.Vdc.ID)
 }
 
 // QueryCatalogItemList returns a list of Catalog Item for the given Admin VDC
-func (vdc *AdminVdc) QueryCatalogItemList() ([]*types.QueryResultCatalogItemType, error) {
-	return queryCatalogItemList(vdc.client, "vdc", vdc.AdminVdc.ID)
+func (vdc *AdminVdc) QueryCatalogItemList(ctx context.Context) ([]*types.QueryResultCatalogItemType, error) {
+	return queryCatalogItemList(ctx, vdc.client, "vdc", vdc.AdminVdc.ID)
 }
 
 // queryVappTemplateList returns a list of vApp templates for the given parent
-func queryVappTemplateList(client *Client, parentField, parentValue string) ([]*types.QueryResultVappTemplateType, error) {
+func queryVappTemplateList(ctx context.Context, client *Client, parentField, parentValue string) ([]*types.QueryResultVappTemplateType, error) {
 
 	vappTemplateType := types.QtVappTemplate
 	if client.IsSysAdmin {
 		vappTemplateType = types.QtAdminVappTemplate
 	}
-	results, err := client.cumulativeQuery(vappTemplateType, nil, map[string]string{
+	results, err := client.cumulativeQuery(ctx, vappTemplateType, nil, map[string]string{
 		"type":   vappTemplateType,
 		"filter": fmt.Sprintf("%s==%s", parentField, url.QueryEscape(parentValue)),
 	})
@@ -113,16 +114,16 @@ func queryVappTemplateList(client *Client, parentField, parentValue string) ([]*
 }
 
 // QueryVappTemplateList returns a list of vApp templates for the given VDC
-func (vdc *Vdc) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
-	return queryVappTemplateList(vdc.client, "vdcName", vdc.Vdc.Name)
+func (vdc *Vdc) QueryVappTemplateList(ctx context.Context) ([]*types.QueryResultVappTemplateType, error) {
+	return queryVappTemplateList(ctx, vdc.client, "vdcName", vdc.Vdc.Name)
 }
 
 // QueryVappTemplateList returns a list of vApp templates for the given VDC
-func (vdc *AdminVdc) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
-	return queryVappTemplateList(vdc.client, "vdcName", vdc.AdminVdc.Name)
+func (vdc *AdminVdc) QueryVappTemplateList(ctx context.Context) ([]*types.QueryResultVappTemplateType, error) {
+	return queryVappTemplateList(ctx, vdc.client, "vdcName", vdc.AdminVdc.Name)
 }
 
 // QueryVappTemplateList returns a list of vApp templates for the given catalog
-func (catalog *Catalog) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
-	return queryVappTemplateList(catalog.client, "catalogName", catalog.Catalog.Name)
+func (catalog *Catalog) QueryVappTemplateList(ctx context.Context) ([]*types.QueryResultVappTemplateType, error) {
+	return queryVappTemplateList(ctx, catalog.client, "catalogName", catalog.Catalog.Name)
 }

--- a/govcd/context_test.go
+++ b/govcd/context_test.go
@@ -1,0 +1,6 @@
+package govcd
+
+import "context"
+
+// global background context for test convenience
+var ctx = context.Background()

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -401,7 +401,7 @@ func (vdc *Vdc) GetDisksByName(ctx context.Context, diskName string, refresh boo
 	util.Logger.Printf("[TRACE] Get Disk By Name: %s\n", diskName)
 	var diskList []Disk
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -429,7 +429,7 @@ func (vdc *Vdc) GetDisksByName(ctx context.Context, diskName string, refresh boo
 func (vdc *Vdc) GetDiskById(ctx context.Context, diskId string, refresh bool) (*Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Id: %s\n", diskId)
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -51,7 +52,7 @@ const MinimumDiskSize int64 = 1048576 // = 1Mb
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 102 - 103,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, error) {
+func (vdc *Vdc) CreateDisk(ctx context.Context, diskCreateParams *types.DiskCreateParams) (Task, error) {
 	util.Logger.Printf("[TRACE] Create disk, name: %s, size: %d \n",
 		diskCreateParams.Disk.Name,
 		diskCreateParams.Disk.Size,
@@ -91,7 +92,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 
 	disk := NewDisk(vdc.client)
 
-	_, err = vdc.client.ExecuteRequest(createDiskLink.HREF, http.MethodPost,
+	_, err = vdc.client.ExecuteRequest(ctx, createDiskLink.HREF, http.MethodPost,
 		createDiskLink.Type, "error create disk: %s", diskCreateParams, disk.Disk)
 	if err != nil {
 		return Task{}, err
@@ -116,7 +117,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 104 - 106,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
+func (disk *Disk) Update(ctx context.Context, newDiskInfo *types.Disk) (Task, error) {
 	util.Logger.Printf("[TRACE] Update disk, name: %s, size: %d, HREF: %s \n",
 		newDiskInfo.Name,
 		newDiskInfo.Size,
@@ -134,7 +135,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	}
 
 	// Verify the independent disk is not connected to any VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error find attached VM: %s", err)
 	}
@@ -173,7 +174,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	}
 
 	// Return the task
-	return disk.client.ExecuteTaskRequest(updateDiskLink.HREF, http.MethodPut,
+	return disk.client.ExecuteTaskRequest(ctx, updateDiskLink.HREF, http.MethodPut,
 		updateDiskLink.Type, "error updating disk: %s", xmlPayload)
 }
 
@@ -185,13 +186,13 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 106 - 107,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (disk *Disk) Delete() (Task, error) {
+func (disk *Disk) Delete(ctx context.Context) (Task, error) {
 	util.Logger.Printf("[TRACE] Delete disk, HREF: %s \n", disk.Disk.HREF)
 
 	var err error
 
 	// Verify the independent disk is not connected to any VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error find attached VM: %s", err)
 	}
@@ -220,12 +221,12 @@ func (disk *Disk) Delete() (Task, error) {
 	}
 
 	// Return the task
-	return disk.client.ExecuteTaskRequest(deleteDiskLink.HREF, http.MethodDelete,
+	return disk.client.ExecuteTaskRequest(ctx, deleteDiskLink.HREF, http.MethodDelete,
 		"", "error delete disk: %s", nil)
 }
 
 // Refresh the disk information by disk href
-func (disk *Disk) Refresh() error {
+func (disk *Disk) Refresh(ctx context.Context) error {
 	util.Logger.Printf("[TRACE] Disk refresh, HREF: %s\n", disk.Disk.HREF)
 
 	if disk.Disk == nil || disk.Disk.HREF == "" {
@@ -234,7 +235,7 @@ func (disk *Disk) Refresh() error {
 
 	unmarshalledDisk := &types.Disk{}
 
-	_, err := disk.client.ExecuteRequest(disk.Disk.HREF, http.MethodGet,
+	_, err := disk.client.ExecuteRequest(ctx, disk.Disk.HREF, http.MethodGet,
 		"", "error refreshing independent disk: %s", nil, unmarshalledDisk)
 	if err != nil {
 		return err
@@ -252,7 +253,7 @@ func (disk *Disk) Refresh() error {
 // Reference: vCloud API Programming Guide for Service Providers vCloud API 30.0 PDF Page 107,
 // https://vdc-download.vmware.com/vmwb-repository/dcr-public/1b6cf07d-adb3-4dba-8c47-9c1c92b04857/
 // 241956dd-e128-4fcc-8131-bf66e1edd895/vcloud_sp_api_guide_30_0.pdf
-func (disk *Disk) AttachedVM() (*types.Reference, error) {
+func (disk *Disk) AttachedVM(ctx context.Context) (*types.Reference, error) {
 	util.Logger.Printf("[TRACE] Disk attached VM, HREF: %s\n", disk.Disk.HREF)
 
 	var attachedVMLink *types.Link
@@ -279,7 +280,7 @@ func (disk *Disk) AttachedVM() (*types.Reference, error) {
 	// Decode request
 	var vms = new(types.Vms)
 
-	_, err := disk.client.ExecuteRequest(attachedVMLink.HREF, http.MethodGet,
+	_, err := disk.client.ExecuteRequest(ctx, attachedVMLink.HREF, http.MethodGet,
 		attachedVMLink.Type, "error getting attached vms: %s", nil, vms)
 	if err != nil {
 		return nil, err
@@ -296,20 +297,20 @@ func (disk *Disk) AttachedVM() (*types.Reference, error) {
 
 // Find an independent disk by disk href in VDC
 // Deprecated: Use VDC.GetDiskByHref()
-func (vdc *Vdc) FindDiskByHREF(href string) (*Disk, error) {
+func (vdc *Vdc) FindDiskByHREF(ctx context.Context, href string) (*Disk, error) {
 	util.Logger.Printf("[TRACE] VDC find disk By HREF: %s\n", href)
 
-	return FindDiskByHREF(vdc.client, href)
+	return FindDiskByHREF(ctx, vdc.client, href)
 }
 
 // Find an independent disk by VDC client and disk href
 // Deprecated: Use VDC.GetDiskByHref()
-func FindDiskByHREF(client *Client, href string) (*Disk, error) {
+func FindDiskByHREF(ctx context.Context, client *Client, href string) (*Disk, error) {
 	util.Logger.Printf("[TRACE] Find disk By HREF: %s\n", href)
 
 	disk := NewDisk(client)
 
-	_, err := client.ExecuteRequest(href, http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, href, http.MethodGet,
 		"", "error finding disk: %s", nil, disk.Disk)
 
 	// Return the disk
@@ -318,7 +319,7 @@ func FindDiskByHREF(client *Client, href string) (*Disk, error) {
 }
 
 // QueryDisk find independent disk using disk name. Returns DiskRecord type
-func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
+func (vdc *Vdc) QueryDisk(ctx context.Context, diskName string) (DiskRecord, error) {
 
 	if diskName == "" {
 		return DiskRecord{}, fmt.Errorf("disk name can not be empty")
@@ -329,7 +330,7 @@ func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
 		typeMedia = "adminDisk"
 	}
 
-	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": "name==" + url.QueryEscape(diskName), "filterEncoded": "true"})
+	results, err := vdc.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia, "filter": "name==" + url.QueryEscape(diskName), "filterEncoded": "true"})
 	if err != nil {
 		return DiskRecord{}, fmt.Errorf("error querying disk %s", err)
 	}
@@ -351,7 +352,7 @@ func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
 }
 
 // QueryDisks find independent disks using disk name. Returns list of DiskRecordType
-func (vdc *Vdc) QueryDisks(diskName string) (*[]*types.DiskRecordType, error) {
+func (vdc *Vdc) QueryDisks(ctx context.Context, diskName string) (*[]*types.DiskRecordType, error) {
 
 	if diskName == "" {
 		return nil, fmt.Errorf("disk name can't be empty")
@@ -362,7 +363,7 @@ func (vdc *Vdc) QueryDisks(diskName string) (*[]*types.DiskRecordType, error) {
 		typeMedia = "adminDisk"
 	}
 
-	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": "name==" + url.QueryEscape(diskName), "filterEncoded": "true"})
+	results, err := vdc.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia, "filter": "name==" + url.QueryEscape(diskName), "filterEncoded": "true"})
 	if err != nil {
 		return nil, fmt.Errorf("error querying disks %s", err)
 	}
@@ -378,11 +379,11 @@ func (vdc *Vdc) QueryDisks(diskName string) (*[]*types.DiskRecordType, error) {
 // GetDiskByHref finds a Disk by HREF
 // On success, returns a pointer to the Disk structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
+func (vdc *Vdc) GetDiskByHref(ctx context.Context, diskHref string) (*Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Href: %s\n", diskHref)
 	Disk := NewDisk(vdc.client)
 
-	_, err := vdc.client.ExecuteRequest(diskHref, http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, diskHref, http.MethodGet,
 		"", "error retrieving Disk: %#v", nil, Disk.Disk)
 	if err != nil && strings.Contains(err.Error(), "MajorErrorCode:403") {
 		return nil, ErrorEntityNotFound
@@ -396,7 +397,7 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 // GetDisksByName finds one or more Disks by Name
 // On success, returns a pointer to the Disk list and a nil error
 // On failure, returns a nil pointer and an error
-func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
+func (vdc *Vdc) GetDisksByName(ctx context.Context, diskName string, refresh bool) (*[]Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Name: %s\n", diskName)
 	var diskList []Disk
 	if refresh {
@@ -408,7 +409,7 @@ func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
 		for _, resourceEntity := range resourceEntities.ResourceEntity {
 			if resourceEntity.Name == diskName && resourceEntity.Type == "application/vnd.vmware.vcloud.disk+xml" {
-				disk, err := vdc.GetDiskByHref(resourceEntity.HREF)
+				disk, err := vdc.GetDiskByHref(ctx, resourceEntity.HREF)
 				if err != nil {
 					return nil, err
 				}
@@ -425,7 +426,7 @@ func (vdc *Vdc) GetDisksByName(diskName string, refresh bool) (*[]Disk, error) {
 // GetDiskById finds a Disk by ID
 // On success, returns a pointer to the Disk structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vdc *Vdc) GetDiskById(diskId string, refresh bool) (*Disk, error) {
+func (vdc *Vdc) GetDiskById(ctx context.Context, diskId string, refresh bool) (*Disk, error) {
 	util.Logger.Printf("[TRACE] Get Disk By Id: %s\n", diskId)
 	if refresh {
 		err := vdc.Refresh()
@@ -436,7 +437,7 @@ func (vdc *Vdc) GetDiskById(diskId string, refresh bool) (*Disk, error) {
 	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
 		for _, resourceEntity := range resourceEntities.ResourceEntity {
 			if equalIds(diskId, resourceEntity.ID, resourceEntity.HREF) && resourceEntity.Type == "application/vnd.vmware.vcloud.disk+xml" {
-				return vdc.GetDiskByHref(resourceEntity.HREF)
+				return vdc.GetDiskByHref(ctx, resourceEntity.HREF)
 			}
 		}
 	}

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 
 	. "gopkg.in/check.v1"
@@ -41,7 +42,8 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -50,12 +52,12 @@ func (vcd *TestVCD) Test_CreateDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -86,7 +88,8 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -95,12 +98,12 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -113,13 +116,13 @@ func (vcd *TestVCD) Test_UpdateDisk(check *C) {
 		Description: TestUpdateDisk + "_Update",
 	}
 
-	updateTask, err := disk.Update(newDiskInfo)
+	updateTask, err := disk.Update(ctx, newDiskInfo)
 	check.Assert(err, IsNil)
-	err = updateTask.WaitTaskCompletion()
+	err = updateTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Refresh disk info, getting updated info
-	err = disk.Refresh()
+	err = disk.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, newDiskInfo.Name)
 	check.Assert(disk.Disk.Size, Equals, newDiskInfo.Size)
@@ -148,7 +151,8 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -157,22 +161,22 @@ func (vcd *TestVCD) Test_DeleteDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Delete disk
-	deleteDiskTask, err := disk.Delete()
+	deleteDiskTask, err := disk.Delete(ctx)
 	check.Assert(err, IsNil)
 
-	err = deleteDiskTask.WaitTaskCompletion()
+	err = deleteDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 }
 
@@ -199,7 +203,8 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -208,12 +213,12 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
@@ -226,13 +231,13 @@ func (vcd *TestVCD) Test_RefreshDisk(check *C) {
 		Description: TestRefreshDisk + "_Update",
 	}
 
-	updateTask, err := disk.Update(newDiskInfo)
+	updateTask, err := disk.Update(ctx, newDiskInfo)
 	check.Assert(err, IsNil)
-	err = updateTask.WaitTaskCompletion()
+	err = updateTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Refresh disk info, getting updated info
-	err = disk.Refresh()
+	err = disk.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, newDiskInfo.Name)
 	check.Assert(disk.Disk.Size, Equals, newDiskInfo.Size)
@@ -250,9 +255,10 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	// Find VM
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -265,9 +271,9 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 
 	// Ensure vApp and VM are suitable for this test
 	// Disk attach and detach operations are not working if VM is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -281,7 +287,7 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -290,36 +296,36 @@ func (vcd *TestVCD) Test_AttachedVMDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.AttachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.AttachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Get attached VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
 	// Detach disk
-	err = vcd.detachIndependentDisk(Disk{disk.Disk, &vcd.client.Client})
+	err = vcd.detachIndependentDisk(ctx, Disk{disk.Disk, &vcd.client.Client})
 	check.Assert(err, IsNil)
 }
 
@@ -341,8 +347,9 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	diskCreateParams := &types.DiskCreateParams{
 		Disk: diskCreateParamsDisk,
 	}
+	ctx := context.Background()
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -351,12 +358,12 @@ func (vcd *TestVCD) Test_VdcFindDiskByHREF(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.FindDiskByHREF(ctx, diskHREF)
 
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
@@ -383,8 +390,9 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	diskCreateParams := &types.DiskCreateParams{
 		Disk: diskCreateParamsDisk,
 	}
+	ctx := context.Background()
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -393,12 +401,12 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.FindDiskByHREF(diskHREF)
+	disk, err := vcd.vdc.FindDiskByHREF(ctx, diskHREF)
 
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
@@ -406,7 +414,7 @@ func (vcd *TestVCD) Test_FindDiskByHREF(check *C) {
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Find disk by href
-	foundDisk, err := FindDiskByHREF(vcd.vdc.client, disk.Disk.HREF)
+	foundDisk, err := FindDiskByHREF(ctx, vcd.vdc.client, disk.Disk.HREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk, NotNil)
 	check.Assert(disk.Disk.Name, Equals, foundDisk.Disk.Name)
@@ -426,9 +434,10 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	// Find VM
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -441,9 +450,9 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 
 	// Ensure vApp and VM are suitable for this test
 	// Disk attach and detach operations are not working if VM is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -457,7 +466,7 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -466,43 +475,43 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.AttachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.AttachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Get attached VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
 	// Detach disk
-	detachDiskTask, err := vm.DetachDisk(&types.DiskAttachOrDetachParams{
+	detachDiskTask, err := vm.DetachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = detachDiskTask.WaitTaskCompletion()
+	err = detachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Update disk
@@ -512,14 +521,14 @@ func (vcd *TestVCD) Test_Disk(check *C) {
 		Description: TestDisk + "_Update",
 	}
 
-	updateTask, err := disk.Update(newDiskInfo)
+	updateTask, err := disk.Update(ctx, newDiskInfo)
 	check.Assert(err, IsNil)
 
-	err = updateTask.WaitTaskCompletion()
+	err = updateTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Refresh disk Info
-	err = disk.Refresh()
+	err = disk.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, newDiskInfo.Name)
 	check.Assert(disk.Disk.Description, Equals, newDiskInfo.Description)
@@ -548,7 +557,8 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -557,16 +567,16 @@ func (vcd *TestVCD) Test_QueryDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	diskRecord, err := vcd.vdc.QueryDisk(name)
+	diskRecord, err := vcd.vdc.QueryDisk(ctx, name)
 
 	check.Assert(err, IsNil)
 	check.Assert(diskRecord.Disk.Name, Equals, diskCreateParamsDisk.Name)
-	check.Assert(diskRecord.Disk.SizeB, Equals, int64(diskCreateParamsDisk.Size))
+	check.Assert(diskRecord.Disk.SizeB, Equals, diskCreateParamsDisk.Size)
 	check.Assert(diskRecord.Disk.Description, Equals, diskCreateParamsDisk.Description)
 }
 
@@ -591,8 +601,9 @@ func (vcd *TestVCD) Test_QueryDisks(check *C) {
 	diskCreateParams := &types.DiskCreateParams{
 		Disk: diskCreateParamsDisk,
 	}
+	ctx := context.Background()
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -601,11 +612,11 @@ func (vcd *TestVCD) Test_QueryDisks(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// create second disk with same name
-	task, err = vcd.vdc.CreateDisk(diskCreateParams)
+	task, err = vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -614,12 +625,12 @@ func (vcd *TestVCD) Test_QueryDisks(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	diskRecords, err := vcd.vdc.QueryDisks(name)
+	diskRecords, err := vcd.vdc.QueryDisks(ctx, name)
 
 	check.Assert(err, IsNil)
 	check.Assert(len(*diskRecords), Equals, 2)
@@ -651,8 +662,9 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	diskCreateParams := &types.DiskCreateParams{
 		Disk: diskCreateParamsDisk,
 	}
+	ctx := context.Background()
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -661,31 +673,31 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	err = vcd.vdc.Refresh()
+	err = vcd.vdc.Refresh(ctx)
 	check.Assert(err, IsNil)
-	diskList, err := vcd.vdc.GetDisksByName(diskName, false)
+	diskList, err := vcd.vdc.GetDisksByName(ctx, diskName, false)
 	check.Assert(err, IsNil)
 	check.Assert(diskList, NotNil)
 	check.Assert(len(*diskList), Equals, 1)
 	check.Assert((*diskList)[0].Disk.Name, Equals, diskName)
 	check.Assert((*diskList)[0].Disk.Description, Equals, diskName+"Description")
 
-	disk, err := vcd.vdc.GetDiskById((*diskList)[0].Disk.Id, false)
+	disk, err := vcd.vdc.GetDiskById(ctx, (*diskList)[0].Disk.Id, false)
 	check.Assert(err, IsNil)
 	check.Assert(disk, NotNil)
 	check.Assert(disk.Disk.Name, Equals, diskName)
 	check.Assert(disk.Disk.Description, Equals, diskName+"Description")
 
-	diskList, err = vcd.vdc.GetDisksByName("INVALID", false)
+	diskList, err = vcd.vdc.GetDisksByName(ctx, "INVALID", false)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(diskList, IsNil)
 
 	// test two disk with same name
-	task, err = vcd.vdc.CreateDisk(diskCreateParams)
+	task, err = vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -694,12 +706,12 @@ func (vcd *TestVCD) Test_GetDisks(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	err = vcd.vdc.Refresh()
+	err = vcd.vdc.Refresh(ctx)
 	check.Assert(err, IsNil)
-	diskList, err = vcd.vdc.GetDisksByName(diskName, false)
+	diskList, err = vcd.vdc.GetDisksByName(ctx, diskName, false)
 	check.Assert(err, IsNil)
 	check.Assert(diskList, NotNil)
 	check.Assert(len(*diskList), Equals, 2)
@@ -731,7 +743,8 @@ func (vcd *TestVCD) Test_GetDiskByHref(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	ctx := context.Background()
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -740,17 +753,17 @@ func (vcd *TestVCD) Test_GetDiskByHref(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk, NotNil)
 	check.Assert(disk.Disk.Name, Equals, diskName)
 	check.Assert(disk.Disk.Description, Equals, diskName+"Description")
 
 	invalidDiskHREF := diskHREF + "1"
-	disk, err = vcd.vdc.GetDiskByHref(invalidDiskHREF)
+	disk, err = vcd.vdc.GetDiskByHref(ctx, invalidDiskHREF)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(disk, IsNil)

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -18,11 +18,11 @@ func (vcd *TestVCD) Test_RefreshEdgeGateway(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	copyEdge := edge
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(copyEdge.EdgeGateway.Name, Equals, edge.EdgeGateway.Name)
 	check.Assert(copyEdge.EdgeGateway.HREF, Equals, edge.EdgeGateway.HREF)
@@ -40,20 +40,20 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	task, err := edge.AddNATRule(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
+	task, err := edge.AddNATRule(ctx, orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 	found := false
 	var rule *types.NatRule
@@ -70,9 +70,9 @@ func (vcd *TestVCD) Test_NATMapping(check *C) {
 
 	//task, err = edge.Remove1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp)
 	// Cause Remove1to1Mapping isn't working correctly we will use new function
-	err = edge.RemoveNATRule(rule.ID)
+	err = edge.RemoveNATRule(ctx, rule.ID)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 }
 
@@ -88,20 +88,20 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	task, err := edge.AddNATPortMappingWithUplink(orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
+	task, err := edge.AddNATPortMappingWithUplink(ctx, orgVdcNetwork.OrgVDCNetwork, "DNAT", vcd.config.VCD.ExternalIp, "1177", vcd.config.VCD.InternalIp, "77", "TCP", "")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 	found := false
 	var rule *types.NatRule
@@ -122,10 +122,10 @@ func (vcd *TestVCD) Test_NATPortMapping(check *C) {
 
 	//task, err = edge.Remove1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp)
 	// Cause Remove1to1Mapping isn't working correctly we will use new function
-	err = edge.RemoveNATRule(rule.ID)
+	err = edge.RemoveNATRule(ctx, rule.ID)
 
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 }
 
@@ -137,16 +137,16 @@ func (vcd *TestVCD) Test_1to1Mappings(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edgegatway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	task, err := edge.Create1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "description")
+	task, err := edge.Create1to1Mapping(ctx, vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, "description")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	task, err = edge.Remove1to1Mapping(vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp)
+	task, err = edge.Remove1to1Mapping(ctx, vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 }
 
@@ -157,7 +157,7 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edgegatway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -202,13 +202,13 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	}
 
 	// Configures VPN service
-	task, err := edge.AddIpsecVPN(ipsecVPNConfig)
+	task, err := edge.AddIpsecVPN(ctx, ipsecVPNConfig)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// To check the effects of service configuration, we need to reload the edge gateway entity
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	// We expect an enabled service, and non-null tunnel and endpoint
@@ -224,13 +224,13 @@ func (vcd *TestVCD) Test_AddIpsecVPN(check *C) {
 	// check.Assert(newConfEndpoint, NotNil)
 
 	// Removes VPN service
-	task, err = edge.RemoveIpsecVPN()
+	task, err = edge.RemoveIpsecVPN(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// To check the effects of service configuration, we need to reload the edge gateway entity
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	// We expect a disabled service, and null tunnel and endpoint
@@ -253,10 +253,10 @@ func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 	if vcd.config.VCD.Network.Net1 == "" {
 		check.Skip("Skipping test because no network given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
-	network, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	isRouted := false
 	// If the network is not linked to the edge gateway, we won't check for its name in the network list
@@ -265,7 +265,7 @@ func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 	}
 
 	var networkList []SimpleNetworkIdentifier
-	networkList, err = edge.GetNetworks()
+	networkList, err = edge.GetNetworks(ctx)
 	check.Assert(err, IsNil)
 	foundExternalNetwork := false
 	foundNetwork := false
@@ -301,22 +301,22 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	description1 := "my Description 1"
 	description2 := "my Description 2"
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(ctx, vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
 	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
 
 	beforeChangeNatRulesNumber := len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule)
 
-	natRule, err := edge.AddSNATRule(orgVdcNetwork.OrgVDCNetwork.HREF, vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, description1)
+	natRule, err := edge.AddSNATRule(ctx, orgVdcNetwork.OrgVDCNetwork.HREF, vcd.config.VCD.ExternalIp, vcd.config.VCD.InternalIp, description1)
 	check.Assert(err, IsNil)
 
 	check.Assert(natRule.GatewayNatRule.TranslatedIP, Equals, vcd.config.VCD.InternalIp)
@@ -325,17 +325,17 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "SNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(orgVdcNetwork.OrgVDCNetwork.HREF, "network/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
-	natRule, err = edge.AddSNATRule(externalNetwork.ExternalNetwork.HREF, vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, description2)
+	natRule, err = edge.AddSNATRule(ctx, externalNetwork.ExternalNetwork.HREF, vcd.config.VCD.InternalIp, vcd.config.VCD.ExternalIp, description2)
 	check.Assert(err, IsNil)
 
 	check.Assert(natRule.GatewayNatRule.TranslatedIP, Equals, vcd.config.VCD.ExternalIp)
@@ -344,11 +344,11 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "SNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(externalNetwork.ExternalNetwork.HREF, "externalnet/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
@@ -369,15 +369,15 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(ctx, vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
 	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
@@ -387,7 +387,7 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	description1 := "my Dnat Description 1"
 	description2 := "my Dnatt Description 2"
 
-	natRule, err := edge.AddDNATRule(NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
+	natRule, err := edge.AddDNATRule(ctx, NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
 		ExternalPort: "1177", InternalIP: vcd.config.VCD.InternalIp, InternalPort: "77", Protocol: "TCP", Description: description1})
 	check.Assert(err, IsNil)
 
@@ -401,17 +401,17 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "DNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(orgVdcNetwork.OrgVDCNetwork.HREF, "network/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
-	natRule, err = edge.AddDNATRule(NatRule{NetworkHref: externalNetwork.ExternalNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
+	natRule, err = edge.AddDNATRule(ctx, NatRule{NetworkHref: externalNetwork.ExternalNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
 		ExternalPort: "1188", InternalIP: vcd.config.VCD.InternalIp, InternalPort: "88", Protocol: "TCP", Description: description2})
 	check.Assert(err, IsNil)
 
@@ -425,11 +425,11 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "DNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(externalNetwork.ExternalNetwork.HREF, "externalnet/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
@@ -449,15 +449,15 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 		check.Skip("Skipping test because no network was given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net1, false)
+	orgVdcNetwork, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net1, false)
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork.OrgVDCNetwork.Name, Equals, vcd.config.VCD.Network.Net1)
 
-	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(ctx, vcd.config.VCD.ExternalNetwork)
 	check.Assert(err, IsNil)
 	check.Assert(externalNetwork, NotNil)
 	check.Assert(externalNetwork.ExternalNetwork.Name, Equals, vcd.config.VCD.ExternalNetwork)
@@ -467,7 +467,7 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	description1 := "my Dnat Description 1"
 	description2 := "my Dnatt Description 2"
 
-	natRule, err := edge.AddDNATRule(NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
+	natRule, err := edge.AddDNATRule(ctx, NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
 		ExternalPort: "1177", InternalIP: vcd.config.VCD.InternalIp, InternalPort: "77", Protocol: "TCP", Description: description1})
 	check.Assert(err, IsNil)
 
@@ -481,17 +481,17 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "DNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(orgVdcNetwork.OrgVDCNetwork.HREF, "network/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
 
 	// check with external network
-	natRule, err = edge.AddDNATRule(NatRule{NetworkHref: externalNetwork.ExternalNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
+	natRule, err = edge.AddDNATRule(ctx, NatRule{NetworkHref: externalNetwork.ExternalNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
 		ExternalPort: "1188", InternalIP: vcd.config.VCD.InternalIp, InternalPort: "88", Protocol: "TCP", Description: description2})
 	check.Assert(err, IsNil)
 
@@ -505,11 +505,11 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	check.Assert(natRule.RuleType, Equals, "DNAT")
 	check.Assert(strings.Split(natRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(externalNetwork.ExternalNetwork.HREF, "externalnet/")[1])
 
-	err = edge.RemoveNATRule(natRule.ID)
+	err = edge.RemoveNATRule(ctx, natRule.ID)
 	check.Assert(err, IsNil)
 
 	// update test
-	natRule, err = edge.AddDNATRule(NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
+	natRule, err = edge.AddDNATRule(ctx, NatRule{NetworkHref: orgVdcNetwork.OrgVDCNetwork.HREF, ExternalIP: vcd.config.VCD.ExternalIp,
 		ExternalPort: "1177", InternalIP: vcd.config.VCD.InternalIp, InternalPort: "77", Protocol: "TCP", Description: description1})
 	check.Assert(err, IsNil)
 
@@ -519,7 +519,7 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	natRule.Description = description2
 	natRule.GatewayNatRule.Interface.HREF = externalNetwork.ExternalNetwork.HREF
 
-	updateNatRule, err := edge.UpdateNatRule(natRule)
+	updateNatRule, err := edge.UpdateNatRule(ctx, natRule)
 
 	check.Assert(err, IsNil)
 	check.Assert(updateNatRule.GatewayNatRule.TranslatedIP, Equals, vcd.config.VCD.InternalIp)
@@ -532,11 +532,11 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 	check.Assert(updateNatRule.RuleType, Equals, "DNAT")
 	check.Assert(strings.Split(updateNatRule.GatewayNatRule.Interface.HREF, "network/")[1], Equals, strings.Split(externalNetwork.ExternalNetwork.HREF, "externalnet/")[1])
 
-	err = edge.RemoveNATRule(updateNatRule.ID)
+	err = edge.RemoveNATRule(ctx, updateNatRule.ID)
 	check.Assert(err, IsNil)
 
 	// verify delete
-	err = edge.Refresh()
+	err = edge.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(len(edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.NatService.NatRule), Equals, beforeChangeNatRulesNumber)
@@ -554,7 +554,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 
 	if !edge.HasAdvancedNetworking() {
@@ -562,25 +562,25 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
 	}
 
 	// Cache current load balancer settings for change validation in the end
-	beforeLb, beforeLbXml := testCacheLoadBalancer(*edge, check)
+	beforeLb, beforeLbXml := testCacheLoadBalancer(ctx, *edge, check)
 
-	_, err = edge.UpdateLBGeneralParams(true, true, true, "critical")
+	_, err = edge.UpdateLBGeneralParams(ctx, true, true, true, "critical")
 	check.Assert(err, IsNil)
 
-	_, err = edge.UpdateLBGeneralParams(false, false, false, "emergency")
+	_, err = edge.UpdateLBGeneralParams(ctx, false, false, false, "emergency")
 	check.Assert(err, IsNil)
 
 	// Try to set invalid loglevel to get validation error
-	_, err = edge.UpdateLBGeneralParams(false, false, false, "invalid_loglevel")
+	_, err = edge.UpdateLBGeneralParams(ctx, false, false, false, "invalid_loglevel")
 	check.Assert(err, ErrorMatches, ".*Valid log levels are.*")
 
 	// Restore to initial settings and validate that it
-	_, err = edge.UpdateLBGeneralParams(beforeLb.Enabled, beforeLb.AccelerationEnabled,
+	_, err = edge.UpdateLBGeneralParams(ctx, beforeLb.Enabled, beforeLb.AccelerationEnabled,
 		beforeLb.Logging.Enable, beforeLb.Logging.LogLevel)
 	check.Assert(err, IsNil)
 
 	// Validate load balancer configuration against initially cached version
-	testCheckLoadBalancerConfig(beforeLb, beforeLbXml, *edge, check)
+	testCheckLoadBalancerConfig(ctx, beforeLb, beforeLbXml, *edge, check)
 }
 
 // TestEdgeGateway_UpdateFwGeneralParams main point is to test that no firewall configuration
@@ -595,7 +595,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateFwGeneralParams(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 
 	if !edge.HasAdvancedNetworking() {
@@ -605,18 +605,18 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateFwGeneralParams(check *C) {
 	// Cache current firewall settings for change validation in the end
 	beforeFw, beforeFwXml := testCacheFirewall(*edge, check)
 
-	_, err = edge.UpdateFirewallConfig(false, false, "deny")
+	_, err = edge.UpdateFirewallConfig(ctx, false, false, "deny")
 	check.Assert(err, IsNil)
 
-	_, err = edge.UpdateFirewallConfig(true, true, "accept")
+	_, err = edge.UpdateFirewallConfig(ctx, true, true, "accept")
 	check.Assert(err, IsNil)
 
 	// Try to set invalid loglevel to get validation error
-	_, err = edge.UpdateFirewallConfig(false, false, "invalid_action")
+	_, err = edge.UpdateFirewallConfig(ctx, false, false, "invalid_action")
 	check.Assert(err, ErrorMatches, ".*default action must be either 'accept' or 'deny'.*")
 
 	// Restore to initial settings and validate that it
-	_, err = edge.UpdateFirewallConfig(beforeFw.Enabled, beforeFw.DefaultPolicy.LoggingEnabled, beforeFw.DefaultPolicy.Action)
+	_, err = edge.UpdateFirewallConfig(ctx, beforeFw.Enabled, beforeFw.DefaultPolicy.LoggingEnabled, beforeFw.DefaultPolicy.Action)
 	check.Assert(err, IsNil)
 
 	// Validate configuration against initially cached version
@@ -627,14 +627,14 @@ func (vcd *TestVCD) TestEdgeGateway_GetVdcNetworks(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.FindEdgeGateway(vcd.config.VCD.EdgeGateway)
+	edge, err := vcd.vdc.FindEdgeGateway(ctx, vcd.config.VCD.EdgeGateway)
 	check.Assert(err, IsNil)
 
 	if !edge.HasAdvancedNetworking() {
 		check.Skip("Skipping test because the edge gateway does not have advanced networking enabled")
 	}
 
-	vnics, err := edge.getVdcNetworks()
+	vnics, err := edge.getVdcNetworks(ctx)
 	check.Assert(err, IsNil)
 
 	foundExtNet := false
@@ -663,19 +663,19 @@ func (vcd *TestVCD) TestEdgeGateway_GetVdcNetworks(check *C) {
 // testCacheFirewall is meant to store firewall settings before any operations so that all
 // configuration can be checked after manipulation
 func testCacheFirewall(edge EdgeGateway, check *C) (*types.FirewallConfigWithXml, string) {
-	beforeFw, err := edge.GetFirewallConfig()
+	beforeFw, err := edge.GetFirewallConfig(ctx)
 	check.Assert(err, IsNil)
-	beforeFwbXml := testGetEdgeEndpointXML(types.EdgeFirewallPath, edge, check)
+	beforeFwbXml := testGetEdgeEndpointXML(ctx, types.EdgeFirewallPath, edge, check)
 	return beforeFw, beforeFwbXml
 }
 
 // testCheckFirewallConfig validates if both raw XML string and firewall struct remain
 // identical after settings manipulation.
 func testCheckFirewallConfig(beforeFw *types.FirewallConfigWithXml, beforeFwXml string, edge EdgeGateway, check *C) {
-	afterFw, err := edge.GetFirewallConfig()
+	afterFw, err := edge.GetFirewallConfig(ctx)
 	check.Assert(err, IsNil)
 
-	afterFwXml := testGetEdgeEndpointXML(types.EdgeFirewallPath, edge, check)
+	afterFwXml := testGetEdgeEndpointXML(ctx, types.EdgeFirewallPath, edge, check)
 
 	// remove `<version></version>` tag from both XML represntation and struct for deep comparison
 	// because this version changes with each update and will never be the same after a few
@@ -723,10 +723,10 @@ func (vcd *TestVCD) TestListEdgeGateway(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge, NotNil)
-	edgeRec, err := vcd.vdc.GetEdgeGatewayRecordsType(false)
+	edgeRec, err := vcd.vdc.GetEdgeGatewayRecordsType(ctx, false)
 	check.Assert(err, IsNil)
 	check.Assert(edgeRec, NotNil)
 	check.Assert(len(edgeRec.EdgeGatewayRecord) > 0, Equals, true)
@@ -748,7 +748,7 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 	var saveEGW = types.EdgeGateway{
@@ -768,7 +768,7 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	edge.EdgeGateway.Name = newName
 	edge.EdgeGateway.Description = newDescription
 
-	err = edge.Update()
+	err = edge.Update(ctx)
 	check.Assert(err, IsNil)
 
 	// The edge gateway should be updated in place
@@ -777,7 +777,7 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	check.Assert(edge.EdgeGateway.Description, Equals, newDescription)
 
 	// Check that a new copy of the edge gateway contains the expected data
-	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
+	edge, err = vcd.vdc.GetEdgeGatewayById(ctx, saveEGW.ID, true)
 	check.Assert(err, IsNil)
 
 	check.Assert(edge.EdgeGateway.HREF, Equals, saveEGW.HREF)
@@ -787,7 +787,7 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	edge.EdgeGateway.Name = saveEGW.Name
 	edge.EdgeGateway.Description = saveEGW.Description
 
-	err = edge.Update()
+	err = edge.Update(ctx)
 	check.Assert(err, IsNil)
 
 	// checking the in-place values
@@ -796,7 +796,7 @@ func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
 	check.Assert(saveEGW.HREF, Equals, edge.EdgeGateway.HREF)
 
 	// Checking values in a fresh copy of the edge gateway
-	edge, err = vcd.vdc.GetEdgeGatewayById(saveEGW.ID, true)
+	edge, err = vcd.vdc.GetEdgeGatewayById(ctx, saveEGW.ID, true)
 	check.Assert(err, IsNil)
 
 	check.Assert(saveEGW.Name, Equals, edge.EdgeGateway.Name)

--- a/govcd/extension.go
+++ b/govcd/extension.go
@@ -5,20 +5,21 @@
 package govcd
 
 import (
+	"context"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"net/http"
 )
 
 // Deprecated: please use GetExternalNetwork function instead
-func GetExternalNetworkByName(vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
+func GetExternalNetworkByName(ctx context.Context, vcdClient *VCDClient, networkName string) (*types.ExternalNetworkReference, error) {
 	extNetworkRefs := &types.ExternalNetworkReferences{}
 
-	extNetworkHREF, err := getExternalNetworkHref(&vcdClient.Client)
+	extNetworkHREF, err := getExternalNetworkHref(ctx, &vcdClient.Client)
 	if err != nil {
 		return &types.ExternalNetworkReference{}, err
 	}
 
-	_, err = vcdClient.Client.ExecuteRequest(extNetworkHREF, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, extNetworkHREF, http.MethodGet,
 		"", "error retrieving external networks: %s", nil, extNetworkRefs)
 	if err != nil {
 		return &types.ExternalNetworkReference{}, err

--- a/govcd/external_network_v2.go
+++ b/govcd/external_network_v2.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -21,9 +22,9 @@ type ExternalNetworkV2 struct {
 // CreateExternalNetworkV2 creates a new external network using OpenAPI endpoint. It can create
 // NSX-V and NSX-T backed networks based on what ExternalNetworkV2.NetworkBackings is
 // provided. types.ExternalNetworkV2 has documented fields.
-func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetworkV2) (*ExternalNetworkV2, error) {
+func CreateExternalNetworkV2(ctx context.Context, vcdClient *VCDClient, newExtNet *types.ExternalNetworkV2) (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +39,7 @@ func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetw
 		client:          &vcdClient.Client,
 	}
 
-	err = vcdClient.Client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newExtNet, returnExtNet.ExternalNetwork)
+	err = vcdClient.Client.OpenApiPostItem(ctx, minimumApiVersion, urlRef, nil, newExtNet, returnExtNet.ExternalNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("error creating external network: %s", err)
 	}
@@ -47,9 +48,9 @@ func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetw
 }
 
 // GetExternalNetworkV2ById retrieves external network by given ID using OpenAPI endpoint
-func GetExternalNetworkV2ById(vcdClient *VCDClient, id string) (*ExternalNetworkV2, error) {
+func GetExternalNetworkV2ById(ctx context.Context, vcdClient *VCDClient, id string) (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +69,7 @@ func GetExternalNetworkV2ById(vcdClient *VCDClient, id string) (*ExternalNetwork
 		client:          &vcdClient.Client,
 	}
 
-	err = vcdClient.Client.OpenApiGetItem(minimumApiVersion, urlRef, nil, extNet.ExternalNetwork)
+	err = vcdClient.Client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, nil, extNet.ExternalNetwork)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +79,7 @@ func GetExternalNetworkV2ById(vcdClient *VCDClient, id string) (*ExternalNetwork
 
 // GetExternalNetworkV2ByName retrieves external network by given name using OpenAPI endpoint.
 // Returns an error if not exactly one network is found.
-func GetExternalNetworkV2ByName(vcdClient *VCDClient, name string) (*ExternalNetworkV2, error) {
+func GetExternalNetworkV2ByName(ctx context.Context, vcdClient *VCDClient, name string) (*ExternalNetworkV2, error) {
 
 	if name == "" {
 		return nil, fmt.Errorf("name cannot be empty")
@@ -87,7 +88,7 @@ func GetExternalNetworkV2ByName(vcdClient *VCDClient, name string) (*ExternalNet
 	queryParams := url.Values{}
 	queryParams.Add("filter", "name=="+name)
 
-	res, err := GetAllExternalNetworksV2(vcdClient, queryParams)
+	res, err := GetAllExternalNetworksV2(ctx, vcdClient, queryParams)
 	if err != nil {
 		return nil, fmt.Errorf("could not find external network by name: %s", err)
 	}
@@ -105,9 +106,9 @@ func GetExternalNetworkV2ByName(vcdClient *VCDClient, name string) (*ExternalNet
 
 // GetAllExternalNetworksV2 retrieves all external networks using OpenAPI endpoint. Query parameters can be supplied to
 // perform additional filtering
-func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) ([]*ExternalNetworkV2, error) {
+func GetAllExternalNetworksV2(ctx context.Context, vcdClient *VCDClient, queryParameters url.Values) ([]*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) 
 	}
 
 	typeResponses := []*types.ExternalNetworkV2{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &typeResponses)
+	err = vcdClient.Client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &typeResponses)
 	if err != nil {
 		return nil, err
 	}
@@ -136,9 +137,9 @@ func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) 
 }
 
 // Update updates existing external network using OpenAPI endpoint
-func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
+func (extNet *ExternalNetworkV2) Update(ctx context.Context) (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
 		client:          extNet.client,
 	}
 
-	err = extNet.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, extNet.ExternalNetwork, returnExtNet.ExternalNetwork)
+	err = extNet.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, extNet.ExternalNetwork, returnExtNet.ExternalNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("error updating external network: %s", err)
 	}
@@ -166,9 +167,9 @@ func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
 }
 
 // Delete deletes external network using OpenAPI endpoint
-func (extNet *ExternalNetworkV2) Delete() error {
+func (extNet *ExternalNetworkV2) Delete(ctx context.Context) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -182,7 +183,7 @@ func (extNet *ExternalNetworkV2) Delete() error {
 		return err
 	}
 
-	err = extNet.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = extNet.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting extNet: %s", err)

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -23,7 +23,7 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2NsxtVrf(check *C) {
 	// backing type to be specified
 	// As of 10.1.2 release it is not officially supported (support only introduced in 10.2.0) therefore skipping this test for
 	// 10.1.X. 10.1.1 allowed to create it, but 10.1.2 introduced a validator and throws error.
-	if vcd.client.Client.APIVCDMaxVersionIs("< 35") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 35") {
 		check.Skip("NSX-T VRF-Lite backed external networks are officially supported only in 10.2.0+")
 	}
 	vcd.testCreateExternalNetworkV2Nsxt(check, vcd.config.VCD.Nsxt.Tier0routerVrf, types.ExternalNetworkBackingTypeNsxtTier0Router)
@@ -31,23 +31,23 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2NsxtVrf(check *C) {
 
 func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, backingType string) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	skipOpenApiEndpointTest(vcd, check, endpoint)
+	skipOpenApiEndpointTest(ctx, vcd, check, endpoint)
 	skipNoNsxtConfiguration(vcd, check)
 
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	// NSX-T details
-	man, err := vcd.client.QueryNsxtManagerByName(vcd.config.VCD.Nsxt.Manager)
+	man, err := vcd.client.QueryNsxtManagerByName(ctx, vcd.config.VCD.Nsxt.Manager)
 	check.Assert(err, IsNil)
 	nsxtManagerId, err := BuildUrnWithUuid("urn:vcloud:nsxtmanager:", extractUuid(man[0].HREF))
 	check.Assert(err, IsNil)
 
-	tier0RouterVrf, err := vcd.client.GetImportableNsxtTier0RouterByName(nsxtTier0Router, nsxtManagerId)
+	tier0RouterVrf, err := vcd.client.GetImportableNsxtTier0RouterByName(ctx, nsxtTier0Router, nsxtManagerId)
 	check.Assert(err, IsNil)
 
 	// Create network and test CRUD capabilities
 	netNsxt := testExternalNetworkV2(check.TestName(), backingType, tier0RouterVrf.NsxtTier0Router.ID, nsxtManagerId)
-	createdNet, err := CreateExternalNetworkV2(vcd.client, netNsxt)
+	createdNet, err := CreateExternalNetworkV2(ctx, vcd.client, netNsxt)
 	check.Assert(err, IsNil)
 
 	// Use generic "OpenApiEntity" resource cleanup type
@@ -55,19 +55,19 @@ func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, b
 	AddToCleanupListOpenApi(createdNet.ExternalNetwork.Name, check.TestName(), openApiEndpoint)
 
 	createdNet.ExternalNetwork.Name = check.TestName() + "changed_name"
-	updatedNet, err := createdNet.Update()
+	updatedNet, err := createdNet.Update(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(updatedNet.ExternalNetwork.Name, Equals, createdNet.ExternalNetwork.Name)
 
-	read1, err := GetExternalNetworkV2ById(vcd.client, createdNet.ExternalNetwork.ID)
+	read1, err := GetExternalNetworkV2ById(ctx, vcd.client, createdNet.ExternalNetwork.ID)
 	check.Assert(err, IsNil)
 	check.Assert(createdNet.ExternalNetwork.ID, Equals, read1.ExternalNetwork.ID)
 
-	byName, err := GetExternalNetworkV2ByName(vcd.client, read1.ExternalNetwork.Name)
+	byName, err := GetExternalNetworkV2ByName(ctx, vcd.client, read1.ExternalNetwork.Name)
 	check.Assert(err, IsNil)
 	check.Assert(createdNet.ExternalNetwork.ID, Equals, byName.ExternalNetwork.ID)
 
-	readAllNetworks, err := GetAllExternalNetworksV2(vcd.client, nil)
+	readAllNetworks, err := GetAllExternalNetworksV2(ctx, vcd.client, nil)
 	check.Assert(err, IsNil)
 	var foundNetwork bool
 	for i := range readAllNetworks {
@@ -78,16 +78,16 @@ func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, b
 	}
 	check.Assert(foundNetwork, Equals, true)
 
-	err = createdNet.Delete()
+	err = createdNet.Delete(ctx)
 	check.Assert(err, IsNil)
 
-	_, err = GetExternalNetworkV2ById(vcd.client, createdNet.ExternalNetwork.ID)
+	_, err = GetExternalNetworkV2ById(ctx, vcd.client, createdNet.ExternalNetwork.ID)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
 func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	skipOpenApiEndpointTest(vcd, check, endpoint)
+	skipOpenApiEndpointTest(ctx, vcd, check, endpoint)
 
 	fmt.Printf("Running: %s\n", check.TestName())
 
@@ -96,9 +96,9 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 
 	switch vcd.config.VCD.ExternalNetworkPortGroupType {
 	case types.ExternalNetworkBackingDvPortgroup:
-		pgs, err = QueryDistributedPortGroup(vcd.client, vcd.config.VCD.ExternalNetworkPortGroup)
+		pgs, err = QueryDistributedPortGroup(ctx, vcd.client, vcd.config.VCD.ExternalNetworkPortGroup)
 	case types.ExternalNetworkBackingTypeNetwork:
-		pgs, err = QueryNetworkPortGroup(vcd.client, vcd.config.VCD.ExternalNetworkPortGroup)
+		pgs, err = QueryNetworkPortGroup(ctx, vcd.client, vcd.config.VCD.ExternalNetworkPortGroup)
 	default:
 		check.Errorf("unrecognized external network portgroup type: %s", vcd.config.VCD.ExternalNetworkPortGroupType)
 	}
@@ -115,7 +115,7 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 
 	neT := testExternalNetworkV2(check.TestName(), vcd.config.VCD.ExternalNetworkPortGroupType, pgs[0].MoRef, vcUrn)
 
-	r, err := CreateExternalNetworkV2(vcd.client, neT)
+	r, err := CreateExternalNetworkV2(ctx, vcd.client, neT)
 	check.Assert(err, IsNil)
 
 	// Use generic "OpenApiEntity" resource cleanup type
@@ -123,11 +123,11 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 	AddToCleanupListOpenApi(r.ExternalNetwork.Name, check.TestName(), openApiEndpoint)
 
 	r.ExternalNetwork.Name = check.TestName() + "changed_name"
-	updatedNet, err := r.Update()
+	updatedNet, err := r.Update(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(updatedNet.ExternalNetwork.Name, Equals, r.ExternalNetwork.Name)
 
-	err = r.Delete()
+	err = r.Delete(ctx)
 	check.Assert(err, IsNil)
 }
 
@@ -171,7 +171,7 @@ func testExternalNetworkV2(name, backingType, backingId, NetworkProviderId strin
 }
 
 func getVcenterHref(vcdClient *VCDClient, name string) (string, error) {
-	virtualCenters, err := QueryVirtualCenters(vcdClient, fmt.Sprintf("(name==%s)", name))
+	virtualCenters, err := QueryVirtualCenters(ctx, vcdClient, fmt.Sprintf("(name==%s)", name))
 	if err != nil {
 		return "", err
 	}

--- a/govcd/filter_engine_test.go
+++ b/govcd/filter_engine_test.go
@@ -19,10 +19,10 @@ func (vcd *TestVCD) Test_SearchSpecificVappTemplate(check *C) {
 		check.Skip("no catalog provided. Skipping test")
 	}
 	// Fetching organization and catalog
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	client := catalog.client
 
@@ -36,7 +36,7 @@ func (vcd *TestVCD) Test_SearchSpecificVappTemplate(check *C) {
 	}
 
 	// Upload several vApp templates (will skip if they already exist)
-	data, err := HelperCreateMultipleCatalogItems(catalog, requestData, testVerbose)
+	data, err := HelperCreateMultipleCatalogItems(ctx, catalog, requestData, testVerbose)
 	check.Assert(err, IsNil)
 	check.Assert(len(data), Equals, len(requestData))
 	for _, item := range data {
@@ -65,7 +65,7 @@ func (vcd *TestVCD) Test_SearchSpecificVappTemplate(check *C) {
 		var criteria = NewFilterDef()
 		err = criteria.AddMetadataFilter(tc.key, tc.value, "", false, false)
 		check.Assert(err, IsNil)
-		queryItems, _, err := catalog.SearchByFilter(queryType, "catalogName", criteria)
+		queryItems, _, err := catalog.SearchByFilter(ctx, queryType, "catalogName", criteria)
 		check.Assert(err, IsNil)
 		printVerbose("\n%d, %#v\n", n, tc)
 		for i, item := range queryItems {
@@ -90,9 +90,9 @@ func (vcd *TestVCD) Test_SearchSpecificVappTemplate(check *C) {
 			continue
 		}
 
-		catalogItem, err := catalog.GetCatalogItemByName(item.Name, true)
+		catalogItem, err := catalog.GetCatalogItemByName(ctx, item.Name, true)
 		check.Assert(err, IsNil)
-		err = catalogItem.Delete()
+		err = catalogItem.Delete(ctx)
 		check.Assert(err, IsNil)
 		printVerbose("deleted %s\n", item.Name)
 	}
@@ -103,16 +103,16 @@ func (vcd *TestVCD) Test_SearchVappTemplate(check *C) {
 		check.Skip("no catalog provided. Skipping test")
 	}
 	// Fetching organization and catalog
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	client := catalog.client
 
 	queryType := client.GetQueryType(types.QtVappTemplate)
 	// Test with any vApp templates, using mass produced filters
-	filters, err := HelperMakeFiltersFromVappTemplate(catalog)
+	filters, err := HelperMakeFiltersFromVappTemplate(ctx, catalog)
 	check.Assert(err, IsNil)
 	for _, fm := range filters {
 		// Tests both the search by metadata through the query and the search offline after fetching the items
@@ -123,7 +123,7 @@ func (vcd *TestVCD) Test_SearchVappTemplate(check *C) {
 			}
 			fm.Criteria.UseMetadataApiFilter = useApiSearch
 			printVerbose("Use metadata API filter: %v\n", useApiSearch)
-			queryItems, explanation, err := catalog.SearchByFilter(queryType, "catalogName", fm.Criteria)
+			queryItems, explanation, err := catalog.SearchByFilter(ctx, queryType, "catalogName", fm.Criteria)
 			check.Assert(err, IsNil)
 
 			convertedMatch, okMatch := fm.Entity.(QueryVAppTemplate)
@@ -146,19 +146,19 @@ func (vcd *TestVCD) Test_SearchCatalogItem(check *C) {
 		check.Skip("no catalog provided. Skipping test")
 	}
 	// Fetching organization and catalog
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	client := catalog.client
 
 	queryType := client.GetQueryType(types.QtCatalogItem)
 	// Test with any catalog items, using mass produced filters
-	filters, err := HelperMakeFiltersFromCatalogItem(catalog)
+	filters, err := HelperMakeFiltersFromCatalogItem(ctx, catalog)
 	check.Assert(err, IsNil)
 	for _, fm := range filters {
-		queryItems, explanation, err := catalog.SearchByFilter(queryType, "catalog", fm.Criteria)
+		queryItems, explanation, err := catalog.SearchByFilter(ctx, queryType, "catalog", fm.Criteria)
 		check.Assert(err, IsNil)
 
 		convertedMatch, okMatch := fm.Entity.(QueryCatalogItem)
@@ -180,20 +180,20 @@ func (vcd *TestVCD) Test_SearchNetwork(check *C) {
 	}
 	client := vcd.client
 	// Fetching organization and VDC
-	org, err := client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := org.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 
 	// Get existing networks, and create sample filters to retrieve them
-	filters, err := HelperMakeFiltersFromNetworks(vdc)
+	filters, err := HelperMakeFiltersFromNetworks(ctx, vdc)
 	check.Assert(err, IsNil)
 	check.Assert(filters, NotNil)
 
 	for _, fm := range filters {
-		queryItems, explanation, err := vdc.SearchByFilter(types.QtOrgVdcNetwork, "vdc", fm.Criteria)
+		queryItems, explanation, err := vdc.SearchByFilter(ctx, types.QtOrgVdcNetwork, "vdc", fm.Criteria)
 		check.Assert(err, IsNil)
 		printVerbose("%s\n", explanation)
 		check.Assert(len(queryItems), Equals, 1)
@@ -203,7 +203,7 @@ func (vcd *TestVCD) Test_SearchNetwork(check *C) {
 		if len(fm.Criteria.Metadata) > 0 {
 			// Search with Metadata API
 			fm.Criteria.UseMetadataApiFilter = true
-			queryItems, explanation, err = vdc.SearchByFilter(types.QtOrgVdcNetwork, "vdc", fm.Criteria)
+			queryItems, explanation, err = vdc.SearchByFilter(ctx, types.QtOrgVdcNetwork, "vdc", fm.Criteria)
 			check.Assert(err, IsNil)
 			check.Assert(len(queryItems), Equals, 1)
 			check.Assert(queryItems[0].GetName(), Equals, fm.ExpectedName)
@@ -222,20 +222,20 @@ func (vcd *TestVCD) Test_SearchEdgeGateway(check *C) {
 	}
 	client := vcd.client
 	// Fetching organization and VDC
-	org, err := client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := org.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 
 	// Get existing edge gateways, and create sample filters to retrieve them
-	filters, err := HelperMakeFiltersFromEdgeGateways(vdc)
+	filters, err := HelperMakeFiltersFromEdgeGateways(ctx, vdc)
 	check.Assert(err, IsNil)
 	check.Assert(filters, NotNil)
 
 	for _, fm := range filters {
-		queryItems, explanation, err := vdc.SearchByFilter(types.QtEdgeGateway, "vdc", fm.Criteria)
+		queryItems, explanation, err := vdc.SearchByFilter(ctx, types.QtEdgeGateway, "vdc", fm.Criteria)
 		check.Assert(err, IsNil)
 		printVerbose("%s\n", explanation)
 		check.Assert(len(queryItems), Equals, 1)
@@ -252,18 +252,18 @@ func (vcd *TestVCD) Test_SearchCatalog(check *C) {
 	}
 	client := vcd.client
 	// Fetching organization
-	org, err := client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
 	// Get existing catalogs, and create sample filters to retrieve them
-	filters, err := HelperMakeFiltersFromCatalogs(org)
+	filters, err := HelperMakeFiltersFromCatalogs(ctx, org)
 	check.Assert(err, IsNil)
 	check.Assert(filters, NotNil)
 
 	queryType := client.Client.GetQueryType(types.QtCatalog)
 	for _, fm := range filters {
-		queryItems, explanation, err := org.SearchByFilter(queryType, fm.Criteria)
+		queryItems, explanation, err := org.SearchByFilter(ctx, queryType, fm.Criteria)
 		check.Assert(err, IsNil)
 		check.Assert(len(queryItems), Equals, 1)
 		printVerbose("%s\n", explanation)
@@ -280,26 +280,26 @@ func (vcd *TestVCD) Test_SearchMediaItem(check *C) {
 	}
 	client := vcd.client
 	// Fetching organization and VDC
-	org, err := client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := org.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
 	// Get existing media, and create sample filters to retrieve them
-	filters, err := HelperMakeFiltersFromMedia(vdc, catalog.Catalog.Name)
+	filters, err := HelperMakeFiltersFromMedia(ctx, vdc, catalog.Catalog.Name)
 	check.Assert(err, IsNil)
 	check.Assert(filters, NotNil)
 
 	queryType := client.Client.GetQueryType(types.QtMedia)
 
 	for _, fm := range filters {
-		queryItems, explanation, err := catalog.SearchByFilter(queryType, "catalog", fm.Criteria)
+		queryItems, explanation, err := catalog.SearchByFilter(ctx, queryType, "catalog", fm.Criteria)
 		check.Assert(err, IsNil)
 		printVerbose("%s\n", explanation)
 		check.Assert(len(queryItems), Equals, 1)

--- a/govcd/filter_engine_unit_test.go
+++ b/govcd/filter_engine_unit_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -27,13 +28,13 @@ type TestItem struct {
 }
 
 // mock queryWithMetadataFields function that returns an empty result
-var dummyQwithM = func(queryType string, params, notEncodedParams map[string]string,
+var dummyQwithM = func(ctx context.Context, queryType string, params, notEncodedParams map[string]string,
 	metadataFields []string, isSystem bool) (Results, error) {
 	return Results{}, nil
 }
 
 // mock QueryByMetadataFields function that returns an empty result
-var dummyQbyM = func(queryType string, params, notEncodedParams map[string]string,
+var dummyQbyM = func(ctx context.Context, queryType string, params, notEncodedParams map[string]string,
 	metadataFilters map[string]MetadataFilter, isSystem bool) (Results, error) {
 	return Results{}, nil
 }
@@ -441,7 +442,7 @@ func Test_searchByFilter(t *testing.T) {
 	}
 	for _, tt := range testsSuccess {
 		t.Run(tt.name, func(t *testing.T) {
-			got, explanation, err := searchByFilter(tt.args.qByM, tt.args.qWithM, tt.args.converter, tt.args.queryType, tt.args.criteria)
+			got, explanation, err := searchByFilter(ctx, tt.args.qByM, tt.args.qWithM, tt.args.converter, tt.args.queryType, tt.args.criteria)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("searchByFilter() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -454,7 +455,7 @@ func Test_searchByFilter(t *testing.T) {
 	}
 	for _, tt := range testsFailure {
 		t.Run(tt.name, func(t *testing.T) {
-			got, explanation, err := searchByFilter(tt.args.qByM, tt.args.qWithM, tt.args.converter, tt.args.queryType, tt.args.criteria)
+			got, explanation, err := searchByFilter(ctx, tt.args.qByM, tt.args.qWithM, tt.args.converter, tt.args.queryType, tt.args.criteria)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("searchByFilter() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/govcd/filter_helpers.go
+++ b/govcd/filter_helpers.go
@@ -61,8 +61,8 @@ var retrievedMetadataTypes = map[string]string{
 }
 
 // HelperMakeFiltersFromEdgeGateways looks at the existing edge gateways and creates a set of criteria to retrieve each of them
-func HelperMakeFiltersFromEdgeGateways(vdc *Vdc) ([]FilterMatch, error) {
-	egwResult, err := vdc.GetEdgeGatewayRecordsType(false)
+func HelperMakeFiltersFromEdgeGateways(ctx context.Context, vdc *Vdc) ([]FilterMatch, error) {
+	egwResult, err := vdc.GetEdgeGatewayRecordsType(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func makeDateFilter(items []DateItem) ([]FilterMatch, error) {
 }
 
 func HelperMakeFiltersFromCatalogs(ctx context.Context, org *AdminOrg) ([]FilterMatch, error) {
-	catalogs, err := org.QueryCatalogList()
+	catalogs, err := org.QueryCatalogList(ctx)
 	if err != nil {
 		return []FilterMatch{}, err
 	}

--- a/govcd/filter_helpers.go
+++ b/govcd/filter_helpers.go
@@ -5,6 +5,7 @@ package govcd
  */
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -83,8 +84,8 @@ func HelperMakeFiltersFromEdgeGateways(vdc *Vdc) ([]FilterMatch, error) {
 }
 
 // HelperMakeFiltersFromNetworks looks at the existing networks and creates a set of criteria to retrieve each of them
-func HelperMakeFiltersFromNetworks(vdc *Vdc) ([]FilterMatch, error) {
-	netList, err := vdc.GetNetworkList()
+func HelperMakeFiltersFromNetworks(ctx context.Context, vdc *Vdc) ([]FilterMatch, error) {
+	netList, err := vdc.GetNetworkList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func HelperMakeFiltersFromNetworks(vdc *Vdc) ([]FilterMatch, error) {
 			return nil, err
 		}
 
-		filter, err = vdc.client.metadataToFilter(net.HREF, filter)
+		filter, err = vdc.client.metadataToFilter(ctx, net.HREF, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +173,7 @@ func makeDateFilter(items []DateItem) ([]FilterMatch, error) {
 	return filters, nil
 }
 
-func HelperMakeFiltersFromCatalogs(org *AdminOrg) ([]FilterMatch, error) {
+func HelperMakeFiltersFromCatalogs(ctx context.Context, org *AdminOrg) ([]FilterMatch, error) {
 	catalogs, err := org.QueryCatalogList()
 	if err != nil {
 		return []FilterMatch{}, err
@@ -191,7 +192,7 @@ func HelperMakeFiltersFromCatalogs(org *AdminOrg) ([]FilterMatch, error) {
 
 		dateInfo = append(dateInfo, dInfo...)
 
-		filter, err = org.client.metadataToFilter(cat.HREF, filter)
+		filter, err = org.client.metadataToFilter(ctx, cat.HREF, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -208,9 +209,9 @@ func HelperMakeFiltersFromCatalogs(org *AdminOrg) ([]FilterMatch, error) {
 	return filters, nil
 }
 
-func HelperMakeFiltersFromMedia(vdc *Vdc, catalogName string) ([]FilterMatch, error) {
+func HelperMakeFiltersFromMedia(ctx context.Context, vdc *Vdc, catalogName string) ([]FilterMatch, error) {
 	var filters []FilterMatch
-	items, err := getExistingMedia(vdc)
+	items, err := getExistingMedia(ctx, vdc)
 	if err != nil {
 		return filters, err
 	}
@@ -229,7 +230,7 @@ func HelperMakeFiltersFromMedia(vdc *Vdc, catalogName string) ([]FilterMatch, er
 
 		dateInfo = append(dateInfo, dInfo...)
 
-		filter, err = vdc.client.metadataToFilter(item.HREF, filter)
+		filter, err = vdc.client.metadataToFilter(ctx, item.HREF, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -267,9 +268,9 @@ func queryItemToFilter(item QueryItem, entityType string) (*FilterDef, []DateIte
 	return filter, dateInfo, nil
 }
 
-func HelperMakeFiltersFromCatalogItem(catalog *Catalog) ([]FilterMatch, error) {
+func HelperMakeFiltersFromCatalogItem(ctx context.Context, catalog *Catalog) ([]FilterMatch, error) {
 	var filters []FilterMatch
-	items, err := catalog.QueryCatalogItemList()
+	items, err := catalog.QueryCatalogItemList(ctx)
 	if err != nil {
 		return filters, err
 	}
@@ -286,7 +287,7 @@ func HelperMakeFiltersFromCatalogItem(catalog *Catalog) ([]FilterMatch, error) {
 
 		dateInfo = append(dateInfo, dInfo...)
 
-		filter, err = catalog.client.metadataToFilter(item.HREF, filter)
+		filter, err = catalog.client.metadataToFilter(ctx, item.HREF, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -303,9 +304,9 @@ func HelperMakeFiltersFromCatalogItem(catalog *Catalog) ([]FilterMatch, error) {
 	return filters, nil
 }
 
-func HelperMakeFiltersFromVappTemplate(catalog *Catalog) ([]FilterMatch, error) {
+func HelperMakeFiltersFromVappTemplate(ctx context.Context, catalog *Catalog) ([]FilterMatch, error) {
 	var filters []FilterMatch
-	items, err := catalog.QueryVappTemplateList()
+	items, err := catalog.QueryVappTemplateList(ctx)
 	if err != nil {
 		return filters, err
 	}
@@ -322,7 +323,7 @@ func HelperMakeFiltersFromVappTemplate(catalog *Catalog) ([]FilterMatch, error) 
 
 		dateInfo = append(dateInfo, dInfo...)
 
-		filter, err = catalog.client.metadataToFilter(item.HREF, filter)
+		filter, err = catalog.client.metadataToFilter(ctx, item.HREF, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +343,7 @@ func HelperMakeFiltersFromVappTemplate(catalog *Catalog) ([]FilterMatch, error) 
 // HelperCreateMultipleCatalogItems deploys several catalog items, as defined in requestData
 // Returns a set of VappTemplateData with what was created.
 // If the requested objects exist already, returns updated information about the existing items.
-func HelperCreateMultipleCatalogItems(catalog *Catalog, requestData []VappTemplateData, verbose bool) ([]VappTemplateData, error) {
+func HelperCreateMultipleCatalogItems(ctx context.Context, catalog *Catalog, requestData []VappTemplateData, verbose bool) ([]VappTemplateData, error) {
 	var data []VappTemplateData
 	ova := "../test-resources/test_vapp_template.ova"
 	_, err := os.Stat(ova)
@@ -356,10 +357,10 @@ func HelperCreateMultipleCatalogItems(catalog *Catalog, requestData []VappTempla
 		var item *CatalogItem
 		var vappTemplate VAppTemplate
 		created := false
-		item, err := catalog.GetCatalogItemByName(name, false)
+		item, err := catalog.GetCatalogItemByName(ctx, name, false)
 		if err == nil {
 			// If the item already exists, we skip the creation, and just retrieve the vapp template
-			vappTemplate, err = item.GetVAppTemplate()
+			vappTemplate, err = item.GetVAppTemplate(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems] error retrieving vApp template from catalog item %s : %s", item.CatalogItem.Name, err)
 			}
@@ -369,25 +370,25 @@ func HelperCreateMultipleCatalogItems(catalog *Catalog, requestData []VappTempla
 			if verbose {
 				fmt.Printf("%-55s %s ", start, name)
 			}
-			task, err := catalog.UploadOvf(ova, name, "test "+name, 10)
+			task, err := catalog.UploadOvf(ctx, ova, name, "test "+name, 10)
 			if err != nil {
 				return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems] error uploading OVA: %s", err)
 			}
-			err = task.WaitTaskCompletion()
+			err = task.WaitTaskCompletion(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems] error completing task :%s", err)
 			}
-			item, err = catalog.GetCatalogItemByName(name, true)
+			item, err = catalog.GetCatalogItemByName(ctx, name, true)
 			if err != nil {
 				return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems] error retrieving item %s: %s", name, err)
 			}
-			vappTemplate, err = item.GetVAppTemplate()
+			vappTemplate, err = item.GetVAppTemplate(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems] error retrieving vApp template: %s", err)
 			}
 
 			for k, v := range requested.Metadata {
-				_, err := vappTemplate.AddMetadata(k, v)
+				_, err := vappTemplate.AddMetadata(ctx, k, v)
 				if err != nil {
 					return nil, fmt.Errorf("[HelperCreateMultipleCatalogItems], error adding metadata: %s", err)
 				}
@@ -461,11 +462,11 @@ func guessMetadataType(value string) string {
 // metadataToFilter adds metadata elements to an existing filter
 // href is the address of the entity for which we want to retrieve metadata
 // filter is an existing filter to which we want to add metadata elements
-func (client *Client) metadataToFilter(href string, filter *FilterDef) (*FilterDef, error) {
+func (client *Client) metadataToFilter(ctx context.Context, href string, filter *FilterDef) (*FilterDef, error) {
 	if filter == nil {
 		filter = &FilterDef{}
 	}
-	metadata, err := getMetadata(client, href)
+	metadata, err := getMetadata(ctx, client, href)
 	if err == nil && metadata != nil && len(metadata.MetadataEntry) > 0 {
 		for _, md := range metadata.MetadataEntry {
 			isSystem := md.Domain == "SYSTEM"

--- a/govcd/group_test.go
+++ b/govcd/group_test.go
@@ -18,7 +18,7 @@ import (
 // which sets up LDAP configuration.
 func (vcd *TestVCD) test_GroupCRUD(check *C) {
 	fmt.Printf("Running: %s\n", "test_GroupCRUD")
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
@@ -87,11 +87,11 @@ func (vcd *TestVCD) test_GroupCRUD(check *C) {
 		if testVerbose {
 			fmt.Printf("# creating '%s' group '%s' with role '%s'\n", gd.providerType, gd.name, gd.roleName)
 		}
-		createdGroup, err := adminOrg.CreateGroup(newGroup.Group)
+		createdGroup, err := adminOrg.CreateGroup(ctx, newGroup.Group)
 		check.Assert(err, IsNil)
 		AddToCleanupList(gd.name, "group", newGroup.AdminOrg.AdminOrg.Name, "test_GroupCRUD")
 
-		foundGroup, err := adminOrg.GetGroupByName(gd.name, true)
+		foundGroup, err := adminOrg.GetGroupByName(ctx, gd.name, true)
 		check.Assert(err, IsNil)
 
 		check.Assert(foundGroup.Group.Href, Equals, createdGroup.Group.Href)
@@ -105,10 +105,10 @@ func (vcd *TestVCD) test_GroupCRUD(check *C) {
 		if testVerbose {
 			fmt.Printf("# updating '%s' group '%s' to role '%s'\n", gd.providerType, gd.name, gd.secondRole)
 		}
-		err = createdGroup.Update()
+		err = createdGroup.Update(ctx)
 		check.Assert(err, IsNil)
 
-		foundGroup2, err := adminOrg.GetGroupByName(gd.name, true)
+		foundGroup2, err := adminOrg.GetGroupByName(ctx, gd.name, true)
 		check.Assert(err, IsNil)
 
 		check.Assert(err, IsNil)
@@ -118,7 +118,7 @@ func (vcd *TestVCD) test_GroupCRUD(check *C) {
 		if testVerbose {
 			fmt.Printf("# removing '%s' group '%s'\n", gd.providerType, gd.name)
 		}
-		err = createdGroup.Delete()
+		err = createdGroup.Delete(ctx)
 		check.Assert(err, IsNil)
 	}
 }
@@ -131,7 +131,7 @@ func (vcd *TestVCD) test_GroupFinderGetGenericEntity(check *C) {
 	fmt.Printf("Running: %s\n", "test_GroupFinderGetGenericEntity")
 
 	const groupName = "ship_crew"
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
@@ -145,20 +145,20 @@ func (vcd *TestVCD) test_GroupFinderGetGenericEntity(check *C) {
 		ProviderType: OrgUserProviderIntegrated,
 	}
 
-	_, err = adminOrg.CreateGroup(group.Group)
+	_, err = adminOrg.CreateGroup(ctx, group.Group)
 	check.Assert(err, IsNil)
 	AddToCleanupList(groupName, "group", group.AdminOrg.AdminOrg.Name, check.TestName())
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetGroupByName(name, refresh)
+		return adminOrg.GetGroupByName(ctx, name, refresh)
 	}
-	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetGroupById(id, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetGroupById(ctx, id, refresh) }
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetGroupByNameOrId(id, refresh)
+		return adminOrg.GetGroupByNameOrId(ctx, id, refresh)
 	}
 
 	// Refresh adminOrg so that user data is present
-	err = adminOrg.Refresh()
+	err = adminOrg.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	var def = getterTestDefinition{
@@ -173,8 +173,8 @@ func (vcd *TestVCD) test_GroupFinderGetGenericEntity(check *C) {
 	vcd.testFinderGetGenericEntity(def, check)
 
 	// Remove group because LDAP cleanup will fail.
-	grp, err := adminOrg.GetGroupByName(group.Group.Name, true)
+	grp, err := adminOrg.GetGroupByName(ctx, group.Group.Name, true)
 	check.Assert(err, IsNil)
-	err = grp.Delete()
+	err = grp.Delete(ctx)
 	check.Assert(err, IsNil)
 }

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -8,6 +8,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -28,11 +29,12 @@ import (
 // being server in 2 VMs
 // 7. Tears down
 func (vcd *TestVCD) Test_LB(check *C) {
+	ctx := context.Background()
 
 	// Validate prerequisites
-	validateTestLbPrerequisites(vcd, check)
+	validateTestLbPrerequisites(ctx, vcd, check)
 
-	vdc, edge, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, TestLb)
+	vdc, edge, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(ctx, check, TestLb)
 	check.Assert(err, IsNil)
 
 	// The script below creates a file /tmp/node/server with single value `name` being set in it.
@@ -43,9 +45,9 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	vm2CustomizationScript := "mkdir /tmp/node && cd /tmp/node && echo -n 'SecondNode' > server && " +
 		"/bin/systemctl stop iptables && /usr/bin/python3 -m http.server 8000 &"
 
-	vm1, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, vm1CustomizationScript, true)
+	vm1, err := spawnVM(ctx, "FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, vm1CustomizationScript, true)
 	check.Assert(err, IsNil)
-	vm2, err := spawnVM("SecondNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, vm2CustomizationScript, true)
+	vm2, err := spawnVM(ctx, "SecondNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, vm2CustomizationScript, true)
 	check.Assert(err, IsNil)
 
 	// Get IPs allocated to the VMs
@@ -58,18 +60,18 @@ func (vcd *TestVCD) Test_LB(check *C) {
 	fmt.Printf("# Setting up load balancer for VMs: '%s' (%s), '%s' (%s)\n", vm1.VM.Name, ip1, vm2.VM.Name, ip2)
 
 	fmt.Printf("# Creating firewall rule for load balancer virtual server access. ")
-	ruleDescription := addFirewallRule(*vdc, vcd, check)
+	ruleDescription := addFirewallRule(ctx, *vdc, vcd, check)
 	fmt.Printf("Done\n")
 
 	// Build load balancer
-	buildLb(*edge, ip1, ip2, vcd, check)
+	buildLb(ctx, *edge, ip1, ip2, vcd, check)
 
 	// Cache current load balancer settings for change validation in the end
-	beforeLb, beforeLbXml := testCacheLoadBalancer(*edge, check)
+	beforeLb, beforeLbXml := testCacheLoadBalancer(ctx, *edge, check)
 
 	// Enable load balancer globally
 	fmt.Printf("# Enabling load balancer with acceleration: ")
-	_, err = edge.UpdateLBGeneralParams(true, true, true, "warning")
+	_, err = edge.UpdateLBGeneralParams(ctx, true, true, true, "warning")
 	check.Assert(err, IsNil)
 	fmt.Printf("Done\n")
 
@@ -80,19 +82,19 @@ func (vcd *TestVCD) Test_LB(check *C) {
 
 	// Remove firewall rule
 	fmt.Printf("# Deleting firewall rule used for load balancer virtual server access. ")
-	deleteFirewallRule(ruleDescription, *vdc, vcd, check)
+	deleteFirewallRule(ctx, ruleDescription, *vdc, vcd, check)
 	fmt.Printf("Done\n")
 
 	// Restore global load balancer configuration
 	fmt.Printf("# Restoring load balancer global configuration: ")
-	_, err = edge.UpdateLBGeneralParams(beforeLb.Enabled, beforeLb.AccelerationEnabled,
+	_, err = edge.UpdateLBGeneralParams(ctx, beforeLb.Enabled, beforeLb.AccelerationEnabled,
 		beforeLb.Logging.Enable, beforeLb.Logging.LogLevel)
 	check.Assert(err, IsNil)
 	fmt.Printf("Done\n")
 
 	// Validate load balancer configuration against initially cached version
 	fmt.Printf("# Validating load balancer XML structure: ")
-	testCheckLoadBalancerConfig(beforeLb, beforeLbXml, *edge, check)
+	testCheckLoadBalancerConfig(ctx, beforeLb, beforeLbXml, *edge, check)
 	fmt.Printf("Done\n")
 
 	// Finally after some cleanups - check if querying succeeded
@@ -104,7 +106,7 @@ func (vcd *TestVCD) Test_LB(check *C) {
 // * ExternalIp is set in config (will be edge gateway external IP)
 // * PhotonOsOvaPath is set (will be used for spawning VMs)
 // * Edge Gateway can be found and it has advanced networking enabled (a must for load balancers)
-func validateTestLbPrerequisites(vcd *TestVCD, check *C) {
+func validateTestLbPrerequisites(ctx context.Context, vcd *TestVCD, check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
@@ -113,7 +115,7 @@ func validateTestLbPrerequisites(vcd *TestVCD, check *C) {
 		check.Skip("Skipping test because no edge gateway external IP given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -124,7 +126,7 @@ func validateTestLbPrerequisites(vcd *TestVCD, check *C) {
 }
 
 // buildLB establishes an HTTP load balancer for 2 IPs specified as arguments
-func buildLb(edge EdgeGateway, node1Ip, node2Ip string, vcd *TestVCD, check *C) {
+func buildLb(ctx context.Context, edge EdgeGateway, node1Ip, node2Ip string, vcd *TestVCD, check *C) {
 
 	_, serverPoolId, appProfileId, _ := buildTestLBVirtualServerPrereqs(node1Ip, node2Ip, TestLb,
 		check, vcd, edge)
@@ -147,7 +149,7 @@ func buildLb(edge EdgeGateway, node1Ip, node2Ip string, vcd *TestVCD, check *C) 
 	err := deleteLbVirtualServerIfExists(edge, lbVirtualServerConfig.Name)
 	check.Assert(err, IsNil)
 
-	_, err = edge.CreateLbVirtualServer(lbVirtualServerConfig)
+	_, err = edge.CreateLbVirtualServer(ctx, lbVirtualServerConfig)
 	check.Assert(err, IsNil)
 
 	// We created virtual server successfully therefore let's prepend it to cleanup list so that it
@@ -224,10 +226,10 @@ func checkLb(queryUrl string, expectedResponses []string, maxRetryTimeout int) e
 }
 
 // addFirewallRule adds a firewall rule needed to access virtual server port on edge gateway
-func addFirewallRule(vdc Vdc, vcd *TestVCD, check *C) string {
+func addFirewallRule(ctx context.Context, vdc Vdc, vcd *TestVCD, check *C) string {
 	description := "Created by: " + TestLb
 
-	edge, err := vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 
 	// Open up firewall to access edge gateway on load balancer port
@@ -241,17 +243,17 @@ func addFirewallRule(vdc Vdc, vcd *TestVCD, check *C) string {
 		SourcePort:    -1,
 	}
 	fwRules := []*types.FirewallRule{fwRule}
-	task, err := edge.CreateFirewallRules("allow", fwRules)
+	task, err := edge.CreateFirewallRules(ctx, "allow", fwRules)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	return description
 }
 
 // deleteFirewallRule removes firewall rule which was used for testing load balancer
-func deleteFirewallRule(ruleDescription string, vdc Vdc, vcd *TestVCD, check *C) {
-	edge, err := vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+func deleteFirewallRule(ctx context.Context, ruleDescription string, vdc Vdc, vcd *TestVCD, check *C) {
+	edge, err := vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	rules := edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration.FirewallService.FirewallRule
 	for index := range rules {
@@ -260,8 +262,8 @@ func deleteFirewallRule(ruleDescription string, vdc Vdc, vcd *TestVCD, check *C)
 		}
 	}
 
-	task, err := edge.CreateFirewallRules("allow", rules)
+	task, err := edge.CreateFirewallRules(ctx, "allow", rules)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 }

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -324,7 +324,7 @@ func queryMediaWithFilter(ctx context.Context, vdc *Vdc, filter string) ([]*type
 // Looks for media and, if found, will delete it.
 // Deprecated: Use catalog.RemoveMediaIfExist
 func RemoveMediaImageIfExists(ctx context.Context, vdc Vdc, mediaName string) error {
-	mediaItem, err := vdc.FindMediaImage(mediaName)
+	mediaItem, err := vdc.FindMediaImage(ctx, mediaName)
 	if err == nil && mediaItem != (MediaItem{}) {
 		task, err := mediaItem.Delete(ctx)
 		if err != nil {
@@ -403,7 +403,7 @@ func FindMediaAsCatalogItem(ctx context.Context, org *Org, catalogName, mediaNam
 
 // Refresh refreshes the media item information by href
 // Deprecated: Use MediaRecord.Refresh
-func (mediaItem *MediaItem) Refresh() error {
+func (mediaItem *MediaItem) Refresh(ctx context.Context) error {
 
 	if mediaItem.MediaItem == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
@@ -413,7 +413,7 @@ func (mediaItem *MediaItem) Refresh() error {
 		return fmt.Errorf("cannot refresh, Name is empty")
 	}
 
-	latestMediaItem, err := mediaItem.vdc.FindMediaImage(mediaItem.MediaItem.Name)
+	latestMediaItem, err := mediaItem.vdc.FindMediaImage(ctx, mediaItem.MediaItem.Name)
 	*mediaItem = latestMediaItem
 
 	return err

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -64,7 +65,7 @@ func NewMediaRecord(cli *Client) *MediaRecord {
 //
 // Deprecated: This method is broken in API V32.0+. Please use catalog.UploadMediaImage because VCD does not support
 // uploading directly to VDC anymore.
-func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, uploadPieceSize int64) (UploadTask, error) {
+func (vdc *Vdc) UploadMediaImage(ctx context.Context, mediaName, mediaDescription, filePath string, uploadPieceSize int64) (UploadTask, error) {
 	util.Logger.Printf("[TRACE] UploadImage: %s, image name: %v \n", mediaName, mediaDescription)
 
 	//	On a very high level the flow is as follows
@@ -86,7 +87,7 @@ func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, u
 		return UploadTask{}, fmt.Errorf("[ERROR] File %s isn't correct iso file: %s", mediaFilePath, err)
 	}
 
-	mediaList, err := getExistingMedia(vdc)
+	mediaList, err := getExistingMedia(ctx, vdc)
 	if err != nil {
 		return UploadTask{}, fmt.Errorf("[ERROR] Checking existing media files failed: %s", err)
 	}
@@ -103,15 +104,15 @@ func (vdc *Vdc) UploadMediaImage(mediaName, mediaDescription, filePath string, u
 	}
 	fileSize := file.Size()
 
-	media, err := createMedia(vdc.client, vdc.Vdc.HREF+"/media", mediaName, mediaDescription, fileSize)
+	media, err := createMedia(ctx, vdc.client, vdc.Vdc.HREF+"/media", mediaName, mediaDescription, fileSize)
 	if err != nil {
 		return UploadTask{}, fmt.Errorf("[ERROR] Issue creating media: %s", err)
 	}
 
-	return executeUpload(vdc.client, media, mediaFilePath, mediaName, fileSize, uploadPieceSize)
+	return executeUpload(ctx, vdc.client, media, mediaFilePath, mediaName, fileSize, uploadPieceSize)
 }
 
-func executeUpload(client *Client, media *types.Media, mediaFilePath, mediaName string, fileSize, uploadPieceSize int64) (UploadTask, error) {
+func executeUpload(ctx context.Context, client *Client, media *types.Media, mediaFilePath, mediaName string, fileSize, uploadPieceSize int64) (UploadTask, error) {
 	uploadLink, err := getUploadLink(media.Files)
 	if err != nil {
 		return UploadTask{}, fmt.Errorf("[ERROR] Issue getting upload link: %s", err)
@@ -132,17 +133,17 @@ func executeUpload(client *Client, media *types.Media, mediaFilePath, mediaName 
 		uploadError:              &uploadError,
 	}
 
-	go uploadFile(client, mediaFilePath, details)
+	go uploadFile(ctx, client, mediaFilePath, details)
 
 	var task Task
 	for _, item := range media.Tasks.Task {
-		task, err = createTaskForVcdImport(client, item.HREF)
+		task, err = createTaskForVcdImport(ctx, client, item.HREF)
 		if err != nil {
-			removeImageOnError(client, media, mediaName)
+			removeImageOnError(ctx, client, media, mediaName)
 			return UploadTask{}, err
 		}
 		if task.Task.Status == "error" {
-			removeImageOnError(client, media, mediaName)
+			removeImageOnError(ctx, client, media, mediaName)
 			return UploadTask{}, fmt.Errorf("task did not complete succesfully: %s", task.Task.Description)
 		}
 	}
@@ -155,7 +156,7 @@ func executeUpload(client *Client, media *types.Media, mediaFilePath, mediaName 
 }
 
 // Initiates creation of media item and returns temporary upload URL.
-func createMedia(client *Client, link, mediaName, mediaDescription string, fileSize int64) (*types.Media, error) {
+func createMedia(ctx context.Context, client *Client, link, mediaName, mediaDescription string, fileSize int64) (*types.Media, error) {
 	uploadUrl, err := url.ParseRequestURI(link)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vdc href: %s", err)
@@ -166,7 +167,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 			"<Description>" + mediaDescription + "</Description>" +
 			"</Media>")
 
-	request := client.NewRequest(map[string]string{}, http.MethodPost, *uploadUrl, reqBody)
+	request := client.NewRequest(ctx, map[string]string{}, http.MethodPost, *uploadUrl, reqBody)
 	request.Header.Add("Content-Type", "application/vnd.vmware.vcloud.media+xml")
 
 	response, err := checkResp(client.Http.Do(request))
@@ -194,7 +195,7 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 	return mediaForUpload, nil
 }
 
-func removeImageOnError(client *Client, media *types.Media, itemName string) {
+func removeImageOnError(ctx context.Context, client *Client, media *types.Media, itemName string) {
 	if media != nil {
 		util.Logger.Printf("[TRACE] Deleting media item %#v", media)
 
@@ -203,7 +204,7 @@ func removeImageOnError(client *Client, media *types.Media, itemName string) {
 		for {
 			util.Logger.Printf("[TRACE] Sleep... for 5 seconds.\n")
 			time.Sleep(time.Second * 5)
-			media, err = queryMedia(client, media.HREF, itemName)
+			media, err = queryMedia(ctx, client, media.HREF, itemName)
 			if err != nil {
 				util.Logger.Printf("[Error] Error deleting media item %v: %s", media, err)
 			}
@@ -217,7 +218,7 @@ func removeImageOnError(client *Client, media *types.Media, itemName string) {
 			if itemName == taskItem.Owner.Name {
 				task := NewTask(client)
 				task.Task = taskItem
-				err = task.CancelTask()
+				err = task.CancelTask(ctx)
 				if err != nil {
 					util.Logger.Printf("[ERROR] Error canceling task for media upload %s", err)
 				}
@@ -228,12 +229,12 @@ func removeImageOnError(client *Client, media *types.Media, itemName string) {
 	}
 }
 
-func queryMedia(client *Client, mediaUrl string, newItemName string) (*types.Media, error) {
+func queryMedia(ctx context.Context, client *Client, mediaUrl string, newItemName string) (*types.Media, error) {
 	util.Logger.Printf("[TRACE] Querying media: %s\n", mediaUrl)
 
 	mediaParsed := &types.Media{}
 
-	_, err := client.ExecuteRequest(mediaUrl, http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, mediaUrl, http.MethodGet,
 		"", "error quering media: %s", nil, mediaParsed)
 	if err != nil {
 		return nil, err
@@ -293,22 +294,22 @@ func verifyHeader(buf []byte) bool {
 
 // Reference for API usage http://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-9356B99B-E414-474A-853C-1411692AF84C.html
 // http://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-43DFF30E-391F-42DC-87B3-5923ABCEB366.html
-func getExistingMedia(vdc *Vdc) ([]*types.MediaRecordType, error) {
+func getExistingMedia(ctx context.Context, vdc *Vdc) ([]*types.MediaRecordType, error) {
 	util.Logger.Printf("[TRACE] Querying medias \n")
 
-	mediaResults, err := queryMediaWithFilter(vdc, "vdc=="+url.QueryEscape(vdc.Vdc.HREF))
+	mediaResults, err := queryMediaWithFilter(ctx, vdc, "vdc=="+url.QueryEscape(vdc.Vdc.HREF))
 
 	util.Logger.Printf("[TRACE] Found media records: %d \n", len(mediaResults))
 	return mediaResults, err
 }
 
-func queryMediaWithFilter(vdc *Vdc, filter string) ([]*types.MediaRecordType, error) {
+func queryMediaWithFilter(ctx context.Context, vdc *Vdc, filter string) ([]*types.MediaRecordType, error) {
 	typeMedia := "media"
 	if vdc.client.IsSysAdmin {
 		typeMedia = "adminMedia"
 	}
 
-	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": filter, "filterEncoded": "true"})
+	results, err := vdc.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia, "filter": filter, "filterEncoded": "true"})
 	if err != nil {
 		return nil, fmt.Errorf("error querying medias %s", err)
 	}
@@ -322,14 +323,14 @@ func queryMediaWithFilter(vdc *Vdc, filter string) ([]*types.MediaRecordType, er
 
 // Looks for media and, if found, will delete it.
 // Deprecated: Use catalog.RemoveMediaIfExist
-func RemoveMediaImageIfExists(vdc Vdc, mediaName string) error {
+func RemoveMediaImageIfExists(ctx context.Context, vdc Vdc, mediaName string) error {
 	mediaItem, err := vdc.FindMediaImage(mediaName)
 	if err == nil && mediaItem != (MediaItem{}) {
-		task, err := mediaItem.Delete()
+		task, err := mediaItem.Delete(ctx)
 		if err != nil {
 			return fmt.Errorf("error deleting media [phase 1] %s", mediaName)
 		}
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("error deleting media [task] %s", mediaName)
 		}
@@ -340,14 +341,14 @@ func RemoveMediaImageIfExists(vdc Vdc, mediaName string) error {
 }
 
 // Looks for media and, if found, will delete it.
-func (adminCatalog *AdminCatalog) RemoveMediaIfExists(mediaName string) error {
-	media, err := adminCatalog.GetMediaByName(mediaName, true)
+func (adminCatalog *AdminCatalog) RemoveMediaIfExists(ctx context.Context, mediaName string) error {
+	media, err := adminCatalog.GetMediaByName(ctx, mediaName, true)
 	if err == nil {
-		task, err := media.Delete()
+		task, err := media.Delete(ctx)
 		if err != nil {
 			return fmt.Errorf("error deleting media [phase 1] %s", mediaName)
 		}
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("error deleting media [task] %s", mediaName)
 		}
@@ -360,27 +361,27 @@ func (adminCatalog *AdminCatalog) RemoveMediaIfExists(mediaName string) error {
 // Deletes the Media Item, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Media.html
 // Deprecated: Use MediaRecord.Delete
-func (mediaItem *MediaItem) Delete() (Task, error) {
+func (mediaItem *MediaItem) Delete(ctx context.Context) (Task, error) {
 	util.Logger.Printf("[TRACE] Deleting media item: %#v", mediaItem.MediaItem.Name)
 
 	// Return the task
-	return mediaItem.vdc.client.ExecuteTaskRequest(mediaItem.MediaItem.HREF, http.MethodDelete,
+	return mediaItem.vdc.client.ExecuteTaskRequest(ctx, mediaItem.MediaItem.HREF, http.MethodDelete,
 		"", "error deleting Media item: %s", nil)
 }
 
 // Deletes the Media Item, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Media.html
-func (media *Media) Delete() (Task, error) {
+func (media *Media) Delete(ctx context.Context) (Task, error) {
 	util.Logger.Printf("[TRACE] Deleting media item: %#v", media.Media.Name)
 
 	// Return the task
-	return media.client.ExecuteTaskRequest(media.Media.HREF, http.MethodDelete,
+	return media.client.ExecuteTaskRequest(ctx, media.Media.HREF, http.MethodDelete,
 		"", "error deleting Media item: %s", nil)
 }
 
 // Finds media in catalog and returns catalog item
 // Deprecated: Use catalog.GetMediaByName()
-func FindMediaAsCatalogItem(org *Org, catalogName, mediaName string) (CatalogItem, error) {
+func FindMediaAsCatalogItem(ctx context.Context, org *Org, catalogName, mediaName string) (CatalogItem, error) {
 	if catalogName == "" {
 		return CatalogItem{}, errors.New("catalog name is empty")
 	}
@@ -388,12 +389,12 @@ func FindMediaAsCatalogItem(org *Org, catalogName, mediaName string) (CatalogIte
 		return CatalogItem{}, errors.New("media name is empty")
 	}
 
-	catalog, err := org.FindCatalog(catalogName)
+	catalog, err := org.FindCatalog(ctx, catalogName)
 	if err != nil || catalog == (Catalog{}) {
 		return CatalogItem{}, fmt.Errorf("catalog not found or error %s", err)
 	}
 
-	media, err := catalog.FindCatalogItem(mediaName)
+	media, err := catalog.FindCatalogItem(ctx, mediaName)
 	if err != nil || media == (CatalogItem{}) {
 		return CatalogItem{}, fmt.Errorf("media not found or error %s", err)
 	}
@@ -419,7 +420,7 @@ func (mediaItem *MediaItem) Refresh() error {
 }
 
 // Refresh refreshes the media information by href
-func (media *Media) Refresh() error {
+func (media *Media) Refresh(ctx context.Context) error {
 
 	if media.Media == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
@@ -431,7 +432,7 @@ func (media *Media) Refresh() error {
 	// elements in slices.
 	media.Media = &types.Media{}
 
-	_, err := media.client.ExecuteRequest(url, http.MethodGet,
+	_, err := media.client.ExecuteRequest(ctx, url, http.MethodGet,
 		"", "error retrieving media: %s", nil, media.Media)
 
 	return err
@@ -440,11 +441,11 @@ func (media *Media) Refresh() error {
 // GetMediaByHref finds a Media by HREF
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetMediaByHref(mediaHref string) (*Media, error) {
+func (cat *Catalog) GetMediaByHref(ctx context.Context, mediaHref string) (*Media, error) {
 
 	media := NewMedia(cat.client)
 
-	_, err := cat.client.ExecuteRequest(mediaHref, http.MethodGet,
+	_, err := cat.client.ExecuteRequest(ctx, mediaHref, http.MethodGet,
 		"", "error retrieving media: %#v", nil, media.Media)
 	if err != nil && strings.Contains(err.Error(), "MajorErrorCode:403") {
 		return nil, ErrorEntityNotFound
@@ -458,9 +459,9 @@ func (cat *Catalog) GetMediaByHref(mediaHref string) (*Media, error) {
 // GetMediaByName finds a Media by Name
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetMediaByName(mediaName string, refresh bool) (*Media, error) {
+func (cat *Catalog) GetMediaByName(ctx context.Context, mediaName string, refresh bool) (*Media, error) {
 	if refresh {
-		err := cat.Refresh()
+		err := cat.Refresh(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -468,11 +469,11 @@ func (cat *Catalog) GetMediaByName(mediaName string, refresh bool) (*Media, erro
 	for _, catalogItems := range cat.Catalog.CatalogItems {
 		for _, catalogItem := range catalogItems.CatalogItem {
 			if catalogItem.Name == mediaName && catalogItem.Type == "application/vnd.vmware.vcloud.catalogItem+xml" {
-				catalogItemElement, err := cat.GetCatalogItemByHref(catalogItem.HREF)
+				catalogItemElement, err := cat.GetCatalogItemByHref(ctx, catalogItem.HREF)
 				if err != nil {
 					return nil, err
 				}
-				return cat.GetMediaByHref(catalogItemElement.CatalogItem.Entity.HREF)
+				return cat.GetMediaByHref(ctx, catalogItemElement.CatalogItem.Entity.HREF)
 			}
 		}
 	}
@@ -482,13 +483,13 @@ func (cat *Catalog) GetMediaByName(mediaName string, refresh bool) (*Media, erro
 // GetMediaById finds a Media by ID
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (catalog *Catalog) GetMediaById(mediaId string) (*Media, error) {
+func (catalog *Catalog) GetMediaById(ctx context.Context, mediaId string) (*Media, error) {
 	typeMedia := "media"
 	if catalog.client.IsSysAdmin {
 		typeMedia = "adminMedia"
 	}
 
-	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
+	results, err := catalog.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia,
 		"filter":        fmt.Sprintf("catalogName==%s", url.QueryEscape(catalog.Catalog.Name)),
 		"filterEncoded": "true"})
 	if err != nil {
@@ -501,7 +502,7 @@ func (catalog *Catalog) GetMediaById(mediaId string) (*Media, error) {
 	}
 	for _, mediaRecord := range mediaResults {
 		if equalIds(mediaId, mediaRecord.ID, mediaRecord.HREF) {
-			return catalog.GetMediaByHref(mediaRecord.HREF)
+			return catalog.GetMediaByHref(ctx, mediaRecord.HREF)
 		}
 	}
 	return nil, ErrorEntityNotFound
@@ -510,9 +511,9 @@ func (catalog *Catalog) GetMediaById(mediaId string) (*Media, error) {
 // GetMediaByNameOrId finds a Media by Name or ID
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (cat *Catalog) GetMediaByNameOrId(identifier string, refresh bool) (*Media, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return cat.GetMediaByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return cat.GetMediaById(id) }
+func (cat *Catalog) GetMediaByNameOrId(ctx context.Context, identifier string, refresh bool) (*Media, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return cat.GetMediaByName(ctx, name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return cat.GetMediaById(ctx, id) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
 	if entity == nil {
 		return nil, err
@@ -523,41 +524,41 @@ func (cat *Catalog) GetMediaByNameOrId(identifier string, refresh bool) (*Media,
 // GetMediaByHref finds a Media by HREF
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminCatalog *AdminCatalog) GetMediaByHref(mediaHref string) (*Media, error) {
+func (adminCatalog *AdminCatalog) GetMediaByHref(ctx context.Context, mediaHref string) (*Media, error) {
 	catalog := NewCatalog(adminCatalog.client)
 	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.GetMediaByHref(mediaHref)
+	return catalog.GetMediaByHref(ctx, mediaHref)
 }
 
 // GetMediaByName finds a Media by Name
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminCatalog *AdminCatalog) GetMediaByName(mediaName string, refresh bool) (*Media, error) {
+func (adminCatalog *AdminCatalog) GetMediaByName(ctx context.Context, mediaName string, refresh bool) (*Media, error) {
 	catalog := NewCatalog(adminCatalog.client)
 	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.GetMediaByName(mediaName, refresh)
+	return catalog.GetMediaByName(ctx, mediaName, refresh)
 }
 
 // GetMediaById finds a Media by ID
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminCatalog *AdminCatalog) GetMediaById(mediaId string) (*Media, error) {
+func (adminCatalog *AdminCatalog) GetMediaById(ctx context.Context, mediaId string) (*Media, error) {
 	catalog := NewCatalog(adminCatalog.client)
 	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.GetMediaById(mediaId)
+	return catalog.GetMediaById(ctx, mediaId)
 }
 
 // GetMediaByNameOrId finds a Media by Name or ID
 // On success, returns a pointer to the Media structure and a nil error
 // On failure, returns a nil pointer and an error
-func (adminCatalog *AdminCatalog) GetMediaByNameOrId(identifier string, refresh bool) (*Media, error) {
+func (adminCatalog *AdminCatalog) GetMediaByNameOrId(ctx context.Context, identifier string, refresh bool) (*Media, error) {
 	catalog := NewCatalog(adminCatalog.client)
 	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.GetMediaByNameOrId(identifier, refresh)
+	return catalog.GetMediaByNameOrId(ctx, identifier, refresh)
 }
 
 // QueryMedia returns media image found in system using `name` and `catalog name` as query.
-func (catalog *Catalog) QueryMedia(mediaName string) (*MediaRecord, error) {
+func (catalog *Catalog) QueryMedia(ctx context.Context, mediaName string) (*MediaRecord, error) {
 	util.Logger.Printf("[TRACE] Querying medias by name and catalog\n")
 
 	if catalog == nil || catalog.Catalog == nil || catalog.Catalog.Name == "" {
@@ -572,7 +573,7 @@ func (catalog *Catalog) QueryMedia(mediaName string) (*MediaRecord, error) {
 		typeMedia = "adminMedia"
 	}
 
-	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
+	results, err := catalog.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia,
 		"filter": fmt.Sprintf("name==%s;catalogName==%s",
 			url.QueryEscape(mediaName),
 			url.QueryEscape(catalog.Catalog.Name)),
@@ -603,14 +604,14 @@ func (catalog *Catalog) QueryMedia(mediaName string) (*MediaRecord, error) {
 }
 
 // QueryMedia returns media image found in system using `name` and `catalog name` as query.
-func (adminCatalog *AdminCatalog) QueryMedia(mediaName string) (*MediaRecord, error) {
+func (adminCatalog *AdminCatalog) QueryMedia(ctx context.Context, mediaName string) (*MediaRecord, error) {
 	catalog := NewCatalog(adminCatalog.client)
 	catalog.Catalog = &adminCatalog.AdminCatalog.Catalog
-	return catalog.QueryMedia(mediaName)
+	return catalog.QueryMedia(ctx, mediaName)
 }
 
 // Refresh refreshes the media information by href
-func (mediaRecord *MediaRecord) Refresh() error {
+func (mediaRecord *MediaRecord) Refresh(ctx context.Context) error {
 
 	if mediaRecord.MediaRecord == nil {
 		return fmt.Errorf("cannot refresh, Object is empty")
@@ -626,7 +627,7 @@ func (mediaRecord *MediaRecord) Refresh() error {
 	// elements in slices.
 	mediaRecord.MediaRecord = &types.MediaRecordType{}
 
-	_, err := mediaRecord.client.ExecuteRequest(url, http.MethodGet,
+	_, err := mediaRecord.client.ExecuteRequest(ctx, url, http.MethodGet,
 		"", "error retrieving media: %s", nil, mediaRecord.MediaRecord)
 
 	return err
@@ -634,16 +635,16 @@ func (mediaRecord *MediaRecord) Refresh() error {
 
 // Deletes the Media Item, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Media.html
-func (mediaRecord *MediaRecord) Delete() (Task, error) {
+func (mediaRecord *MediaRecord) Delete(ctx context.Context) (Task, error) {
 	util.Logger.Printf("[TRACE] Deleting media item: %#v", mediaRecord.MediaRecord.Name)
 
 	// Return the task
-	return mediaRecord.client.ExecuteTaskRequest(mediaRecord.MediaRecord.HREF, http.MethodDelete,
+	return mediaRecord.client.ExecuteTaskRequest(ctx, mediaRecord.MediaRecord.HREF, http.MethodDelete,
 		"", "error deleting Media item: %s", nil)
 }
 
 // QueryAllMedia returns all media images found in system using `name` as query.
-func (vdc *Vdc) QueryAllMedia(mediaName string) ([]*MediaRecord, error) {
+func (vdc *Vdc) QueryAllMedia(ctx context.Context, mediaName string) ([]*MediaRecord, error) {
 	util.Logger.Printf("[TRACE] Querying medias by name\n")
 
 	if mediaName == "" {
@@ -655,7 +656,7 @@ func (vdc *Vdc) QueryAllMedia(mediaName string) ([]*MediaRecord, error) {
 		typeMedia = "adminMedia"
 	}
 
-	results, err := vdc.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
+	results, err := vdc.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia,
 		"filter": fmt.Sprintf("name==%s", url.QueryEscape(mediaName))})
 	if err != nil {
 		return nil, fmt.Errorf("error querying medias %s", err)

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -26,33 +26,33 @@ func (vcd *TestVCD) Test_DeleteMedia(check *C) {
 		check.Skip("Test_DeleteMedia: Catalog name not given")
 		return
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
 	itemName := "TestDeleteMedia"
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_DeleteMediaImage")
 
-	media, err := catalog.GetMediaByName(itemName, true)
+	media, err := catalog.GetMediaByName(ctx, itemName, true)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 	check.Assert(media.Media.Name, Equals, itemName)
 
-	task, err := media.Delete()
+	task, err := media.Delete(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	_, err = catalog.GetMediaByName(itemName, true)
+	_, err = catalog.GetMediaByName(ctx, itemName, true)
 	check.Assert(err, NotNil)
 	check.Assert(IsNotFound(err), Equals, true)
 }
@@ -74,23 +74,23 @@ func (vcd *TestVCD) Test_RefreshMedia(check *C) {
 		check.Skip("Test_RefreshMediaRecord: Media name not given")
 		return
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
 	itemName := vcd.config.Media.Media
 
-	media, err := catalog.GetMediaByName(itemName, true)
+	media, err := catalog.GetMediaByName(ctx, itemName, true)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 	check.Assert(media.Media.Name, Equals, itemName)
 
 	oldMedia := media
-	err = media.Refresh()
+	err = media.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(media, NotNil)
@@ -111,24 +111,24 @@ func (vcd *TestVCD) Test_GetMedia(check *C) {
 		check.Skip("Test_GetMedia: Catalog name not given")
 		return
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		err = catalog.Refresh()
+		err = catalog.Refresh(ctx)
 		check.Assert(err, IsNil)
-		return catalog.GetMediaByName(name, refresh)
+		return catalog.GetMediaByName(ctx, name, refresh)
 	}
 	getById := func(id string, refresh bool) (genericEntity, error) {
-		return catalog.GetMediaById(id)
+		return catalog.GetMediaById(ctx, id)
 	}
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return catalog.GetMediaByNameOrId(id, refresh)
+		return catalog.GetMediaByNameOrId(ctx, id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -161,16 +161,16 @@ func (vcd *TestVCD) Test_QueryMedia(check *C) {
 		return
 	}
 	// Fetching organization
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 
 	testQueryMediaName := vcd.config.Media.Media
 
-	media, err := catalog.QueryMedia(testQueryMediaName)
+	media, err := catalog.QueryMedia(ctx, testQueryMediaName)
 	check.Assert(err, IsNil)
 	check.Assert(media, Not(Equals), nil)
 
@@ -178,7 +178,7 @@ func (vcd *TestVCD) Test_QueryMedia(check *C) {
 	check.Assert(media.MediaRecord.HREF, Not(Equals), "")
 
 	// find Invalid media
-	media, err = catalog.QueryMedia("INVALID")
+	media, err = catalog.QueryMedia(ctx, "INVALID")
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(media, IsNil)
 }
@@ -202,23 +202,23 @@ func (vcd *TestVCD) Test_RefreshMediaRecord(check *C) {
 		return
 	}
 
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
 	itemName := vcd.config.Media.Media
 
-	mediaRecord, err := catalog.QueryMedia(itemName)
+	mediaRecord, err := catalog.QueryMedia(ctx, itemName)
 	check.Assert(err, IsNil)
 	check.Assert(mediaRecord, NotNil)
 	check.Assert(mediaRecord.MediaRecord.Name, Equals, itemName)
 
 	oldMediaRecord := mediaRecord
-	err = mediaRecord.Refresh()
+	err = mediaRecord.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(mediaRecord, NotNil)
@@ -242,13 +242,13 @@ func (vcd *TestVCD) Test_QueryAllMedia(check *C) {
 		return
 	}
 	// Fetching organization
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
 	testQueryMediaName := vcd.config.Media.Media
 
-	mediaList, err := vcd.vdc.QueryAllMedia(testQueryMediaName)
+	mediaList, err := vcd.vdc.QueryAllMedia(ctx, testQueryMediaName)
 	check.Assert(err, IsNil)
 	check.Assert(mediaList, Not(Equals), nil)
 
@@ -256,7 +256,7 @@ func (vcd *TestVCD) Test_QueryAllMedia(check *C) {
 	check.Assert(mediaList[0].MediaRecord.HREF, Not(Equals), "")
 
 	// find Invalid media
-	mediaList, err = vcd.vdc.QueryAllMedia("INVALID")
+	mediaList, err = vcd.vdc.QueryAllMedia(ctx, "INVALID")
 	check.Assert(IsNotFound(err), Equals, true)
 	check.Assert(mediaList, IsNil)
 }

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -49,7 +49,7 @@ func (vdc *Vdc) DeleteMetadata(ctx context.Context, key string) (Vdc, error) {
 		return Vdc{}, err
 	}
 
-	err = vdc.Refresh()
+	err = vdc.Refresh(ctx)
 	if err != nil {
 		return Vdc{}, err
 	}
@@ -69,7 +69,7 @@ func (vdc *Vdc) AddMetadata(ctx context.Context, key string, value string) (Vdc,
 		return Vdc{}, err
 	}
 
-	err = vdc.Refresh()
+	err = vdc.Refresh(ctx)
 	if err != nil {
 		return Vdc{}, err
 	}
@@ -168,7 +168,7 @@ func (vAppTemplate *VAppTemplate) AddMetadata(ctx context.Context, key string, v
 		return nil, fmt.Errorf("error completing add metadata for vApp template task: %s", err)
 	}
 
-	err = vAppTemplate.Refresh()
+	err = vAppTemplate.Refresh(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing vApp template: %s", err)
 	}
@@ -221,7 +221,7 @@ func (mediaItem *MediaItem) AddMetadata(ctx context.Context, key string, value s
 		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
 	}
 
-	err = mediaItem.Refresh()
+	err = mediaItem.Refresh(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing media item: %s", err)
 	}

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,35 +16,35 @@ import (
 
 // GetMetadata calls private function getMetadata() with vm.client and vm.VM.HREF
 // which returns a *types.Metadata struct for provided VM input.
-func (vm *VM) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vm.client, vm.VM.HREF)
+func (vm *VM) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, vm.client, vm.VM.HREF)
 }
 
 // DeleteMetadata() function calls private function deleteMetadata() with vm.client and vm.VM.HREF
 // which deletes metadata depending on key provided as input from VM.
-func (vm *VM) DeleteMetadata(key string) (Task, error) {
-	return deleteMetadata(vm.client, key, vm.VM.HREF)
+func (vm *VM) DeleteMetadata(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, vm.client, key, vm.VM.HREF)
 }
 
 // AddMetadata calls private function addMetadata() with vm.client and vm.VM.HREF
 // which adds metadata key/value pair provided as input to VM.
-func (vm *VM) AddMetadata(key string, value string) (Task, error) {
-	return addMetadata(vm.client, key, value, vm.VM.HREF)
+func (vm *VM) AddMetadata(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, vm.client, key, value, vm.VM.HREF)
 }
 
 // GetMetadata returns meta data for VDC.
-func (vdc *Vdc) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vdc.client, getAdminVdcURL(vdc.Vdc.HREF))
+func (vdc *Vdc) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, vdc.client, getAdminVdcURL(vdc.Vdc.HREF))
 }
 
 // DeleteMetadata() function deletes metadata by key provided as input
-func (vdc *Vdc) DeleteMetadata(key string) (Vdc, error) {
-	task, err := deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
+func (vdc *Vdc) DeleteMetadata(ctx context.Context, key string) (Vdc, error) {
+	task, err := deleteMetadata(ctx, vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
 	if err != nil {
 		return Vdc{}, err
 	}
 
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return Vdc{}, err
 	}
@@ -57,13 +58,13 @@ func (vdc *Vdc) DeleteMetadata(key string) (Vdc, error) {
 }
 
 // AddMetadata adds metadata key/value pair provided as input to VDC.
-func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
-	task, err := addMetadata(vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
+func (vdc *Vdc) AddMetadata(ctx context.Context, key string, value string) (Vdc, error) {
+	task, err := addMetadata(ctx, vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
 	if err != nil {
 		return Vdc{}, err
 	}
 
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return Vdc{}, err
 	}
@@ -78,14 +79,14 @@ func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
 
 // AddMetadata adds metadata key/value pair provided as input to VDC.
 // and returns task
-func (vdc *Vdc) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
+func (vdc *Vdc) AddMetadataAsync(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, vdc.client, key, value, getAdminVdcURL(vdc.Vdc.HREF))
 }
 
 // DeleteMetadata() function deletes metadata by key provided as input
 // and returns task
-func (vdc *Vdc) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
+func (vdc *Vdc) DeleteMetadataAsync(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
 }
 
 func getAdminVdcURL(vdcURL string) string {
@@ -94,14 +95,14 @@ func getAdminVdcURL(vdcURL string) string {
 
 // GetMetadata calls private function getMetadata() with vapp.client and vapp.VApp.HREF
 // which returns a *types.Metadata struct for provided vapp input.
-func (vapp *VApp) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vapp.client, vapp.VApp.HREF)
+func (vapp *VApp) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, vapp.client, vapp.VApp.HREF)
 }
 
-func getMetadata(client *Client, requestUri string) (*types.Metadata, error) {
+func getMetadata(ctx context.Context, client *Client, requestUri string) (*types.Metadata, error) {
 	metadata := &types.Metadata{}
 
-	_, err := client.ExecuteRequest(requestUri+"/metadata/", http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, requestUri+"/metadata/", http.MethodGet,
 		types.MimeMetaData, "error retrieving metadata: %s", nil, metadata)
 
 	return metadata, err
@@ -109,30 +110,30 @@ func getMetadata(client *Client, requestUri string) (*types.Metadata, error) {
 
 // DeleteMetadata() function calls private function deleteMetadata() with vapp.client and vapp.VApp.HREF
 // which deletes metadata depending on key provided as input from vApp.
-func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
-	return deleteMetadata(vapp.client, key, vapp.VApp.HREF)
+func (vapp *VApp) DeleteMetadata(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, vapp.client, key, vapp.VApp.HREF)
 }
 
 // Deletes metadata (type MetadataStringValue) from the vApp
 // TODO: Support all MetadataTypedValue types with this function
-func deleteMetadata(client *Client, key string, requestUri string) (Task, error) {
+func deleteMetadata(ctx context.Context, client *Client, key string, requestUri string) (Task, error) {
 	apiEndpoint, _ := url.ParseRequestURI(requestUri)
 	apiEndpoint.Path += "/metadata/" + key
 
 	// Return the task
-	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodDelete,
+	return client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodDelete,
 		"", "error deleting metadata: %s", nil)
 }
 
 // AddMetadata calls private function addMetadata() with vapp.client and vapp.VApp.HREF
 // which adds metadata key/value pair provided as input
-func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
-	return addMetadata(vapp.client, key, value, vapp.VApp.HREF)
+func (vapp *VApp) AddMetadata(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, vapp.client, key, value, vapp.VApp.HREF)
 }
 
 // Adds metadata (type MetadataStringValue) to the vApp
 // TODO: Support all MetadataTypedValue types with this function
-func addMetadata(client *Client, key string, value string, requestUri string) (Task, error) {
+func addMetadata(ctx context.Context, client *Client, key string, value string, requestUri string) (Task, error) {
 	newMetadata := &types.MetadataValue{
 		Xmlns: types.XMLNamespaceVCloud,
 		Xsi:   types.XMLNamespaceXSI,
@@ -146,23 +147,23 @@ func addMetadata(client *Client, key string, value string, requestUri string) (T
 	apiEndpoint.Path += "/metadata/" + key
 
 	// Return the task
-	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
 }
 
 // GetMetadata calls private function getMetadata() with catalogItem.client and catalogItem.CatalogItem.HREF
 // which returns a *types.Metadata struct for provided catalog item input.
-func (vAppTemplate *VAppTemplate) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
+func (vAppTemplate *VAppTemplate) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
 }
 
 // AddMetadata adds metadata key/value pair provided as input and returned update VAppTemplate
-func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTemplate, error) {
-	task, err := vAppTemplate.AddMetadataAsync(key, value)
+func (vAppTemplate *VAppTemplate) AddMetadata(ctx context.Context, key string, value string) (*VAppTemplate, error) {
+	task, err := vAppTemplate.AddMetadataAsync(ctx, key, value)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error completing add metadata for vApp template task: %s", err)
 	}
@@ -177,17 +178,17 @@ func (vAppTemplate *VAppTemplate) AddMetadata(key string, value string) (*VAppTe
 
 // AddMetadataAsync calls private function addMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
 // which adds metadata key/value pair provided as input.
-func (vAppTemplate *VAppTemplate) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(vAppTemplate.client, key, value, vAppTemplate.VAppTemplate.HREF)
+func (vAppTemplate *VAppTemplate) AddMetadataAsync(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, vAppTemplate.client, key, value, vAppTemplate.VAppTemplate.HREF)
 }
 
 // DeleteMetadata deletes metadata depending on key provided as input from media item.
-func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
-	task, err := vAppTemplate.DeleteMetadataAsync(key)
+func (vAppTemplate *VAppTemplate) DeleteMetadata(ctx context.Context, key string) error {
+	task, err := vAppTemplate.DeleteMetadataAsync(ctx, key)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error completing delete metadata for vApp template task: %s", err)
 	}
@@ -197,25 +198,25 @@ func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
 
 // DeleteMetadataAsync calls private function deleteMetadata() with vAppTemplate.client and vAppTemplate.VAppTemplate.HREF
 // which deletes metadata depending on key provided as input from catalog item.
-func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
+func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
 }
 
 // GetMetadata calls private function getMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which returns a *types.Metadata struct for provided media item input.
 // Deprecated: Use MediaRecord.GetMetadata
-func (mediaItem *MediaItem) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(mediaItem.vdc.client, mediaItem.MediaItem.HREF)
+func (mediaItem *MediaItem) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, mediaItem.vdc.client, mediaItem.MediaItem.HREF)
 }
 
 // AddMetadata adds metadata key/value pair provided as input.
 // Deprecated: Use MediaRecord.AddMetadata
-func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, error) {
-	task, err := mediaItem.AddMetadataAsync(key, value)
+func (mediaItem *MediaItem) AddMetadata(ctx context.Context, key string, value string) (*MediaItem, error) {
+	task, err := mediaItem.AddMetadataAsync(ctx, key, value)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
 	}
@@ -231,18 +232,18 @@ func (mediaItem *MediaItem) AddMetadata(key string, value string) (*MediaItem, e
 // AddMetadataAsync calls private function addMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which adds metadata key/value pair provided as input.
 // Deprecated: Use MediaRecord.AddMetadataAsync
-func (mediaItem *MediaItem) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(mediaItem.vdc.client, key, value, mediaItem.MediaItem.HREF)
+func (mediaItem *MediaItem) AddMetadataAsync(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, mediaItem.vdc.client, key, value, mediaItem.MediaItem.HREF)
 }
 
 // DeleteMetadata deletes metadata depending on key provided as input from media item.
 // Deprecated: Use MediaRecord.DeleteMetadata
-func (mediaItem *MediaItem) DeleteMetadata(key string) error {
-	task, err := mediaItem.DeleteMetadataAsync(key)
+func (mediaItem *MediaItem) DeleteMetadata(ctx context.Context, key string) error {
+	task, err := mediaItem.DeleteMetadataAsync(ctx, key)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
 	}
@@ -253,28 +254,28 @@ func (mediaItem *MediaItem) DeleteMetadata(key string) error {
 // DeleteMetadataAsync calls private function deleteMetadata() with mediaItem.client and mediaItem.MediaItem.HREF
 // which deletes metadata depending on key provided as input from media item.
 // Deprecated: Use MediaRecord.DeleteMetadataAsync
-func (mediaItem *MediaItem) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(mediaItem.vdc.client, key, mediaItem.MediaItem.HREF)
+func (mediaItem *MediaItem) DeleteMetadataAsync(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, mediaItem.vdc.client, key, mediaItem.MediaItem.HREF)
 }
 
 // GetMetadata calls private function getMetadata() with MediaRecord.client and MediaRecord.MediaRecord.HREF
 // which returns a *types.Metadata struct for provided media item input.
-func (mediaRecord *MediaRecord) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(mediaRecord.client, mediaRecord.MediaRecord.HREF)
+func (mediaRecord *MediaRecord) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, mediaRecord.client, mediaRecord.MediaRecord.HREF)
 }
 
 // AddMetadata adds metadata key/value pair provided as input.
-func (mediaRecord *MediaRecord) AddMetadata(key string, value string) (*MediaRecord, error) {
-	task, err := mediaRecord.AddMetadataAsync(key, value)
+func (mediaRecord *MediaRecord) AddMetadata(ctx context.Context, key string, value string) (*MediaRecord, error) {
+	task, err := mediaRecord.AddMetadataAsync(ctx, key, value)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
 	}
 
-	err = mediaRecord.Refresh()
+	err = mediaRecord.Refresh(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing media item: %s", err)
 	}
@@ -284,17 +285,17 @@ func (mediaRecord *MediaRecord) AddMetadata(key string, value string) (*MediaRec
 
 // AddMetadataAsync calls private function addMetadata() with MediaRecord.client and MediaRecord.MediaRecord.HREF
 // which adds metadata key/value pair provided as input.
-func (mediaRecord *MediaRecord) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(mediaRecord.client, key, value, mediaRecord.MediaRecord.HREF)
+func (mediaRecord *MediaRecord) AddMetadataAsync(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, mediaRecord.client, key, value, mediaRecord.MediaRecord.HREF)
 }
 
 // DeleteMetadata deletes metadata depending on key provided as input from media item.
-func (mediaRecord *MediaRecord) DeleteMetadata(key string) error {
-	task, err := mediaRecord.DeleteMetadataAsync(key)
+func (mediaRecord *MediaRecord) DeleteMetadata(ctx context.Context, key string) error {
+	task, err := mediaRecord.DeleteMetadataAsync(ctx, key)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
 	}
@@ -304,28 +305,28 @@ func (mediaRecord *MediaRecord) DeleteMetadata(key string) error {
 
 // DeleteMetadataAsync calls private function deleteMetadata() with MediaRecord.client and MediaRecord.MediaRecord.HREF
 // which deletes metadata depending on key provided as input from media item.
-func (mediaRecord *MediaRecord) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(mediaRecord.client, key, mediaRecord.MediaRecord.HREF)
+func (mediaRecord *MediaRecord) DeleteMetadataAsync(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, mediaRecord.client, key, mediaRecord.MediaRecord.HREF)
 }
 
 // GetMetadata calls private function getMetadata() with Media.client and Media.Media.HREF
 // which returns a *types.Metadata struct for provided media item input.
-func (media *Media) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(media.client, media.Media.HREF)
+func (media *Media) GetMetadata(ctx context.Context) (*types.Metadata, error) {
+	return getMetadata(ctx, media.client, media.Media.HREF)
 }
 
 // AddMetadata adds metadata key/value pair provided as input.
-func (media *Media) AddMetadata(key string, value string) (*Media, error) {
-	task, err := media.AddMetadataAsync(key, value)
+func (media *Media) AddMetadata(ctx context.Context, key string, value string) (*Media, error) {
+	task, err := media.AddMetadataAsync(ctx, key, value)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
 	}
 
-	err = media.Refresh()
+	err = media.Refresh(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error refreshing media item: %s", err)
 	}
@@ -335,17 +336,17 @@ func (media *Media) AddMetadata(key string, value string) (*Media, error) {
 
 // AddMetadataAsync calls private function addMetadata() with Media.client and Media.Media.HREF
 // which adds metadata key/value pair provided as input.
-func (media *Media) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(media.client, key, value, media.Media.HREF)
+func (media *Media) AddMetadataAsync(ctx context.Context, key string, value string) (Task, error) {
+	return addMetadata(ctx, media.client, key, value, media.Media.HREF)
 }
 
 // DeleteMetadata deletes metadata depending on key provided as input from media item.
-func (media *Media) DeleteMetadata(key string) error {
-	task, err := media.DeleteMetadataAsync(key)
+func (media *Media) DeleteMetadata(ctx context.Context, key string) error {
+	task, err := media.DeleteMetadataAsync(ctx, key)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
 	}
@@ -355,6 +356,6 @@ func (media *Media) DeleteMetadata(key string) error {
 
 // DeleteMetadataAsync calls private function deleteMetadata() with Media.client and Media.Media.HREF
 // which deletes metadata depending on key provided as input from media item.
-func (media *Media) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(media.client, key, media.Media.HREF)
+func (media *Media) DeleteMetadataAsync(ctx context.Context, key string) (Task, error) {
+	return deleteMetadata(ctx, media.client, key, media.Media.HREF)
 }

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -26,14 +26,14 @@ func (vcd *TestVCD) Test_AddMetadataForVdc(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	// Add metadata
-	vdc, err := vcd.vdc.AddMetadata("key", "value")
+	vdc, err := vcd.vdc.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
 	check.Assert(vdc, Not(Equals), Vdc{})
 
 	AddToCleanupList("key", "vdcMetaData", vcd.org.Org.Name+"|"+vcd.config.VCD.Vdc, check.TestName())
 
 	// Check if metadata was added correctly
-	metadata, err := vcd.vdc.GetMetadata()
+	metadata, err := vcd.vdc.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
@@ -48,18 +48,18 @@ func (vcd *TestVCD) Test_DeleteMetadataForVdc(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	// Add metadata
-	vdc, err := vcd.vdc.AddMetadata("key", "value")
+	vdc, err := vcd.vdc.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
 	check.Assert(vdc, Not(Equals), Vdc{})
 
 	AddToCleanupList("key", "vdcMetaData", vcd.org.Org.Name+"|"+vcd.config.VCD.Vdc, check.TestName())
 
 	// Remove metadata
-	vdc, err = vcd.vdc.DeleteMetadata("key2")
+	vdc, err = vcd.vdc.DeleteMetadata(ctx, "key2")
 	check.Assert(err, IsNil)
 	check.Assert(vdc, Not(Equals), Vdc{})
 
-	metadata, err := vcd.vdc.GetMetadata()
+	metadata, err := vcd.vdc.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	for _, k := range metadata.MetadataEntry {
 		if k.Key == "key2" {
@@ -75,14 +75,14 @@ func (vcd *TestVCD) Test_AddMetadataOnVapp(check *C) {
 		check.Skip("Skipping test because vApp was not successfully created at setup")
 	}
 	// Add metadata
-	task, err := vcd.vapp.AddMetadata("key", "value")
+	task, err := vcd.vapp.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Check if metadata was added correctly
-	metadata, err := vcd.vapp.GetMetadata()
+	metadata, err := vcd.vapp.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
@@ -96,19 +96,19 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVapp(check *C) {
 		check.Skip("Skipping test because vApp was not successfully created at setup")
 	}
 	// Add metadata
-	task, err := vcd.vapp.AddMetadata("key2", "value2")
+	task, err := vcd.vapp.AddMetadata(ctx, "key2", "value2")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Remove metadata
-	task, err = vcd.vapp.DeleteMetadata("key2")
+	task, err = vcd.vapp.DeleteMetadata(ctx, "key2")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-	metadata, err := vcd.vapp.GetMetadata()
+	metadata, err := vcd.vapp.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	for _, k := range metadata.MetadataEntry {
 		if k.Key == "key2" {
@@ -129,7 +129,7 @@ func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -139,14 +139,14 @@ func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
 	vm.VM = &vmType
 
 	// Add metadata
-	task, err := vm.AddMetadata("key", "value")
+	task, err := vm.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Check if metadata was added correctly
-	metadata, err := vm.GetMetadata()
+	metadata, err := vm.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
@@ -165,7 +165,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -175,19 +175,19 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 	vm.VM = &vmType
 
 	// Add metadata
-	task, err := vm.AddMetadata("key2", "value2")
+	task, err := vm.AddMetadata(ctx, "key2", "value2")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Remove metadata
-	task, err = vm.DeleteMetadata("key2")
+	task, err = vm.DeleteMetadata(ctx, "key2")
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-	metadata, err := vm.GetMetadata()
+	metadata, err := vm.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	for _, k := range metadata.MetadataEntry {
 		if k.Key == "key2" {
@@ -198,7 +198,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
 
 func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog not found. Test can't proceed")
 		return
@@ -208,25 +208,25 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
+	catItem, err := cat.GetCatalogItemByName(ctx, vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
-	vAppTemplate, err := catItem.GetVAppTemplate()
+	vAppTemplate, err := catItem.GetVAppTemplate(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate, NotNil)
 	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Add metadata
-	_, err = vAppTemplate.AddMetadata("key2", "value2")
+	_, err = vAppTemplate.AddMetadata(ctx, "key2", "value2")
 	check.Assert(err, IsNil)
 
 	// Remove metadata
-	err = vAppTemplate.DeleteMetadata("key2")
+	err = vAppTemplate.DeleteMetadata(ctx, "key2")
 	check.Assert(err, IsNil)
 
-	metadata, err := vAppTemplate.GetMetadata()
+	metadata, err := vAppTemplate.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
 	for _, k := range metadata.MetadataEntry {
@@ -238,7 +238,7 @@ func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
 
 func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog not found. Test can't proceed")
 		return
@@ -248,28 +248,28 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
+	catItem, err := cat.GetCatalogItemByName(ctx, vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
-	vAppTemplate, err := catItem.GetVAppTemplate()
+	vAppTemplate, err := catItem.GetVAppTemplate(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate, NotNil)
 	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Check how much metaData exist
-	metadata, err := vAppTemplate.GetMetadata()
+	metadata, err := vAppTemplate.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
 	existingMetaDataCount := len(metadata.MetadataEntry)
 
 	// Add metadata
-	_, err = vAppTemplate.AddMetadata("key", "value")
+	_, err = vAppTemplate.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
 
 	// Check if metadata was added correctly
-	metadata, err = vAppTemplate.GetMetadata()
+	metadata, err = vAppTemplate.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, existingMetaDataCount+1)
@@ -283,7 +283,7 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	check.Assert(foundEntry.Key, Equals, "key")
 	check.Assert(foundEntry.TypedValue.Value, Equals, "value")
 
-	err = vAppTemplate.DeleteMetadata("key")
+	err = vAppTemplate.DeleteMetadata(ctx, "key")
 	check.Assert(err, IsNil)
 }
 
@@ -294,39 +294,39 @@ func (vcd *TestVCD) Test_DeleteMetadataOnMediaRecord(check *C) {
 	skipWhenMediaPathMissing(vcd, check)
 	itemName := "TestDeleteMediaMetaData"
 
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
 	check.Assert(uploadTask, NotNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_DeleteMetadataOnMediaRecord")
 
-	err = vcd.org.Refresh()
+	err = vcd.org.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	mediaRecord, err := catalog.QueryMedia(itemName)
+	mediaRecord, err := catalog.QueryMedia(ctx, itemName)
 	check.Assert(err, IsNil)
 	check.Assert(mediaRecord, NotNil)
 	check.Assert(mediaRecord.MediaRecord.Name, Equals, itemName)
 
 	// Add metadata
-	_, err = mediaRecord.AddMetadata("key2", "value2")
+	_, err = mediaRecord.AddMetadata(ctx, "key2", "value2")
 	check.Assert(err, IsNil)
 
 	// Remove metadata
-	err = mediaRecord.DeleteMetadata("key2")
+	err = mediaRecord.DeleteMetadata(ctx, "key2")
 	check.Assert(err, IsNil)
 
-	metadata, err := mediaRecord.GetMetadata()
+	metadata, err := mediaRecord.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
 	for _, k := range metadata.MetadataEntry {
@@ -343,37 +343,37 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaRecord(check *C) {
 	skipWhenMediaPathMissing(vcd, check)
 	itemName := "TestAddMediaMetaData"
 
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	check.Assert(catalog.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
 
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
 	check.Assert(uploadTask, NotNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_AddMetadataOnMediaRecord")
 
-	err = vcd.org.Refresh()
+	err = vcd.org.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	mediaRecord, err := catalog.QueryMedia(itemName)
+	mediaRecord, err := catalog.QueryMedia(ctx, itemName)
 	check.Assert(err, IsNil)
 	check.Assert(mediaRecord, NotNil)
 	check.Assert(mediaRecord.MediaRecord.Name, Equals, itemName)
 
 	// Add metadata
-	_, err = mediaRecord.AddMetadata("key", "value")
+	_, err = mediaRecord.AddMetadata(ctx, "key", "value")
 	check.Assert(err, IsNil)
 
 	// Check if metadata was added correctly
-	metadata, err := mediaRecord.GetMetadata()
+	metadata, err := mediaRecord.GetMetadata(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(metadata, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)

--- a/govcd/nsxt_edge_cluster.go
+++ b/govcd/nsxt_edge_cluster.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -19,7 +20,7 @@ type NsxtEdgeCluster struct {
 
 // GetNsxtEdgeClusterByName retrieves a particular NSX-T Edge Cluster by name available for that VDC
 // Note: Multiple NSX-T Edge Clusters with the same name may exist.
-func (vdc *Vdc) GetNsxtEdgeClusterByName(name string) (*NsxtEdgeCluster, error) {
+func (vdc *Vdc) GetNsxtEdgeClusterByName(ctx context.Context, name string) (*NsxtEdgeCluster, error) {
 	if name == "" {
 		return nil, fmt.Errorf("empty NSX-T Edge Cluster name specified")
 	}
@@ -33,7 +34,7 @@ func (vdc *Vdc) GetNsxtEdgeClusterByName(name string) (*NsxtEdgeCluster, error) 
 		queryParameters.Add("filter", "name=="+name)
 	*/
 
-	nsxtEdgeClusters, err := vdc.GetAllNsxtEdgeClusters(nil)
+	nsxtEdgeClusters, err := vdc.GetAllNsxtEdgeClusters(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not find NSX-T Edge Cluster with name '%s' for Org VDC with id '%s': %s",
 			name, vdc.Vdc.ID, err)
@@ -72,13 +73,13 @@ func filterNsxtEdgeClusters(name string, allNnsxtEdgeCluster []*NsxtEdgeCluster)
 }
 
 // GetAllNsxtEdgeClusters retrieves all available Edge Clusters for a particular VDC
-func (vdc *Vdc) GetAllNsxtEdgeClusters(queryParameters url.Values) ([]*NsxtEdgeCluster, error) {
+func (vdc *Vdc) GetAllNsxtEdgeClusters(ctx context.Context, queryParameters url.Values) ([]*NsxtEdgeCluster, error) {
 	if vdc.Vdc.ID == "" {
 		return nil, fmt.Errorf("VDC must have ID populated to retrieve NSX-T edge clusters")
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func (vdc *Vdc) GetAllNsxtEdgeClusters(queryParameters url.Values) ([]*NsxtEdgeC
 	queryParams := queryParameterFilterAnd("_context=="+vdc.Vdc.ID, queryParameters)
 
 	typeResponses := []*types.NsxtEdgeCluster{{}}
-	err = vdc.client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParams, &typeResponses)
+	err = vdc.client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParams, &typeResponses)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/nsxt_edge_cluster_test.go
+++ b/govcd/nsxt_edge_cluster_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (vcd *TestVCD) Test_GetAllNsxtEdgeClusters(check *C) {
-	if vcd.client.Client.APIVCDMaxVersionIs("< 34") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 34") {
 		check.Skip("At least VCD 10.1 is required")
 	}
 
@@ -23,17 +23,17 @@ func (vcd *TestVCD) Test_GetAllNsxtEdgeClusters(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	nsxtVdc, err := vcd.org.GetVDCByNameOrId(vcd.config.VCD.Nsxt.Vdc, true)
+	nsxtVdc, err := vcd.org.GetVDCByNameOrId(ctx, vcd.config.VCD.Nsxt.Vdc, true)
 	check.Assert(err, IsNil)
 
-	tier0Router, err := nsxtVdc.GetAllNsxtEdgeClusters(nil)
+	tier0Router, err := nsxtVdc.GetAllNsxtEdgeClusters(ctx, nil)
 	check.Assert(err, IsNil)
 	check.Assert(tier0Router, NotNil)
 	check.Assert(len(tier0Router) > 0, Equals, true)
 }
 
 func (vcd *TestVCD) Test_GetNsxtEdgeClusterByName(check *C) {
-	if vcd.client.Client.APIVCDMaxVersionIs("< 34") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 34") {
 		check.Skip("At least VCD 10.1 is required")
 	}
 
@@ -43,14 +43,14 @@ func (vcd *TestVCD) Test_GetNsxtEdgeClusterByName(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	nsxtVdc, err := vcd.org.GetVDCByNameOrId(vcd.config.VCD.Nsxt.Vdc, true)
+	nsxtVdc, err := vcd.org.GetVDCByNameOrId(ctx, vcd.config.VCD.Nsxt.Vdc, true)
 	check.Assert(err, IsNil)
 
-	allEdgeClusters, err := nsxtVdc.GetAllNsxtEdgeClusters(nil)
+	allEdgeClusters, err := nsxtVdc.GetAllNsxtEdgeClusters(ctx, nil)
 	check.Assert(err, IsNil)
 	check.Assert(allEdgeClusters, NotNil)
 
-	edgeCluster, err := nsxtVdc.GetNsxtEdgeClusterByName(allEdgeClusters[0].NsxtEdgeCluster.Name)
+	edgeCluster, err := nsxtVdc.GetNsxtEdgeClusterByName(ctx, allEdgeClusters[0].NsxtEdgeCluster.Name)
 	check.Assert(err, IsNil)
 	check.Assert(allEdgeClusters, NotNil)
 	check.Assert(edgeCluster, DeepEquals, allEdgeClusters[0])

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -18,20 +19,20 @@ type NsxtEdgeGateway struct {
 }
 
 // GetNsxtEdgeGatewayById allows to retrieve NSX-T edge gateway by ID for Org admins
-func (adminOrg *AdminOrg) GetNsxtEdgeGatewayById(id string) (*NsxtEdgeGateway, error) {
-	return getNsxtEdgeGatewayById(adminOrg.client, id, nil)
+func (adminOrg *AdminOrg) GetNsxtEdgeGatewayById(ctx context.Context, id string) (*NsxtEdgeGateway, error) {
+	return getNsxtEdgeGatewayById(ctx, adminOrg.client, id, nil)
 }
 
 // GetNsxtEdgeGatewayById allows to retrieve NSX-T edge gateway by ID for Org users
-func (org *Org) GetNsxtEdgeGatewayById(id string) (*NsxtEdgeGateway, error) {
-	return getNsxtEdgeGatewayById(org.client, id, nil)
+func (org *Org) GetNsxtEdgeGatewayById(ctx context.Context, id string) (*NsxtEdgeGateway, error) {
+	return getNsxtEdgeGatewayById(ctx, org.client, id, nil)
 }
 
 // GetNsxtEdgeGatewayById allows to retrieve NSX-T edge gateway by ID for specific VDC
-func (vdc *Vdc) GetNsxtEdgeGatewayById(id string) (*NsxtEdgeGateway, error) {
+func (vdc *Vdc) GetNsxtEdgeGatewayById(ctx context.Context, id string) (*NsxtEdgeGateway, error) {
 	params := url.Values{}
 	filterParams := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, params)
-	egw, err := getNsxtEdgeGatewayById(vdc.client, id, filterParams)
+	egw, err := getNsxtEdgeGatewayById(ctx, vdc.client, id, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -45,11 +46,11 @@ func (vdc *Vdc) GetNsxtEdgeGatewayById(id string) (*NsxtEdgeGateway, error) {
 }
 
 // GetNsxtEdgeGatewayByName allows to retrieve NSX-T edge gateway by Name for Org admins
-func (adminOrg *AdminOrg) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGateway, error) {
+func (adminOrg *AdminOrg) GetNsxtEdgeGatewayByName(ctx context.Context, name string) (*NsxtEdgeGateway, error) {
 	queryParameters := url.Values{}
 	queryParameters.Add("filter", "name=="+name)
 
-	allEdges, err := adminOrg.GetAllNsxtEdgeGateways(queryParameters)
+	allEdges, err := adminOrg.GetAllNsxtEdgeGateways(ctx, queryParameters)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Edge Gateway by name '%s': %s", name, err)
 	}
@@ -60,11 +61,11 @@ func (adminOrg *AdminOrg) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGatewa
 }
 
 // GetNsxtEdgeGatewayByName allows to retrieve NSX-T edge gateway by Name for Org admins
-func (org *Org) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGateway, error) {
+func (org *Org) GetNsxtEdgeGatewayByName(ctx context.Context, name string) (*NsxtEdgeGateway, error) {
 	queryParameters := url.Values{}
 	queryParameters.Add("filter", "name=="+name)
 
-	allEdges, err := org.GetAllNsxtEdgeGateways(queryParameters)
+	allEdges, err := org.GetAllNsxtEdgeGateways(ctx, queryParameters)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Edge Gateway by name '%s': %s", name, err)
 	}
@@ -75,11 +76,11 @@ func (org *Org) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGateway, error) 
 }
 
 // GetNsxtEdgeGatewayByName allows to retrieve NSX-T edge gateway by Name for specific VDC
-func (vdc *Vdc) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGateway, error) {
+func (vdc *Vdc) GetNsxtEdgeGatewayByName(ctx context.Context, name string) (*NsxtEdgeGateway, error) {
 	queryParameters := url.Values{}
 	queryParameters.Add("filter", "name=="+name)
 
-	allEdges, err := vdc.GetAllNsxtEdgeGateways(queryParameters)
+	allEdges, err := vdc.GetAllNsxtEdgeGateways(ctx, queryParameters)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Edge Gateway by name '%s': %s", name, err)
 	}
@@ -88,29 +89,29 @@ func (vdc *Vdc) GetNsxtEdgeGatewayByName(name string) (*NsxtEdgeGateway, error) 
 }
 
 // GetAllNsxtEdgeGateways allows to retrieve all NSX-T edge gateways for Org Admins
-func (adminOrg *AdminOrg) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
-	return getAllNsxtEdgeGateways(adminOrg.client, queryParameters)
+func (adminOrg *AdminOrg) GetAllNsxtEdgeGateways(ctx context.Context, queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
+	return getAllNsxtEdgeGateways(ctx, adminOrg.client, queryParameters)
 }
 
 // GetAllNsxtEdgeGateways allows to retrieve all NSX-T edge gateways for Org users
-func (org *Org) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
-	return getAllNsxtEdgeGateways(org.client, queryParameters)
+func (org *Org) GetAllNsxtEdgeGateways(ctx context.Context, queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
+	return getAllNsxtEdgeGateways(ctx, org.client, queryParameters)
 }
 
 // GetAllNsxtEdgeGateways allows to retrieve all NSX-T edge gateways for specific VDC
-func (vdc *Vdc) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
+func (vdc *Vdc) GetAllNsxtEdgeGateways(ctx context.Context, queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
 	filteredQueryParams := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, queryParameters)
-	return getAllNsxtEdgeGateways(vdc.client, filteredQueryParams)
+	return getAllNsxtEdgeGateways(ctx, vdc.client, filteredQueryParams)
 }
 
 // CreateNsxtEdgeGateway allows to create NSX-T edge gateway for Org admins
-func (adminOrg *AdminOrg) CreateNsxtEdgeGateway(edgeGatewayConfig *types.OpenAPIEdgeGateway) (*NsxtEdgeGateway, error) {
+func (adminOrg *AdminOrg) CreateNsxtEdgeGateway(ctx context.Context, edgeGatewayConfig *types.OpenAPIEdgeGateway) (*NsxtEdgeGateway, error) {
 	if !adminOrg.client.IsSysAdmin {
 		return nil, fmt.Errorf("only System Administrator can create Edge Gateway")
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways
-	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func (adminOrg *AdminOrg) CreateNsxtEdgeGateway(edgeGatewayConfig *types.OpenAPI
 		client:      adminOrg.client,
 	}
 
-	err = adminOrg.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, edgeGatewayConfig, returnEgw.EdgeGateway)
+	err = adminOrg.client.OpenApiPostItem(ctx, minimumApiVersion, urlRef, nil, edgeGatewayConfig, returnEgw.EdgeGateway)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Edge Gateway: %s", err)
 	}
@@ -134,13 +135,13 @@ func (adminOrg *AdminOrg) CreateNsxtEdgeGateway(edgeGatewayConfig *types.OpenAPI
 }
 
 // Update allows to update NSX-T edge gateway for Org admins
-func (egw *NsxtEdgeGateway) Update(edgeGatewayConfig *types.OpenAPIEdgeGateway) (*NsxtEdgeGateway, error) {
+func (egw *NsxtEdgeGateway) Update(ctx context.Context, edgeGatewayConfig *types.OpenAPIEdgeGateway) (*NsxtEdgeGateway, error) {
 	if !egw.client.IsSysAdmin {
 		return nil, fmt.Errorf("only System Administrator can update Edge Gateway")
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways
-	minimumApiVersion, err := egw.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := egw.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func (egw *NsxtEdgeGateway) Update(edgeGatewayConfig *types.OpenAPIEdgeGateway) 
 		client:      egw.client,
 	}
 
-	err = egw.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, edgeGatewayConfig, returnEgw.EdgeGateway)
+	err = egw.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, edgeGatewayConfig, returnEgw.EdgeGateway)
 	if err != nil {
 		return nil, fmt.Errorf("error updating Edge Gateway: %s", err)
 	}
@@ -168,13 +169,13 @@ func (egw *NsxtEdgeGateway) Update(edgeGatewayConfig *types.OpenAPIEdgeGateway) 
 }
 
 // Update allows to delete NSX-T edge gateway for Org admins
-func (egw *NsxtEdgeGateway) Delete() error {
+func (egw *NsxtEdgeGateway) Delete(ctx context.Context) error {
 	if !egw.client.IsSysAdmin {
 		return fmt.Errorf("only Provider can update Edge Gateway")
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways
-	minimumApiVersion, err := egw.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := egw.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -188,7 +189,7 @@ func (egw *NsxtEdgeGateway) Delete() error {
 		return err
 	}
 
-	err = egw.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = egw.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting Edge Gateway: %s", err)
@@ -201,9 +202,9 @@ func (egw *NsxtEdgeGateway) Delete() error {
 // func (adminOrg *AdminOrg) GetNsxtEdgeGatewayByName(id string) (*NsxtEdgeGateway, error)
 // func (org *Org) GetNsxtEdgeGatewayByName(id string) (*NsxtEdgeGateway, error)
 // func (vdc *Vdc) GetNsxtEdgeGatewayById(id string) (*NsxtEdgeGateway, error)
-func getNsxtEdgeGatewayById(client *Client, id string, queryParameters url.Values) (*NsxtEdgeGateway, error) {
+func getNsxtEdgeGatewayById(ctx context.Context, client *Client, id string, queryParameters url.Values) (*NsxtEdgeGateway, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func getNsxtEdgeGatewayById(client *Client, id string, queryParameters url.Value
 		client:      client,
 	}
 
-	err = client.OpenApiGetItem(minimumApiVersion, urlRef, queryParameters, egw.EdgeGateway)
+	err = client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, queryParameters, egw.EdgeGateway)
 	if err != nil {
 		return nil, err
 	}
@@ -253,9 +254,9 @@ func returnSingleNsxtEdgeGateway(name string, allEdges []*NsxtEdgeGateway) (*Nsx
 // func (adminOrg *AdminOrg) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error)
 // func (org *Org) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error)
 // func (vdc *Vdc) GetAllNsxtEdgeGateways(queryParameters url.Values) ([]*NsxtEdgeGateway, error)
-func getAllNsxtEdgeGateways(client *Client, queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
+func getAllNsxtEdgeGateways(ctx context.Context, client *Client, queryParameters url.Values) ([]*NsxtEdgeGateway, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func getAllNsxtEdgeGateways(client *Client, queryParameters url.Values) ([]*Nsxt
 	}
 
 	typeResponses := []*types.OpenAPIEdgeGateway{{}}
-	err = client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &typeResponses)
+	err = client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &typeResponses)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/nsxt_importable_switch.go
+++ b/govcd/nsxt_importable_switch.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -24,12 +25,12 @@ type NsxtImportableSwitch struct {
 // Note. OpenAPI endpoint does not exist for this resource and by default endpoint
 // "/network/orgvdcnetworks/importableswitches" returns only unused NSX-T importable switches (the ones that are not
 // already consumed in Org VDC networks) and there is no way to get them all (including the used ones).
-func (vdc *Vdc) GetNsxtImportableSwitchByName(name string) (*NsxtImportableSwitch, error) {
+func (vdc *Vdc) GetNsxtImportableSwitchByName(ctx context.Context, name string) (*NsxtImportableSwitch, error) {
 	if name == "" {
 		return nil, fmt.Errorf("empty NSX-T Importable Switch name specified")
 	}
 
-	allNsxtImportableSwitches, err := vdc.GetAllNsxtImportableSwitches()
+	allNsxtImportableSwitches, err := vdc.GetAllNsxtImportableSwitches(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting all NSX-T Importable Switches for VDC '%s': %s", vdc.Vdc.Name, err)
 	}
@@ -61,7 +62,7 @@ func (vdc *Vdc) GetNsxtImportableSwitchByName(name string) (*NsxtImportableSwitc
 // Note. OpenAPI endpoint does not exist for this resource and by default endpoint
 // "/network/orgvdcnetworks/importableswitches" returns only unused NSX-T importable switches (the ones that are not
 // already consumed in Org VDC networks) and there is no way to get them all.
-func (vdc *Vdc) GetAllNsxtImportableSwitches() ([]*NsxtImportableSwitch, error) {
+func (vdc *Vdc) GetAllNsxtImportableSwitches(ctx context.Context) ([]*NsxtImportableSwitch, error) {
 	if vdc.Vdc.ID == "" {
 		return nil, fmt.Errorf("VDC must have ID populated to retrieve NSX-T importable switches")
 	}
@@ -79,7 +80,7 @@ func (vdc *Vdc) GetAllNsxtImportableSwitches() ([]*NsxtImportableSwitch, error) 
 
 	headAccept := http.Header{}
 	headAccept.Set("Accept", types.JSONMime)
-	request := vdc.client.newRequest(map[string]string{"orgVdc": orgVdcId}, nil, http.MethodGet, *urlRef, nil, vdc.client.APIVersion, headAccept)
+	request := vdc.client.newRequest(ctx, map[string]string{"orgVdc": orgVdcId}, nil, http.MethodGet, *urlRef, nil, vdc.client.APIVersion, headAccept)
 	request.Header.Set("Accept", types.JSONMime)
 
 	response, err := checkResp(vdc.client.Http.Do(request))

--- a/govcd/nsxt_importable_switch_test.go
+++ b/govcd/nsxt_importable_switch_test.go
@@ -17,15 +17,15 @@ func (vcd *TestVCD) Test_GetAllNsxtImportableSwitches(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	if vcd.client.Client.APIVCDMaxVersionIs("< 34") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 34") {
 		check.Skip("At least VCD 10.1 is required")
 	}
 	skipNoNsxtConfiguration(vcd, check)
 
-	nsxtVdc, err := vcd.org.GetVDCByNameOrId(vcd.config.VCD.Nsxt.Vdc, true)
+	nsxtVdc, err := vcd.org.GetVDCByNameOrId(ctx, vcd.config.VCD.Nsxt.Vdc, true)
 	check.Assert(err, IsNil)
 
-	allSwitches, err := nsxtVdc.GetAllNsxtImportableSwitches()
+	allSwitches, err := nsxtVdc.GetAllNsxtImportableSwitches(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(allSwitches) > 0, Equals, true)
 }
@@ -35,15 +35,15 @@ func (vcd *TestVCD) Test_GetNsxtImportableSwitchByName(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	if vcd.client.Client.APIVCDMaxVersionIs("< 34") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 34") {
 		check.Skip("At least VCD 10.1 is required")
 	}
 	skipNoNsxtConfiguration(vcd, check)
 
-	nsxtVdc, err := vcd.org.GetVDCByNameOrId(vcd.config.VCD.Nsxt.Vdc, true)
+	nsxtVdc, err := vcd.org.GetVDCByNameOrId(ctx, vcd.config.VCD.Nsxt.Vdc, true)
 	check.Assert(err, IsNil)
 
-	logicalSwitch, err := nsxtVdc.GetNsxtImportableSwitchByName(vcd.config.VCD.Nsxt.NsxtImportSegment)
+	logicalSwitch, err := nsxtVdc.GetNsxtImportableSwitchByName(ctx, vcd.config.VCD.Nsxt.NsxtImportSegment)
 	check.Assert(err, IsNil)
 	check.Assert(logicalSwitch.NsxtImportableSwitch.Name, Equals, vcd.config.VCD.Nsxt.NsxtImportSegment)
 }

--- a/govcd/nsxt_test.go
+++ b/govcd/nsxt_test.go
@@ -14,7 +14,7 @@ import (
 
 func (vcd *TestVCD) Test_QueryNsxtManagerByName(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
-	nsxtManagers, err := vcd.client.QueryNsxtManagerByName(vcd.config.VCD.Nsxt.Manager)
+	nsxtManagers, err := vcd.client.QueryNsxtManagerByName(ctx, vcd.config.VCD.Nsxt.Manager)
 	check.Assert(err, IsNil)
 	check.Assert(len(nsxtManagers), Equals, 1)
 }
@@ -25,7 +25,7 @@ func (vcd *TestVCD) Test_GetAllNsxtTier0Routers(check *C) {
 	}
 	skipNoNsxtConfiguration(vcd, check)
 
-	nsxtManagers, err := vcd.client.QueryNsxtManagerByName(vcd.config.VCD.Nsxt.Manager)
+	nsxtManagers, err := vcd.client.QueryNsxtManagerByName(ctx, vcd.config.VCD.Nsxt.Manager)
 	check.Assert(err, IsNil)
 	check.Assert(len(nsxtManagers), Equals, 1)
 
@@ -34,7 +34,7 @@ func (vcd *TestVCD) Test_GetAllNsxtTier0Routers(check *C) {
 	urn, err := BuildUrnWithUuid("urn:vcloud:nsxtmanager:", uuid)
 	check.Assert(err, IsNil)
 
-	tier0Router, err := vcd.client.GetImportableNsxtTier0RouterByName(vcd.config.VCD.Nsxt.Tier0router, urn)
+	tier0Router, err := vcd.client.GetImportableNsxtTier0RouterByName(ctx, vcd.config.VCD.Nsxt.Tier0router, urn)
 	check.Assert(err, IsNil)
 	check.Assert(tier0Router, NotNil)
 }

--- a/govcd/nsxt_tier0_router.go
+++ b/govcd/nsxt_tier0_router.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -25,7 +26,7 @@ type NsxtTier0Router struct {
 // Note. NSX-T manager ID is mandatory and must be in URN format (e.g.
 // urn:vcloud:nsxtmanager:09722307-aee0-4623-af95-7f8e577c9ebc)
 
-func (vcdCli *VCDClient) GetImportableNsxtTier0RouterByName(name, nsxtManagerId string) (*NsxtTier0Router, error) {
+func (vcdCli *VCDClient) GetImportableNsxtTier0RouterByName(ctx context.Context, name, nsxtManagerId string) (*NsxtTier0Router, error) {
 	if nsxtManagerId == "" {
 		return nil, fmt.Errorf("no NSX-T manager ID specified")
 	}
@@ -47,7 +48,7 @@ func (vcdCli *VCDClient) GetImportableNsxtTier0RouterByName(name, nsxtManagerId 
 		queryParameters.Add("filter", "displayName=="+name)
 	*/
 
-	nsxtTier0Routers, err := vcdCli.GetAllImportableNsxtTier0Routers(nsxtManagerId, nil)
+	nsxtTier0Routers, err := vcdCli.GetAllImportableNsxtTier0Routers(ctx, nsxtManagerId, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not find NSX-T Tier-0 router with name '%s' for NSX-T manager with id '%s': %s",
 			name, nsxtManagerId, err)
@@ -94,13 +95,13 @@ func filterNsxtTier0RoutersInExternalNetworks(name string, allNnsxtTier0Routers 
 //
 // Note. IDs of Tier-0 routers do not have a standard and may look as strings when they are created using UI or as UUIDs
 // when they are created using API
-func (vcdCli *VCDClient) GetAllImportableNsxtTier0Routers(nsxtManagerId string, queryParameters url.Values) ([]*NsxtTier0Router, error) {
+func (vcdCli *VCDClient) GetAllImportableNsxtTier0Routers(ctx context.Context, nsxtManagerId string, queryParameters url.Values) ([]*NsxtTier0Router, error) {
 	if !isUrn(nsxtManagerId) {
 		return nil, fmt.Errorf("NSX-T manager ID is not URN (e.g. 'urn:vcloud:nsxtmanager:09722307-aee0-4623-af95-7f8e577c9ebc)', got: %s", nsxtManagerId)
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointImportableTier0Routers
-	minimumApiVersion, err := vcdCli.Client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vcdCli.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +122,7 @@ func (vcdCli *VCDClient) GetAllImportableNsxtTier0Routers(nsxtManagerId string, 
 	queryParams := queryParameterFilterAnd("_context=="+nsxtManagerId, queryParameters)
 
 	typeResponses := []*types.NsxtTier0Router{{}}
-	err = vcdCli.Client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParams, &typeResponses)
+	err = vcdCli.Client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParams, &typeResponses)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/nsxv_dhcplease.go
+++ b/govcd/nsxv_dhcplease.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -20,11 +21,11 @@ type responseEdgeDhcpLeases struct {
 }
 
 // GetNsxvActiveDhcpLeaseByMac finds active DHCP lease for a given hardware address (MAC)
-func (egw *EdgeGateway) GetNsxvActiveDhcpLeaseByMac(mac string) (*types.EdgeDhcpLeaseInfo, error) {
+func (egw *EdgeGateway) GetNsxvActiveDhcpLeaseByMac(ctx context.Context, mac string) (*types.EdgeDhcpLeaseInfo, error) {
 	if mac == "" {
 		return nil, fmt.Errorf("MAC address must be provided to lookup DHCP lease")
 	}
-	dhcpLeases, err := egw.GetAllNsxvDhcpLeases()
+	dhcpLeases, err := egw.GetAllNsxvDhcpLeases(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func (egw *EdgeGateway) GetNsxvActiveDhcpLeaseByMac(mac string) (*types.EdgeDhcp
 }
 
 // GetAllNsxvDhcpLeases retrieves all DHCP leases defined in NSX-V edge gateway
-func (egw *EdgeGateway) GetAllNsxvDhcpLeases() ([]*types.EdgeDhcpLeaseInfo, error) {
+func (egw *EdgeGateway) GetAllNsxvDhcpLeases(ctx context.Context) ([]*types.EdgeDhcpLeaseInfo, error) {
 	if !egw.HasAdvancedNetworking() {
 		return nil, fmt.Errorf("only advanced edge gateways support DHCP")
 	}
@@ -54,7 +55,7 @@ func (egw *EdgeGateway) GetAllNsxvDhcpLeases() ([]*types.EdgeDhcpLeaseInfo, erro
 	dhcpLeases := &responseEdgeDhcpLeases{}
 
 	// This query returns all DHCP leases
-	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
+	_, err = egw.client.ExecuteRequest(ctx, httpPath, http.MethodGet, types.AnyXMLMime,
 		"unable to read DHCP leases: %s", nil, dhcpLeases)
 	if err != nil {
 		return nil, err

--- a/govcd/nsxv_dhcprelay_test.go
+++ b/govcd/nsxv_dhcprelay_test.go
@@ -25,7 +25,7 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 		check.Skip("Skipping test because no edge gateway given")
 	}
 
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
@@ -36,7 +36,7 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 	AddToCleanupList(createdIpSet.Name, "ipSet", parentEntity, check.TestName())
 
 	// Lookup vNic index for our org network
-	vNicIndex, _, err := edge.GetAnyVnicIndexByNetworkName(vcd.config.VCD.Network.Net1)
+	vNicIndex, _, err := edge.GetAnyVnicIndexByNetworkName(ctx, vcd.config.VCD.Network.Net1)
 	check.Assert(err, IsNil)
 
 	dhcpRelayConfig := &types.EdgeDhcpRelay{
@@ -54,7 +54,7 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 		},
 	}
 
-	createdRelayConfig, err := edge.UpdateDhcpRelay(dhcpRelayConfig)
+	createdRelayConfig, err := edge.UpdateDhcpRelay(ctx, dhcpRelayConfig)
 	check.Assert(err, IsNil)
 
 	parentEntity = vcd.org.Org.Name + "|" + vcd.vdc.Vdc.Name + "|" + vcd.config.VCD.EdgeGateway
@@ -65,7 +65,7 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 	// Cache Gateway auto-assigned address to try specifying it afterwards
 	vNicDefaultGateway := createdRelayConfig.RelayAgents.Agents[0].GatewayInterfaceAddress
 
-	readRelayConfig, err := edge.GetDhcpRelay()
+	readRelayConfig, err := edge.GetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(readRelayConfig, DeepEquals, createdRelayConfig)
 
@@ -75,9 +75,9 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 	check.Assert(readRelayConfig.RelayAgents, DeepEquals, dhcpRelayConfig.RelayAgents)
 
 	// Reset DHCP relay and ensure no settings are present
-	err = edge.ResetDhcpRelay()
+	err = edge.ResetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
-	read, err := edge.GetDhcpRelay()
+	read, err := edge.GetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(read.RelayServer, IsNil)
 	check.Assert(read.RelayAgents, IsNil)
@@ -89,16 +89,16 @@ func (vcd *TestVCD) Test_NsxvDhcpRelay(check *C) {
 	dhcpRelayConfig.RelayServer.IpAddress = nil
 	dhcpRelayConfig.RelayServer.Fqdns = nil
 
-	createdRelayConfig2, err := edge.UpdateDhcpRelay(dhcpRelayConfig)
+	createdRelayConfig2, err := edge.UpdateDhcpRelay(ctx, dhcpRelayConfig)
 	check.Assert(err, IsNil)
-	readRelayConfig2, err := edge.GetDhcpRelay()
+	readRelayConfig2, err := edge.GetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(readRelayConfig2, DeepEquals, createdRelayConfig2)
 
 	// Reset DHCP relay and ensure no settings are present
-	err = edge.ResetDhcpRelay()
+	err = edge.ResetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
-	read, err = edge.GetDhcpRelay()
+	read, err = edge.GetDhcpRelay(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(read.RelayServer, IsNil)
 	check.Assert(read.RelayAgents, IsNil)

--- a/govcd/nsxv_firewall.go
+++ b/govcd/nsxv_firewall.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -30,7 +31,7 @@ type responseEdgeFirewallRules struct {
 // It returns an object with all fields populated (including ID)
 // If aboveRuleId is not empty, it will send a query parameter aboveRuleId= which instructs NSX to
 // place this rule above the specified rule ID
-func (egw *EdgeGateway) CreateNsxvFirewallRule(firewallRuleConfig *types.EdgeFirewallRule, aboveRuleId string) (*types.EdgeFirewallRule, error) {
+func (egw *EdgeGateway) CreateNsxvFirewallRule(ctx context.Context, firewallRuleConfig *types.EdgeFirewallRule, aboveRuleId string) (*types.EdgeFirewallRule, error) {
 	if err := validateCreateNsxvFirewallRule(firewallRuleConfig, egw); err != nil {
 		return nil, err
 	}
@@ -53,11 +54,11 @@ func (egw *EdgeGateway) CreateNsxvFirewallRule(firewallRuleConfig *types.EdgeFir
 	// The query must be wrapped differently, depending if it mus specify the "aboveRuleId" parameter
 	var resp *http.Response
 	if aboveRuleId == "" {
-		resp, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPost, types.AnyXMLMime,
+		resp, err = egw.client.ExecuteRequestWithCustomError(ctx, httpPath, http.MethodPost, types.AnyXMLMime,
 			"error creating firewall rule: %s", firewallRuleRequest, &types.NSXError{})
 	} else {
 		errString := fmt.Sprintf("error creating firewall rule (aboveRuleId: %s): %%s", aboveRuleId)
-		resp, err = egw.client.ExecuteParamRequestWithCustomError(httpPath, params, http.MethodPost, types.AnyXMLMime,
+		resp, err = egw.client.ExecuteParamRequestWithCustomError(ctx, httpPath, params, http.MethodPost, types.AnyXMLMime,
 			errString, firewallRuleConfig, &types.NSXError{})
 	}
 	if err != nil {
@@ -71,7 +72,7 @@ func (egw *EdgeGateway) CreateNsxvFirewallRule(firewallRuleConfig *types.EdgeFir
 		return nil, err
 	}
 
-	readFirewallRule, err := egw.GetNsxvFirewallRuleById(firewallRuleId)
+	readFirewallRule, err := egw.GetNsxvFirewallRuleById(ctx, firewallRuleId)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve firewall rule with ID (%s) after creation: %s",
 			firewallRuleId, err)
@@ -81,7 +82,7 @@ func (egw *EdgeGateway) CreateNsxvFirewallRule(firewallRuleConfig *types.EdgeFir
 
 // UpdateNsxvFirewallRule updates types.EdgeFirewallRule with all fields using proxied NSX-V API.
 // Real firewall rule ID (not the number shown in UI) is mandatory to perform the update.
-func (egw *EdgeGateway) UpdateNsxvFirewallRule(firewallRuleConfig *types.EdgeFirewallRule) (*types.EdgeFirewallRule, error) {
+func (egw *EdgeGateway) UpdateNsxvFirewallRule(ctx context.Context, firewallRuleConfig *types.EdgeFirewallRule) (*types.EdgeFirewallRule, error) {
 	err := validateUpdateNsxvFirewallRule(firewallRuleConfig, egw)
 	if err != nil {
 		return nil, err
@@ -93,13 +94,13 @@ func (egw *EdgeGateway) UpdateNsxvFirewallRule(firewallRuleConfig *types.EdgeFir
 	}
 
 	// Result is either 204 for success, or an error of type types.NSXError
-	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodPut, types.AnyXMLMime,
+	_, err = egw.client.ExecuteRequestWithCustomError(ctx, httpPath, http.MethodPut, types.AnyXMLMime,
 		"error while updating firewall rule : %s", firewallRuleConfig, &types.NSXError{})
 	if err != nil {
 		return nil, err
 	}
 
-	readFirewallRule, err := egw.GetNsxvFirewallRuleById(firewallRuleConfig.ID)
+	readFirewallRule, err := egw.GetNsxvFirewallRuleById(ctx, firewallRuleConfig.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve firewall rule with ID (%s) after update: %s",
 			readFirewallRule.ID, err)
@@ -110,12 +111,12 @@ func (egw *EdgeGateway) UpdateNsxvFirewallRule(firewallRuleConfig *types.EdgeFir
 // GetNsxvFirewallRuleById retrieves types.EdgeFirewallRule by real (not the number shown in UI)
 // firewall rule ID as shown in the UI using proxied NSX-V API.
 // It returns and error `ErrorEntityNotFound` if the firewall rule is not found
-func (egw *EdgeGateway) GetNsxvFirewallRuleById(id string) (*types.EdgeFirewallRule, error) {
+func (egw *EdgeGateway) GetNsxvFirewallRuleById(ctx context.Context, id string) (*types.EdgeFirewallRule, error) {
 	if err := validateGetNsxvFirewallRule(id, egw); err != nil {
 		return nil, err
 	}
 
-	edgeFirewallRules, err := egw.GetAllNsxvFirewallRules()
+	edgeFirewallRules, err := egw.GetAllNsxvFirewallRules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (egw *EdgeGateway) GetNsxvFirewallRuleById(id string) (*types.EdgeFirewallR
 
 // GetAllNsxvFirewallRules retrieves all firewall rules and returns []*types.EdgeFirewallRule or an
 // error of type ErrorEntityNotFound if there are no firewall rules
-func (egw *EdgeGateway) GetAllNsxvFirewallRules() ([]*types.EdgeFirewallRule, error) {
+func (egw *EdgeGateway) GetAllNsxvFirewallRules(ctx context.Context) ([]*types.EdgeFirewallRule, error) {
 	if !egw.HasAdvancedNetworking() {
 		return nil, fmt.Errorf("only advanced edge gateways support firewall rules")
 	}
@@ -146,7 +147,7 @@ func (egw *EdgeGateway) GetAllNsxvFirewallRules() ([]*types.EdgeFirewallRule, er
 	firewallRuleResponse := &responseEdgeFirewallRules{}
 
 	// This query returns all application rules as the API does not have filtering options
-	_, err = egw.client.ExecuteRequest(httpPath, http.MethodGet, types.AnyXMLMime,
+	_, err = egw.client.ExecuteRequest(ctx, httpPath, http.MethodGet, types.AnyXMLMime,
 		"unable to read firewall rules: %s", nil, firewallRuleResponse)
 	if err != nil {
 		return nil, err
@@ -162,7 +163,7 @@ func (egw *EdgeGateway) GetAllNsxvFirewallRules() ([]*types.EdgeFirewallRule, er
 // DeleteNsxvFirewallRuleById deletes types.EdgeFirewallRule by real (not the number shown in UI)
 // firewall rule ID as shown in the UI using proxied NSX-V API.
 // It returns and error `ErrorEntityNotFound` if the firewall rule is not found.
-func (egw *EdgeGateway) DeleteNsxvFirewallRuleById(id string) error {
+func (egw *EdgeGateway) DeleteNsxvFirewallRuleById(ctx context.Context, id string) error {
 	err := validateDeleteNsxvFirewallRule(id, egw)
 	if err != nil {
 		return err
@@ -174,12 +175,12 @@ func (egw *EdgeGateway) DeleteNsxvFirewallRuleById(id string) error {
 	}
 
 	// check if the rule exists and pass back the error at it may be 'ErrorEntityNotFound'
-	_, err = egw.GetNsxvFirewallRuleById(id)
+	_, err = egw.GetNsxvFirewallRuleById(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	_, err = egw.client.ExecuteRequestWithCustomError(httpPath, http.MethodDelete, types.AnyXMLMime,
+	_, err = egw.client.ExecuteRequestWithCustomError(ctx, httpPath, http.MethodDelete, types.AnyXMLMime,
 		"unable to delete firewall rule: %s", nil, &types.NSXError{})
 	if err != nil {
 		return err

--- a/govcd/nsxv_ipset_test.go
+++ b/govcd/nsxv_ipset_test.go
@@ -29,11 +29,11 @@ func (vcd *TestVCD) Test_NsxvIpSet(check *C) {
 		check.Skip(check.TestName() + ": VDC name not given")
 		return
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := org.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 
@@ -49,7 +49,7 @@ func (vcd *TestVCD) Test_NsxvIpSet(check *C) {
 		InheritanceAllowed: takeBoolPointer(false),
 	}
 
-	createdIpSet, err := vdc.CreateNsxvIpSet(ipSetConfig)
+	createdIpSet, err := vdc.CreateNsxvIpSet(ctx, ipSetConfig)
 	check.Assert(err, IsNil)
 	check.Assert(createdIpSet.ID, Not(Equals), "") // Validate that ID was set
 
@@ -64,22 +64,22 @@ func (vcd *TestVCD) Test_NsxvIpSet(check *C) {
 	check.Assert(createdIpSet, DeepEquals, ipSetConfig)
 
 	// 2. Try to create another IP set with the same name and expect error
-	_, err = vdc.CreateNsxvIpSet(ipSetConfig)
+	_, err = vdc.CreateNsxvIpSet(ctx, ipSetConfig)
 	check.Assert(err, ErrorMatches, ".*Another object with same name.* already exists in the current scope.*")
 
 	// 3. Get all IP sets
-	ipSets, err := vdc.GetAllNsxvIpSets()
+	ipSets, err := vdc.GetAllNsxvIpSets(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(ipSets) > 0, Equals, true)
 
 	// 4. Get by Name, Id, NameOrId and check that all results are deeply equal
-	ipSetByName, err := vdc.GetNsxvIpSetByName(createdIpSet.Name)
+	ipSetByName, err := vdc.GetNsxvIpSetByName(ctx, createdIpSet.Name)
 	check.Assert(err, IsNil)
-	ipSetById, err := vdc.GetNsxvIpSetById(createdIpSet.ID)
+	ipSetById, err := vdc.GetNsxvIpSetById(ctx, createdIpSet.ID)
 	check.Assert(err, IsNil)
-	ipSetByName2, err := vdc.GetNsxvIpSetByNameOrId(createdIpSet.Name)
+	ipSetByName2, err := vdc.GetNsxvIpSetByNameOrId(ctx, createdIpSet.Name)
 	check.Assert(err, IsNil)
-	ipSetById2, err := vdc.GetNsxvIpSetByNameOrId(createdIpSet.ID)
+	ipSetById2, err := vdc.GetNsxvIpSetByNameOrId(ctx, createdIpSet.ID)
 	check.Assert(err, IsNil)
 	check.Assert(ipSetByName, DeepEquals, ipSetById)
 	check.Assert(ipSetByName, DeepEquals, ipSetByName2)
@@ -87,7 +87,7 @@ func (vcd *TestVCD) Test_NsxvIpSet(check *C) {
 
 	// 5. Update IP set field
 	createdIpSet.InheritanceAllowed = takeBoolPointer(true)
-	updatedIpSet, err := vcd.vdc.UpdateNsxvIpSet(createdIpSet)
+	updatedIpSet, err := vcd.vdc.UpdateNsxvIpSet(ctx, createdIpSet)
 	check.Assert(err, IsNil)
 
 	// Check that only this field was changed
@@ -97,21 +97,21 @@ func (vcd *TestVCD) Test_NsxvIpSet(check *C) {
 	check.Assert(updatedIpSet, DeepEquals, createdIpSet)
 
 	// 6. Delete created IP set by Id
-	err = vdc.DeleteNsxvIpSetById(createdIpSet.ID)
+	err = vdc.DeleteNsxvIpSetById(ctx, createdIpSet.ID)
 	check.Assert(err, IsNil)
 
 	// Verify that the IP set cannot be found by ID and by Name
-	_, err = vdc.GetNsxvIpSetById(createdIpSet.ID)
+	_, err = vdc.GetNsxvIpSetById(ctx, createdIpSet.ID)
 	check.Assert(IsNotFound(err), Equals, true)
 
-	_, err = vdc.GetNsxvIpSetByName(createdIpSet.Name)
+	_, err = vdc.GetNsxvIpSetByName(ctx, createdIpSet.Name)
 	check.Assert(IsNotFound(err), Equals, true)
 
 	// 7. Create another IP set and try to delete by name
-	ipSet2, err := vdc.CreateNsxvIpSet(ipSetConfig)
+	ipSet2, err := vdc.CreateNsxvIpSet(ctx, ipSetConfig)
 	check.Assert(err, IsNil)
 
-	err = vdc.DeleteNsxvIpSetByName(ipSet2.Name)
+	err = vdc.DeleteNsxvIpSetByName(ctx, ipSet2.Name)
 	check.Assert(err, IsNil)
 }
 
@@ -125,5 +125,5 @@ func testCreateIpSet(name string, vdc *Vdc) (*types.EdgeIpSet, error) {
 		InheritanceAllowed: takeBoolPointer(true),
 	}
 
-	return vdc.CreateNsxvIpSet(ipSetConfig)
+	return vdc.CreateNsxvIpSet(ctx, ipSetConfig)
 }

--- a/govcd/nsxv_nat_test.go
+++ b/govcd/nsxv_nat_test.go
@@ -17,11 +17,11 @@ func (vcd *TestVCD) Test_NsxvSnatRule(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(vcd.config.VCD.Network.Net1, "internal")
+	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(ctx, vcd.config.VCD.Network.Net1, "internal")
 	check.Assert(err, IsNil)
 
 	natRule := &types.EdgeNatRule{
@@ -43,11 +43,11 @@ func (vcd *TestVCD) Test_NsxvDnatRule(check *C) {
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
-	edge, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, false)
+	edge, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, false)
 	check.Assert(err, IsNil)
 	check.Assert(edge.EdgeGateway.Name, Equals, vcd.config.VCD.EdgeGateway)
 
-	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(vcd.config.VCD.ExternalNetwork, "uplink")
+	vnicIndex, err := edge.GetVnicIndexByNetworkNameAndType(ctx, vcd.config.VCD.ExternalNetwork, "uplink")
 	check.Assert(err, IsNil)
 
 	natRule := &types.EdgeNatRule{
@@ -110,13 +110,13 @@ func (vcd *TestVCD) Test_NsxvDnatRule(check *C) {
 // 4. Deletes the rule
 // 5. Validates that the rule was deleted
 func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGateway) {
-	createdNatRule, err := edge.CreateNsxvNatRule(natRule)
+	createdNatRule, err := edge.CreateNsxvNatRule(ctx, natRule)
 	check.Assert(err, IsNil)
 
 	parentEntity := vcd.org.Org.Name + "|" + vcd.vdc.Vdc.Name + "|" + vcd.config.VCD.EdgeGateway
 	AddToCleanupList(createdNatRule.ID, "nsxvNatRule", parentEntity, check.TestName())
 
-	gotNatRule, err := edge.GetNsxvNatRuleById(createdNatRule.ID)
+	gotNatRule, err := edge.GetNsxvNatRuleById(ctx, createdNatRule.ID)
 	check.Assert(err, IsNil)
 	check.Assert(gotNatRule, NotNil)
 	check.Assert(gotNatRule, DeepEquals, createdNatRule)
@@ -125,14 +125,14 @@ func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGa
 	// Set ID and update nat rule with description
 	natRule.ID = gotNatRule.ID
 	natRule.Description = "Description for NAT rule"
-	updatedNatRule, err := edge.UpdateNsxvNatRule(natRule)
+	updatedNatRule, err := edge.UpdateNsxvNatRule(ctx, natRule)
 	check.Assert(err, IsNil)
 	check.Assert(updatedNatRule, NotNil)
 
 	check.Assert(updatedNatRule.Description, Equals, natRule.Description)
 
 	// Test that we can extract a list of NSXV NAT rules, and that one of them is the rule we have got when searching by ID
-	natRules, err := edge.GetNsxvNatRules()
+	natRules, err := edge.GetNsxvNatRules(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(natRules, NotNil)
 	foundRule := false
@@ -147,10 +147,10 @@ func testNsxvNat(natRule *types.EdgeNatRule, vcd *TestVCD, check *C, edge EdgeGa
 	createdNatRule.Description = natRule.Description
 	check.Assert(updatedNatRule, DeepEquals, createdNatRule)
 
-	err = edge.DeleteNsxvNatRuleById(gotNatRule.ID)
+	err = edge.DeleteNsxvNatRuleById(ctx, gotNatRule.ID)
 	check.Assert(err, IsNil)
 
 	// Ensure the rule does not exist anymore
-	_, err = edge.GetNsxvNatRuleById(createdNatRule.ID)
+	_, err = edge.GetNsxvNatRuleById(ctx, createdNatRule.ID)
 	check.Assert(IsNotFound(err), Equals, true)
 }

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -48,9 +49,9 @@ import (
 // OpenApiIsSupported allows to check whether VCD supports OpenAPI. Each OpenAPI endpoint however is introduced with
 // different VCD API versions so this is just a general check if OpenAPI is supported at all. Particular endpoint
 // introduction version can be checked in self hosted docs (https://HOSTNAME/docs/)
-func (client *Client) OpenApiIsSupported() bool {
+func (client *Client) OpenApiIsSupported(ctx context.Context) bool {
 	// OpenAPI was introduced in VCD 9.5+ (API version 31.0+)
-	return client.APIVCDMaxVersionIs(">= 31")
+	return client.APIVCDMaxVersionIs(ctx, ">= 31")
 }
 
 // OpenApiBuildEndpoint helps to construct OpenAPI endpoint by using already configured VCD HREF while requiring only
@@ -72,14 +73,14 @@ func (client *Client) OpenApiBuildEndpoint(endpoint ...string) (*url.URL, error)
 // must be a slice of object (e.g. []*types.OpenAPIEdgeGateway) because this response contains slice of structs.
 //
 // Note. Query parameter 'pageSize' is defaulted to 128 (maximum supported) unless it is specified in queryParams
-func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}) error {
+func (client *Client) OpenApiGetAllItems(ctx context.Context, apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Getting all items from endpoint %s for parsing into %s type\n",
 		urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
@@ -90,7 +91,7 @@ func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, que
 
 	// Perform API call to initial endpoint. The function call recursively follows pages using Link headers "nextPage"
 	// until it crawls all results
-	responses, err := client.openApiGetAllPages(apiVersion, urlRefCopy, newQueryParams, outType, nil)
+	responses, err := client.openApiGetAllPages(ctx, apiVersion, urlRefCopy, newQueryParams, outType, nil)
 	if err != nil {
 		return fmt.Errorf("error getting all pages for endpoint %s: %s", urlRefCopy.String(), err)
 	}
@@ -119,18 +120,18 @@ func (client *Client) OpenApiGetAllItems(apiVersion string, urlRef *url.URL, que
 // It responds with HTTP 403: Forbidden - If the user is not authorized or the entity does not exist. When HTTP 403 is
 // returned this function returns "ErrorEntityNotFound: API_ERROR" so that one can use ContainsNotFound(err) to
 // differentiate when an objects was not found from any other error.
-func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params url.Values, outType interface{}) error {
+func (client *Client) OpenApiGetItem(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Getting item from endpoint %s with expected response of type %s",
 		urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
-	req := client.newOpenApiRequest(apiVersion, params, http.MethodGet, urlRefCopy, nil)
+	req := client.newOpenApiRequest(ctx, apiVersion, params, http.MethodGet, urlRefCopy, nil)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return fmt.Errorf("error performing GET request to %s: %s", urlRefCopy.String(), err)
@@ -171,18 +172,18 @@ func (client *Client) OpenApiGetItem(apiVersion string, urlRef *url.URL, params 
 //
 // Note. Even though it may return error if the item does not support synchronous request - the object may still be
 // created. OpenApiPostItem would handle both cases and always return created item.
-func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+func (client *Client) OpenApiPostItemSync(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Posting %s item to endpoint %s with expected response of type %s",
 		reflect.TypeOf(payload), urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
-	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPost, apiVersion, urlRefCopy, params, payload)
 	if err != nil {
 		return err
 	}
@@ -210,18 +211,18 @@ func (client *Client) OpenApiPostItemSync(apiVersion string, urlRef *url.URL, pa
 //
 // Note. Even though it may return error if the item does not support asynchronous request - the object may still be
 // created. OpenApiPostItem would handle both cases and always return created item.
-func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (Task, error) {
+func (client *Client) OpenApiPostItemAsync(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (Task, error) {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Posting async %s item to endpoint %s with expected task response",
 		reflect.TypeOf(payload), urlRefCopy.String())
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
-	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPost, apiVersion, urlRefCopy, params, payload)
 	if err != nil {
 		return Task{}, err
 	}
@@ -249,18 +250,18 @@ func (client *Client) OpenApiPostItemAsync(apiVersion string, urlRef *url.URL, p
 // OpenApiPostItem is a low level OpenAPI client function to perform POST request for item supporting synchronous or
 // asynchronous requests. The urlRef must point to POST endpoint (e.g. '/1.0.0/edgeGateways'). When a task is
 // synchronous - it will track task until it is finished and pick reference to marshal outType.
-func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+func (client *Client) OpenApiPostItem(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Posting %s item to endpoint %s with expected response of type %s",
 		reflect.TypeOf(payload), urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
-	resp, err := client.openApiPerformPostPut(http.MethodPost, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPost, apiVersion, urlRefCopy, params, payload)
 	if err != nil {
 		return err
 	}
@@ -274,7 +275,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 		util.Logger.Printf("[TRACE] Asynchronous task detected, tracking task with HREF: %s", taskUrl)
 		task := NewTask(client)
 		task.Task.HREF = taskUrl
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
 		}
@@ -284,7 +285,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 		// old XML API and here we need to pull data from OpenAPI.
 
 		newObjectUrl, _ := url.ParseRequestURI(urlRefCopy.String() + task.Task.Owner.ID)
-		err = client.OpenApiGetItem(apiVersion, newObjectUrl, nil, outType)
+		err = client.OpenApiGetItem(ctx, apiVersion, newObjectUrl, nil, outType)
 		if err != nil {
 			return fmt.Errorf("error retrieving item after creation: %s", err)
 		}
@@ -312,18 +313,18 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 //
 // Note. Even though it may return error if the item does not support synchronous request - the object may still be
 // updated. OpenApiPutItem would handle both cases and always return updated item.
-func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+func (client *Client) OpenApiPutItemSync(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Putting %s item to endpoint %s with expected response of type %s",
 		reflect.TypeOf(payload), urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
-	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPut, apiVersion, urlRefCopy, params, payload)
 	if err != nil {
 		return err
 	}
@@ -351,17 +352,17 @@ func (client *Client) OpenApiPutItemSync(apiVersion string, urlRef *url.URL, par
 //
 // Note. Even though it may return error if the item does not support asynchronous request - the object may still be
 // created. OpenApiPutItem would handle both cases and always return created item.
-func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (Task, error) {
+func (client *Client) OpenApiPutItemAsync(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (Task, error) {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Putting async %s item to endpoint %s with expected task response",
 		reflect.TypeOf(payload), urlRefCopy.String())
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return Task{}, fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
-	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPut, apiVersion, urlRefCopy, params, payload)
 	if err != nil {
 		return Task{}, err
 	}
@@ -389,17 +390,17 @@ func (client *Client) OpenApiPutItemAsync(apiVersion string, urlRef *url.URL, pa
 // OpenApiPutItem is a low level OpenAPI client function to perform PUT request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
-func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
+func (client *Client) OpenApiPutItem(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values, payload, outType interface{}) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Putting %s item to endpoint %s with expected response of type %s",
 		reflect.TypeOf(payload), urlRefCopy.String(), reflect.TypeOf(outType))
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
-	resp, err := client.openApiPerformPostPut(http.MethodPut, apiVersion, urlRefCopy, params, payload)
+	resp, err := client.openApiPerformPostPut(ctx, http.MethodPut, apiVersion, urlRefCopy, params, payload)
 
 	if err != nil {
 		return err
@@ -414,13 +415,13 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 		util.Logger.Printf("[TRACE] Asynchronous task detected, tracking task with HREF: %s", taskUrl)
 		task := NewTask(client)
 		task.Task.HREF = taskUrl
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
 		}
 
 		// Here we have to find the resource once more to return it populated. Provided params ir ignored for retrieval.
-		err = client.OpenApiGetItem(apiVersion, urlRefCopy, nil, outType)
+		err = client.OpenApiGetItem(ctx, apiVersion, urlRefCopy, nil, outType)
 		if err != nil {
 			return fmt.Errorf("error retrieving item after updating: %s", err)
 		}
@@ -444,18 +445,18 @@ func (client *Client) OpenApiPutItem(apiVersion string, urlRef *url.URL, params 
 // OpenApiDeleteItem is a low level OpenAPI client function to perform DELETE request for any item.
 // The urlRef must point to ID of exact item (e.g. '/1.0.0/edgeGateways/{EDGE_ID}')
 // It handles synchronous and asynchronous tasks. When a task is synchronous - it will block until it is finished.
-func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, params url.Values) error {
+func (client *Client) OpenApiDeleteItem(ctx context.Context, apiVersion string, urlRef *url.URL, params url.Values) error {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
 	util.Logger.Printf("[TRACE] Deleting item at endpoint %s", urlRefCopy.String())
 
-	if !client.OpenApiIsSupported() {
+	if !client.OpenApiIsSupported(ctx) {
 		return fmt.Errorf("OpenAPI is not supported on this VCD version")
 	}
 
 	// Perform request
-	req := client.newOpenApiRequest(apiVersion, params, http.MethodDelete, urlRefCopy, nil)
+	req := client.newOpenApiRequest(ctx, apiVersion, params, http.MethodDelete, urlRefCopy, nil)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
@@ -480,7 +481,7 @@ func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, para
 		taskUrl := resp.Header.Get("Location")
 		task := NewTask(client)
 		task.Task.HREF = taskUrl
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		if err != nil {
 			return fmt.Errorf("error waiting completion of task (%s): %s", taskUrl, err)
 		}
@@ -491,7 +492,7 @@ func (client *Client) OpenApiDeleteItem(apiVersion string, urlRef *url.URL, para
 
 // openApiPerformPostPut is a shared function for all public PUT and POST function parts - OpenApiPostItemSync,
 // OpenApiPostItemAsync, OpenApiPostItem, OpenApiPutItemSync, OpenApiPutItemAsync, OpenApiPutItem
-func (client *Client) openApiPerformPostPut(httpMethod string, apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (*http.Response, error) {
+func (client *Client) openApiPerformPostPut(ctx context.Context, httpMethod string, apiVersion string, urlRef *url.URL, params url.Values, payload interface{}) (*http.Response, error) {
 	// Marshal payload if we have one
 	var body *bytes.Buffer
 	if payload != nil {
@@ -502,7 +503,7 @@ func (client *Client) openApiPerformPostPut(httpMethod string, apiVersion string
 		body = bytes.NewBuffer(marshaledJson)
 	}
 
-	req := client.newOpenApiRequest(apiVersion, params, httpMethod, urlRef, body)
+	req := client.newOpenApiRequest(ctx, apiVersion, params, httpMethod, urlRef, body)
 	resp, err := client.Http.Do(req)
 	if err != nil {
 		return nil, err
@@ -520,7 +521,7 @@ func (client *Client) openApiPerformPostPut(httpMethod string, apiVersion string
 // works by at first crawling pages and accumulating all responses into []json.RawMessage (as strings). Because there is
 // no intermediate unmarshalling to exact `outType` for every page it can unmarshal into direct `outType` supplied.
 // outType must be a slice of object (e.g. []*types.OpenApiRole) because accumulated responses are in JSON list
-func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
+func (client *Client) openApiGetAllPages(ctx context.Context, apiVersion string, urlRef *url.URL, queryParams url.Values, outType interface{}, responses []json.RawMessage) ([]json.RawMessage, error) {
 	// copy passed in URL ref so that it is not mutated
 	urlRefCopy := copyUrlRef(urlRef)
 
@@ -529,7 +530,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, que
 	}
 
 	// Perform request
-	req := client.newOpenApiRequest(apiVersion, queryParams, http.MethodGet, urlRefCopy, nil)
+	req := client.newOpenApiRequest(ctx, apiVersion, queryParams, http.MethodGet, urlRefCopy, nil)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
@@ -570,7 +571,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, que
 	}
 
 	if nextPageUrlRef != nil {
-		responses, err = client.openApiGetAllPages(apiVersion, nextPageUrlRef, url.Values{}, outType, responses)
+		responses, err = client.openApiGetAllPages(ctx, apiVersion, nextPageUrlRef, url.Values{}, outType, responses)
 		if err != nil {
 			return nil, fmt.Errorf("got error on page %d: %s", pages.Page, err)
 		}
@@ -581,7 +582,7 @@ func (client *Client) openApiGetAllPages(apiVersion string, urlRef *url.URL, que
 
 // newOpenApiRequest is a low level function used in upstream OpenAPI functions which handles logging and
 // authentication for each API request
-func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, method string, reqUrl *url.URL, body io.Reader) *http.Request {
+func (client *Client) newOpenApiRequest(ctx context.Context, apiVersion string, params url.Values, method string, reqUrl *url.URL, body io.Reader) *http.Request {
 	// copy passed in URL ref so that it is not mutated
 	reqUrlCopy := copyUrlRef(reqUrl)
 
@@ -599,7 +600,7 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	// Build the request, no point in checking for errors here as we're just
 	// passing a string version of an url.URL struct and http.NewRequest returns
 	// error only if can't process an url.ParseRequestURI().
-	req, _ := http.NewRequest(method, reqUrlCopy.String(), body)
+	req, _ := http.NewRequestWithContext(ctx, method, reqUrlCopy.String(), body)
 
 	if client.VCDAuthHeader != "" && client.VCDToken != "" {
 		// Add the authorization header

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -5,6 +5,7 @@ package govcd
  */
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -31,13 +32,13 @@ var endpointMinApiVersions = map[string]string{
 // specified OpenAPI endpoint and returns either error, either Api version to use for calling that endpoint. This Api
 // version can then be supplied to low level OpenAPI client functions.
 // If the system default API version is higher than endpoint introduction version - default system one is used.
-func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string, error) {
+func (client *Client) checkOpenApiEndpointCompatibility(ctx context.Context, endpoint string) (string, error) {
 	minimumApiVersion, ok := endpointMinApiVersions[endpoint]
 	if !ok {
 		return "", fmt.Errorf("minimum API version for endopoint '%s' is not defined", endpoint)
 	}
 
-	if client.APIVCDMaxVersionIs("< " + minimumApiVersion) {
+	if client.APIVCDMaxVersionIs(ctx, "< "+minimumApiVersion) {
 		maxSupportedVersion, err := client.MaxSupportedVersion()
 		if err != nil {
 			return "", fmt.Errorf("error reading maximum supported API version: %s", err)

--- a/govcd/openapi_org_network.go
+++ b/govcd/openapi_org_network.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -19,19 +20,19 @@ type OpenApiOrgVdcNetwork struct {
 }
 
 // GetOpenApiOrgVdcNetworkById allows to retrieve both - NSX-T and NSX-V Org VDC networks
-func (org *Org) GetOpenApiOrgVdcNetworkById(id string) (*OpenApiOrgVdcNetwork, error) {
+func (org *Org) GetOpenApiOrgVdcNetworkById(ctx context.Context, id string) (*OpenApiOrgVdcNetwork, error) {
 	// Inject Org ID filter to perform filtering on server side
 	params := url.Values{}
 	filterParams := queryParameterFilterAnd("orgRef.id=="+org.Org.ID, params)
-	return getOpenApiOrgVdcNetworkById(org.client, id, filterParams)
+	return getOpenApiOrgVdcNetworkById(ctx, org.client, id, filterParams)
 }
 
 // GetOpenApiOrgVdcNetworkById allows to retrieve both - NSX-T and NSX-V Org VDC networks
-func (vdc *Vdc) GetOpenApiOrgVdcNetworkById(id string) (*OpenApiOrgVdcNetwork, error) {
+func (vdc *Vdc) GetOpenApiOrgVdcNetworkById(ctx context.Context, id string) (*OpenApiOrgVdcNetwork, error) {
 	// Inject Vdc ID filter to perform filtering on server side
 	params := url.Values{}
 	filterParams := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, params)
-	egw, err := getOpenApiOrgVdcNetworkById(vdc.client, id, filterParams)
+	egw, err := getOpenApiOrgVdcNetworkById(ctx, vdc.client, id, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -40,11 +41,11 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkById(id string) (*OpenApiOrgVdcNetwork, e
 }
 
 // GetOpenApiOrgVdcNetworkByName allows to retrieve both - NSX-T and NSX-V Org VDC networks
-func (vdc *Vdc) GetOpenApiOrgVdcNetworkByName(name string) (*OpenApiOrgVdcNetwork, error) {
+func (vdc *Vdc) GetOpenApiOrgVdcNetworkByName(ctx context.Context, name string) (*OpenApiOrgVdcNetwork, error) {
 	queryParameters := url.Values{}
 	queryParameters.Add("filter", "name=="+name)
 
-	allEdges, err := vdc.GetAllOpenApiOrgVdcNetworks(queryParameters)
+	allEdges, err := vdc.GetAllOpenApiOrgVdcNetworks(ctx, queryParameters)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Org VDC network by name '%s': %s", name, err)
 	}
@@ -56,15 +57,15 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkByName(name string) (*OpenApiOrgVdcNetwor
 //
 // Note. If pageSize > 32 it will be limited to maximum of 32 in this function because API validation does not allow for
 // higher number
-func (vdc *Vdc) GetAllOpenApiOrgVdcNetworks(queryParameters url.Values) ([]*OpenApiOrgVdcNetwork, error) {
+func (vdc *Vdc) GetAllOpenApiOrgVdcNetworks(ctx context.Context, queryParameters url.Values) ([]*OpenApiOrgVdcNetwork, error) {
 	filteredQueryParams := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, queryParameters)
-	return getAllOpenApiOrgVdcNetworks(vdc.client, filteredQueryParams)
+	return getAllOpenApiOrgVdcNetworks(ctx, vdc.client, filteredQueryParams)
 }
 
 // CreateOpenApiOrgVdcNetwork allows to create NSX-T or NSX-V Org VDC network
-func (vdc *Vdc) CreateOpenApiOrgVdcNetwork(OrgVdcNetworkConfig *types.OpenApiOrgVdcNetwork) (*OpenApiOrgVdcNetwork, error) {
+func (vdc *Vdc) CreateOpenApiOrgVdcNetwork(ctx context.Context, OrgVdcNetworkConfig *types.OpenApiOrgVdcNetwork) (*OpenApiOrgVdcNetwork, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,7 @@ func (vdc *Vdc) CreateOpenApiOrgVdcNetwork(OrgVdcNetworkConfig *types.OpenApiOrg
 		client:               vdc.client,
 	}
 
-	err = vdc.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, OrgVdcNetworkConfig, returnEgw.OpenApiOrgVdcNetwork)
+	err = vdc.client.OpenApiPostItem(ctx, minimumApiVersion, urlRef, nil, OrgVdcNetworkConfig, returnEgw.OpenApiOrgVdcNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Org VDC network: %s", err)
 	}
@@ -88,9 +89,9 @@ func (vdc *Vdc) CreateOpenApiOrgVdcNetwork(OrgVdcNetworkConfig *types.OpenApiOrg
 }
 
 // Update allows to update Org VDC network
-func (orgVdcNet *OpenApiOrgVdcNetwork) Update(OrgVdcNetworkConfig *types.OpenApiOrgVdcNetwork) (*OpenApiOrgVdcNetwork, error) {
+func (orgVdcNet *OpenApiOrgVdcNetwork) Update(ctx context.Context, OrgVdcNetworkConfig *types.OpenApiOrgVdcNetwork) (*OpenApiOrgVdcNetwork, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks
-	minimumApiVersion, err := orgVdcNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := orgVdcNet.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) Update(OrgVdcNetworkConfig *types.OpenApi
 		client:               orgVdcNet.client,
 	}
 
-	err = orgVdcNet.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, OrgVdcNetworkConfig, returnEgw.OpenApiOrgVdcNetwork)
+	err = orgVdcNet.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, OrgVdcNetworkConfig, returnEgw.OpenApiOrgVdcNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("error updating Org VDC network: %s", err)
 	}
@@ -118,9 +119,9 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) Update(OrgVdcNetworkConfig *types.OpenApi
 }
 
 // Delete allows to delete Org VDC network
-func (orgVdcNet *OpenApiOrgVdcNetwork) Delete() error {
+func (orgVdcNet *OpenApiOrgVdcNetwork) Delete(ctx context.Context) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks
-	minimumApiVersion, err := orgVdcNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := orgVdcNet.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -134,7 +135,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) Delete() error {
 		return err
 	}
 
-	err = orgVdcNet.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = orgVdcNet.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting Org VDC network: %s", err)
@@ -171,9 +172,9 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) IsDirect() bool {
 // getOpenApiOrgVdcNetworkById is a private parent for wrapped functions:
 // func (org *Org) GetOpenApiOrgVdcNetworkById(id string) (*OpenApiOrgVdcNetwork, error)
 // func (vdc *Vdc) GetOpenApiOrgVdcNetworkById(id string) (*OpenApiOrgVdcNetwork, error)
-func getOpenApiOrgVdcNetworkById(client *Client, id string, queryParameters url.Values) (*OpenApiOrgVdcNetwork, error) {
+func getOpenApiOrgVdcNetworkById(ctx context.Context, client *Client, id string, queryParameters url.Values) (*OpenApiOrgVdcNetwork, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +193,7 @@ func getOpenApiOrgVdcNetworkById(client *Client, id string, queryParameters url.
 		client:               client,
 	}
 
-	err = client.OpenApiGetItem(minimumApiVersion, urlRef, queryParameters, egw.OpenApiOrgVdcNetwork)
+	err = client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, queryParameters, egw.OpenApiOrgVdcNetwork)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +220,7 @@ func returnSingleOpenApiOrgVdcNetwork(name string, allEdges []*OpenApiOrgVdcNetw
 //
 // Note. If pageSize > 32 it will be limited to maximum of 32 in this function because API validation does not allow
 // higher number
-func getAllOpenApiOrgVdcNetworks(client *Client, queryParameters url.Values) ([]*OpenApiOrgVdcNetwork, error) {
+func getAllOpenApiOrgVdcNetworks(ctx context.Context, client *Client, queryParameters url.Values) ([]*OpenApiOrgVdcNetwork, error) {
 
 	// Enforce maximum pageSize to be 32 as API endpoint throws error if it is > 32
 	pageSizeString := queryParameters.Get("pageSize")
@@ -241,7 +242,7 @@ func getAllOpenApiOrgVdcNetworks(client *Client, queryParameters url.Values) ([]
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +253,7 @@ func getAllOpenApiOrgVdcNetworks(client *Client, queryParameters url.Values) ([]
 	}
 
 	typeResponses := []*types.OpenApiOrgVdcNetwork{{}}
-	err = client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &typeResponses)
+	err = client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &typeResponses)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -19,7 +20,7 @@ type OpenApiOrgVdcNetworkDhcp struct {
 
 // GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
 // ID specified as orgNetworkId using OpenAPI
-func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdcNetworkDhcp, error) {
+func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(ctx context.Context, orgNetworkId string) (*OpenApiOrgVdcNetworkDhcp, error) {
 
 	client := vdc.client
 	// Inject Vdc ID filter to perform filtering on server side
@@ -27,7 +28,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 	queryParameters := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, params)
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 		client:                   client,
 	}
 
-	err = client.OpenApiGetItem(minimumApiVersion, urlRef, queryParameters, orgNetDhcp.OpenApiOrgVdcNetworkDhcp)
+	err = client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, queryParameters, orgNetDhcp.OpenApiOrgVdcNetworkDhcp)
 	if err != nil {
 		return nil, err
 	}
@@ -56,9 +57,9 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 
 // UpdateOpenApiOrgVdcNetworkDhcp allows to update DHCP configuration for specific Org VDC network
 // ID specified as orgNetworkId using OpenAPI
-func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
+func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(ctx context.Context, orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +74,7 @@ func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetwor
 		client:                   vdc.client,
 	}
 
-	err = vdc.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp)
+	err = vdc.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp)
 	if err != nil {
 		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
 	}
@@ -86,9 +87,9 @@ func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetwor
 //
 // Note. VCD Versions before 10.2 do not allow to perform "DELETE" on DHCP pool and will return error. The way to
 // remove DHCP configuration is to recreate Org VDC network itself.
-func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
+func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(ctx context.Context, orgNetworkId string) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -102,7 +103,7 @@ func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 		return err
 	}
 
-	err = vdc.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = vdc.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting Org VDC network DHCP configuration: %s", err)

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	skipNoNsxtConfiguration(vcd, check)
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
@@ -55,10 +55,10 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 }
 
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	skipNoNsxtConfiguration(vcd, check)
 
-	egw, err := vcd.org.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	egw, err := vcd.org.GetNsxtEdgeGatewayByName(ctx, vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
@@ -116,14 +116,14 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	skipNoNsxtConfiguration(vcd, check)
 
 	if vcd.config.VCD.Nsxt.NsxtImportSegment == "" {
 		check.Skip("Unused NSX-T segment was not provided")
 	}
 
-	logicalSwitch, err := vcd.nsxtVdc.GetNsxtImportableSwitchByName(vcd.config.VCD.Nsxt.NsxtImportSegment)
+	logicalSwitch, err := vcd.nsxtVdc.GetNsxtImportableSwitchByName(ctx, vcd.config.VCD.Nsxt.NsxtImportSegment)
 	check.Assert(err, IsNil)
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
@@ -164,7 +164,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
 		Name:        check.TestName(),
@@ -204,9 +204,9 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 
-	nsxvEdgeGateway, err := vcd.vdc.GetEdgeGatewayByName(vcd.config.VCD.EdgeGateway, true)
+	nsxvEdgeGateway, err := vcd.vdc.GetEdgeGatewayByName(ctx, vcd.config.VCD.EdgeGateway, true)
 	check.Assert(err, IsNil)
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
@@ -261,13 +261,13 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
-	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
+	skipOpenApiEndpointTest(ctx, vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
 	// Using legacy API lookup function because GetExternalNetworkV2ByName does not support VCD 9.7
-	externalNetwork, err := vcd.client.GetExternalNetworkByName(vcd.config.VCD.ExternalNetwork)
+	externalNetwork, err := vcd.client.GetExternalNetworkByName(ctx, vcd.config.VCD.ExternalNetwork)
 
 	check.Assert(err, IsNil)
 
@@ -317,7 +317,7 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
 }
 
 func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, extpectNetworkType string, dhcpFunc dhcpConfigFunc) {
-	orgVdcNet, err := vdc.CreateOpenApiOrgVdcNetwork(orgVdcNetworkConfig)
+	orgVdcNet, err := vdc.CreateOpenApiOrgVdcNetwork(ctx, orgVdcNetworkConfig)
 	check.Assert(err, IsNil)
 
 	// Use generic "OpenApiEntity" resource cleanup type
@@ -327,9 +327,9 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 	check.Assert(orgVdcNet.GetType(), Equals, extpectNetworkType)
 
 	// Check it can be found
-	orgVdcNetByIdInVdc, err := vdc.GetOpenApiOrgVdcNetworkById(orgVdcNet.OpenApiOrgVdcNetwork.ID)
+	orgVdcNetByIdInVdc, err := vdc.GetOpenApiOrgVdcNetworkById(ctx, orgVdcNet.OpenApiOrgVdcNetwork.ID)
 	check.Assert(err, IsNil)
-	orgVdcNetByName, err := vdc.GetOpenApiOrgVdcNetworkByName(orgVdcNet.OpenApiOrgVdcNetwork.Name)
+	orgVdcNetByName, err := vdc.GetOpenApiOrgVdcNetworkByName(ctx, orgVdcNet.OpenApiOrgVdcNetwork.Name)
 	check.Assert(err, IsNil)
 
 	check.Assert(orgVdcNetByIdInVdc.OpenApiOrgVdcNetwork.ID, Equals, orgVdcNet.OpenApiOrgVdcNetwork.ID)
@@ -337,7 +337,7 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 
 	// Retrieve all networks in VDC and expect newly created network to be there
 	var foundNetInVdc bool
-	allOrgVdcNets, err := vdc.GetAllOpenApiOrgVdcNetworks(nil)
+	allOrgVdcNets, err := vdc.GetAllOpenApiOrgVdcNetworks(ctx, nil)
 	check.Assert(err, IsNil)
 	for _, net := range allOrgVdcNets {
 		if net.OpenApiOrgVdcNetwork.ID == orgVdcNet.OpenApiOrgVdcNetwork.ID {
@@ -348,7 +348,7 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 
 	// Update
 	orgVdcNet.OpenApiOrgVdcNetwork.Description = check.TestName() + "updated description"
-	updatedOrgVdcNet, err := orgVdcNet.Update(orgVdcNet.OpenApiOrgVdcNetwork)
+	updatedOrgVdcNet, err := orgVdcNet.Update(ctx, orgVdcNet.OpenApiOrgVdcNetwork)
 	check.Assert(err, IsNil)
 
 	check.Assert(updatedOrgVdcNet.OpenApiOrgVdcNetwork.Name, Equals, orgVdcNet.OpenApiOrgVdcNetwork.Name)
@@ -360,14 +360,14 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 		dhcpFunc(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
 	}
 	// Delete
-	err = orgVdcNet.Delete()
+	err = orgVdcNet.Delete(ctx)
 	check.Assert(err, IsNil)
 
 	// Test again if it was deleted and expect it to contain ErrorEntityNotFound
-	_, err = vdc.GetOpenApiOrgVdcNetworkByName(orgVdcNet.OpenApiOrgVdcNetwork.Name)
+	_, err = vdc.GetOpenApiOrgVdcNetworkByName(ctx, orgVdcNet.OpenApiOrgVdcNetwork.Name)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
-	_, err = vdc.GetOpenApiOrgVdcNetworkById(orgVdcNet.OpenApiOrgVdcNetwork.ID)
+	_, err = vdc.GetOpenApiOrgVdcNetworkById(ctx, orgVdcNet.OpenApiOrgVdcNetwork.ID)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
@@ -386,15 +386,15 @@ func nsxtRoutedDhcpConfig(check *C, vdc *Vdc, orgNetId string) {
 			},
 		},
 	}
-	updatedDhcp, err := vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetId, dhcpDefinition)
+	updatedDhcp, err := vdc.UpdateOpenApiOrgVdcNetworkDhcp(ctx, orgNetId, dhcpDefinition)
 	check.Assert(err, IsNil)
 
 	check.Assert(dhcpDefinition, DeepEquals, updatedDhcp.OpenApiOrgVdcNetworkDhcp)
 
 	// VCD Versions before 10.2 do not allow to perform "DELETE" on DHCP pool
 	// To remove DHCP configuration one must remove Org VDC network itself.
-	if vdc.client.APIVCDMaxVersionIs(">= 35.0") {
-		err = vdc.DeleteOpenApiOrgVdcNetworkDhcp(orgNetId)
+	if vdc.client.APIVCDMaxVersionIs(ctx, ">= 35.0") {
+		err = vdc.DeleteOpenApiOrgVdcNetworkDhcp(ctx, orgNetId)
 		check.Assert(err, IsNil)
 	}
 }

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -24,8 +24,8 @@ import (
 // how to fetch response from multiple pages in RAW json messages without having defined as struct.
 func (vcd *TestVCD) Test_OpenApiRawJsonAuditTrail(check *C) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAuditTrail
-	skipOpenApiEndpointTest(vcd, check, endpoint)
-	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(endpoint)
+	skipOpenApiEndpointTest(ctx, vcd, check, endpoint)
+	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	check.Assert(err, IsNil)
 
 	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
@@ -42,7 +42,7 @@ func (vcd *TestVCD) Test_OpenApiRawJsonAuditTrail(check *C) {
 	queryParams.Add("sortDesc", "timestamp")
 
 	allResponses := []json.RawMessage{{}}
-	err = vcd.vdc.client.OpenApiGetAllItems(apiVersion, urlRef, queryParams, &allResponses)
+	err = vcd.vdc.client.OpenApiGetAllItems(ctx, apiVersion, urlRef, queryParams, &allResponses)
 
 	check.Assert(err, IsNil)
 	check.Assert(len(allResponses) > 1, Equals, true)
@@ -60,8 +60,8 @@ func (vcd *TestVCD) Test_OpenApiRawJsonAuditTrail(check *C) {
 // to user defined inline type
 func (vcd *TestVCD) Test_OpenApiInlineStructAuditTrail(check *C) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAuditTrail
-	skipOpenApiEndpointTest(vcd, check, endpoint)
-	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(endpoint)
+	skipOpenApiEndpointTest(ctx, vcd, check, endpoint)
+	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	check.Assert(err, IsNil)
 
 	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
@@ -106,7 +106,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructAuditTrail(check *C) {
 	filterTime := time.Now().Add(-6 * time.Hour).Format(types.FiqlQueryTimestampFormat)
 	queryParams.Add("filter", "timestamp=gt="+filterTime)
 
-	err = vcd.vdc.client.OpenApiGetAllItems(apiVersion, urlRef, queryParams, &allResponses)
+	err = vcd.vdc.client.OpenApiGetAllItems(ctx, apiVersion, urlRef, queryParams, &allResponses)
 
 	check.Assert(err, IsNil)
 	check.Assert(len(allResponses) > 1, Equals, true)
@@ -136,9 +136,9 @@ func (vcd *TestVCD) Test_OpenApiInlineStructAuditTrail(check *C) {
 // 9. Delete role once again
 func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := vcd.client.Client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	check.Assert(err, IsNil)
-	skipOpenApiEndpointTest(vcd, check, endpoint)
+	skipOpenApiEndpointTest(ctx, vcd, check, endpoint)
 
 	// Step 1 - Get all roles
 	urlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint)
@@ -153,7 +153,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	}
 
 	allExistingRoles := []*InlineRoles{{}}
-	err = vcd.vdc.client.OpenApiGetAllItems(apiVersion, urlRef, nil, &allExistingRoles)
+	err = vcd.vdc.client.OpenApiGetAllItems(ctx, apiVersion, urlRef, nil, &allExistingRoles)
 	check.Assert(err, IsNil)
 
 	// Step 2 - Get all roles using query filters
@@ -167,7 +167,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 
 		expectOneRoleResultById := []*InlineRoles{{}}
 
-		err = vcd.vdc.client.OpenApiGetAllItems(apiVersion, urlRef2, queryParams, &expectOneRoleResultById)
+		err = vcd.vdc.client.OpenApiGetAllItems(ctx, apiVersion, urlRef2, queryParams, &expectOneRoleResultById)
 		check.Assert(err, IsNil)
 		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
 
@@ -176,7 +176,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 		check.Assert(err, IsNil)
 
 		oneRole := &InlineRoles{}
-		err = vcd.vdc.client.OpenApiGetItem(apiVersion, singleRef, nil, oneRole)
+		err = vcd.vdc.client.OpenApiGetItem(ctx, apiVersion, singleRef, nil, oneRole)
 		check.Assert(err, IsNil)
 		check.Assert(oneRole, NotNil)
 
@@ -197,7 +197,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 		ReadOnly:  false,
 	}
 	newRoleResponse := &InlineRoles{}
-	err = vcd.client.Client.OpenApiPostItem(apiVersion, createUrl, nil, newRole, newRoleResponse)
+	err = vcd.client.Client.OpenApiPostItem(ctx, apiVersion, createUrl, nil, newRole, newRoleResponse)
 	check.Assert(err, IsNil)
 
 	// Ensure supplied and created structs differ only by ID
@@ -210,7 +210,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	check.Assert(err, IsNil)
 
 	updatedRoleResponse := &InlineRoles{}
-	err = vcd.client.Client.OpenApiPutItem(apiVersion, updateUrl, nil, newRoleResponse, updatedRoleResponse)
+	err = vcd.client.Client.OpenApiPutItem(ctx, apiVersion, updateUrl, nil, newRoleResponse, updatedRoleResponse)
 	check.Assert(err, IsNil)
 
 	// Ensure supplied and response objects are identical (update worked)
@@ -220,19 +220,19 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	deleteUrlRef, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
-	err = vcd.client.Client.OpenApiDeleteItem(apiVersion, deleteUrlRef, nil)
+	err = vcd.client.Client.OpenApiDeleteItem(ctx, apiVersion, deleteUrlRef, nil)
 	check.Assert(err, IsNil)
 
 	// Step 6 - try to read deleted role and expect error to contain 'ErrorEntityNotFound'
 	// Read is tricky - it throws an error ACCESS_TO_RESOURCE_IS_FORBIDDEN when the resource with ID does not
 	// exist therefore one cannot know what kind of error occurred.
 	lostRole := &InlineRoles{}
-	err = vcd.client.Client.OpenApiGetItem(apiVersion, deleteUrlRef, nil, lostRole)
+	err = vcd.client.Client.OpenApiGetItem(ctx, apiVersion, deleteUrlRef, nil, lostRole)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
 	// Step 7 - test synchronous POST and PUT functions (because Roles is a synchronous OpenAPI endpoint)
 	newRole.ID = "" // unset ID as it cannot be set for creation
-	err = vcd.client.Client.OpenApiPostItemSync(apiVersion, createUrl, nil, newRole, newRoleResponse)
+	err = vcd.client.Client.OpenApiPostItemSync(ctx, apiVersion, createUrl, nil, newRole, newRoleResponse)
 	check.Assert(err, IsNil)
 
 	// Ensure supplied and created structs differ only by ID
@@ -245,7 +245,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	check.Assert(err, IsNil)
 
 	updatedRoleResponse2 := &InlineRoles{}
-	err = vcd.client.Client.OpenApiPutItem(apiVersion, updateUrl2, nil, newRoleResponse, updatedRoleResponse2)
+	err = vcd.client.Client.OpenApiPutItem(ctx, apiVersion, updateUrl2, nil, newRoleResponse, updatedRoleResponse2)
 	check.Assert(err, IsNil)
 
 	// Ensure supplied and response objects are identical (update worked)
@@ -255,7 +255,7 @@ func (vcd *TestVCD) Test_OpenApiInlineStructCRUDRoles(check *C) {
 	deleteUrlRef2, err := vcd.client.Client.OpenApiBuildEndpoint(endpoint, newRoleResponse.ID)
 	check.Assert(err, IsNil)
 
-	err = vcd.client.Client.OpenApiDeleteItem(apiVersion, deleteUrlRef2, nil)
+	err = vcd.client.Client.OpenApiDeleteItem(ctx, apiVersion, deleteUrlRef2, nil)
 	check.Assert(err, IsNil)
 
 }
@@ -267,7 +267,7 @@ func getAuditTrailTimestampWithElements(elementCount int, check *C, vcd *TestVCD
 	qp := url.Values{}
 	qp.Add("pageSize", "128")
 	qp.Add("sortDesc", "timestamp") // Need to get the newest
-	req := client.newOpenApiRequest(apiVersion, qp, http.MethodGet, urlRef, nil)
+	req := client.newOpenApiRequest(ctx, apiVersion, qp, http.MethodGet, urlRef, nil)
 
 	resp, err := client.Http.Do(req)
 	check.Assert(err, IsNil)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"math"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+var ctx = context.Background()
+
 // Tests Refresh for Org by updating the org and then asserting if the
 // variable is updated.
 func (vcd *TestVCD) Test_RefreshOrg(check *C) {
@@ -22,13 +25,13 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(TestRefreshOrg)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, TestRefreshOrg)
 	if adminOrg != nil {
 		check.Assert(err, IsNil)
-		err := adminOrg.Delete(true, true)
+		err := adminOrg.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
-	task, err := CreateOrg(vcd.client, TestRefreshOrg, TestRefreshOrg, TestRefreshOrg, &types.OrgSettings{
+	task, err := CreateOrg(ctx, vcd.client, TestRefreshOrg, TestRefreshOrg, TestRefreshOrg, &types.OrgSettings{
 		OrgLdapSettings: &types.OrgLdapSettingsType{OrgLdapMode: "NONE"},
 	}, true)
 	check.Assert(err, IsNil)
@@ -36,33 +39,33 @@ func (vcd *TestVCD) Test_RefreshOrg(check *C) {
 	// If something fails after this point, the entity will be removed
 	AddToCleanupList(TestRefreshOrg, "org", "", "Test_RefreshOrg")
 
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// fetch newly created org
-	org, err := vcd.client.GetOrgByName(TestRefreshOrg)
+	org, err := vcd.client.GetOrgByName(ctx, TestRefreshOrg)
 	check.Assert(err, IsNil)
 	check.Assert(org.Org.Name, Equals, TestRefreshOrg)
 	// fetch admin version of org for updating
-	adminOrg, err = vcd.client.GetAdminOrgByName(TestRefreshOrg)
+	adminOrg, err = vcd.client.GetAdminOrgByName(ctx, TestRefreshOrg)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg.AdminOrg.Name, Equals, TestRefreshOrg)
 	adminOrg.AdminOrg.FullName = TestRefreshOrgFullName
-	task, err = adminOrg.Update()
+	task, err = adminOrg.Update(ctx)
 	check.Assert(err, IsNil)
 	// Wait until update is complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	// Test Refresh on normal org
-	err = org.Refresh()
+	err = org.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(org.Org.FullName, Equals, TestRefreshOrgFullName)
 	// Test Refresh on admin org
-	err = adminOrg.Refresh()
+	err = adminOrg.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg.AdminOrg.FullName, Equals, TestRefreshOrgFullName)
 	// Delete, with force and recursive true
-	err = adminOrg.Delete(true, true)
+	err = adminOrg.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
@@ -72,27 +75,27 @@ func (vcd *TestVCD) Test_DeleteOrg(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	org, _ := vcd.client.GetAdminOrgByName(TestDeleteOrg)
+	org, _ := vcd.client.GetAdminOrgByName(ctx, TestDeleteOrg)
 	if org != nil {
-		err := org.Delete(true, true)
+		err := org.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
-	task, err := CreateOrg(vcd.client, TestDeleteOrg, TestDeleteOrg, TestDeleteOrg, &types.OrgSettings{}, true)
+	task, err := CreateOrg(ctx, vcd.client, TestDeleteOrg, TestDeleteOrg, TestDeleteOrg, &types.OrgSettings{}, true)
 	check.Assert(err, IsNil)
 	// After a successful creation, the entity is added to the cleanup list.
 	// If something fails after this point, the entity will be removed
 	AddToCleanupList(TestDeleteOrg, "org", "", "Test_DeleteOrg")
 	// fetch newly created org
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
-	org, err = vcd.client.GetAdminOrgByName(TestDeleteOrg)
+	org, err = vcd.client.GetAdminOrgByName(ctx, TestDeleteOrg)
 	check.Assert(err, IsNil)
 	check.Assert(org.AdminOrg.Name, Equals, TestDeleteOrg)
 	// Delete, with force and recursive true
-	err = org.Delete(true, true)
+	err = org.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
-	doesOrgExist(check, vcd)
+	doesOrgExist(ctx, check, vcd)
 }
 
 // Creates a org UPDATEORG, changes the deployed vm quota on the org,
@@ -121,17 +124,17 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 	for _, uo := range updateOrgs {
 
 		fmt.Printf("Org %s - enabled %v - catalogs %v\n", uo.orgName, uo.enabled, uo.canPublishCatalogs)
-		task, err := CreateOrg(vcd.client, uo.orgName, uo.orgName, uo.orgName, &types.OrgSettings{
+		task, err := CreateOrg(ctx, vcd.client, uo.orgName, uo.orgName, uo.orgName, &types.OrgSettings{
 			OrgGeneralSettings: &types.OrgGeneralSettings{CanPublishCatalogs: uo.canPublishCatalogs},
 			OrgLdapSettings:    &types.OrgLdapSettingsType{OrgLdapMode: "NONE"},
 		}, uo.enabled)
 		check.Assert(err, IsNil)
 		check.Assert(task, Not(Equals), Task{})
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		check.Assert(err, IsNil)
 		AddToCleanupList(uo.orgName, "org", "", "TestUpdateOrg")
 		// fetch newly created org
-		adminOrg, err := vcd.client.GetAdminOrgByName(uo.orgName)
+		adminOrg, err := vcd.client.GetAdminOrgByName(ctx, uo.orgName)
 		check.Assert(err, IsNil)
 		check.Assert(adminOrg, NotNil)
 
@@ -145,15 +148,15 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs = !uo.canPublishCatalogs
 		adminOrg.AdminOrg.IsEnabled = !uo.enabled
 
-		task, err = adminOrg.Update()
+		task, err = adminOrg.Update(ctx)
 		check.Assert(err, IsNil)
 		check.Assert(task, Not(Equals), Task{})
 		// Wait until update is complete
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		check.Assert(err, IsNil)
 
 		// Get the Org again
-		updatedAdminOrg, err := vcd.client.GetAdminOrgByName(uo.orgName)
+		updatedAdminOrg, err := vcd.client.GetAdminOrgByName(ctx, uo.orgName)
 		check.Assert(err, IsNil)
 		check.Assert(updatedAdminOrg, NotNil)
 
@@ -170,9 +173,9 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 		check.Assert(updatedAdminOrg.AdminOrg.FullName, Equals, updatedFullName)
 		check.Assert(updatedAdminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.DeployedVMQuota, Equals, 100)
 		// Delete, with force and recursive true
-		err = updatedAdminOrg.Delete(true, true)
+		err = updatedAdminOrg.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
-		doesOrgExist(check, vcd)
+		doesOrgExist(ctx, check, vcd)
 	}
 }
 
@@ -183,12 +186,12 @@ func (vcd *TestVCD) Test_UpdateOrg(check *C) {
 // that doesn't exist. Asserts an error if the function finds it or
 // if the error is not nil.
 func (vcd *TestVCD) Test_GetVdcByName(check *C) {
-	vdc, err := vcd.org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := vcd.org.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 	check.Assert(vdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	vdc, err = vcd.org.GetVDCByName(INVALID_NAME, false)
+	vdc, err = vcd.org.GetVDCByName(ctx, INVALID_NAME, false)
 	check.Assert(err, NotNil)
 	check.Assert(vdc, IsNil)
 }
@@ -202,15 +205,15 @@ func (vcd *TestVCD) Test_Admin_GetVdcByName(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	vdc, err := adminOrg.GetVDCByName(vcd.config.VCD.Vdc, false)
+	vdc, err := adminOrg.GetVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 	check.Assert(vdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	vdc, err = adminOrg.GetVDCByName(INVALID_NAME, false)
+	vdc, err = adminOrg.GetVDCByName(ctx, INVALID_NAME, false)
 	check.Assert(vdc, IsNil)
 	check.Assert(err, NotNil)
 }
@@ -235,11 +238,11 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	if vcd.config.VCD.ProviderVdc.NetworkPool == "" {
 		check.Skip("No Network Pool given for VDC tests")
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err := vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "providerVdc",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.Name),
 	})
@@ -249,7 +252,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	}
 	providerVdcHref := results.Results.VMWProviderVdcRecord[0].HREF
 
-	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err = vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.StorageProfile),
 	})
@@ -259,7 +262,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 	}
 	providerVdcStorageProfileHref := results.Results.ProviderVdcStorageProfileRecord[0].HREF
 
-	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err = vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "networkPool",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.NetworkPool),
 	})
@@ -308,34 +311,34 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 			UsesFastProvisioning: true,
 		}
 
-		vdc, _ := adminOrg.GetVDCByName(vdcConfiguration.Name, false)
+		vdc, _ := adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, false)
 		if vdc != nil {
-			err = vdc.DeleteWait(true, true)
+			err = vdc.DeleteWait(ctx, true, true)
 			check.Assert(err, IsNil)
 		}
 
-		task, err := adminOrg.CreateVdc(vdcConfiguration)
+		task, err := adminOrg.CreateVdc(ctx, vdcConfiguration)
 		check.Assert(err, NotNil)
 		check.Assert(task, Equals, Task{})
 		check.Assert(err.Error(), Equals, "VdcConfiguration missing required field: ComputeCapacity[0].Memory.Units")
 		vdcConfiguration.ComputeCapacity[0].Memory.Units = "MB"
 
-		err = adminOrg.CreateVdcWait(vdcConfiguration)
+		err = adminOrg.CreateVdcWait(ctx, vdcConfiguration)
 		check.Assert(err, IsNil)
 
 		AddToCleanupList(vdcConfiguration.Name, "vdc", vcd.org.Org.Name, "Test_CreateVdc")
 
-		vdc, err = adminOrg.GetVDCByName(vdcConfiguration.Name, true)
+		vdc, err = adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, true)
 		check.Assert(err, IsNil)
 		check.Assert(vdc, NotNil)
 		check.Assert(vdc.Vdc.Name, Equals, vdcConfiguration.Name)
 		check.Assert(vdc.Vdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 		check.Assert(vdc.Vdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
 
-		err = vdc.DeleteWait(true, true)
+		err = vdc.DeleteWait(ctx, true, true)
 		check.Assert(err, IsNil)
 
-		vdc, err = adminOrg.GetVDCByName(vdcConfiguration.Name, true)
+		vdc, err = adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, true)
 		check.Assert(err, NotNil)
 		check.Assert(vdc, IsNil)
 	}
@@ -348,7 +351,7 @@ func (vcd *TestVCD) Test_CreateVdc(check *C) {
 // if the error is not nil.
 func (vcd *TestVCD) Test_FindCatalog(check *C) {
 	// Find Catalog
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(cat, NotNil)
 	check.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
@@ -357,7 +360,7 @@ func (vcd *TestVCD) Test_FindCatalog(check *C) {
 		check.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
 	// Check Invalid Catalog
-	cat, err = vcd.org.GetCatalogByName(INVALID_NAME, false)
+	cat, err = vcd.org.GetCatalogByName(ctx, INVALID_NAME, false)
 	check.Assert(err, NotNil)
 	check.Assert(cat, IsNil)
 }
@@ -372,11 +375,11 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	// Fetch admin org version of current test org
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 	// Find Catalog
-	cat, err := adminOrg.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	cat, err := adminOrg.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(cat, Not(Equals), Catalog{})
 	check.Assert(err, IsNil)
 	check.Assert(cat.Catalog.Name, Equals, vcd.config.VCD.Catalog.Name)
@@ -385,7 +388,7 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 		check.Assert(cat.Catalog.Description, Equals, vcd.config.VCD.Catalog.Description)
 	}
 	// Check Invalid Catalog
-	cat, err = adminOrg.GetCatalogByName(INVALID_NAME, false)
+	cat, err = adminOrg.GetCatalogByName(ctx, INVALID_NAME, false)
 	check.Assert(err, NotNil)
 	check.Assert(cat, IsNil)
 }
@@ -394,26 +397,26 @@ func (vcd *TestVCD) Test_Admin_FindCatalog(check *C) {
 // asserts that the catalog returned contains the right contents or if it fails.
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_AdminOrgCreateCatalog(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	oldAdminCatalog, _ := adminOrg.GetAdminCatalogByName(TestCreateCatalog, false)
+	oldAdminCatalog, _ := adminOrg.GetAdminCatalogByName(ctx, TestCreateCatalog, false)
 	if oldAdminCatalog != nil {
-		err = oldAdminCatalog.Delete(true, true)
+		err = oldAdminCatalog.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
-	adminCatalog, err := adminOrg.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
+	adminCatalog, err := adminOrg.CreateCatalog(ctx, TestCreateCatalog, TestCreateCatalogDesc)
 	check.Assert(err, IsNil)
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestCreateCatalog)
 	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
 	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	adminOrg, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err = vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(TestCreateCatalog, false)
+	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(ctx, TestCreateCatalog, false)
 	check.Assert(err, IsNil)
 	check.Assert(copyAdminCatalog, NotNil)
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, copyAdminCatalog.AdminCatalog.Name)
@@ -421,37 +424,37 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalog(check *C) {
 	check.Assert(adminCatalog.AdminCatalog.IsPublished, Equals, false)
 	check.Assert(adminCatalog.AdminCatalog.CatalogStorageProfiles, NotNil)
 	check.Assert(adminCatalog.AdminCatalog.CatalogStorageProfiles.VdcStorageProfile, IsNil)
-	err = adminCatalog.Delete(true, true)
+	err = adminCatalog.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_AdminOrgCreateCatalogWithStorageProfile(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	oldAdminCatalog, _ := adminOrg.GetAdminCatalogByName(check.TestName(), false)
+	oldAdminCatalog, _ := adminOrg.GetAdminCatalogByName(ctx, check.TestName(), false)
 	if oldAdminCatalog != nil {
-		err = oldAdminCatalog.Delete(true, true)
+		err = oldAdminCatalog.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
 
 	// Lookup storage profile to use in catalog
-	storageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	storageProfile, err := vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 	check.Assert(err, IsNil)
 	createStorageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&storageProfile}}
 
-	adminCatalog, err := adminOrg.CreateCatalogWithStorageProfile(check.TestName(), TestCreateCatalogDesc, createStorageProfiles)
+	adminCatalog, err := adminOrg.CreateCatalogWithStorageProfile(ctx, check.TestName(), TestCreateCatalogDesc, createStorageProfiles)
 	check.Assert(err, IsNil)
 	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, check.TestName())
 	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
 	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	adminOrg, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err = vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(check.TestName(), false)
+	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(ctx, check.TestName(), false)
 	check.Assert(err, IsNil)
 	check.Assert(copyAdminCatalog, NotNil)
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, copyAdminCatalog.AdminCatalog.Name)
@@ -460,18 +463,18 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalogWithStorageProfile(check *C) {
 
 	// Try to update storage profile for catalog if secondary profile is defined
 	if vcd.config.VCD.StorageProfile.SP2 != "" {
-		updateStorageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP2)
+		updateStorageProfile, err := vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP2)
 		check.Assert(err, IsNil)
 		updateStorageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&updateStorageProfile}}
 		adminCatalog.AdminCatalog.CatalogStorageProfiles = updateStorageProfiles
-		err = adminCatalog.Update()
+		err = adminCatalog.Update(ctx)
 		check.Assert(err, IsNil)
 	} else {
 		fmt.Printf("# Skipping storage profile update for %s because secondary storage profile is not provided",
 			adminCatalog.AdminCatalog.Name)
 	}
 
-	err = adminCatalog.Delete(true, true)
+	err = adminCatalog.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
@@ -479,68 +482,68 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalogWithStorageProfile(check *C) {
 // asserts that the catalog returned contains the right contents or if it fails.
 // Then Deletes the catalog.
 func (vcd *TestVCD) Test_OrgCreateCatalog(check *C) {
-	org, err := vcd.client.GetOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	oldCatalog, _ := org.GetCatalogByName(TestCreateCatalog, false)
+	oldCatalog, _ := org.GetCatalogByName(ctx, TestCreateCatalog, false)
 	if oldCatalog != nil {
-		err = oldCatalog.Delete(true, true)
+		err = oldCatalog.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
-	catalog, err := org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
+	catalog, err := org.CreateCatalog(ctx, TestCreateCatalog, TestCreateCatalogDesc)
 	check.Assert(err, IsNil)
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
 	check.Assert(catalog.Catalog.Name, Equals, TestCreateCatalog)
 	check.Assert(catalog.Catalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
 	task.Task = catalog.Catalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
+	org, err = vcd.client.GetOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyCatalog, err := org.GetCatalogByName(TestCreateCatalog, false)
+	copyCatalog, err := org.GetCatalogByName(ctx, TestCreateCatalog, false)
 	check.Assert(err, IsNil)
 	check.Assert(copyCatalog, NotNil)
 	check.Assert(catalog.Catalog.Name, Equals, copyCatalog.Catalog.Name)
 	check.Assert(catalog.Catalog.Description, Equals, copyCatalog.Catalog.Description)
 	check.Assert(catalog.Catalog.IsPublished, Equals, false)
-	err = catalog.Delete(true, true)
+	err = catalog.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_OrgCreateCatalogWithStorageProfile(check *C) {
-	org, err := vcd.client.GetOrgByName(vcd.org.Org.Name)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
-	oldCatalog, _ := org.GetCatalogByName(check.TestName(), false)
+	oldCatalog, _ := org.GetCatalogByName(ctx, check.TestName(), false)
 	if oldCatalog != nil {
-		err = oldCatalog.Delete(true, true)
+		err = oldCatalog.Delete(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
 
 	// Lookup storage profile to use in catalog
-	storageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	storageProfile, err := vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 	check.Assert(err, IsNil)
 	storageProfiles := &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&storageProfile}}
 
-	catalog, err := org.CreateCatalogWithStorageProfile(check.TestName(), TestCreateCatalogDesc, storageProfiles)
+	catalog, err := org.CreateCatalogWithStorageProfile(ctx, check.TestName(), TestCreateCatalogDesc, storageProfiles)
 	check.Assert(err, IsNil)
 	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
 	check.Assert(catalog.Catalog.Name, Equals, check.TestName())
 	check.Assert(catalog.Catalog.Description, Equals, TestCreateCatalogDesc)
 	task := NewTask(&vcd.client.Client)
 	task.Task = catalog.Catalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
+	org, err = vcd.client.GetOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
-	copyCatalog, err := org.GetCatalogByName(check.TestName(), false)
+	copyCatalog, err := org.GetCatalogByName(ctx, check.TestName(), false)
 	check.Assert(err, IsNil)
 	check.Assert(copyCatalog, NotNil)
 	check.Assert(catalog.Catalog.Name, Equals, copyCatalog.Catalog.Name)
 	check.Assert(catalog.Catalog.Description, Equals, copyCatalog.Catalog.Description)
 	check.Assert(catalog.Catalog.IsPublished, Equals, false)
-	err = catalog.Delete(true, true)
+	err = catalog.Delete(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
@@ -551,10 +554,10 @@ func (vcd *TestVCD) Test_GetAdminCatalog(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 	// Fetch admin org version of current test org
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	// Find Catalog
-	adminCatalog, err := adminOrg.GetAdminCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	adminCatalog, err := adminOrg.GetAdminCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(adminCatalog, NotNil)
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, vcd.config.VCD.Catalog.Name)
@@ -572,10 +575,10 @@ func (vcd *TestVCD) Test_RefreshVdc(check *C) {
 	check.Assert(err, IsNil)
 
 	// Refresh so the new VDC shows up in the org's list
-	err = adminOrg.Refresh()
+	err = adminOrg.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	adminVdc, err := adminOrg.GetAdminVDCByName(vdcConfiguration.Name, false)
+	adminVdc, err := adminOrg.GetAdminVDCByName(ctx, vdcConfiguration.Name, false)
 
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
@@ -584,20 +587,20 @@ func (vcd *TestVCD) Test_RefreshVdc(check *C) {
 	check.Assert(adminVdc.AdminVdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
 
 	adminVdc.AdminVdc.Name = TestRefreshOrgVdc
-	_, err = adminVdc.Update()
+	_, err = adminVdc.Update(ctx)
 	check.Assert(err, IsNil)
 	AddToCleanupList(TestRefreshOrgVdc, "vdc", vcd.org.Org.Name, check.TestName())
 
 	// Test Refresh on vdc
-	err = adminVdc.Refresh()
+	err = adminVdc.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc.AdminVdc.Name, Equals, TestRefreshOrgVdc)
 
 	//cleanup
-	vdc, err := adminOrg.GetVDCByName(vdcConfiguration.Name, false)
+	vdc, err := adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
-	err = vdc.DeleteWait(true, true)
+	err = vdc.DeleteWait(ctx, true, true)
 	check.Assert(err, IsNil)
 }
 
@@ -614,10 +617,10 @@ func setupVdc(vcd *TestVCD, check *C, allocationModel string) (AdminOrg, *types.
 	if vcd.config.VCD.ProviderVdc.NetworkPool == "" {
 		check.Skip("No Network Pool given for VDC tests")
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err := vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "providerVdc",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.Name),
 	})
@@ -626,7 +629,7 @@ func setupVdc(vcd *TestVCD, check *C, allocationModel string) (AdminOrg, *types.
 		check.Skip(fmt.Sprintf("No Provider VDC found with name '%s'", vcd.config.VCD.ProviderVdc.Name))
 	}
 	providerVdcHref := results.Results.VMWProviderVdcRecord[0].HREF
-	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err = vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "providerVdcStorageProfile",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.StorageProfile),
 	})
@@ -635,7 +638,7 @@ func setupVdc(vcd *TestVCD, check *C, allocationModel string) (AdminOrg, *types.
 		check.Skip(fmt.Sprintf("No storage profile found with name '%s'", vcd.config.VCD.ProviderVdc.StorageProfile))
 	}
 	providerVdcStorageProfileHref := results.Results.ProviderVdcStorageProfileRecord[0].HREF
-	results, err = vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
+	results, err = vcd.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "networkPool",
 		"filter": fmt.Sprintf("name==%s", vcd.config.VCD.ProviderVdc.NetworkPool),
 	})
@@ -688,12 +691,12 @@ func setupVdc(vcd *TestVCD, check *C, allocationModel string) (AdminOrg, *types.
 		vdcConfiguration.IncludeMemoryOverhead = &trueValue
 	}
 
-	vdc, _ := adminOrg.GetVDCByName(vdcConfiguration.Name, false)
+	vdc, _ := adminOrg.GetVDCByName(ctx, vdcConfiguration.Name, false)
 	if vdc != nil {
-		err = vdc.DeleteWait(true, true)
+		err = vdc.DeleteWait(ctx, true, true)
 		check.Assert(err, IsNil)
 	}
-	_, err = adminOrg.CreateOrgVdc(vdcConfiguration)
+	_, err = adminOrg.CreateOrgVdc(ctx, vdcConfiguration)
 	check.Assert(err, IsNil)
 	AddToCleanupList(vdcConfiguration.Name, "vdc", vcd.org.Org.Name, check.TestName())
 	return *adminOrg, vdcConfiguration, err
@@ -706,10 +709,10 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	check.Assert(err, IsNil)
 
 	// Refresh so the new VDC shows up in the org's list
-	err = adminOrg.Refresh()
+	err = adminOrg.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	adminVdc, err := adminOrg.GetAdminVDCByName(vdcConfiguration.Name, false)
+	adminVdc, err := adminOrg.GetAdminVDCByName(ctx, vdcConfiguration.Name, false)
 
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
@@ -748,7 +751,7 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	adminVdc.AdminVdc.ResourceGuaranteedCpu = &guaranteed
 	adminVdc.AdminVdc.ResourceGuaranteedMemory = &guaranteed
 
-	updatedVdc, err := adminVdc.Update()
+	updatedVdc, err := adminVdc.Update(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVdc, Not(IsNil))
 	check.Assert(updatedVdc.AdminVdc.Description, Equals, updateDescription)
@@ -775,16 +778,16 @@ func (vcd *TestVCD) Test_GetAdminVdcByName(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.config.VCD.Vdc, false)
+	adminVdc, err := adminOrg.GetAdminVDCByName(ctx, vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
 	check.Assert(adminVdc.AdminVdc.Name, Equals, vcd.config.VCD.Vdc)
 	// Try a vdc that doesn't exist
-	adminVdc, err = adminOrg.GetAdminVDCByName(INVALID_NAME, false)
+	adminVdc, err = adminOrg.GetAdminVDCByName(ctx, INVALID_NAME, false)
 	check.Assert(err, NotNil)
 	check.Assert(adminVdc, IsNil)
 }
@@ -793,11 +796,11 @@ func (vcd *TestVCD) Test_GetAdminVdcByName(check *C) {
 func (vcd *TestVCD) Test_OrgGetCatalog(check *C) {
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return vcd.org.GetCatalogByName(name, refresh)
+		return vcd.org.GetCatalogByName(ctx, name, refresh)
 	}
-	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.org.GetCatalogById(id, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return vcd.org.GetCatalogById(ctx, id, refresh) }
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return vcd.org.GetCatalogByNameOrId(id, refresh)
+		return vcd.org.GetCatalogByNameOrId(ctx, id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -821,18 +824,18 @@ func (vcd *TestVCD) Test_AdminOrgGetAdminCatalog(check *C) {
 		return
 	}
 
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetAdminCatalogByName(name, refresh)
+		return adminOrg.GetAdminCatalogByName(ctx, name, refresh)
 	}
 	getById := func(id string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetAdminCatalogById(id, refresh)
+		return adminOrg.GetAdminCatalogById(ctx, id, refresh)
 	}
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetAdminCatalogByNameOrId(id, refresh)
+		return adminOrg.GetAdminCatalogByNameOrId(ctx, id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -857,16 +860,16 @@ func (vcd *TestVCD) Test_AdminOrgGetCatalog(check *C) {
 		check.Skip("Test_AdminOrgGetCatalog: Org name not given.")
 		return
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetCatalogByName(name, refresh)
+		return adminOrg.GetCatalogByName(ctx, name, refresh)
 	}
-	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetCatalogById(id, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetCatalogById(ctx, id, refresh) }
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetCatalogByNameOrId(id, refresh)
+		return adminOrg.GetCatalogByNameOrId(ctx, id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -890,13 +893,17 @@ func (vcd *TestVCD) Test_AdminOrgGetVdc(check *C) {
 		check.Skip("Test_AdminOrgGetVdc: Org name not given.")
 		return
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	getByName := func(name string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCByName(name, refresh) }
-	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCById(id, refresh) }
-	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCByNameOrId(id, refresh) }
+	getByName := func(name string, refresh bool) (genericEntity, error) {
+		return adminOrg.GetVDCByName(ctx, name, refresh)
+	}
+	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetVDCById(ctx, id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
+		return adminOrg.GetVDCByNameOrId(ctx, id, refresh)
+	}
 
 	var def = getterTestDefinition{
 		parentType:    "AdminOrg",
@@ -918,16 +925,18 @@ func (vcd *TestVCD) Test_AdminOrgGetAdminVdc(check *C) {
 		check.Skip("Test_AdminOrgGetAdminVdc: Org name not given.")
 		return
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
 	getByName := func(name string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetAdminVDCByName(name, refresh)
+		return adminOrg.GetAdminVDCByName(ctx, name, refresh)
 	}
-	getById := func(id string, refresh bool) (genericEntity, error) { return adminOrg.GetAdminVDCById(id, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) {
+		return adminOrg.GetAdminVDCById(ctx, id, refresh)
+	}
 	getByNameOrId := func(id string, refresh bool) (genericEntity, error) {
-		return adminOrg.GetAdminVDCByNameOrId(id, refresh)
+		return adminOrg.GetAdminVDCByNameOrId(ctx, id, refresh)
 	}
 
 	var def = getterTestDefinition{
@@ -950,13 +959,13 @@ func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
 		check.Skip("Test_OrgGetVdc: Org name not given.")
 		return
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(name, refresh) }
-	getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(id, refresh) }
-	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+	getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(ctx, name, refresh) }
+	getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(ctx, id, refresh) }
+	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(ctx, id, refresh) }
 
 	var def = getterTestDefinition{
 		parentType:    "Org",
@@ -982,11 +991,11 @@ func (vcd *TestVCD) Test_GetTaskList(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
-	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	taskList, err := org.GetTaskList()
+	taskList, err := org.GetTaskList(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(len(taskList.Task), Not(Equals), 0)
 	check.Assert(taskList.Task[0], NotNil)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -7,7 +7,6 @@
 package govcd
 
 import (
-	"context"
 	"fmt"
 	"math"
 
@@ -15,8 +14,6 @@ import (
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
-
-var ctx = context.Background()
 
 // Tests Refresh for Org by updating the org and then asserting if the
 // variable is updated.

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -90,7 +90,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete(ctx context.Context) (Task, error) {
 
 // RemoveOrgVdcNetworkIfExists looks for an Org Vdc network and, if found, will delete it.
 func RemoveOrgVdcNetworkIfExists(ctx context.Context, vdc Vdc, networkName string) error {
-	network, err := vdc.GetOrgVdcNetworkByName(networkName, true)
+	network, err := vdc.GetOrgVdcNetworkByName(ctx, networkName, true)
 
 	if IsNotFound(err) {
 		// Network not found. No action needed
@@ -273,7 +273,7 @@ func (orgVdcNet *OrgVDCNetwork) getEdgeGateway(ctx context.Context) (*EdgeGatewa
 	// Since this function can be called from Update(), we must take into account the
 	// possibility of a name change. If this is happening, we need to retrieve the original
 	// name, which is still stored in the VDC.
-	oldNetwork, err := vdc.GetOrgVdcNetworkById(orgVdcNet.OrgVDCNetwork.ID, false)
+	oldNetwork, err := vdc.GetOrgVdcNetworkById(ctx, orgVdcNet.OrgVDCNetwork.ID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (orgVdcNet *OrgVDCNetwork) getEdgeGateway(ctx context.Context) (*EdgeGatewa
 		return nil, err
 	}
 
-	return vdc.GetEdgeGatewayByName(edgeGatewayName, false)
+	return vdc.GetEdgeGatewayByName(ctx, edgeGatewayName, false)
 }
 
 // UpdateAsync will change the contents of a network using the information in the

--- a/govcd/orgvdcnetwork.go
+++ b/govcd/orgvdcnetwork.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -35,7 +36,7 @@ func NewOrgVDCNetwork(cli *Client) *OrgVDCNetwork {
 	}
 }
 
-func (orgVdcNet *OrgVDCNetwork) Refresh() error {
+func (orgVdcNet *OrgVDCNetwork) Refresh(ctx context.Context) error {
 	if orgVdcNet.OrgVDCNetwork.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
 	}
@@ -46,7 +47,7 @@ func (orgVdcNet *OrgVDCNetwork) Refresh() error {
 	// elements in slices.
 	orgVdcNet.OrgVDCNetwork = &types.OrgVDCNetwork{}
 
-	_, err := orgVdcNet.client.ExecuteRequest(refreshUrl, http.MethodGet,
+	_, err := orgVdcNet.client.ExecuteRequest(ctx, refreshUrl, http.MethodGet,
 		"", "error retrieving vDC network: %s", nil, orgVdcNet.OrgVDCNetwork)
 
 	return err
@@ -54,8 +55,8 @@ func (orgVdcNet *OrgVDCNetwork) Refresh() error {
 
 // Delete a network. Fails if the network is busy.
 // Returns a task to monitor the deletion.
-func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
-	err := orgVdcNet.Refresh()
+func (orgVdcNet *OrgVDCNetwork) Delete(ctx context.Context) (Task, error) {
+	err := orgVdcNet.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing network: %s", err)
 	}
@@ -65,7 +66,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 
 	var resp *http.Response
 	for {
-		req := orgVdcNet.client.NewRequest(map[string]string{}, http.MethodDelete, *apiEndpoint, nil)
+		req := orgVdcNet.client.NewRequest(ctx, map[string]string{}, http.MethodDelete, *apiEndpoint, nil)
 		resp, err = checkResp(orgVdcNet.client.Http.Do(req))
 		if err != nil {
 			if reErrorBusy2.MatchString(err.Error()) {
@@ -88,7 +89,7 @@ func (orgVdcNet *OrgVDCNetwork) Delete() (Task, error) {
 }
 
 // RemoveOrgVdcNetworkIfExists looks for an Org Vdc network and, if found, will delete it.
-func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
+func RemoveOrgVdcNetworkIfExists(ctx context.Context, vdc Vdc, networkName string) error {
 	network, err := vdc.GetOrgVdcNetworkByName(networkName, true)
 
 	if IsNotFound(err) {
@@ -100,11 +101,11 @@ func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
 		return err
 	}
 	// The network was found. We attempt deletion
-	task, err := network.Delete()
+	task, err := network.Delete(ctx)
 	if err != nil {
 		return fmt.Errorf("error deleting network '%s' [phase 1]: %s", networkName, err)
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error deleting network '%s' [task]: %s", networkName, err)
 	}
@@ -113,9 +114,9 @@ func RemoveOrgVdcNetworkIfExists(vdc Vdc, networkName string) error {
 
 // A wrapper call around CreateOrgVDCNetwork.
 // Creates a network and then uses the associated task to monitor its configuration
-func (vdc *Vdc) CreateOrgVDCNetworkWait(networkConfig *types.OrgVDCNetwork) error {
+func (vdc *Vdc) CreateOrgVDCNetworkWait(ctx context.Context, networkConfig *types.OrgVDCNetwork) error {
 
-	task, err := vdc.CreateOrgVDCNetwork(networkConfig)
+	task, err := vdc.CreateOrgVDCNetwork(ctx, networkConfig)
 	if err != nil {
 		return fmt.Errorf("error creating the network: %s", err)
 	}
@@ -123,7 +124,7 @@ func (vdc *Vdc) CreateOrgVDCNetworkWait(networkConfig *types.OrgVDCNetwork) erro
 		return fmt.Errorf("NULL task retrieved after network creation")
 
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	// err = task.WaitInspectTaskCompletion(InspectTask, 10)
 	if err != nil {
 		return fmt.Errorf("error performing task: %s", err)
@@ -136,7 +137,7 @@ func (vdc *Vdc) CreateOrgVDCNetworkWait(networkConfig *types.OrgVDCNetwork) erro
 // the network configuration)
 // This function can create any type of Org Vdc network. The exact type is determined by
 // the combination of properties given with the network configuration structure.
-func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, error) {
+func (vdc *Vdc) CreateOrgVDCNetwork(ctx context.Context, networkConfig *types.OrgVDCNetwork) (Task, error) {
 	for _, av := range vdc.Vdc.Link {
 		if av.Rel == "add" && av.Type == "application/vnd.vmware.vcloud.orgVdcNetwork+xml" {
 			createUrl, err := url.ParseRequestURI(av.HREF)
@@ -156,7 +157,7 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 			for {
 				b := bytes.NewBufferString(xml.Header + string(output))
 				util.Logger.Printf("[DEBUG] VCD Client configuration: %s", b)
-				req := vdc.client.NewRequest(map[string]string{}, http.MethodPost, *createUrl, b)
+				req := vdc.client.NewRequest(ctx, map[string]string{}, http.MethodPost, *createUrl, b)
 				req.Header.Add("Content-Type", av.Type)
 				resp, err = checkResp(vdc.client.Http.Do(req))
 				if err != nil {
@@ -197,9 +198,9 @@ func (vdc *Vdc) CreateOrgVDCNetwork(networkConfig *types.OrgVDCNetwork) (Task, e
 }
 
 // GetNetworkList returns a list of networks for the VDC
-func (vdc *Vdc) GetNetworkList() ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
+func (vdc *Vdc) GetNetworkList(ctx context.Context) ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
 	// Find the list of networks with the wanted name
-	result, err := vdc.client.QueryWithNotEncodedParams(nil, map[string]string{
+	result, err := vdc.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "orgVdcNetwork",
 		"filter":        fmt.Sprintf("vdc==%s", url.QueryEscape(vdc.Vdc.ID)),
 		"filterEncoded": "true",
@@ -212,10 +213,10 @@ func (vdc *Vdc) GetNetworkList() ([]*types.QueryResultOrgVdcNetworkRecordType, e
 
 // FindEdgeGatewayNameByNetwork searches the VDC for a connection between an edge gateway and a given network.
 // On success, returns the name of the edge gateway
-func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error) {
+func (vdc *Vdc) FindEdgeGatewayNameByNetwork(ctx context.Context, networkName string) (string, error) {
 
 	// Find the list of networks with the wanted name
-	result, err := vdc.client.QueryWithNotEncodedParams(nil, map[string]string{
+	result, err := vdc.client.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "orgVdcNetwork",
 		"filter":        fmt.Sprintf("name==%s;vdc==%s", url.QueryEscape(networkName), url.QueryEscape(vdc.Vdc.ID)),
 		"filterEncoded": "true",
@@ -240,13 +241,13 @@ func (vdc *Vdc) FindEdgeGatewayNameByNetwork(networkName string) (string, error)
 }
 
 // getParentVdc retrieves the VDC to which the network is attached
-func (orgVdcNet *OrgVDCNetwork) getParentVdc() (*Vdc, error) {
+func (orgVdcNet *OrgVDCNetwork) getParentVdc(ctx context.Context) (*Vdc, error) {
 	for _, link := range orgVdcNet.OrgVDCNetwork.Link {
 		if link.Type == "application/vnd.vmware.vcloud.vdc+xml" {
 
 			vdc := NewVdc(orgVdcNet.client)
 
-			_, err := orgVdcNet.client.ExecuteRequest(link.HREF, http.MethodGet,
+			_, err := orgVdcNet.client.ExecuteRequest(ctx, link.HREF, http.MethodGet,
 				"", "error retrieving parent vdc: %s", nil, vdc.Vdc)
 			if err != nil {
 				return nil, err
@@ -259,12 +260,12 @@ func (orgVdcNet *OrgVDCNetwork) getParentVdc() (*Vdc, error) {
 }
 
 // getEdgeGateway retrieves the edge gateway connected to a routed network
-func (orgVdcNet *OrgVDCNetwork) getEdgeGateway() (*EdgeGateway, error) {
+func (orgVdcNet *OrgVDCNetwork) getEdgeGateway(ctx context.Context) (*EdgeGateway, error) {
 	// If it is not routed, returns an error
 	if orgVdcNet.OrgVDCNetwork.Configuration.FenceMode != types.FenceModeNAT {
 		return nil, fmt.Errorf("network %s is not routed", orgVdcNet.OrgVDCNetwork.Name)
 	}
-	vdc, err := orgVdcNet.getParentVdc()
+	vdc, err := orgVdcNet.getParentVdc(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +279,7 @@ func (orgVdcNet *OrgVDCNetwork) getEdgeGateway() (*EdgeGateway, error) {
 	}
 	networkName := oldNetwork.OrgVDCNetwork.Name
 
-	edgeGatewayName, err := vdc.FindEdgeGatewayNameByNetwork(networkName)
+	edgeGatewayName, err := vdc.FindEdgeGatewayNameByNetwork(ctx, networkName)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +289,7 @@ func (orgVdcNet *OrgVDCNetwork) getEdgeGateway() (*EdgeGateway, error) {
 
 // UpdateAsync will change the contents of a network using the information in the
 // receiver data structure.
-func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
+func (orgVdcNet *OrgVDCNetwork) UpdateAsync(ctx context.Context) (Task, error) {
 	if orgVdcNet.OrgVDCNetwork.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update Org VDC network: HREF is empty")
 	}
@@ -309,7 +310,7 @@ func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 	// Since the network data structure doesn't return edge gateway information,
 	// we fetch it explicitly.
 	if orgVdcNet.OrgVDCNetwork.Configuration.FenceMode == types.FenceModeNAT {
-		edgeGateway, err := orgVdcNet.getEdgeGateway()
+		edgeGateway, err := orgVdcNet.getEdgeGateway(ctx)
 		if err != nil {
 			return Task{}, fmt.Errorf("error retrieving edge gateway for Org VDC network %s : %s", orgVdcNet.OrgVDCNetwork.Name, err)
 		}
@@ -320,33 +321,33 @@ func (orgVdcNet *OrgVDCNetwork) UpdateAsync() (Task, error) {
 			Name: edgeGateway.EdgeGateway.Name,
 		}
 	}
-	return orgVdcNet.client.ExecuteTaskRequest(href, http.MethodPut,
+	return orgVdcNet.client.ExecuteTaskRequest(ctx, href, http.MethodPut,
 		types.MimeOrgVdcNetwork, "error updating Org VDC network: %s", orgVdcNet.OrgVDCNetwork)
 }
 
 // Update is a wrapper around UpdateAsync, where we
 // explicitly wait for the task to finish.
 // The pointer receiver is refreshed after update
-func (orgVdcNet *OrgVDCNetwork) Update() error {
-	task, err := orgVdcNet.UpdateAsync()
+func (orgVdcNet *OrgVDCNetwork) Update(ctx context.Context) error {
+	task, err := orgVdcNet.UpdateAsync(ctx)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return err
 	}
 
-	return orgVdcNet.Refresh()
+	return orgVdcNet.Refresh(ctx)
 }
 
 // Rename is a wrapper around Update(), where we only change the name of the network
 // Since the purpose is explicitly changing the name, the function will fail if the new name
 // is not different from the existing one
-func (orgVdcNet *OrgVDCNetwork) Rename(newName string) error {
+func (orgVdcNet *OrgVDCNetwork) Rename(ctx context.Context, newName string) error {
 	if orgVdcNet.OrgVDCNetwork.Name == newName {
 		return fmt.Errorf("new name is the same ase the existing name")
 	}
 	orgVdcNet.OrgVDCNetwork.Name = newName
-	return orgVdcNet.Update()
+	return orgVdcNet.Update(ctx)
 }

--- a/govcd/productsection.go
+++ b/govcd/productsection.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // setProductSectionList is a shared function for both vApp and VM
-func setProductSectionList(client *Client, href string, productSection *types.ProductSectionList) error {
+func setProductSectionList(ctx context.Context, client *Client, href string, productSection *types.ProductSectionList) error {
 	if href == "" {
 		return fmt.Errorf("href cannot be empty to set product section")
 	}
@@ -20,14 +21,14 @@ func setProductSectionList(client *Client, href string, productSection *types.Pr
 	productSection.Xmlns = types.XMLNamespaceVCloud
 	productSection.Ovf = types.XMLNamespaceOVF
 
-	task, err := client.ExecuteTaskRequest(href+"/productSections", http.MethodPut,
+	task, err := client.ExecuteTaskRequest(ctx, href+"/productSections", http.MethodPut,
 		types.MimeProductSection, "error setting product section: %s", productSection)
 
 	if err != nil {
 		return fmt.Errorf("unable to set product section: %s", err)
 	}
 
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("task for setting product section failed: %s", err)
 	}
@@ -36,13 +37,13 @@ func setProductSectionList(client *Client, href string, productSection *types.Pr
 }
 
 // getProductSectionList is a shared function for both vApp and VM
-func getProductSectionList(client *Client, href string) (*types.ProductSectionList, error) {
+func getProductSectionList(ctx context.Context, client *Client, href string) (*types.ProductSectionList, error) {
 	if href == "" {
 		return nil, fmt.Errorf("href cannot be empty to get product section")
 	}
 	productSection := &types.ProductSectionList{}
 
-	_, err := client.ExecuteRequest(href+"/productSections", http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, href+"/productSections", http.MethodGet,
 		types.MimeProductSection, "error retrieving product section : %s", nil, productSection)
 
 	if err != nil {

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -23,53 +24,53 @@ func NewResults(cli *Client) *Results {
 	}
 }
 
-func (vcdCli *VCDClient) Query(params map[string]string) (Results, error) {
+func (vcdCli *VCDClient) Query(ctx context.Context, params map[string]string) (Results, error) {
 
-	req := vcdCli.Client.NewRequest(params, http.MethodGet, vcdCli.QueryHREF, nil)
+	req := vcdCli.Client.NewRequest(ctx, params, http.MethodGet, vcdCli.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vcdCli.Client.APIVersion)
 
 	return getResult(&vcdCli.Client, req)
 }
 
-func (vdc *Vdc) Query(params map[string]string) (Results, error) {
+func (vdc *Vdc) Query(ctx context.Context, params map[string]string) (Results, error) {
 	queryUrl := vdc.client.VCDHREF
 	queryUrl.Path += "/query"
-	req := vdc.client.NewRequest(params, http.MethodGet, queryUrl, nil)
+	req := vdc.client.NewRequest(ctx, params, http.MethodGet, queryUrl, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+vdc.client.APIVersion)
 
 	return getResult(vdc.client, req)
 }
 
 // QueryWithNotEncodedParams uses Query API to search for requested data
-func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	return client.QueryWithNotEncodedParamsWithApiVersion(params, notEncodedParams, client.APIVersion)
+func (client *Client) QueryWithNotEncodedParams(ctx context.Context, params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	return client.QueryWithNotEncodedParamsWithApiVersion(ctx, params, notEncodedParams, client.APIVersion)
 }
 
 // QueryWithNotEncodedParams uses Query API to search for requested data
-func (client *Client) QueryWithNotEncodedParamsWithApiVersion(params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
+func (client *Client) QueryWithNotEncodedParamsWithApiVersion(ctx context.Context, params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
 	queryUlr := client.VCDHREF
 	queryUlr.Path += "/query"
 
-	req := client.NewRequestWitNotEncodedParamsWithApiVersion(params, notEncodedParams, http.MethodGet, queryUlr, nil, apiVersion)
+	req := client.NewRequestWitNotEncodedParamsWithApiVersion(ctx, params, notEncodedParams, http.MethodGet, queryUlr, nil, apiVersion)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+apiVersion)
 
 	return getResult(client, req)
 }
 
-func (vcdCli *VCDClient) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	return vcdCli.Client.QueryWithNotEncodedParams(params, notEncodedParams)
+func (vcdCli *VCDClient) QueryWithNotEncodedParams(ctx context.Context, params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	return vcdCli.Client.QueryWithNotEncodedParams(ctx, params, notEncodedParams)
 }
 
-func (vdc *Vdc) QueryWithNotEncodedParams(params map[string]string, notEncodedParams map[string]string) (Results, error) {
-	return vdc.client.QueryWithNotEncodedParams(params, notEncodedParams)
+func (vdc *Vdc) QueryWithNotEncodedParams(ctx context.Context, params map[string]string, notEncodedParams map[string]string) (Results, error) {
+	return vdc.client.QueryWithNotEncodedParams(ctx, params, notEncodedParams)
 }
 
-func (vcdCli *VCDClient) QueryWithNotEncodedParamsWithApiVersion(params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
-	return vcdCli.Client.QueryWithNotEncodedParamsWithApiVersion(params, notEncodedParams, apiVersion)
+func (vcdCli *VCDClient) QueryWithNotEncodedParamsWithApiVersion(ctx context.Context, params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
+	return vcdCli.Client.QueryWithNotEncodedParamsWithApiVersion(ctx, params, notEncodedParams, apiVersion)
 }
 
-func (vdc *Vdc) QueryWithNotEncodedParamsWithApiVersion(params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
-	return vdc.client.QueryWithNotEncodedParamsWithApiVersion(params, notEncodedParams, apiVersion)
+func (vdc *Vdc) QueryWithNotEncodedParamsWithApiVersion(ctx context.Context, params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
+	return vdc.client.QueryWithNotEncodedParamsWithApiVersion(ctx, params, notEncodedParams, apiVersion)
 }
 
 func getResult(client *Client, request *http.Request) (Results, error) {

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -14,6 +14,6 @@ import (
 // TODO: Need to add a check to check the contents of the query
 func (vcd *TestVCD) Test_Query(check *C) {
 	// Get the Org populated
-	_, err := vcd.client.Query(map[string]string{"type": "vm"})
+	_, err := vcd.client.Query(ctx, map[string]string{"type": "vm"})
 	check.Assert(err, IsNil)
 }

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -5,6 +5,7 @@ package govcd
  */
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -18,9 +19,9 @@ type Role struct {
 }
 
 // GetOpenApiRoleById retrieves role by given ID
-func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*Role, error) {
+func (adminOrg *AdminOrg) GetOpenApiRoleById(ctx context.Context, id string) (*Role, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +40,7 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*Role, error) {
 		client: adminOrg.client,
 	}
 
-	err = adminOrg.client.OpenApiGetItem(minimumApiVersion, urlRef, nil, role.Role)
+	err = adminOrg.client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, nil, role.Role)
 	if err != nil {
 		return nil, err
 	}
@@ -49,9 +50,9 @@ func (adminOrg *AdminOrg) GetOpenApiRoleById(id string) (*Role, error) {
 
 // GetAllOpenApiRoles retrieves all roles using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
-func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*Role, error) {
+func (adminOrg *AdminOrg) GetAllOpenApiRoles(ctx context.Context, queryParameters url.Values) ([]*Role, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*Rol
 	}
 
 	typeResponses := []*types.Role{{}}
-	err = adminOrg.client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &typeResponses)
+	err = adminOrg.client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &typeResponses)
 	if err != nil {
 		return nil, err
 	}
@@ -80,9 +81,9 @@ func (adminOrg *AdminOrg) GetAllOpenApiRoles(queryParameters url.Values) ([]*Rol
 }
 
 // CreateRole creates a new role using OpenAPI endpoint
-func (adminOrg *AdminOrg) CreateRole(newRole *types.Role) (*Role, error) {
+func (adminOrg *AdminOrg) CreateRole(ctx context.Context, newRole *types.Role) (*Role, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := adminOrg.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ func (adminOrg *AdminOrg) CreateRole(newRole *types.Role) (*Role, error) {
 		client: adminOrg.client,
 	}
 
-	err = adminOrg.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newRole, returnRole.Role)
+	err = adminOrg.client.OpenApiPostItem(ctx, minimumApiVersion, urlRef, nil, newRole, returnRole.Role)
 	if err != nil {
 		return nil, fmt.Errorf("error creating role: %s", err)
 	}
@@ -106,9 +107,9 @@ func (adminOrg *AdminOrg) CreateRole(newRole *types.Role) (*Role, error) {
 }
 
 // Update updates existing OpenAPI role
-func (role *Role) Update() (*Role, error) {
+func (role *Role) Update(ctx context.Context) (*Role, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (role *Role) Update() (*Role, error) {
 		client: role.client,
 	}
 
-	err = role.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, role.Role, returnRole.Role)
+	err = role.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, role.Role, returnRole.Role)
 	if err != nil {
 		return nil, fmt.Errorf("error updating role: %s", err)
 	}
@@ -136,9 +137,9 @@ func (role *Role) Update() (*Role, error) {
 }
 
 // Delete deletes OpenAPI role
-func (role *Role) Delete() error {
+func (role *Role) Delete(ctx context.Context) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles
-	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := role.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -152,7 +153,7 @@ func (role *Role) Delete() error {
 		return err
 	}
 
-	err = role.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = role.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting role: %s", err)

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func (vcd *TestVCD) Test_Roles(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
 	// Step 1 - Get all roles
-	allExistingRoles, err := adminOrg.GetAllOpenApiRoles(nil)
+	allExistingRoles, err := adminOrg.GetAllOpenApiRoles(ctx, nil)
 	check.Assert(err, IsNil)
 	check.Assert(allExistingRoles, NotNil)
 
@@ -30,12 +30,12 @@ func (vcd *TestVCD) Test_Roles(check *C) {
 		queryParams := url.Values{}
 		queryParams.Add("filter", "id=="+oneRole.Role.ID)
 
-		expectOneRoleResultById, err := adminOrg.GetAllOpenApiRoles(queryParams)
+		expectOneRoleResultById, err := adminOrg.GetAllOpenApiRoles(ctx, queryParams)
 		check.Assert(err, IsNil)
 		check.Assert(len(expectOneRoleResultById) == 1, Equals, true)
 
 		// Step 2.2 - retrieve specific role by using endpoint
-		exactItem, err := adminOrg.GetOpenApiRoleById(oneRole.Role.ID)
+		exactItem, err := adminOrg.GetOpenApiRoleById(ctx, oneRole.Role.ID)
 		check.Assert(err, IsNil)
 
 		check.Assert(err, IsNil)
@@ -56,7 +56,7 @@ func (vcd *TestVCD) Test_Roles(check *C) {
 		ReadOnly:  false,
 	}
 
-	createdRole, err := adminOrg.CreateRole(newR)
+	createdRole, err := adminOrg.CreateRole(ctx, newR)
 	check.Assert(err, IsNil)
 
 	// Ensure supplied and created structs differ only by ID
@@ -65,17 +65,17 @@ func (vcd *TestVCD) Test_Roles(check *C) {
 
 	// Step 4 - updated created role
 	createdRole.Role.Description = "Updated description"
-	updatedRole, err := createdRole.Update()
+	updatedRole, err := createdRole.Update(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(updatedRole.Role, DeepEquals, createdRole.Role)
 
 	// Step 5 - delete created role
-	err = updatedRole.Delete()
+	err = updatedRole.Delete(ctx)
 	check.Assert(err, IsNil)
 	// Step 5 - try to read deleted role and expect error to contain 'ErrorEntityNotFound'
 	// Read is tricky - it throws an error ACCESS_TO_RESOURCE_IS_FORBIDDEN when the resource with ID does not
 	// exist therefore one cannot know what kind of error occurred.
-	deletedRole, err := adminOrg.GetOpenApiRoleById(createdRole.Role.ID)
+	deletedRole, err := adminOrg.GetOpenApiRoleById(ctx, createdRole.Role.ID)
 	check.Assert(ContainsNotFound(err), Equals, true)
 	check.Assert(deletedRole, IsNil)
 }

--- a/govcd/saml_auth_test.go
+++ b/govcd/saml_auth_test.go
@@ -28,22 +28,22 @@ func (vcd *TestVCD) Test_SamlAdfsAuth(check *C) {
 	}
 
 	// Get vDC details using existing vCD client
-	org, err := vcd.client.GetOrgByName(cfg.VCD.Org)
+	org, err := vcd.client.GetOrgByName(ctx, cfg.VCD.Org)
 	check.Assert(err, IsNil)
 
-	vdc, err := org.GetVDCByName(cfg.VCD.Vdc, true)
+	vdc, err := org.GetVDCByName(ctx, cfg.VCD.Vdc, true)
 	check.Assert(err, IsNil)
 
 	// Get new vCD session and client using specifically SAML credentials
 	samlVcdCli := NewVCDClient(vcd.client.Client.VCDHREF, true,
 		WithSamlAdfs(true, cfg.Provider.SamlCustomRptId))
-	err = samlVcdCli.Authenticate(cfg.Provider.SamlUser, cfg.Provider.SamlPassword, cfg.VCD.Org)
+	err = samlVcdCli.Authenticate(ctx, cfg.Provider.SamlUser, cfg.Provider.SamlPassword, cfg.VCD.Org)
 	check.Assert(err, IsNil)
 
-	samlOrg, err := vcd.client.GetOrgByName(cfg.VCD.Org)
+	samlOrg, err := vcd.client.GetOrgByName(ctx, cfg.VCD.Org)
 	check.Assert(err, IsNil)
 
-	samlVdc, err := samlOrg.GetVDCByName(cfg.VCD.Vdc, true)
+	samlVdc, err := samlOrg.GetVDCByName(ctx, cfg.VCD.Vdc, true)
 	check.Assert(err, IsNil)
 
 	check.Assert(samlVdc, DeepEquals, vdc)
@@ -51,18 +51,18 @@ func (vcd *TestVCD) Test_SamlAdfsAuth(check *C) {
 	// If SamlCustomRptId was not specified - try to feed VCD entity ID manually (this is usually
 	// done automatically, but doing it to test this path is not broken)
 	if cfg.Provider.SamlCustomRptId == "" {
-		samlEntityId, err := getSamlEntityId(vcd.client, cfg.VCD.Org)
+		samlEntityId, err := getSamlEntityId(ctx, vcd.client, cfg.VCD.Org)
 		check.Assert(err, IsNil)
 
 		samlCustomRptVcdCli := NewVCDClient(vcd.client.Client.VCDHREF, true,
 			WithSamlAdfs(true, samlEntityId))
-		err = samlCustomRptVcdCli.Authenticate(cfg.Provider.SamlUser, cfg.Provider.SamlPassword, cfg.VCD.Org)
+		err = samlCustomRptVcdCli.Authenticate(ctx, cfg.Provider.SamlUser, cfg.Provider.SamlPassword, cfg.VCD.Org)
 		check.Assert(err, IsNil)
 
-		samlCustomRptOrg, err := vcd.client.GetOrgByName(cfg.VCD.Org)
+		samlCustomRptOrg, err := vcd.client.GetOrgByName(ctx, cfg.VCD.Org)
 		check.Assert(err, IsNil)
 
-		samlCustomRptVdc, err := samlCustomRptOrg.GetVDCByName(cfg.VCD.Vdc, true)
+		samlCustomRptVdc, err := samlCustomRptOrg.GetVDCByName(ctx, cfg.VCD.Vdc, true)
 		check.Assert(err, IsNil)
 
 		check.Assert(samlCustomRptVdc, DeepEquals, samlVdc)

--- a/govcd/saml_auth_unit_test.go
+++ b/govcd/saml_auth_unit_test.go
@@ -49,7 +49,7 @@ func TestSamlAdfsAuthenticate(t *testing.T) {
 		t.Errorf("got errors: %s", err)
 	}
 	vcdCli := NewVCDClient(*vcdUrl, true, WithSamlAdfs(true, ""))
-	err = vcdCli.Authenticate("fakeUser", "fakePass", "my-org")
+	err = vcdCli.Authenticate(ctx, "fakeUser", "fakePass", "my-org")
 	if err != nil {
 		t.Errorf("got errors: %s", err)
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -269,7 +269,7 @@ func createEdgeGateway(ctx context.Context, vcdClient *VCDClient, egwc EdgeGatew
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	egw, err := vdc.GetEdgeGatewayByName(egwc.Name, false)
+	egw, err := vdc.GetEdgeGatewayByName(ctx, egwc.Name, false)
 	if err != nil {
 		return EdgeGateway{}, err
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -42,7 +43,7 @@ type EdgeGatewayCreation struct {
 // should be set when providing generalOrgSettings.
 // If either VAppLeaseSettings or VAppTemplateLeaseSettings is provided then all elements need to have values, otherwise don't provide them at all.
 // Overall elements must be in the correct order.
-func CreateOrg(vcdClient *VCDClient, name string, fullName string, description string, settings *types.OrgSettings, isEnabled bool) (Task, error) {
+func CreateOrg(ctx context.Context, vcdClient *VCDClient, name string, fullName string, description string, settings *types.OrgSettings, isEnabled bool) (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       types.XMLNamespaceVCloud,
 		Name:        name,
@@ -64,7 +65,7 @@ func CreateOrg(vcdClient *VCDClient, name string, fullName string, description s
 	orgCreateHREF.Path += "/admin/orgs"
 
 	// Return the task
-	return vcdClient.Client.ExecuteTaskRequest(orgCreateHREF.String(), http.MethodPost,
+	return vcdClient.Client.ExecuteTaskRequest(ctx, orgCreateHREF.String(), http.MethodPost,
 		"application/vnd.vmware.admin.organization+xml", "error instantiating a new Org: %s", vcomp)
 
 }
@@ -98,7 +99,7 @@ func getBareEntityUuid(entityId string) (string, error) {
 //
 // Note. This function does not allow to pick exact subnet in external network to use for edge
 // gateway. It will pick first one instead.
-func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, error) {
+func CreateEdgeGatewayAsync(ctx context.Context, vcdClient *VCDClient, egwc EdgeGatewayCreation) (Task, error) {
 
 	distributed := egwc.DistributedRoutingEnabled
 	if !egwc.AdvancedNetworkingEnabled {
@@ -141,7 +142,7 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 	}
 	// Add external networks inside the configuration structure
 	for _, extNetName := range egwc.ExternalNetworks {
-		extNet, err := vcdClient.GetExternalNetworkByName(extNetName)
+		extNet, err := vcdClient.GetExternalNetworkByName(ctx, extNetName)
 		if err != nil {
 			return Task{}, err
 		}
@@ -179,11 +180,11 @@ func CreateEdgeGatewayAsync(vcdClient *VCDClient, egwc EdgeGatewayCreation) (Tas
 
 	// Once the configuration structure has been filled using the simplified data, we delegate
 	// the edge gateway creation to the main configuration function.
-	return CreateAndConfigureEdgeGatewayAsync(vcdClient, egwc.OrgName, egwc.VdcName, egwc.Name, egwConfiguration)
+	return CreateAndConfigureEdgeGatewayAsync(ctx, vcdClient, egwc.OrgName, egwc.VdcName, egwc.Name, egwConfiguration)
 }
 
 // CreateAndConfigureEdgeGatewayAsync creates an edge gateway using a full configuration structure
-func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, egwName string, egwConfiguration *types.EdgeGateway) (Task, error) {
+func CreateAndConfigureEdgeGatewayAsync(ctx context.Context, vcdClient *VCDClient, orgName, vdcName, egwName string, egwConfiguration *types.EdgeGateway) (Task, error) {
 
 	if egwConfiguration.Name != egwName {
 		return Task{}, fmt.Errorf("name mismatch: '%s' used as parameter but '%s' in the configuration structure", egwName, egwConfiguration.Name)
@@ -191,11 +192,11 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 
 	egwConfiguration.Xmlns = types.XMLNamespaceVCloud
 
-	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
+	adminOrg, err := vcdClient.GetAdminOrgByName(ctx, orgName)
 	if err != nil {
 		return Task{}, err
 	}
-	vdc, err := adminOrg.GetVDCByName(vdcName, false)
+	vdc, err := adminOrg.GetVDCByName(ctx, vdcName, false)
 	if err != nil {
 		return Task{}, err
 	}
@@ -213,14 +214,14 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 
 	// The first task is the creation task. It is quick, and does only create the vCD entity,
 	// but not yet deploy the underlying VM
-	creationTask, err := vcdClient.Client.ExecuteTaskRequest(egwCreateHREF.String(), http.MethodPost,
+	creationTask, err := vcdClient.Client.ExecuteTaskRequest(ctx, egwCreateHREF.String(), http.MethodPost,
 		"application/vnd.vmware.admin.edgeGateway+xml", "error instantiating a new Edge Gateway: %s", egwConfiguration)
 
 	if err != nil {
 		return Task{}, err
 	}
 
-	err = creationTask.WaitTaskCompletion()
+	err = creationTask.WaitTaskCompletion(ctx)
 
 	if err != nil {
 		return Task{}, err
@@ -242,29 +243,29 @@ func CreateAndConfigureEdgeGatewayAsync(vcdClient *VCDClient, orgName, vdcName, 
 // Private convenience function used by CreateAndConfigureEdgeGateway and CreateEdgeGateway to
 // process the task and return the object that was created.
 // It should not be invoked directly.
-func createEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfiguration *types.EdgeGateway) (EdgeGateway, error) {
+func createEdgeGateway(ctx context.Context, vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfiguration *types.EdgeGateway) (EdgeGateway, error) {
 	var task Task
 	var err error
 	if egwConfiguration != nil {
-		task, err = CreateAndConfigureEdgeGatewayAsync(vcdClient, egwc.OrgName, egwc.VdcName, egwc.Name, egwConfiguration)
+		task, err = CreateAndConfigureEdgeGatewayAsync(ctx, vcdClient, egwc.OrgName, egwc.VdcName, egwc.Name, egwConfiguration)
 	} else {
-		task, err = CreateEdgeGatewayAsync(vcdClient, egwc)
+		task, err = CreateEdgeGatewayAsync(ctx, vcdClient, egwc)
 	}
 
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return EdgeGateway{}, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
 	// The edge gateway is created. Now we retrieve it from the server
-	org, err := vcdClient.GetAdminOrgByName(egwc.OrgName)
+	org, err := vcdClient.GetAdminOrgByName(ctx, egwc.OrgName)
 	if err != nil {
 		return EdgeGateway{}, err
 	}
-	vdc, err := org.GetVDCByName(egwc.VdcName, false)
+	vdc, err := org.GetVDCByName(ctx, egwc.VdcName, false)
 	if err != nil {
 		return EdgeGateway{}, err
 	}
@@ -276,13 +277,13 @@ func createEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation, egwConfig
 }
 
 // CreateAndConfigureEdgeGateway creates an edge gateway using a full configuration structure
-func CreateAndConfigureEdgeGateway(vcdClient *VCDClient, orgName, vdcName, egwName string, egwConfiguration *types.EdgeGateway) (EdgeGateway, error) {
-	return createEdgeGateway(vcdClient, EdgeGatewayCreation{OrgName: orgName, VdcName: vdcName, Name: egwName}, egwConfiguration)
+func CreateAndConfigureEdgeGateway(ctx context.Context, vcdClient *VCDClient, orgName, vdcName, egwName string, egwConfiguration *types.EdgeGateway) (EdgeGateway, error) {
+	return createEdgeGateway(ctx, vcdClient, EdgeGatewayCreation{OrgName: orgName, VdcName: vdcName, Name: egwName}, egwConfiguration)
 }
 
 // CreateEdgeGateway creates an edge gateway using a simplified configuration structure
-func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (EdgeGateway, error) {
-	return createEdgeGateway(vcdClient, egwc, nil)
+func CreateEdgeGateway(ctx context.Context, vcdClient *VCDClient, egwc EdgeGatewayCreation) (EdgeGateway, error) {
+	return createEdgeGateway(ctx, vcdClient, egwc, nil)
 }
 
 // If user specifies a valid organization name, then this returns a
@@ -290,14 +291,14 @@ func CreateEdgeGateway(vcdClient *VCDClient, egwc EdgeGatewayCreation) (EdgeGate
 // org and no error. Otherwise it returns an error and an empty
 // Org object
 // Deprecated: Use vcdClient.GetOrgByName instead
-func GetOrgByName(vcdClient *VCDClient, orgName string) (Org, error) {
-	orgUrl, err := getOrgHREF(vcdClient, orgName)
+func GetOrgByName(ctx context.Context, vcdClient *VCDClient, orgName string) (Org, error) {
+	orgUrl, err := getOrgHREF(ctx, vcdClient, orgName)
 	if err != nil {
 		return Org{}, fmt.Errorf("organization '%s' fetch failed: %s", orgName, err)
 	}
 	org := NewOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgUrl, http.MethodGet,
 		"", "error retrieving org list: %s", nil, org.Org)
 	if err != nil {
 		return Org{}, err
@@ -313,8 +314,8 @@ func GetOrgByName(vcdClient *VCDClient, orgName string) (Org, error) {
 // and an error.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/GET-Organization-AdminView.html
 // Deprecated: Use vcdClient.GetAdminOrgByName instead
-func GetAdminOrgByName(vcdClient *VCDClient, orgName string) (AdminOrg, error) {
-	orgUrl, err := getOrgHREF(vcdClient, orgName)
+func GetAdminOrgByName(ctx context.Context, vcdClient *VCDClient, orgName string) (AdminOrg, error) {
+	orgUrl, err := getOrgHREF(ctx, vcdClient, orgName)
 	if err != nil {
 		return AdminOrg{}, err
 	}
@@ -323,7 +324,7 @@ func GetAdminOrgByName(vcdClient *VCDClient, orgName string) (AdminOrg, error) {
 
 	org := NewAdminOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgHREF.String(), http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgHREF.String(), http.MethodGet,
 		"", "error retrieving org: %s", nil, org.AdminOrg)
 	if err != nil {
 		return AdminOrg{}, err
@@ -333,13 +334,13 @@ func GetAdminOrgByName(vcdClient *VCDClient, orgName string) (AdminOrg, error) {
 }
 
 // Returns the HREF of the org with the name orgName
-func getOrgHREF(vcdClient *VCDClient, orgName string) (string, error) {
+func getOrgHREF(ctx context.Context, vcdClient *VCDClient, orgName string) (string, error) {
 	orgListHREF := vcdClient.Client.VCDHREF
 	orgListHREF.Path += "/org"
 
 	orgList := new(types.OrgList)
 
-	_, err := vcdClient.Client.ExecuteRequest(orgListHREF.String(), http.MethodGet,
+	_, err := vcdClient.Client.ExecuteRequest(ctx, orgListHREF.String(), http.MethodGet,
 		"", "error retrieving org list: %s", nil, orgList)
 	if err != nil {
 		return "", err
@@ -355,13 +356,13 @@ func getOrgHREF(vcdClient *VCDClient, orgName string) (string, error) {
 }
 
 // Returns the HREF of the org from the org ID
-func getOrgHREFById(vcdClient *VCDClient, orgId string) (string, error) {
+func getOrgHREFById(ctx context.Context, vcdClient *VCDClient, orgId string) (string, error) {
 	orgListHREF := vcdClient.Client.VCDHREF
 	orgListHREF.Path += "/org"
 
 	orgList := new(types.OrgList)
 
-	_, err := vcdClient.Client.ExecuteRequest(orgListHREF.String(), http.MethodGet,
+	_, err := vcdClient.Client.ExecuteRequest(ctx, orgListHREF.String(), http.MethodGet,
 		"", "error retrieving org list: %s", nil, orgList)
 	if err != nil {
 		return "", err
@@ -389,8 +390,8 @@ func getOrgHREFById(vcdClient *VCDClient, orgId string) (string, error) {
 // Filter constructing guide: https://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-CDF04296-5EB5-47E1-9BEC-228837C584CE.html
 // Possible parameters are any attribute from QueryResultVirtualCenterRecordType struct
 // E.g. filter could look like: name==vC1
-func QueryVirtualCenters(vcdClient *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryVirtualCenters(ctx context.Context, vcdClient *VCDClient, filter string) ([]*types.QueryResultVirtualCenterRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":   "virtualCenter",
 		"filter": filter,
 	})
@@ -402,18 +403,18 @@ func QueryVirtualCenters(vcdClient *VCDClient, filter string) ([]*types.QueryRes
 }
 
 // Find a Network port group by name
-func QueryNetworkPortGroup(vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
-	return QueryPortGroups(vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "NETWORK"))
+func QueryNetworkPortGroup(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
+	return QueryPortGroups(ctx, vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "NETWORK"))
 }
 
 // Find a Distributed port group by name
-func QueryDistributedPortGroup(vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
-	return QueryPortGroups(vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "DV_PORTGROUP"))
+func QueryDistributedPortGroup(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.PortGroupRecordType, error) {
+	return QueryPortGroups(ctx, vcdCli, fmt.Sprintf("name==%s;portgroupType==%s", url.QueryEscape(name), "DV_PORTGROUP"))
 }
 
 // Find a list of Port groups matching the filter parameter.
-func QueryPortGroups(vcdCli *VCDClient, filter string) ([]*types.PortGroupRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryPortGroups(ctx context.Context, vcdCli *VCDClient, filter string) ([]*types.PortGroupRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "portgroup",
 		"filter":        filter,
 		"filterEncoded": "true",
@@ -428,19 +429,19 @@ func QueryPortGroups(vcdCli *VCDClient, filter string) ([]*types.PortGroupRecord
 // GetExternalNetwork returns an ExternalNetwork reference if the network name matches an existing one.
 // If no valid external network is found, it returns an empty ExternalNetwork reference and an error
 // Deprecated: use vcdClient.GetExternalNetworkByName instead
-func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
+func GetExternalNetwork(ctx context.Context, vcdClient *VCDClient, networkName string) (*ExternalNetwork, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
 		return &ExternalNetwork{}, fmt.Errorf("functionality requires System Administrator privileges")
 	}
 
-	extNetworkHREF, err := getExternalNetworkHref(&vcdClient.Client)
+	extNetworkHREF, err := getExternalNetworkHref(ctx, &vcdClient.Client)
 	if err != nil {
 		return &ExternalNetwork{}, err
 	}
 
 	extNetworkRefs := &types.ExternalNetworkReferences{}
-	_, err = vcdClient.Client.ExecuteRequest(extNetworkHREF, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, extNetworkHREF, http.MethodGet,
 		types.MimeNetworkConnectionSection, "error retrieving external networks: %s", nil, extNetworkRefs)
 	if err != nil {
 		return &ExternalNetwork{}, err
@@ -452,7 +453,7 @@ func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetw
 	for _, netRef := range extNetworkRefs.ExternalNetworkReference {
 		if netRef.Name == networkName {
 			externalNetwork.ExternalNetwork.HREF = netRef.HREF
-			err = externalNetwork.Refresh()
+			err = externalNetwork.Refresh(ctx)
 			found = true
 			if err != nil {
 				return &ExternalNetwork{}, err
@@ -468,19 +469,19 @@ func GetExternalNetwork(vcdClient *VCDClient, networkName string) (*ExternalNetw
 }
 
 // GetExternalNetworks returns a list of available external networks
-func (vcdClient *VCDClient) GetExternalNetworks() (*types.ExternalNetworkReferences, error) {
+func (vcdClient *VCDClient) GetExternalNetworks(ctx context.Context) (*types.ExternalNetworkReferences, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
 		return nil, fmt.Errorf("functionality requires System Administrator privileges")
 	}
 
-	extNetworkHREF, err := getExternalNetworkHref(&vcdClient.Client)
+	extNetworkHREF, err := getExternalNetworkHref(ctx, &vcdClient.Client)
 	if err != nil {
 		return nil, err
 	}
 
 	extNetworkRefs := &types.ExternalNetworkReferences{}
-	_, err = vcdClient.Client.ExecuteRequest(extNetworkHREF, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, extNetworkHREF, http.MethodGet,
 		types.MimeNetworkConnectionSection, "error retrieving external networks: %s", nil, extNetworkRefs)
 	if err != nil {
 		return nil, err
@@ -491,9 +492,9 @@ func (vcdClient *VCDClient) GetExternalNetworks() (*types.ExternalNetworkReferen
 
 // GetExternalNetworkByName returns an ExternalNetwork reference if the network name matches an existing one.
 // If no valid external network is found, it returns a nil ExternalNetwork reference and an error
-func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*ExternalNetwork, error) {
+func (vcdClient *VCDClient) GetExternalNetworkByName(ctx context.Context, networkName string) (*ExternalNetwork, error) {
 
-	extNetworkRefs, err := vcdClient.GetExternalNetworks()
+	extNetworkRefs, err := vcdClient.GetExternalNetworks(ctx)
 
 	if err != nil {
 		return nil, err
@@ -504,7 +505,7 @@ func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*Exter
 	for _, netRef := range extNetworkRefs.ExternalNetworkReference {
 		if netRef.Name == networkName {
 			externalNetwork.ExternalNetwork.HREF = netRef.HREF
-			err = externalNetwork.Refresh()
+			err = externalNetwork.Refresh(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -517,9 +518,9 @@ func (vcdClient *VCDClient) GetExternalNetworkByName(networkName string) (*Exter
 
 // GetExternalNetworkById returns an ExternalNetwork reference if the network ID matches an existing one.
 // If no valid external network is found, it returns a nil ExternalNetwork reference and an error
-func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork, error) {
+func (vcdClient *VCDClient) GetExternalNetworkById(ctx context.Context, id string) (*ExternalNetwork, error) {
 
-	extNetworkRefs, err := vcdClient.GetExternalNetworks()
+	extNetworkRefs, err := vcdClient.GetExternalNetworks(ctx)
 
 	if err != nil {
 		return nil, err
@@ -532,7 +533,7 @@ func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork,
 		// We compare using the UUID from HREF
 		if equalIds(id, "", netRef.HREF) {
 			externalNetwork.ExternalNetwork.HREF = netRef.HREF
-			err = externalNetwork.Refresh()
+			err = externalNetwork.Refresh(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -545,9 +546,11 @@ func (vcdClient *VCDClient) GetExternalNetworkById(id string) (*ExternalNetwork,
 
 // GetExternalNetworkByNameOrId returns an ExternalNetwork reference if either the network name or ID matches an existing one.
 // If no valid external network is found, it returns a nil ExternalNetwork reference and an error
-func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*ExternalNetwork, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkByName(name) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(id) }
+func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(ctx context.Context, identifier string) (*ExternalNetwork, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
+		return vcdClient.GetExternalNetworkByName(ctx, name)
+	}
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetExternalNetworkById(ctx, id) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -558,7 +561,7 @@ func (vcdClient *VCDClient) GetExternalNetworkByNameOrId(identifier string) (*Ex
 // CreateExternalNetwork allows create external network and returns Task or error.
 // types.ExternalNetwork struct is general and used for various types of networks. But for external network
 // fence mode is always isolated, isInherited is false, parentNetwork is empty.
-func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.ExternalNetwork) (Task, error) {
+func CreateExternalNetwork(ctx context.Context, vcdClient *VCDClient, externalNetworkData *types.ExternalNetwork) (Task, error) {
 
 	if !vcdClient.Client.IsSysAdmin {
 		return Task{}, fmt.Errorf("functionality requires System Administrator privileges")
@@ -653,7 +656,7 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.Exte
 	externalNetwork.Configuration.FenceMode = "isolated"
 
 	// Return the task
-	task, err := vcdClient.Client.ExecuteTaskRequest(externalNetHREF.String(), http.MethodPost,
+	task, err := vcdClient.Client.ExecuteTaskRequest(ctx, externalNetHREF.String(), http.MethodPost,
 		types.MimeExternalNetwork, "error instantiating a new ExternalNetwork: %s", externalNetwork)
 
 	// Real task in task array
@@ -667,24 +670,24 @@ func CreateExternalNetwork(vcdClient *VCDClient, externalNetworkData *types.Exte
 	return task, err
 }
 
-func getExtension(client *Client) (*types.Extension, error) {
+func getExtension(ctx context.Context, client *Client) (*types.Extension, error) {
 	extensions := &types.Extension{}
 
 	extensionHREF := client.VCDHREF
 	extensionHREF.Path += "/admin/extension/"
 
-	_, err := client.ExecuteRequest(extensionHREF.String(), http.MethodGet,
+	_, err := client.ExecuteRequest(ctx, extensionHREF.String(), http.MethodGet,
 		"", "error retrieving extension: %s", nil, extensions)
 
 	return extensions, err
 }
 
 // GetStorageProfileByHref fetches storage profile using provided HREF.
-func GetStorageProfileByHref(vcdClient *VCDClient, url string) (*types.VdcStorageProfile, error) {
+func GetStorageProfileByHref(ctx context.Context, vcdClient *VCDClient, url string) (*types.VdcStorageProfile, error) {
 
 	vdcStorageProfile := &types.VdcStorageProfile{}
 
-	_, err := vcdClient.Client.ExecuteRequest(url, http.MethodGet,
+	_, err := vcdClient.Client.ExecuteRequest(ctx, url, http.MethodGet,
 		"", "error retrieving storage profile: %s", nil, vdcStorageProfile)
 	if err != nil {
 		return nil, err
@@ -694,8 +697,8 @@ func GetStorageProfileByHref(vcdClient *VCDClient, url string) (*types.VdcStorag
 }
 
 // QueryProviderVdcStorageProfileByName finds a provider VDC storage profile by name
-func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryProviderVdcStorageProfileByName(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "providerVdcStorageProfile",
 		"filter":        fmt.Sprintf("name==%s", url.QueryEscape(name)),
 		"filterEncoded": "true",
@@ -708,8 +711,8 @@ func QueryProviderVdcStorageProfileByName(vcdCli *VCDClient, name string) ([]*ty
 }
 
 // QueryNetworkPoolByName finds a network pool by name
-func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResultNetworkPoolRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryNetworkPoolByName(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.QueryResultNetworkPoolRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "networkPool",
 		"filter":        fmt.Sprintf("name==%s", url.QueryEscape(name)),
 		"filterEncoded": "true",
@@ -722,8 +725,8 @@ func QueryNetworkPoolByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 }
 
 // QueryProviderVdcByName finds a provider VDC by name
-func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryProviderVdcByName(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "providerVdc",
 		"filter":        fmt.Sprintf("name==%s", url.QueryEscape(name)),
 		"filterEncoded": "true",
@@ -736,8 +739,8 @@ func QueryProviderVdcByName(vcdCli *VCDClient, name string) ([]*types.QueryResul
 }
 
 // QueryProviderVdcs gets the list of available provider VDCs
-func (vcdClient *VCDClient) QueryProviderVdcs() ([]*types.QueryResultVMWProviderVdcRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+func (vcdClient *VCDClient) QueryProviderVdcs(ctx context.Context) ([]*types.QueryResultVMWProviderVdcRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type": "providerVdc",
 	})
 	if err != nil {
@@ -748,8 +751,8 @@ func (vcdClient *VCDClient) QueryProviderVdcs() ([]*types.QueryResultVMWProvider
 }
 
 // QueryNetworkPools gets the list of network pools
-func (vcdClient *VCDClient) QueryNetworkPools() ([]*types.QueryResultNetworkPoolRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+func (vcdClient *VCDClient) QueryNetworkPools(ctx context.Context) ([]*types.QueryResultNetworkPoolRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type": "networkPool",
 	})
 	if err != nil {
@@ -760,8 +763,8 @@ func (vcdClient *VCDClient) QueryNetworkPools() ([]*types.QueryResultNetworkPool
 }
 
 // QueryProviderVdcStorageProfiles gets the list of provider VDC storage profiles
-func (vcdClient *VCDClient) QueryProviderVdcStorageProfiles() ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
-	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
+func (vcdClient *VCDClient) QueryProviderVdcStorageProfiles(ctx context.Context) ([]*types.QueryResultProviderVdcStorageProfileRecordType, error) {
+	results, err := vcdClient.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type": "providerVdcStorageProfile",
 	})
 	if err != nil {
@@ -772,12 +775,12 @@ func (vcdClient *VCDClient) QueryProviderVdcStorageProfiles() ([]*types.QueryRes
 }
 
 // GetNetworkPoolByHREF functions fetches an network pool using VDC client and network pool href
-func GetNetworkPoolByHREF(client *VCDClient, href string) (*types.VMWNetworkPool, error) {
+func GetNetworkPoolByHREF(ctx context.Context, client *VCDClient, href string) (*types.VMWNetworkPool, error) {
 	util.Logger.Printf("[TRACE] Get network pool by HREF: %s\n", href)
 
 	networkPool := &types.VMWNetworkPool{}
 
-	_, err := client.Client.ExecuteRequest(href, http.MethodGet,
+	_, err := client.Client.ExecuteRequest(ctx, href, http.MethodGet,
 		"", "error fetching network pool: %s", nil, networkPool)
 
 	// Return the disk
@@ -786,8 +789,8 @@ func GetNetworkPoolByHREF(client *VCDClient, href string) (*types.VMWNetworkPool
 }
 
 // QueryOrgVdcNetworkByName finds a org VDC network by name which has edge gateway as reference
-func QueryOrgVdcNetworkByName(vcdCli *VCDClient, name string) ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func QueryOrgVdcNetworkByName(ctx context.Context, vcdCli *VCDClient, name string) ([]*types.QueryResultOrgVdcNetworkRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "orgVdcNetwork",
 		"filter":        fmt.Sprintf("name==%s", url.QueryEscape(name)),
 		"filterEncoded": "true",
@@ -800,8 +803,8 @@ func QueryOrgVdcNetworkByName(vcdCli *VCDClient, name string) ([]*types.QueryRes
 }
 
 // QueryNsxtManagerByName searches for NSX-T managers available in VCD
-func (vcdCli *VCDClient) QueryNsxtManagerByName(name string) ([]*types.QueryResultNsxtManagerRecordType, error) {
-	results, err := vcdCli.QueryWithNotEncodedParams(nil, map[string]string{
+func (vcdCli *VCDClient) QueryNsxtManagerByName(ctx context.Context, name string) ([]*types.QueryResultNsxtManagerRecordType, error) {
+	results, err := vcdCli.QueryWithNotEncodedParams(ctx, nil, map[string]string{
 		"type":          "nsxTManager",
 		"filter":        fmt.Sprintf("name==%s", url.QueryEscape(name)),
 		"filterEncoded": "true",
@@ -816,15 +819,15 @@ func (vcdCli *VCDClient) QueryNsxtManagerByName(name string) ([]*types.QueryResu
 // GetOrgByName finds an Organization by name
 // On success, returns a pointer to the Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetOrgByName(orgName string) (*Org, error) {
-	orgUrl, err := getOrgHREF(vcdClient, orgName)
+func (vcdClient *VCDClient) GetOrgByName(ctx context.Context, orgName string) (*Org, error) {
+	orgUrl, err := getOrgHREF(ctx, vcdClient, orgName)
 	if err != nil {
 		// Since this operation is a lookup from a list, we return the standard ErrorEntityNotFound
 		return nil, ErrorEntityNotFound
 	}
 	org := NewOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgUrl, http.MethodGet,
 		"", "error retrieving org: %s", nil, org.Org)
 	if err != nil {
 		return nil, err
@@ -836,15 +839,15 @@ func (vcdClient *VCDClient) GetOrgByName(orgName string) (*Org, error) {
 // GetOrgById finds an Organization by ID
 // On success, returns a pointer to the Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetOrgById(orgId string) (*Org, error) {
-	orgUrl, err := getOrgHREFById(vcdClient, orgId)
+func (vcdClient *VCDClient) GetOrgById(ctx context.Context, orgId string) (*Org, error) {
+	orgUrl, err := getOrgHREFById(ctx, vcdClient, orgId)
 	if err != nil {
 		// Since this operation is a lookup from a list, we return the standard ErrorEntityNotFound
 		return nil, ErrorEntityNotFound
 	}
 	org := NewOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgUrl, http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgUrl, http.MethodGet,
 		"", "error retrieving org list: %s", nil, org.Org)
 	if err != nil {
 		return nil, err
@@ -856,9 +859,9 @@ func (vcdClient *VCDClient) GetOrgById(orgId string) (*Org, error) {
 // GetOrgByNameOrId finds an Organization by name or ID
 // On success, returns a pointer to the Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetOrgByNameOrId(identifier string) (*Org, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(name) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(id) }
+func (vcdClient *VCDClient) GetOrgByNameOrId(ctx context.Context, identifier string) (*Org, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetOrgByName(ctx, name) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetOrgById(ctx, id) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -869,8 +872,8 @@ func (vcdClient *VCDClient) GetOrgByNameOrId(identifier string) (*Org, error) {
 // GetAdminOrgByName finds an Admin Organization by name
 // On success, returns a pointer to the Admin Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetAdminOrgByName(orgName string) (*AdminOrg, error) {
-	orgUrl, err := getOrgHREF(vcdClient, orgName)
+func (vcdClient *VCDClient) GetAdminOrgByName(ctx context.Context, orgName string) (*AdminOrg, error) {
+	orgUrl, err := getOrgHREF(ctx, vcdClient, orgName)
 	if err != nil {
 		return nil, ErrorEntityNotFound
 	}
@@ -879,7 +882,7 @@ func (vcdClient *VCDClient) GetAdminOrgByName(orgName string) (*AdminOrg, error)
 
 	adminOrg := NewAdminOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgHREF.String(), http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgHREF.String(), http.MethodGet,
 		"", "error retrieving org: %s", nil, adminOrg.AdminOrg)
 	if err != nil {
 		return nil, err
@@ -891,8 +894,8 @@ func (vcdClient *VCDClient) GetAdminOrgByName(orgName string) (*AdminOrg, error)
 // GetAdminOrgById finds an Admin Organization by ID
 // On success, returns a pointer to the Admin Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetAdminOrgById(orgId string) (*AdminOrg, error) {
-	orgUrl, err := getOrgHREFById(vcdClient, orgId)
+func (vcdClient *VCDClient) GetAdminOrgById(ctx context.Context, orgId string) (*AdminOrg, error) {
+	orgUrl, err := getOrgHREFById(ctx, vcdClient, orgId)
 	if err != nil {
 		return nil, ErrorEntityNotFound
 	}
@@ -901,7 +904,7 @@ func (vcdClient *VCDClient) GetAdminOrgById(orgId string) (*AdminOrg, error) {
 
 	adminOrg := NewAdminOrg(&vcdClient.Client)
 
-	_, err = vcdClient.Client.ExecuteRequest(orgHREF.String(), http.MethodGet,
+	_, err = vcdClient.Client.ExecuteRequest(ctx, orgHREF.String(), http.MethodGet,
 		"", "error retrieving org: %s", nil, adminOrg.AdminOrg)
 	if err != nil {
 		return nil, err
@@ -913,9 +916,9 @@ func (vcdClient *VCDClient) GetAdminOrgById(orgId string) (*AdminOrg, error) {
 // GetAdminOrgByNameOrId finds an Admin Organization by name or ID
 // On success, returns a pointer to the Admin Org structure and a nil error
 // On failure, returns a nil pointer and an error
-func (vcdClient *VCDClient) GetAdminOrgByNameOrId(identifier string) (*AdminOrg, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(name) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(id) }
+func (vcdClient *VCDClient) GetAdminOrgByNameOrId(ctx context.Context, identifier string) (*AdminOrg, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgByName(ctx, name) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vcdClient.GetAdminOrgById(ctx, id) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -951,13 +954,13 @@ func GetUuidFromHref(href string, idAtEnd bool) (string, error) {
 }
 
 // GetOrgList returns the list ov available orgs
-func (vcdCli *VCDClient) GetOrgList() (*types.OrgList, error) {
+func (vcdCli *VCDClient) GetOrgList(ctx context.Context) (*types.OrgList, error) {
 	orgListHREF := vcdCli.Client.VCDHREF
 	orgListHREF.Path += "/org"
 
 	orgList := new(types.OrgList)
 
-	_, err := vcdCli.Client.ExecuteRequest(orgListHREF.String(), http.MethodGet,
+	_, err := vcdCli.Client.ExecuteRequest(ctx, orgListHREF.String(), http.MethodGet,
 		"", "error getting list of organizations: %s", nil, orgList)
 	if err != nil {
 		return nil, err

--- a/govcd/uploadtask.go
+++ b/govcd/uploadtask.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -29,7 +30,7 @@ func (uploadTask *UploadTask) GetUploadProgress() string {
 	return fmt.Sprintf("%.2f", uploadTask.uploadProgress.LockedGet())
 }
 
-func (uploadTask *UploadTask) ShowUploadProgress() error {
+func (uploadTask *UploadTask) ShowUploadProgress(ctx context.Context) error {
 	fmt.Printf("Waiting...")
 
 	for {
@@ -43,7 +44,7 @@ func (uploadTask *UploadTask) ShowUploadProgress() error {
 			break
 		}
 		// Upload may be cancelled by user on GUI manually, detect task status
-		if err := uploadTask.Refresh(); err != nil {
+		if err := uploadTask.Refresh(ctx); err != nil {
 			return err
 		}
 		if uploadTask.Task.Task.Status != "queued" && uploadTask.Task.Task.Status != "preRunning" && uploadTask.Task.Task.Status != "running" {

--- a/govcd/user_test.go
+++ b/govcd/user_test.go
@@ -41,7 +41,7 @@ OR
 
 // Checks that the default roles are available from the organization
 func (vcd *TestVCD) Test_GetRoleReference(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 	Roles := []string{
@@ -61,7 +61,7 @@ func (vcd *TestVCD) Test_GetRoleReference(check *C) {
 
 // Checks that we can retrieve a user by name or ID
 func (vcd *TestVCD) Test_GetUserByNameOrId(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
@@ -73,24 +73,24 @@ func (vcd *TestVCD) Test_GetUserByNameOrId(check *C) {
 
 	// Using the list above, we first try to get each user by name
 	for _, userRef := range userRefs {
-		user, err := adminOrg.GetUserByName(userRef.Name, false)
+		user, err := adminOrg.GetUserByName(ctx, userRef.Name, false)
 		check.Assert(err, IsNil)
 		check.Assert(user, NotNil)
 		check.Assert(user.User.Name, Equals, userRef.Name)
 
 		// Then we try to get the same user by ID
-		user, err = adminOrg.GetUserById(userRef.ID, false)
+		user, err = adminOrg.GetUserById(ctx, userRef.ID, false)
 		check.Assert(err, IsNil)
 		check.Assert(user, NotNil)
 		check.Assert(user.User.Name, Equals, userRef.Name)
 
 		// Then we try to get the same user by Name or ID combined
-		user, err = adminOrg.GetUserByNameOrId(userRef.ID, true)
+		user, err = adminOrg.GetUserByNameOrId(ctx, userRef.ID, true)
 		check.Assert(err, IsNil)
 		check.Assert(user, NotNil)
 		check.Assert(user.User.Name, Equals, userRef.Name)
 
-		user, err = adminOrg.GetUserByNameOrId(userRef.Name, false)
+		user, err = adminOrg.GetUserByNameOrId(ctx, userRef.Name, false)
 		check.Assert(err, IsNil)
 		check.Assert(user, NotNil)
 		check.Assert(user.User.Name, Equals, userRef.Name)
@@ -102,7 +102,7 @@ func (vcd *TestVCD) Test_GetUserByNameOrId(check *C) {
 // Furthermore, disables, and then enables the users again
 // and finally deletes all of them
 func (vcd *TestVCD) Test_UserCRUD(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
@@ -163,7 +163,7 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 			Telephone:       "999 888-7777",
 		}
 
-		user, err := adminOrg.CreateUserSimple(userDefinition)
+		user, err := adminOrg.CreateUserSimple(ctx, userDefinition)
 		// disableDebugShowRequest()
 		// disableDebugShowResponse()
 		check.Assert(err, IsNil)
@@ -180,19 +180,19 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 		check.Assert(user.User.StoredVmQuota, Equals, userDefinition.StoredVmQuota)
 		check.Assert(user.User.DeployedVmQuota, Equals, userDefinition.DeployedVmQuota)
 
-		err = user.Disable()
+		err = user.Disable(ctx)
 		check.Assert(err, IsNil)
 		check.Assert(user.User.IsEnabled, Equals, false)
 
 		fmt.Printf("# Updating user %s with role %s\n", ud.name, ud.secondRole)
-		err = user.ChangeRole(ud.secondRole)
+		err = user.ChangeRole(ctx, ud.secondRole)
 		check.Assert(err, IsNil)
 		check.Assert(user.GetRoleName(), Equals, ud.secondRole)
 
-		err = user.Enable()
+		err = user.Enable(ctx)
 		check.Assert(err, IsNil)
 		check.Assert(user.User.IsEnabled, Equals, true)
-		err = user.ChangePassword("new_pass")
+		err = user.ChangePassword(ctx, "new_pass")
 		check.Assert(err, IsNil)
 	}
 
@@ -201,18 +201,18 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 		false: "disabled",
 	}
 	for _, ud := range userData {
-		user, err := adminOrg.GetUserByNameOrId(ud.name, true)
+		user, err := adminOrg.GetUserByNameOrId(ctx, ud.name, true)
 		check.Assert(err, IsNil)
 
 		fmt.Printf("# deleting user %s (%s - %s)\n", ud.name, user.GetRoleName(), enableMap[user.User.IsEnabled])
 		// uncomment the following two lines to see the deletion request and response
 		// enableDebugShowRequest()
 		// enableDebugShowResponse()
-		err = user.Delete(true)
+		err = user.Delete(ctx, true)
 		// disableDebugShowRequest()
 		// disableDebugShowResponse()
 		check.Assert(err, IsNil)
-		user, err = adminOrg.GetUserByNameOrId(user.User.ID, true)
+		user, err = adminOrg.GetUserByNameOrId(ctx, user.User.ID, true)
 		check.Assert(err, NotNil)
 		// Tests both the error directly and the function IsNotFound
 		check.Assert(err, Equals, ErrorEntityNotFound)

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -89,7 +89,7 @@ func (vapp *VApp) Refresh(ctx context.Context) error {
 	// elements in slices.
 	vapp.VApp = &types.VApp{}
 
-	_, err := vapp.client.ExecuteRequest(url, http.MethodGet,
+	_, err := vapp.client.ExecuteRequest(ctx, url, http.MethodGet,
 		"", "error refreshing vApp: %s", nil, vapp.VApp)
 
 	// The request was successful
@@ -245,7 +245,7 @@ func addNewVMW(ctx context.Context, vapp *VApp, name string, vappTemplate VAppTe
 	// Return the task
 	return vapp.client.ExecuteTaskRequestWithApiVersion(ctx, apiEndpoint.String(), http.MethodPost,
 		types.MimeRecomposeVappParams, "error instantiating a new VM: %s", vAppComposition,
-		vapp.client.GetSpecificApiVersionOnCondition(">= 33.0", "33.0"))
+		vapp.client.GetSpecificApiVersionOnCondition(ctx, ">= 33.0", "33.0"))
 
 }
 
@@ -265,7 +265,7 @@ func (vapp *VApp) RemoveVM(ctx context.Context, vm VM) error {
 			// Leftover tasks may have unhandled errors that can be dismissed at this stage
 			// we complete any incomplete tasks at this stage, to finish the refresh.
 			if task.Task.Status != "error" && task.Task.Status != "success" {
-				err := task.WaitTaskCompletion()
+				err := task.WaitTaskCompletion(ctx)
 				if err != nil {
 					return fmt.Errorf("error performing task: %s", err)
 				}
@@ -285,13 +285,13 @@ func (vapp *VApp) RemoveVM(ctx context.Context, vm VM) error {
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/action/recomposeVApp"
 
-	deleteTask, err := vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	deleteTask, err := vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		types.MimeRecomposeVappParams, "error removing VM: %s", vcomp)
 	if err != nil {
 		return err
 	}
 
-	err = deleteTask.WaitTaskCompletion()
+	err = deleteTask.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error performing removing VM task: %s", err)
 	}
@@ -299,9 +299,9 @@ func (vapp *VApp) RemoveVM(ctx context.Context, vm VM) error {
 	return nil
 }
 
-func (vapp *VApp) PowerOn() (Task, error) {
+func (vapp *VApp) PowerOn(ctx context.Context) (Task, error) {
 
-	err := vapp.BlockWhileStatus("UNRESOLVED", vapp.client.MaxRetryTimeout)
+	err := vapp.BlockWhileStatus(ctx, "UNRESOLVED", vapp.client.MaxRetryTimeout)
 	if err != nil {
 		return Task{}, fmt.Errorf("error powering on vApp: %s", err)
 	}
@@ -310,62 +310,62 @@ func (vapp *VApp) PowerOn() (Task, error) {
 	apiEndpoint.Path += "/power/action/powerOn"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error powering on vApp: %s", nil)
 }
 
-func (vapp *VApp) PowerOff() (Task, error) {
+func (vapp *VApp) PowerOff(ctx context.Context) (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/powerOff"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error powering off vApp: %s", nil)
 
 }
 
-func (vapp *VApp) Reboot() (Task, error) {
+func (vapp *VApp) Reboot(ctx context.Context) (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/reboot"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error rebooting vApp: %s", nil)
 }
 
-func (vapp *VApp) Reset() (Task, error) {
+func (vapp *VApp) Reset(ctx context.Context) (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/reset"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error resetting vApp: %s", nil)
 }
 
-func (vapp *VApp) Suspend() (Task, error) {
+func (vapp *VApp) Suspend(ctx context.Context) (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/suspend"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error suspending vApp: %s", nil)
 }
 
-func (vapp *VApp) Shutdown() (Task, error) {
+func (vapp *VApp) Shutdown(ctx context.Context) (Task, error) {
 
 	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
 	apiEndpoint.Path += "/power/action/shutdown"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		"", "error shutting down vApp: %s", nil)
 }
 
-func (vapp *VApp) Undeploy() (Task, error) {
+func (vapp *VApp) Undeploy(ctx context.Context) (Task, error) {
 
 	vu := &types.UndeployVAppParams{
 		Xmlns:               types.XMLNamespaceVCloud,
@@ -376,11 +376,11 @@ func (vapp *VApp) Undeploy() (Task, error) {
 	apiEndpoint.Path += "/action/undeploy"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		types.MimeUndeployVappParams, "error undeploy vApp: %s", vu)
 }
 
-func (vapp *VApp) Deploy() (Task, error) {
+func (vapp *VApp) Deploy(ctx context.Context) (Task, error) {
 
 	vu := &types.DeployVAppParams{
 		Xmlns:   types.XMLNamespaceVCloud,
@@ -391,25 +391,25 @@ func (vapp *VApp) Deploy() (Task, error) {
 	apiEndpoint.Path += "/action/deploy"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPost,
 		types.MimeDeployVappParams, "error deploy vApp: %s", vu)
 }
 
-func (vapp *VApp) Delete() (Task, error) {
+func (vapp *VApp) Delete(ctx context.Context) (Task, error) {
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(vapp.VApp.HREF, http.MethodDelete,
+	return vapp.client.ExecuteTaskRequest(ctx, vapp.VApp.HREF, http.MethodDelete,
 		"", "error deleting vApp: %s", nil)
 }
 
-func (vapp *VApp) RunCustomizationScript(computername, script string) (Task, error) {
-	return vapp.Customize(computername, script, false)
+func (vapp *VApp) RunCustomizationScript(ctx context.Context, computername, script string) (Task, error) {
+	return vapp.Customize(ctx, computername, script, false)
 }
 
 // Customize applies customization to first child VM
 //
 // Deprecated: Use vm.SetGuestCustomizationSection()
-func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, error) {
+func (vapp *VApp) Customize(ctx context.Context, computername, script string, changeSid bool) (Task, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
@@ -438,11 +438,11 @@ func (vapp *VApp) Customize(computername, script string, changeSid bool) (Task, 
 	apiEndpoint.Path += "/guestCustomizationSection/"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeGuestCustomizationSection, "error customizing VM: %s", vu)
 }
 
-func (vapp *VApp) GetStatus() (string, error) {
+func (vapp *VApp) GetStatus(ctx context.Context) (string, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error refreshing vApp: %s", err)
@@ -462,7 +462,7 @@ func (vapp *VApp) GetStatus() (string, error) {
 // BlockWhileStatus blocks until the status of vApp exits unwantedStatus.
 // It sleeps 200 milliseconds between iterations and times out after timeOutAfterSeconds
 // of seconds.
-func (vapp *VApp) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds int) error {
+func (vapp *VApp) BlockWhileStatus(ctx context.Context, unwantedStatus string, timeOutAfterSeconds int) error {
 	timeoutAfter := time.After(time.Duration(timeOutAfterSeconds) * time.Second)
 	tick := time.NewTicker(200 * time.Millisecond)
 
@@ -472,7 +472,7 @@ func (vapp *VApp) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds in
 			return fmt.Errorf("timed out waiting for vApp to exit state %s after %d seconds",
 				unwantedStatus, timeOutAfterSeconds)
 		case <-tick.C:
-			currentStatus, err := vapp.GetStatus()
+			currentStatus, err := vapp.GetStatus(ctx)
 
 			if err != nil {
 				return fmt.Errorf("could not get vApp status %s", err)
@@ -484,7 +484,7 @@ func (vapp *VApp) BlockWhileStatus(unwantedStatus string, timeOutAfterSeconds in
 	}
 }
 
-func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
+func (vapp *VApp) GetNetworkConnectionSection(ctx context.Context) (*types.NetworkConnectionSection, error) {
 
 	networkConnectionSection := &types.NetworkConnectionSection{}
 
@@ -492,7 +492,7 @@ func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection
 		return networkConnectionSection, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	_, err := vapp.client.ExecuteRequest(vapp.VApp.Children.VM[0].HREF+"/networkConnectionSection/", http.MethodGet,
+	_, err := vapp.client.ExecuteRequest(ctx, vapp.VApp.Children.VM[0].HREF+"/networkConnectionSection/", http.MethodGet,
 		types.MimeNetworkConnectionSection, "error retrieving network connection: %s", nil, networkConnectionSection)
 
 	// The request was successful
@@ -503,8 +503,8 @@ func (vapp *VApp) GetNetworkConnectionSection() (*types.NetworkConnectionSection
 // (i.e. CPUs x cores per socket)
 // https://communities.vmware.com/thread/576209
 // Deprecated: Use vm.ChangeCPUcount()
-func (vapp *VApp) ChangeCPUCount(virtualCpuCount int) (Task, error) {
-	return vapp.ChangeCPUCountWithCore(virtualCpuCount, nil)
+func (vapp *VApp) ChangeCPUCount(ctx context.Context, virtualCpuCount int) (Task, error) {
+	return vapp.ChangeCPUCountWithCore(ctx, virtualCpuCount, nil)
 }
 
 // Sets number of available virtual logical processors
@@ -512,7 +512,7 @@ func (vapp *VApp) ChangeCPUCount(virtualCpuCount int) (Task, error) {
 // Socket count is a result of: virtual logical processors/cores per socket
 // https://communities.vmware.com/thread/576209
 // Deprecated: Use vm.ChangeCPUCountWithCore()
-func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (Task, error) {
+func (vapp *VApp) ChangeCPUCountWithCore(ctx context.Context, virtualCpuCount int, coresPerSocket *int) (Task, error) {
 
 	err := vapp.Refresh(ctx)
 	if err != nil {
@@ -551,11 +551,11 @@ func (vapp *VApp) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *in
 	apiEndpoint.Path += "/virtualHardwareSection/cpu"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeRasdItem, "error changing CPU count: %s", newcpu)
 }
 
-func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
+func (vapp *VApp) ChangeStorageProfile(ctx context.Context, name string) (Task, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
@@ -565,11 +565,11 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
-	vdc, err := vapp.getParentVDC()
+	vdc, err := vapp.getParentVDC(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error retrieving parent VDC for vApp %s", vapp.VApp.Name)
 	}
-	storageProfileRef, err := vdc.FindStorageProfileReference(name)
+	storageProfileRef, err := vdc.FindStorageProfileReference(ctx, name)
 	if err != nil {
 		return Task{}, fmt.Errorf("error retrieving storage profile %s for vApp %s", name, vapp.VApp.Name)
 	}
@@ -581,12 +581,12 @@ func (vapp *VApp) ChangeStorageProfile(name string) (Task, error) {
 	}
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(vapp.VApp.Children.VM[0].HREF, http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, vapp.VApp.Children.VM[0].HREF, http.MethodPut,
 		types.MimeVM, "error changing CPU count: %s", newProfile)
 }
 
 // Deprecated as it changes only first VM's name
-func (vapp *VApp) ChangeVMName(name string) (Task, error) {
+func (vapp *VApp) ChangeVMName(ctx context.Context, name string) (Task, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
@@ -602,14 +602,14 @@ func (vapp *VApp) ChangeVMName(name string) (Task, error) {
 	}
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(vapp.VApp.Children.VM[0].HREF, http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, vapp.VApp.Children.VM[0].HREF, http.MethodPut,
 		types.MimeVM, "error changing VM name: %s", newName)
 }
 
 // SetOvf sets guest properties for the first child VM in vApp
 //
 // Deprecated: Use vm.SetProductSectionList()
-func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
+func (vapp *VApp) SetOvf(ctx context.Context, parameters map[string]string) (Task, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing vApp before running customization: %s", err)
@@ -642,11 +642,11 @@ func (vapp *VApp) SetOvf(parameters map[string]string) (Task, error) {
 	apiEndpoint.Path += "/productSections"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeProductSection, "error setting ovf: %s", ovf)
 }
 
-func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip string) (Task, error) {
+func (vapp *VApp) ChangeNetworkConfig(ctx context.Context, networks []map[string]interface{}, ip string) (Task, error) {
 	err := vapp.Refresh(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error refreshing VM before running customization: %s", err)
@@ -656,7 +656,7 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, interrupting customization")
 	}
 
-	networksection, err := vapp.GetNetworkConnectionSection()
+	networksection, err := vapp.GetNetworkConnectionSection(ctx)
 	if err != nil {
 		return Task{}, err
 	}
@@ -700,12 +700,12 @@ func (vapp *VApp) ChangeNetworkConfig(networks []map[string]interface{}, ip stri
 	apiEndpoint.Path += "/networkConnectionSection/"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeNetworkConnectionSection, "error changing network config: %s", networksection)
 }
 
 // Deprecated as it changes only first VM's memory
-func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
+func (vapp *VApp) ChangeMemorySize(ctx context.Context, size int) (Task, error) {
 
 	err := vapp.Refresh(ctx)
 	if err != nil {
@@ -742,11 +742,11 @@ func (vapp *VApp) ChangeMemorySize(size int) (Task, error) {
 	apiEndpoint.Path += "/virtualHardwareSection/memory"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeRasdItem, "error changing memory size: %s", newMem)
 }
 
-func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
+func (vapp *VApp) GetNetworkConfig(ctx context.Context) (*types.NetworkConfigSection, error) {
 
 	networkConfig := &types.NetworkConfigSection{}
 
@@ -754,7 +754,7 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 		return networkConfig, fmt.Errorf("cannot refresh, Object is empty")
 	}
 
-	_, err := vapp.client.ExecuteRequest(vapp.VApp.HREF+"/networkConfigSection/", http.MethodGet,
+	_, err := vapp.client.ExecuteRequest(ctx, vapp.VApp.HREF+"/networkConfigSection/", http.MethodGet,
 		types.MimeNetworkConfigSection, "error retrieving network config: %s", nil, networkConfig)
 
 	// The request was successful
@@ -763,9 +763,9 @@ func (vapp *VApp) GetNetworkConfig() (*types.NetworkConfigSection, error) {
 
 // AddRAWNetworkConfig adds existing VDC network to vApp
 // Deprecated: in favor of vapp.AddOrgNetwork
-func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
+func (vapp *VApp) AddRAWNetworkConfig(ctx context.Context, orgvdcnetworks []*types.OrgVDCNetwork) (Task, error) {
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return Task{}, fmt.Errorf("error getting vApp networks: %s", err)
 	}
@@ -785,12 +785,12 @@ func (vapp *VApp) AddRAWNetworkConfig(orgvdcnetworks []*types.OrgVDCNetwork) (Ta
 		)
 	}
 
-	return updateNetworkConfigurations(vapp, networkConfigurations)
+	return updateNetworkConfigurations(ctx, vapp, networkConfigurations)
 }
 
 // Function allows to create isolated network for vApp. This is equivalent to vCD UI function - vApp network creation.
 // Deprecated: in favor of vapp.CreateVappNetwork
-func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSettings) (Task, error) {
+func (vapp *VApp) AddIsolatedNetwork(ctx context.Context, newIsolatedNetworkSettings *VappNetworkSettings) (Task, error) {
 
 	err := validateNetworkConfigSettings(newIsolatedNetworkSettings)
 	if err != nil {
@@ -829,24 +829,24 @@ func (vapp *VApp) AddIsolatedNetwork(newIsolatedNetworkSettings *VappNetworkSett
 			IsDeployed: false,
 		})
 
-	return updateNetworkConfigurations(vapp, networkConfigurations)
+	return updateNetworkConfigurations(ctx, vapp, networkConfigurations)
 
 }
 
 // CreateVappNetwork creates isolated or nat routed(connected to Org VDC network) network for vApp.
 // Returns pointer to types.NetworkConfigSection or error
 // If orgNetwork is nil, then isolated network created.
-func (vapp *VApp) CreateVappNetwork(newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (*types.NetworkConfigSection, error) {
-	task, err := vapp.CreateVappNetworkAsync(newNetworkSettings, orgNetwork)
+func (vapp *VApp) CreateVappNetwork(ctx context.Context, newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (*types.NetworkConfigSection, error) {
+	task, err := vapp.CreateVappNetworkAsync(ctx, newNetworkSettings, orgNetwork)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp networks: %#v", err)
 	}
@@ -856,7 +856,7 @@ func (vapp *VApp) CreateVappNetwork(newNetworkSettings *VappNetworkSettings, org
 
 // CreateVappNetworkAsync creates asynchronously isolated or nat routed network for vApp. Returns Task or error
 // If orgNetwork is nil, then isolated network created.
-func (vapp *VApp) CreateVappNetworkAsync(newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (Task, error) {
+func (vapp *VApp) CreateVappNetworkAsync(ctx context.Context, newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (Task, error) {
 
 	err := validateNetworkConfigSettings(newNetworkSettings)
 	if err != nil {
@@ -905,22 +905,22 @@ func (vapp *VApp) CreateVappNetworkAsync(newNetworkSettings *VappNetworkSettings
 	networkConfigurations = append(networkConfigurations,
 		vappConfiguration)
 
-	return updateNetworkConfigurations(vapp, networkConfigurations)
+	return updateNetworkConfigurations(ctx, vapp, networkConfigurations)
 }
 
 // AddOrgNetwork adds Org VDC network as vApp network.
 // Returns pointer to types.NetworkConfigSection or error
-func (vapp *VApp) AddOrgNetwork(newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork, isFenced bool) (*types.NetworkConfigSection, error) {
-	task, err := vapp.AddOrgNetworkAsync(newNetworkSettings, orgNetwork, isFenced)
+func (vapp *VApp) AddOrgNetwork(ctx context.Context, newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork, isFenced bool) (*types.NetworkConfigSection, error) {
+	task, err := vapp.AddOrgNetworkAsync(ctx, newNetworkSettings, orgNetwork, isFenced)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp networks: %#v", err)
 	}
@@ -929,7 +929,7 @@ func (vapp *VApp) AddOrgNetwork(newNetworkSettings *VappNetworkSettings, orgNetw
 }
 
 // AddOrgNetworkAsync adds asynchronously Org VDC network as vApp network. Returns Task or error
-func (vapp *VApp) AddOrgNetworkAsync(newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork, isFenced bool) (Task, error) {
+func (vapp *VApp) AddOrgNetworkAsync(ctx context.Context, newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork, isFenced bool) (Task, error) {
 
 	if orgNetwork == nil {
 		return Task{}, errors.New("org VDC network is missing")
@@ -955,23 +955,23 @@ func (vapp *VApp) AddOrgNetworkAsync(newNetworkSettings *VappNetworkSettings, or
 	networkConfigurations = append(networkConfigurations,
 		vappConfiguration)
 
-	return updateNetworkConfigurations(vapp, networkConfigurations)
+	return updateNetworkConfigurations(ctx, vapp, networkConfigurations)
 
 }
 
 // UpdateNetwork updates vApp networks (isolated or connected to Org VDC network)
 // Returns pointer to types.NetworkConfigSection or error
-func (vapp *VApp) UpdateNetwork(newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (*types.NetworkConfigSection, error) {
-	task, err := vapp.UpdateNetworkAsync(newNetworkSettings, orgNetwork)
+func (vapp *VApp) UpdateNetwork(ctx context.Context, newNetworkSettings *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (*types.NetworkConfigSection, error) {
+	task, err := vapp.UpdateNetworkAsync(ctx, newNetworkSettings, orgNetwork)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp networks: %#v", err)
 	}
@@ -981,9 +981,9 @@ func (vapp *VApp) UpdateNetwork(newNetworkSettings *VappNetworkSettings, orgNetw
 
 // UpdateNetworkAsync asynchronously updates vApp networks (isolated or connected to Org VDC network).
 // Returns task or error
-func (vapp *VApp) UpdateNetworkAsync(networkSettingsToUpdate *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (Task, error) {
+func (vapp *VApp) UpdateNetworkAsync(ctx context.Context, networkSettingsToUpdate *VappNetworkSettings, orgNetwork *types.OrgVDCNetwork) (Task, error) {
 	util.Logger.Printf("[TRACE] UpdateNetworkAsync with values: %#v and connect to org network: %#v", networkSettingsToUpdate, orgNetwork)
-	currentNetworkConfiguration, err := vapp.GetNetworkConfig()
+	currentNetworkConfiguration, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return Task{}, err
 	}
@@ -1060,22 +1060,22 @@ func (vapp *VApp) UpdateNetworkAsync(networkSettingsToUpdate *VappNetworkSetting
 
 	currentNetworkConfiguration.NetworkConfig[networkToUpdateIndex] = networkToUpdate
 
-	return updateNetworkConfigurations(vapp, currentNetworkConfiguration.NetworkConfig)
+	return updateNetworkConfigurations(ctx, vapp, currentNetworkConfiguration.NetworkConfig)
 }
 
 // UpdateOrgNetwork updates Org VDC network which is part of a vApp
 // Returns pointer to types.NetworkConfigSection or error
-func (vapp *VApp) UpdateOrgNetwork(newNetworkSettings *VappNetworkSettings, isFenced bool) (*types.NetworkConfigSection, error) {
-	task, err := vapp.UpdateOrgNetworkAsync(newNetworkSettings, isFenced)
+func (vapp *VApp) UpdateOrgNetwork(ctx context.Context, newNetworkSettings *VappNetworkSettings, isFenced bool) (*types.NetworkConfigSection, error) {
+	task, err := vapp.UpdateOrgNetworkAsync(ctx, newNetworkSettings, isFenced)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp networks: %#v", err)
 	}
@@ -1085,9 +1085,9 @@ func (vapp *VApp) UpdateOrgNetwork(newNetworkSettings *VappNetworkSettings, isFe
 
 // UpdateOrgNetworkAsync asynchronously updates Org VDC network which is part of a vApp
 // Returns task or error
-func (vapp *VApp) UpdateOrgNetworkAsync(networkSettingsToUpdate *VappNetworkSettings, isFenced bool) (Task, error) {
+func (vapp *VApp) UpdateOrgNetworkAsync(ctx context.Context, networkSettingsToUpdate *VappNetworkSettings, isFenced bool) (Task, error) {
 	util.Logger.Printf("[TRACE] UpdateOrgNetworkAsync with values: %#v ", networkSettingsToUpdate)
-	currentNetworkConfiguration, err := vapp.GetNetworkConfig()
+	currentNetworkConfiguration, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return Task{}, err
 	}
@@ -1123,7 +1123,7 @@ func (vapp *VApp) UpdateOrgNetworkAsync(networkSettingsToUpdate *VappNetworkSett
 
 	currentNetworkConfiguration.NetworkConfig[networkToUpdateIndex] = networkToUpdate
 
-	return updateNetworkConfigurations(vapp, currentNetworkConfiguration.NetworkConfig)
+	return updateNetworkConfigurations(ctx, vapp, currentNetworkConfiguration.NetworkConfig)
 }
 
 func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
@@ -1156,17 +1156,17 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 
 // RemoveNetwork removes any network (be it isolated or connected to an Org Network) from vApp
 // Returns pointer to types.NetworkConfigSection or error
-func (vapp *VApp) RemoveNetwork(identifier string) (*types.NetworkConfigSection, error) {
-	task, err := vapp.RemoveNetworkAsync(identifier)
+func (vapp *VApp) RemoveNetwork(ctx context.Context, identifier string) (*types.NetworkConfigSection, error) {
+	task, err := vapp.RemoveNetworkAsync(ctx, identifier)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 
-	vAppNetworkConfig, err := vapp.GetNetworkConfig()
+	vAppNetworkConfig, err := vapp.GetNetworkConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp networks: %#v", err)
 	}
@@ -1176,7 +1176,7 @@ func (vapp *VApp) RemoveNetwork(identifier string) (*types.NetworkConfigSection,
 
 // RemoveNetworkAsync asynchronously removes any network (be it isolated or connected to an Org Network) from vApp
 // Accepts network ID or name
-func (vapp *VApp) RemoveNetworkAsync(identifier string) (Task, error) {
+func (vapp *VApp) RemoveNetworkAsync(ctx context.Context, identifier string) (Task, error) {
 
 	if identifier == "" {
 		return Task{}, fmt.Errorf("network ID/name can't be empty")
@@ -1191,7 +1191,7 @@ func (vapp *VApp) RemoveNetworkAsync(identifier string) (Task, error) {
 		if networkId == extractUuid(identifier) || networkConfig.NetworkName == identifier {
 			deleteUrl := vapp.client.VCDHREF.String() + "/network/" + networkId
 			errMessage := fmt.Sprintf("detaching vApp network %s (id '%s'): %%s", networkConfig.NetworkName, networkId)
-			task, err := vapp.client.ExecuteTaskRequest(deleteUrl, http.MethodDelete, types.AnyXMLMime, errMessage, nil)
+			task, err := vapp.client.ExecuteTaskRequest(ctx, deleteUrl, http.MethodDelete, types.AnyXMLMime, errMessage, nil)
 			if err != nil {
 				return Task{}, err
 			}
@@ -1206,7 +1206,7 @@ func (vapp *VApp) RemoveNetworkAsync(identifier string) (Task, error) {
 
 // Removes vApp isolated network
 // Deprecated: in favor vapp.RemoveNetwork
-func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
+func (vapp *VApp) RemoveIsolatedNetwork(ctx context.Context, networkName string) (Task, error) {
 
 	if networkName == "" {
 		return Task{}, fmt.Errorf("network name can't be empty")
@@ -1225,14 +1225,14 @@ func (vapp *VApp) RemoveIsolatedNetwork(networkName string) (Task, error) {
 		return Task{}, fmt.Errorf("network to remove %s, wasn't found", networkName)
 	}
 
-	return updateNetworkConfigurations(vapp, networkConfigurations)
+	return updateNetworkConfigurations(ctx, vapp, networkConfigurations)
 }
 
 // Function allows to update vApp network configuration. This works for updating, deleting and adding.
 // Network configuration has to be full with new, changed elements and unchanged.
 // https://opengrok.eng.vmware.com/source/xref/cloud-sp-main.perforce-shark.1700/sp-main/dev-integration/system-tests/SystemTests/src/main/java/com/vmware/cloud/systemtests/util/VAppNetworkUtils.java#createVAppNetwork
 // http://pubs.vmware.com/vcloud-api-1-5/wwhelp/wwhimpl/js/html/wwhelp.htm#href=api_prog/GUID-92622A15-E588-4FA1-92DA-A22A4757F2A0.html#1_14_12_10_1
-func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppNetworkConfiguration) (Task, error) {
+func updateNetworkConfigurations(ctx context.Context, vapp *VApp, networkConfigurations []types.VAppNetworkConfiguration) (Task, error) {
 	util.Logger.Printf("[TRACE] updateNetworkConfigurations for vAPP: %#v and network config: %#v", vapp, networkConfigurations)
 	networkConfig := &types.NetworkConfigSection{
 		Info:          "Configuration parameters for logical networks",
@@ -1246,39 +1246,39 @@ func updateNetworkConfigurations(vapp *VApp, networkConfigurations []types.VAppN
 	apiEndpoint.Path += "/networkConfigSection/"
 
 	// Return the task
-	return vapp.client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+	return vapp.client.ExecuteTaskRequest(ctx, apiEndpoint.String(), http.MethodPut,
 		types.MimeNetworkConfigSection, "error updating vApp Network: %s", networkConfig)
 }
 
 // RemoveAllNetworks detaches all networks from vApp
-func (vapp *VApp) RemoveAllNetworks() (Task, error) {
-	return updateNetworkConfigurations(vapp, []types.VAppNetworkConfiguration{})
+func (vapp *VApp) RemoveAllNetworks(ctx context.Context) (Task, error) {
+	return updateNetworkConfigurations(ctx, vapp, []types.VAppNetworkConfiguration{})
 }
 
 // SetProductSectionList sets product section for a vApp. It allows to change vApp guest properties.
 //
 // The slice of properties "ProductSectionList.ProductSection.Property" is not necessarily ordered
 // or returned as set before
-func (vapp *VApp) SetProductSectionList(productSection *types.ProductSectionList) (*types.ProductSectionList, error) {
-	err := setProductSectionList(vapp.client, vapp.VApp.HREF, productSection)
+func (vapp *VApp) SetProductSectionList(ctx context.Context, productSection *types.ProductSectionList) (*types.ProductSectionList, error) {
+	err := setProductSectionList(ctx, vapp.client, vapp.VApp.HREF, productSection)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set vApp product section: %s", err)
 	}
 
-	return vapp.GetProductSectionList()
+	return vapp.GetProductSectionList(ctx)
 }
 
 // GetProductSectionList retrieves product section for a vApp. It allows to read vApp guest properties.
 //
 // The slice of properties "ProductSectionList.ProductSection.Property" is not necessarily ordered
 // or returned as set before
-func (vapp *VApp) GetProductSectionList() (*types.ProductSectionList, error) {
-	return getProductSectionList(vapp.client, vapp.VApp.HREF)
+func (vapp *VApp) GetProductSectionList(ctx context.Context) (*types.ProductSectionList, error) {
+	return getProductSectionList(ctx, vapp.client, vapp.VApp.HREF)
 }
 
 // GetVMByName returns a VM reference if the VM name matches an existing one.
 // If no valid VM is found, it returns a nil VM reference and an error
-func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
+func (vapp *VApp) GetVMByName(ctx context.Context, vmName string, refresh bool) (*VM, error) {
 	if refresh {
 		err := vapp.Refresh(ctx)
 		if err != nil {
@@ -1296,7 +1296,7 @@ func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
 
 		util.Logger.Printf("[TRACE] Looking at: %s", child.Name)
 		if child.Name == vmName {
-			return vapp.client.GetVMByHref(child.HREF)
+			return vapp.client.GetVMByHref(ctx, child.HREF)
 		}
 
 	}
@@ -1306,7 +1306,7 @@ func (vapp *VApp) GetVMByName(vmName string, refresh bool) (*VM, error) {
 
 // GetVMById returns a VM reference if the VM ID matches an existing one.
 // If no valid VM is found, it returns a nil VM reference and an error
-func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
+func (vapp *VApp) GetVMById(ctx context.Context, id string, refresh bool) (*VM, error) {
 	if refresh {
 		err := vapp.Refresh(ctx)
 		if err != nil {
@@ -1324,7 +1324,7 @@ func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
 
 		util.Logger.Printf("[TRACE] Looking at: %s", child.Name)
 		if equalIds(id, child.ID, child.HREF) {
-			return vapp.client.GetVMByHref(child.HREF)
+			return vapp.client.GetVMByHref(ctx, child.HREF)
 		}
 	}
 	util.Logger.Printf("[TRACE] Couldn't find VM: %s", id)
@@ -1333,9 +1333,9 @@ func (vapp *VApp) GetVMById(id string, refresh bool) (*VM, error) {
 
 // GetVMByNameOrId returns a VM reference if either the VM name or ID matches an existing one.
 // If no valid VM is found, it returns a nil VM reference and an error
-func (vapp *VApp) GetVMByNameOrId(identifier string, refresh bool) (*VM, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vapp.GetVMByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vapp.GetVMById(id, refresh) }
+func (vapp *VApp) GetVMByNameOrId(ctx context.Context, identifier string, refresh bool) (*VM, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vapp.GetVMByName(ctx, name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vapp.GetVMById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -1344,14 +1344,14 @@ func (vapp *VApp) GetVMByNameOrId(identifier string, refresh bool) (*VM, error) 
 }
 
 // QueryVappList returns a list of all vApps in all the organizations available to the caller
-func (client *Client) QueryVappList() ([]*types.QueryResultVAppRecordType, error) {
+func (client *Client) QueryVappList(ctx context.Context) ([]*types.QueryResultVAppRecordType, error) {
 	var vappList []*types.QueryResultVAppRecordType
 	queryType := client.GetQueryType(types.QtVapp)
 	params := map[string]string{
 		"type":          queryType,
 		"filterEncoded": "true",
 	}
-	vappResult, err := client.cumulativeQuery(queryType, nil, params)
+	vappResult, err := client.cumulativeQuery(ctx, queryType, nil, params)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vApp list : %s", err)
 	}
@@ -1363,16 +1363,16 @@ func (client *Client) QueryVappList() ([]*types.QueryResultVAppRecordType, error
 }
 
 // getOrgInfo finds the organization to which the vApp belongs (through the VDC), and returns its name and ID
-func (vapp *VApp) getOrgInfo() (orgInfoType, error) {
+func (vapp *VApp) getOrgInfo(ctx context.Context) (orgInfoType, error) {
 	previous, exists := orgInfoCache[vapp.VApp.ID]
 	if exists {
 		return previous, nil
 	}
 	//var orgHref string
 	var err error
-	vdc, err := vapp.getParentVDC()
+	vdc, err := vapp.getParentVDC(ctx)
 	if err != nil {
 		return orgInfoType{}, err
 	}
-	return getOrgInfo(vapp.client, vdc.Vdc.Link, vapp.VApp.ID, vapp.VApp.Name, "vApp")
+	return getOrgInfo(ctx, vapp.client, vdc.Vdc.Link, vapp.VApp.ID, vapp.VApp.Name, "vApp")
 }

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -24,13 +24,13 @@ func (vcd *TestVCD) Test_VAPPRefreshConcurrent(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp, err := vcd.vdc.GetVAppByName(vcd.vapp.VApp.Name, false)
+	vapp, err := vcd.vdc.GetVAppByName(ctx, vcd.vapp.VApp.Name, false)
 	check.Assert(err, IsNil)
 
 	for counter := 0; counter < 5; counter++ {
 		waitgroup.Add(1)
 		go func() {
-			_ = vapp.Refresh()
+			_ = vapp.Refresh(ctx)
 			waitgroup.Done()
 			// check.Assert(err, IsNil)
 		}()

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -7,19 +7,20 @@
 package govcd
 
 import (
+	"context"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
 
 // guestPropertyGetSetter interface is used for covering tests in both VM and vApp guest property
 type productSectionListGetSetter interface {
-	GetProductSectionList() (*types.ProductSectionList, error)
-	SetProductSectionList(productSection *types.ProductSectionList) (*types.ProductSectionList, error)
+	GetProductSectionList(ctx context.Context) (*types.ProductSectionList, error)
+	SetProductSectionList(ctx context.Context, productSection *types.ProductSectionList) (*types.ProductSectionList, error)
 }
 
 // propertyTester is a guest property setter accepting guestPropertyGetSetter interface for trying
 // out settings on all objects implementing such interface
-func propertyTester(vcd *TestVCD, check *C, object productSectionListGetSetter) {
+func propertyTester(ctx context.Context, vcd *TestVCD, check *C, object productSectionListGetSetter) {
 	productSection := &types.ProductSectionList{
 		ProductSection: &types.ProductSection{
 			Info: "Custom properties",
@@ -54,11 +55,11 @@ func propertyTester(vcd *TestVCD, check *C, object productSectionListGetSetter) 
 
 	productSection.SortByPropertyKeyName()
 
-	gotproductSection, err := object.SetProductSectionList(productSection)
+	gotproductSection, err := object.SetProductSectionList(ctx, productSection)
 	check.Assert(err, IsNil)
 	gotproductSection.SortByPropertyKeyName()
 
-	getproductSection, err := object.GetProductSectionList()
+	getproductSection, err := object.GetProductSectionList(ctx)
 	check.Assert(err, IsNil)
 	getproductSection.SortByPropertyKeyName()
 
@@ -95,13 +96,13 @@ func propertyTester(vcd *TestVCD, check *C, object productSectionListGetSetter) 
 
 // guestPropertyGetSetter interface is used for covering tests
 type getGuestCustomizationSectionGetSetter interface {
-	GetGuestCustomizationSection() (*types.GuestCustomizationSection, error)
-	SetGuestCustomizationSection(guestCustomizationSection *types.GuestCustomizationSection) (*types.GuestCustomizationSection, error)
+	GetGuestCustomizationSection(ctx context.Context) (*types.GuestCustomizationSection, error)
+	SetGuestCustomizationSection(ctx context.Context, guestCustomizationSection *types.GuestCustomizationSection) (*types.GuestCustomizationSection, error)
 }
 
 // guestCustomizationPropertyTester is a guest customization property get and setter accepting guestPropertyGetSetter interface for trying
 // out settings on all objects implementing such interface
-func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCustomizationSectionGetSetter) {
+func guestCustomizationPropertyTester(ctx context.Context, vcd *TestVCD, check *C, object getGuestCustomizationSectionGetSetter) {
 	setupedGuestCustomizationSection := &types.GuestCustomizationSection{
 		Enabled: takeBoolPointer(true), JoinDomainEnabled: takeBoolPointer(false), UseOrgSettings: takeBoolPointer(false),
 		DomainUserName: "", DomainName: "", DomainUserPassword: "",
@@ -109,7 +110,7 @@ func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCus
 		AdminAutoLogonEnabled: takeBoolPointer(true), AdminAutoLogonCount: 15, ResetPasswordRequired: takeBoolPointer(true),
 		CustomizationScript: "ls", ComputerName: "Cname18"}
 
-	guestCustomizationSection, err := object.SetGuestCustomizationSection(setupedGuestCustomizationSection)
+	guestCustomizationSection, err := object.SetGuestCustomizationSection(ctx, setupedGuestCustomizationSection)
 	check.Assert(err, IsNil)
 
 	// Check that values were set from API
@@ -135,7 +136,7 @@ func guestCustomizationPropertyTester(vcd *TestVCD, check *C, object getGuestCus
 	vm := object.(*VM)
 
 	// Refresh VM to have the latest structure
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	// Deep compare values retrieved from separate API to the ones embedded into VM

--- a/govcd/vapptemplate.go
+++ b/govcd/vapptemplate.go
@@ -31,16 +31,16 @@ func (vdc *Vdc) InstantiateVAppTemplate(template *types.InstantiateVAppTemplateP
 	}
 	vdcHref.Path += "/action/instantiateVAppTemplate"
 
-	vapptemplate := NewVAppTemplate(vdc.client)
+	var vapp types.VApp
 
-	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPut,
-		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, vapptemplate)
+	_, err = vdc.client.ExecuteRequest(vdcHref.String(), http.MethodPost,
+		types.MimeInstantiateVappTemplateParams, "error instantiating a new template: %s", template, &vapp)
 	if err != nil {
 		return err
 	}
 
 	task := NewTask(vdc.client)
-	for _, taskItem := range vapptemplate.VAppTemplate.Tasks.Task {
+	for _, taskItem := range vapp.Tasks.Task {
 		task.Task = taskItem
 		err = task.WaitTaskCompletion()
 		if err != nil {

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -7,6 +7,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 
 	. "gopkg.in/check.v1"
@@ -15,9 +16,9 @@ import (
 // TODO: Write test for InstantiateVAppTemplate
 
 func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
-
+	ctx := context.Background()
 	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
 		check.Skip("Test_GetVAppTemplate: Catalog not found. Test can't proceed")
 		return
@@ -28,20 +29,20 @@ func (vcd *TestVCD) Test_RefreshVAppTemplate(check *C) {
 		check.Skip("Test_GetVAppTemplate: Catalog Item not given. Test can't proceed")
 	}
 
-	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
+	catItem, err := cat.GetCatalogItemByName(ctx, vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catItem, NotNil)
 	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	// Get VAppTemplate
-	vAppTemplate, err := catItem.GetVAppTemplate()
+	vAppTemplate, err := catItem.GetVAppTemplate(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate, NotNil)
 	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
 
 	oldVAppTemplate := vAppTemplate
 
-	err = vAppTemplate.Refresh()
+	err = vAppTemplate.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(oldVAppTemplate.VAppTemplate.ID, Equals, vAppTemplate.VAppTemplate.ID)
 	check.Assert(oldVAppTemplate.VAppTemplate.Name, Equals, vAppTemplate.VAppTemplate.Name)

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -30,18 +31,18 @@ func NewVdc(cli *Client) *Vdc {
 }
 
 // Gets a vapp with a specific url vappHREF
-func (vdc *Vdc) getVdcVAppbyHREF(vappHREF *url.URL) (*VApp, error) {
+func (vdc *Vdc) getVdcVAppbyHREF(ctx context.Context, vappHREF *url.URL) (*VApp, error) {
 	vapp := NewVApp(vdc.client)
 
-	_, err := vdc.client.ExecuteRequest(vappHREF.String(), http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, vappHREF.String(), http.MethodGet,
 		"", "error retrieving VApp: %s", nil, vapp.VApp)
 
 	return vapp, err
 }
 
 // Undeploys every vapp in the vdc
-func (vdc *Vdc) undeployAllVdcVApps() error {
-	err := vdc.Refresh()
+func (vdc *Vdc) undeployAllVdcVApps(ctx context.Context) error {
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -52,18 +53,18 @@ func (vdc *Vdc) undeployAllVdcVApps() error {
 				if err != nil {
 					return err
 				}
-				vapp, err := vdc.getVdcVAppbyHREF(vappHREF)
+				vapp, err := vdc.getVdcVAppbyHREF(ctx, vappHREF)
 				if err != nil {
 					return fmt.Errorf("error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
 				}
-				task, err := vapp.Undeploy()
+				task, err := vapp.Undeploy(ctx)
 				if err != nil {
 					return err
 				}
 				if task == (Task{}) {
 					continue
 				}
-				err = task.WaitTaskCompletion()
+				err = task.WaitTaskCompletion(ctx)
 				if err != nil {
 					return err
 				}
@@ -74,8 +75,8 @@ func (vdc *Vdc) undeployAllVdcVApps() error {
 }
 
 // Removes all vapps in the vdc
-func (vdc *Vdc) removeAllVdcVApps() error {
-	err := vdc.Refresh()
+func (vdc *Vdc) removeAllVdcVApps(ctx context.Context) error {
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -86,15 +87,15 @@ func (vdc *Vdc) removeAllVdcVApps() error {
 				if err != nil {
 					return err
 				}
-				vapp, err := vdc.getVdcVAppbyHREF(vappHREF)
+				vapp, err := vdc.getVdcVAppbyHREF(ctx, vappHREF)
 				if err != nil {
 					return fmt.Errorf("error retrieving vapp with url: %s and with error %s", vappHREF.Path, err)
 				}
-				task, err := vapp.Delete()
+				task, err := vapp.Delete(ctx)
 				if err != nil {
 					return fmt.Errorf("error deleting vapp: %s", err)
 				}
-				err = task.WaitTaskCompletion()
+				err = task.WaitTaskCompletion(ctx)
 				if err != nil {
 					return fmt.Errorf("couldn't finish removing vapp %s", err)
 				}
@@ -104,7 +105,7 @@ func (vdc *Vdc) removeAllVdcVApps() error {
 	return nil
 }
 
-func (vdc *Vdc) Refresh() error {
+func (vdc *Vdc) Refresh(ctx context.Context) error {
 
 	if vdc.Vdc.HREF == "" {
 		return fmt.Errorf("cannot refresh, Object is empty")
@@ -114,7 +115,7 @@ func (vdc *Vdc) Refresh() error {
 	// elements in slices.
 	unmarshalledVdc := &types.Vdc{}
 
-	_, err := vdc.client.ExecuteRequest(vdc.Vdc.HREF, http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, vdc.Vdc.HREF, http.MethodGet,
 		"", "error refreshing vDC: %s", nil, unmarshalledVdc)
 	if err != nil {
 		return err
@@ -128,7 +129,7 @@ func (vdc *Vdc) Refresh() error {
 
 // Deletes the vdc, returning an error of the vCD call fails.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Vdc.html
-func (vdc *Vdc) Delete(force bool, recursive bool) (Task, error) {
+func (vdc *Vdc) Delete(ctx context.Context, force bool, recursive bool) (Task, error) {
 	util.Logger.Printf("[TRACE] Vdc.Delete - deleting VDC with force: %t, recursive: %t", force, recursive)
 
 	if vdc.Vdc.HREF == "" {
@@ -140,7 +141,7 @@ func (vdc *Vdc) Delete(force bool, recursive bool) (Task, error) {
 		return Task{}, fmt.Errorf("error parsing vdc url: %s", err)
 	}
 
-	req := vdc.client.NewRequest(map[string]string{
+	req := vdc.client.NewRequest(ctx, map[string]string{
 		"force":     strconv.FormatBool(force),
 		"recursive": strconv.FormatBool(recursive),
 	}, http.MethodDelete, *vdcUrl, nil)
@@ -159,12 +160,12 @@ func (vdc *Vdc) Delete(force bool, recursive bool) (Task, error) {
 }
 
 // Deletes the vdc and waits for the asynchronous task to complete.
-func (vdc *Vdc) DeleteWait(force bool, recursive bool) error {
-	task, err := vdc.Delete(force, recursive)
+func (vdc *Vdc) DeleteWait(ctx context.Context, force bool, recursive bool) error {
+	task, err := vdc.Delete(ctx, force, recursive)
 	if err != nil {
 		return err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't finish removing vdc %s", err)
 	}
@@ -172,9 +173,9 @@ func (vdc *Vdc) DeleteWait(force bool, recursive bool) error {
 }
 
 // Deprecated: use GetOrgVdcNetworkByName
-func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
+func (vdc *Vdc) FindVDCNetwork(ctx context.Context, network string) (OrgVDCNetwork, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return OrgVDCNetwork{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -183,7 +184,7 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 			if reference.Name == network {
 				orgNet := NewOrgVDCNetwork(vdc.client)
 
-				_, err := vdc.client.ExecuteRequest(reference.HREF, http.MethodGet,
+				_, err := vdc.client.ExecuteRequest(ctx, reference.HREF, http.MethodGet,
 					"", "error retrieving org vdc network: %s", nil, orgNet.OrgVDCNetwork)
 
 				// The request was successful
@@ -198,11 +199,11 @@ func (vdc *Vdc) FindVDCNetwork(network string) (OrgVDCNetwork, error) {
 
 // GetOrgVdcNetworkByHref returns an Org VDC Network reference if the network HREF matches an existing one.
 // If no valid external network is found, it returns a nil Network reference and an error
-func (vdc *Vdc) GetOrgVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkByHref(ctx context.Context, href string) (*OrgVDCNetwork, error) {
 
 	orgNet := NewOrgVDCNetwork(vdc.client)
 
-	_, err := vdc.client.ExecuteRequest(href, http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, href, http.MethodGet,
 		"", "error retrieving org vdc network: %s", nil, orgNet.OrgVDCNetwork)
 
 	// The request was successful
@@ -211,9 +212,9 @@ func (vdc *Vdc) GetOrgVdcNetworkByHref(href string) (*OrgVDCNetwork, error) {
 
 // GetOrgVdcNetworkByName returns an Org VDC Network reference if the network name matches an existing one.
 // If no valid external network is found, it returns a nil Network reference and an error
-func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkByName(ctx context.Context, name string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error refreshing vdc: %s", err)
 		}
@@ -221,7 +222,7 @@ func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwor
 	for _, an := range vdc.Vdc.AvailableNetworks {
 		for _, reference := range an.Network {
 			if reference.Name == name {
-				return vdc.GetOrgVdcNetworkByHref(reference.HREF)
+				return vdc.GetOrgVdcNetworkByHref(ctx, reference.HREF)
 			}
 		}
 	}
@@ -231,9 +232,9 @@ func (vdc *Vdc) GetOrgVdcNetworkByName(name string, refresh bool) (*OrgVDCNetwor
 
 // GetOrgVdcNetworkById returns an Org VDC Network reference if the network ID matches an existing one.
 // If no valid external network is found, it returns a nil Network reference and an error
-func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, error) {
+func (vdc *Vdc) GetOrgVdcNetworkById(ctx context.Context, id string, refresh bool) (*OrgVDCNetwork, error) {
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error refreshing vdc: %s", err)
 		}
@@ -243,7 +244,7 @@ func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, e
 			// Some versions of vCD do not return an ID in the network reference
 			// We use equalIds to overcome this issue
 			if equalIds(id, reference.ID, reference.HREF) {
-				return vdc.GetOrgVdcNetworkByHref(reference.HREF)
+				return vdc.GetOrgVdcNetworkByHref(ctx, reference.HREF)
 			}
 		}
 	}
@@ -253,9 +254,11 @@ func (vdc *Vdc) GetOrgVdcNetworkById(id string, refresh bool) (*OrgVDCNetwork, e
 
 // GetOrgVdcNetworkByNameOrId returns a VDC Network reference if either the network name or ID matches an existing one.
 // If no valid external network is found, it returns a nil ExternalNetwork reference and an error
-func (vdc *Vdc) GetOrgVdcNetworkByNameOrId(identifier string, refresh bool) (*OrgVDCNetwork, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkById(id, refresh) }
+func (vdc *Vdc) GetOrgVdcNetworkByNameOrId(ctx context.Context, identifier string, refresh bool) (*OrgVDCNetwork, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
+		return vdc.GetOrgVdcNetworkByName(ctx, name, refresh)
+	}
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetOrgVdcNetworkById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -263,9 +266,9 @@ func (vdc *Vdc) GetOrgVdcNetworkByNameOrId(identifier string, refresh bool) (*Or
 	return entity.(*OrgVDCNetwork), err
 }
 
-func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error) {
+func (vdc *Vdc) FindStorageProfileReference(ctx context.Context, name string) (types.Reference, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return types.Reference{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -277,9 +280,9 @@ func (vdc *Vdc) FindStorageProfileReference(name string) (types.Reference, error
 	return types.Reference{}, fmt.Errorf("can't find any VDC Storage_profiles")
 }
 
-func (vdc *Vdc) GetDefaultStorageProfileReference(storageprofiles *types.QueryResultRecordsType) (types.Reference, error) {
+func (vdc *Vdc) GetDefaultStorageProfileReference(ctx context.Context, storageprofiles *types.QueryResultRecordsType) (types.Reference, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return types.Reference{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -292,9 +295,9 @@ func (vdc *Vdc) GetDefaultStorageProfileReference(storageprofiles *types.QueryRe
 }
 
 // Deprecated: use GetEdgeGatewayByName
-func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
+func (vdc *Vdc) FindEdgeGateway(ctx context.Context, edgegateway string) (EdgeGateway, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return EdgeGateway{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -303,7 +306,7 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
 			query := new(types.QueryResultEdgeGatewayRecordsType)
 
-			_, err := vdc.client.ExecuteRequest(av.HREF, http.MethodGet,
+			_, err := vdc.client.ExecuteRequest(ctx, av.HREF, http.MethodGet,
 				"", "error querying edge gateways: %s", nil, query)
 			if err != nil {
 				return EdgeGateway{}, err
@@ -323,7 +326,7 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 
 			edge := NewEdgeGateway(vdc.client)
 
-			_, err = vdc.client.ExecuteRequest(href, http.MethodGet,
+			_, err = vdc.client.ExecuteRequest(ctx, href, http.MethodGet,
 				"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
 
 			// TODO - remove this if a solution is found or once 9.7 is deprecated
@@ -338,7 +341,7 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 				for i := 1; i < 4 && err != nil; i++ {
 					time.Sleep(200 * time.Millisecond)
 					util.Logger.Printf("%d ", i)
-					_, err = vdc.client.ExecuteRequest(href, http.MethodGet,
+					_, err = vdc.client.ExecuteRequest(ctx, href, http.MethodGet,
 						"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
 				}
 				util.Logger.Printf("\n")
@@ -355,14 +358,14 @@ func (vdc *Vdc) FindEdgeGateway(edgegateway string) (EdgeGateway, error) {
 // GetEdgeGatewayByHref retrieves an edge gateway from VDC
 // by querying directly its HREF.
 // The name passed as parameter is only used for error reporting
-func (vdc *Vdc) GetEdgeGatewayByHref(href string) (*EdgeGateway, error) {
+func (vdc *Vdc) GetEdgeGatewayByHref(ctx context.Context, href string) (*EdgeGateway, error) {
 	if href == "" {
 		return nil, fmt.Errorf("empty edge gateway HREF")
 	}
 
 	edge := NewEdgeGateway(vdc.client)
 
-	_, err := vdc.client.ExecuteRequest(href, http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, href, http.MethodGet,
 		"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
 
 	// TODO - remove this if a solution is found or once 9.7 is deprecated
@@ -377,7 +380,7 @@ func (vdc *Vdc) GetEdgeGatewayByHref(href string) (*EdgeGateway, error) {
 		for i := 1; i < 4 && err != nil; i++ {
 			time.Sleep(200 * time.Millisecond)
 			util.Logger.Printf("%d ", i)
-			_, err = vdc.client.ExecuteRequest(href, http.MethodGet,
+			_, err = vdc.client.ExecuteRequest(ctx, href, http.MethodGet,
 				"", "error retrieving edge gateway: %s", nil, edge.EdgeGateway)
 		}
 		util.Logger.Printf("\n")
@@ -390,10 +393,10 @@ func (vdc *Vdc) GetEdgeGatewayByHref(href string) (*EdgeGateway, error) {
 }
 
 // GetEdgeGatewayRecordsType retrieves a list of edge gateways from VDC
-func (vdc *Vdc) GetEdgeGatewayRecordsType(refresh bool) (*types.QueryResultEdgeGatewayRecordsType, error) {
+func (vdc *Vdc) GetEdgeGatewayRecordsType(ctx context.Context, refresh bool) (*types.QueryResultEdgeGatewayRecordsType, error) {
 
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error refreshing vdc: %s", err)
 		}
@@ -403,7 +406,7 @@ func (vdc *Vdc) GetEdgeGatewayRecordsType(refresh bool) (*types.QueryResultEdgeG
 
 			edgeGatewayRecordsType := new(types.QueryResultEdgeGatewayRecordsType)
 
-			_, err := vdc.client.ExecuteRequest(av.HREF, http.MethodGet,
+			_, err := vdc.client.ExecuteRequest(ctx, av.HREF, http.MethodGet,
 				"", "error querying edge gateways: %s", nil, edgeGatewayRecordsType)
 			if err != nil {
 				return nil, err
@@ -417,15 +420,15 @@ func (vdc *Vdc) GetEdgeGatewayRecordsType(refresh bool) (*types.QueryResultEdgeG
 // GetEdgeGatewayByName search the VDC list of edge gateways for a given name.
 // If the name matches, it returns a pointer to an edge gateway object.
 // On failure, it returns a nil object and an error
-func (vdc *Vdc) GetEdgeGatewayByName(name string, refresh bool) (*EdgeGateway, error) {
-	edgeGatewayRecord, err := vdc.GetEdgeGatewayRecordsType(refresh)
+func (vdc *Vdc) GetEdgeGatewayByName(ctx context.Context, name string, refresh bool) (*EdgeGateway, error) {
+	edgeGatewayRecord, err := vdc.GetEdgeGatewayRecordsType(ctx, refresh)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving edge gateways list: %s", err)
 	}
 
 	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
 		if edge.Name == name {
-			return vdc.GetEdgeGatewayByHref(edge.HREF)
+			return vdc.GetEdgeGatewayByHref(ctx, edge.HREF)
 		}
 	}
 
@@ -435,15 +438,15 @@ func (vdc *Vdc) GetEdgeGatewayByName(name string, refresh bool) (*EdgeGateway, e
 // GetEdgeGatewayById search VDC list of edge gateways for a given ID.
 // If the id matches, it returns a pointer to an edge gateway object.
 // On failure, it returns a nil object and an error
-func (vdc *Vdc) GetEdgeGatewayById(id string, refresh bool) (*EdgeGateway, error) {
-	edgeGatewayRecord, err := vdc.GetEdgeGatewayRecordsType(refresh)
+func (vdc *Vdc) GetEdgeGatewayById(ctx context.Context, id string, refresh bool) (*EdgeGateway, error) {
+	edgeGatewayRecord, err := vdc.GetEdgeGatewayRecordsType(ctx, refresh)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving edge gateways list: %s", err)
 	}
 
 	for _, edge := range edgeGatewayRecord.EdgeGatewayRecord {
 		if equalIds(id, "", edge.HREF) {
-			return vdc.GetEdgeGatewayByHref(edge.HREF)
+			return vdc.GetEdgeGatewayByHref(ctx, edge.HREF)
 		}
 	}
 
@@ -453,9 +456,11 @@ func (vdc *Vdc) GetEdgeGatewayById(id string, refresh bool) (*EdgeGateway, error
 // GetEdgeGatewayByNameOrId search the VDC list of edge gateways for a given name or ID.
 // If the name or the ID match, it returns a pointer to an edge gateway object.
 // On failure, it returns a nil object and an error
-func (vdc *Vdc) GetEdgeGatewayByNameOrId(identifier string, refresh bool) (*EdgeGateway, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetEdgeGatewayByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetEdgeGatewayById(id, refresh) }
+func (vdc *Vdc) GetEdgeGatewayByNameOrId(ctx context.Context, identifier string, refresh bool) (*EdgeGateway, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) {
+		return vdc.GetEdgeGatewayByName(ctx, name, refresh)
+	}
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetEdgeGatewayById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -463,7 +468,7 @@ func (vdc *Vdc) GetEdgeGatewayByNameOrId(identifier string, refresh bool) (*Edge
 	return entity.(*EdgeGateway), err
 }
 
-func (vdc *Vdc) ComposeRawVApp(name string) error {
+func (vdc *Vdc) ComposeRawVApp(ctx context.Context, name string) error {
 	vcomp := &types.ComposeVAppParams{
 		Ovf:     types.XMLNamespaceOVF,
 		Xsi:     types.XMLNamespaceXSI,
@@ -479,13 +484,13 @@ func (vdc *Vdc) ComposeRawVApp(name string) error {
 	}
 	vdcHref.Path += "/action/composeVApp"
 
-	task, err := vdc.client.ExecuteTaskRequest(vdcHref.String(), http.MethodPost,
+	task, err := vdc.client.ExecuteTaskRequest(ctx, vdcHref.String(), http.MethodPost,
 		types.MimeComposeVappParams, "error instantiating a new vApp:: %s", vcomp)
 	if err != nil {
 		return fmt.Errorf("error executing task request: %s", err)
 	}
 
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("error performing task: %s", err)
 	}
@@ -497,7 +502,7 @@ func (vdc *Vdc) ComposeRawVApp(name string) error {
 // that uses the storageprofile and networks given. If you want all eulas
 // to be accepted set acceptalleulas to true. Returns a successful task
 // if completed successfully, otherwise returns an error and an empty task.
-func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string, acceptalleulas bool) (Task, error) {
+func (vdc *Vdc) ComposeVApp(ctx context.Context, orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string, acceptalleulas bool) (Task, error) {
 	if vapptemplate.VAppTemplate.Children == nil || orgvdcnetworks == nil {
 		return Task{}, fmt.Errorf("can't compose a new vApp, objects passed are not valid")
 	}
@@ -578,14 +583,14 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 	}
 	vdcHref.Path += "/action/composeVApp"
 
-	return vdc.client.ExecuteTaskRequest(vdcHref.String(), http.MethodPost,
+	return vdc.client.ExecuteTaskRequest(ctx, vdcHref.String(), http.MethodPost,
 		types.MimeComposeVappParams, "error instantiating a new vApp: %s", vcomp)
 }
 
 // Deprecated: use vdc.GetVAppByName instead
-func (vdc *Vdc) FindVAppByName(vapp string) (VApp, error) {
+func (vdc *Vdc) FindVAppByName(ctx context.Context, vapp string) (VApp, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -597,7 +602,7 @@ func (vdc *Vdc) FindVAppByName(vapp string) (VApp, error) {
 
 				newVapp := NewVApp(vdc.client)
 
-				_, err := vdc.client.ExecuteRequest(resent.HREF, http.MethodGet,
+				_, err := vdc.client.ExecuteRequest(ctx, resent.HREF, http.MethodGet,
 					"", "error retrieving vApp: %s", nil, newVapp.VApp)
 
 				return *newVapp, err
@@ -609,14 +614,14 @@ func (vdc *Vdc) FindVAppByName(vapp string) (VApp, error) {
 }
 
 // Deprecated: use vapp.GetVMByName instead
-func (vdc *Vdc) FindVMByName(vapp VApp, vm string) (VM, error) {
+func (vdc *Vdc) FindVMByName(ctx context.Context, vapp VApp, vm string) (VM, error) {
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return VM{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
 
-	err = vapp.Refresh()
+	err = vapp.Refresh(ctx)
 	if err != nil {
 		return VM{}, fmt.Errorf("error refreshing vApp: %s", err)
 	}
@@ -635,7 +640,7 @@ func (vdc *Vdc) FindVMByName(vapp VApp, vm string) (VM, error) {
 
 			newVm := NewVM(vdc.client)
 
-			_, err := vdc.client.ExecuteRequest(child.HREF, http.MethodGet,
+			_, err := vdc.client.ExecuteRequest(ctx, child.HREF, http.MethodGet,
 				"", "error retrieving vm: %s", nil, newVm.VM)
 
 			return *newVm, err
@@ -647,7 +652,7 @@ func (vdc *Vdc) FindVMByName(vapp VApp, vm string) (VM, error) {
 }
 
 // Find vm using vApp name and VM name. Returns VMRecord query return type
-func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
+func (vdc *Vdc) QueryVM(ctx context.Context, vappName, vmName string) (VMRecord, error) {
 
 	if vmName == "" {
 		return VMRecord{}, errors.New("error querying vm name is empty")
@@ -662,7 +667,7 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 		typeMedia = "adminVM"
 	}
 
-	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia,
+	results, err := vdc.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": typeMedia,
 		"filter":        "name==" + url.QueryEscape(vmName) + ";containerName==" + url.QueryEscape(vappName),
 		"filterEncoded": "true"})
 	if err != nil {
@@ -686,12 +691,12 @@ func (vdc *Vdc) QueryVM(vappName, vmName string) (VMRecord, error) {
 }
 
 // Deprecated: use vdc.GetVAppById instead
-func (vdc *Vdc) FindVAppByID(vappid string) (VApp, error) {
+func (vdc *Vdc) FindVAppByID(ctx context.Context, vappid string) (VApp, error) {
 
 	// Horrible hack to fetch a vapp with its id.
 	// urn:vcloud:vapp:00000000-0000-0000-0000-000000000000
 
-	err := vdc.Refresh()
+	err := vdc.Refresh(ctx)
 	if err != nil {
 		return VApp{}, fmt.Errorf("error refreshing vdc: %s", err)
 	}
@@ -710,7 +715,7 @@ func (vdc *Vdc) FindVAppByID(vappid string) (VApp, error) {
 
 				newVapp := NewVApp(vdc.client)
 
-				_, err := vdc.client.ExecuteRequest(resent.HREF, http.MethodGet,
+				_, err := vdc.client.ExecuteRequest(ctx, resent.HREF, http.MethodGet,
 					"", "error retrieving vApp: %s", nil, newVapp.VApp)
 
 				return *newVapp, err
@@ -725,10 +730,10 @@ func (vdc *Vdc) FindVAppByID(vappid string) (VApp, error) {
 // FindMediaImage returns media image found in system using `name` as query.
 // Can find a few of them if media with same name exist in different catalogs.
 // Deprecated: Use catalog.GetMediaByName()
-func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
+func (vdc *Vdc) FindMediaImage(ctx context.Context, mediaName string) (MediaItem, error) {
 	util.Logger.Printf("[TRACE] Querying medias by name\n")
 
-	mediaResults, err := queryMediaWithFilter(vdc,
+	mediaResults, err := queryMediaWithFilter(ctx, vdc,
 		fmt.Sprintf("name==%s", url.QueryEscape(mediaName)))
 	if err != nil {
 		return MediaItem{}, err
@@ -754,11 +759,11 @@ func (vdc *Vdc) FindMediaImage(mediaName string) (MediaItem, error) {
 
 // GetVappByHref returns a vApp reference by running a vCD API call
 // If no valid vApp is found, it returns a nil VApp reference and an error
-func (vdc *Vdc) GetVAppByHref(vappHref string) (*VApp, error) {
+func (vdc *Vdc) GetVAppByHref(ctx context.Context, vappHref string) (*VApp, error) {
 
 	newVapp := NewVApp(vdc.client)
 
-	_, err := vdc.client.ExecuteRequest(vappHref, http.MethodGet,
+	_, err := vdc.client.ExecuteRequest(ctx, vappHref, http.MethodGet,
 		"", "error retrieving vApp: %s", nil, newVapp.VApp)
 
 	if err != nil {
@@ -769,10 +774,10 @@ func (vdc *Vdc) GetVAppByHref(vappHref string) (*VApp, error) {
 
 // GetVappByName returns a vApp reference if the vApp Name matches an existing one.
 // If no valid vApp is found, it returns a nil VApp reference and an error
-func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
+func (vdc *Vdc) GetVAppByName(ctx context.Context, vappName string, refresh bool) (*VApp, error) {
 
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error refreshing VDC: %s", err)
 		}
@@ -781,7 +786,7 @@ func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
 	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
 		for _, resourceReference := range resourceEntities.ResourceEntity {
 			if resourceReference.Name == vappName && resourceReference.Type == "application/vnd.vmware.vcloud.vApp+xml" {
-				return vdc.GetVAppByHref(resourceReference.HREF)
+				return vdc.GetVAppByHref(ctx, resourceReference.HREF)
 			}
 		}
 	}
@@ -790,10 +795,10 @@ func (vdc *Vdc) GetVAppByName(vappName string, refresh bool) (*VApp, error) {
 
 // GetVappById returns a vApp reference if the vApp ID matches an existing one.
 // If no valid vApp is found, it returns a nil VApp reference and an error
-func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
+func (vdc *Vdc) GetVAppById(ctx context.Context, id string, refresh bool) (*VApp, error) {
 
 	if refresh {
-		err := vdc.Refresh()
+		err := vdc.Refresh(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error refreshing VDC: %s", err)
 		}
@@ -802,7 +807,7 @@ func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
 	for _, resourceEntities := range vdc.Vdc.ResourceEntities {
 		for _, resourceReference := range resourceEntities.ResourceEntity {
 			if equalIds(id, resourceReference.ID, resourceReference.HREF) {
-				return vdc.GetVAppByHref(resourceReference.HREF)
+				return vdc.GetVAppByHref(ctx, resourceReference.HREF)
 			}
 		}
 	}
@@ -811,9 +816,9 @@ func (vdc *Vdc) GetVAppById(id string, refresh bool) (*VApp, error) {
 
 // GetVappByNameOrId returns a vApp reference if either the vApp name or ID matches an existing one.
 // If no valid vApp is found, it returns a nil VApp reference and an error
-func (vdc *Vdc) GetVAppByNameOrId(identifier string, refresh bool) (*VApp, error) {
-	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVAppByName(name, refresh) }
-	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVAppById(id, refresh) }
+func (vdc *Vdc) GetVAppByNameOrId(ctx context.Context, identifier string, refresh bool) (*VApp, error) {
+	getByName := func(name string, refresh bool) (interface{}, error) { return vdc.GetVAppByName(ctx, name, refresh) }
+	getById := func(id string, refresh bool) (interface{}, error) { return vdc.GetVAppById(ctx, id, refresh) }
 	entity, err := getEntityByNameOrId(getByName, getById, identifier, false)
 	if entity == nil {
 		return nil, err
@@ -839,12 +844,12 @@ func (vdc *Vdc) buildNsxvNetworkServiceEndpointURL(optionalSuffix string) (strin
 }
 
 // QueryMediaList retrieves a list of media items for the VDC
-func (vdc *Vdc) QueryMediaList() ([]*types.MediaRecordType, error) {
-	return getExistingMedia(vdc)
+func (vdc *Vdc) QueryMediaList(ctx context.Context) ([]*types.MediaRecordType, error) {
+	return getExistingMedia(ctx, vdc)
 }
 
 // QueryVappVmTemplate Finds VM template using catalog name, vApp template name, VN name in template. Returns types.QueryResultVMRecordType
-func (vdc *Vdc) QueryVappVmTemplate(catalogName, vappTemplateName, vmNameInTemplate string) (*types.QueryResultVMRecordType, error) {
+func (vdc *Vdc) QueryVappVmTemplate(ctx context.Context, catalogName, vappTemplateName, vmNameInTemplate string) (*types.QueryResultVMRecordType, error) {
 
 	queryType := "vm"
 	if vdc.client.IsSysAdmin {
@@ -852,7 +857,7 @@ func (vdc *Vdc) QueryVappVmTemplate(catalogName, vappTemplateName, vmNameInTempl
 	}
 
 	// this allows to query deployed and not deployed templates
-	results, err := vdc.QueryWithNotEncodedParams(nil, map[string]string{"type": queryType,
+	results, err := vdc.QueryWithNotEncodedParams(ctx, nil, map[string]string{"type": queryType,
 		"filter": "catalogName==" + url.QueryEscape(catalogName) + ";containerName==" + url.QueryEscape(vappTemplateName) + ";name==" + url.QueryEscape(vmNameInTemplate) +
 			";isVAppTemplate==true;status!=FAILED_CREATION;status!=UNKNOWN;status!=UNRECOGNIZED;status!=UNRESOLVED&links=true;",
 		"filterEncoded": "true"})
@@ -902,7 +907,7 @@ func (vdc *Vdc) GetVappList() []*types.ResourceReference {
 }
 
 // CreateStandaloneVmAsync starts a standalone VM creation without a template, returning a task
-func (vdc *Vdc) CreateStandaloneVmAsync(params *types.CreateVmParams) (Task, error) {
+func (vdc *Vdc) CreateStandaloneVmAsync(ctx context.Context, params *types.CreateVmParams) (Task, error) {
 	util.Logger.Printf("[TRACE] Vdc.CreateStandaloneVmAsync - Creating VM ")
 
 	if vdc.Vdc.HREF == "" {
@@ -924,17 +929,17 @@ func (vdc *Vdc) CreateStandaloneVmAsync(params *types.CreateVmParams) (Task, err
 	}
 	params.XmlnsOvf = types.XMLNamespaceOVF
 
-	return vdc.client.ExecuteTaskRequest(href, http.MethodPost, types.MimeCreateVmParams, "error creating standalone VM: %s", params)
+	return vdc.client.ExecuteTaskRequest(ctx, href, http.MethodPost, types.MimeCreateVmParams, "error creating standalone VM: %s", params)
 }
 
 // getVmFromTask finds a VM from a running standalone VM creation task
 // It retrieves the VM owner (the hidden vApp), and from that one finds the new VM
-func (vdc *Vdc) getVmFromTask(task Task, name string) (*VM, error) {
+func (vdc *Vdc) getVmFromTask(ctx context.Context, task Task, name string) (*VM, error) {
 	owner := task.Task.Owner.HREF
 	if owner == "" {
 		return nil, fmt.Errorf("task owner is null for VM %s", name)
 	}
-	vapp, err := vdc.GetVAppByHref(owner)
+	vapp, err := vdc.GetVAppByHref(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -949,30 +954,30 @@ func (vdc *Vdc) getVmFromTask(task Task, name string) (*VM, error) {
 	}
 	for _, child := range vapp.VApp.Children.VM {
 		util.Logger.Printf("[TRACE] Looking at: %s", child.Name)
-		return vapp.client.GetVMByHref(child.HREF)
+		return vapp.client.GetVMByHref(ctx, child.HREF)
 	}
 	return nil, ErrorEntityNotFound
 }
 
 // CreateStandaloneVm creates a standalone VM without a template
-func (vdc *Vdc) CreateStandaloneVm(params *types.CreateVmParams) (*VM, error) {
+func (vdc *Vdc) CreateStandaloneVm(ctx context.Context, params *types.CreateVmParams) (*VM, error) {
 
-	task, err := vdc.CreateStandaloneVmAsync(params)
+	task, err := vdc.CreateStandaloneVmAsync(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return vdc.getVmFromTask(task, params.Name)
+	return vdc.getVmFromTask(ctx, task, params.Name)
 }
 
 // QueryVmByName finds a standalone VM by name
 // The search fails either if there are more VMs with the wanted name, or if there are none
 // It can also retrieve a standard VM (created from vApp)
-func (vdc *Vdc) QueryVmByName(name string) (*VM, error) {
-	vmList, err := vdc.QueryVmList(types.VmQueryFilterOnlyDeployed)
+func (vdc *Vdc) QueryVmByName(ctx context.Context, name string) (*VM, error) {
+	vmList, err := vdc.QueryVmList(ctx, types.VmQueryFilterOnlyDeployed)
 	if err != nil {
 		return nil, err
 	}
@@ -988,13 +993,13 @@ func (vdc *Vdc) QueryVmByName(name string) (*VM, error) {
 	if len(foundVM) > 1 {
 		return nil, fmt.Errorf("more than one VM found with name %s", name)
 	}
-	return vdc.client.GetVMByHref(foundVM[0].HREF)
+	return vdc.client.GetVMByHref(ctx, foundVM[0].HREF)
 }
 
 // QueryVmById retrieves a standalone VM by ID
 // It can also retrieve a standard VM (created from vApp)
-func (vdc *Vdc) QueryVmById(id string) (*VM, error) {
-	vmList, err := vdc.QueryVmList(types.VmQueryFilterOnlyDeployed)
+func (vdc *Vdc) QueryVmById(ctx context.Context, id string) (*VM, error) {
+	vmList, err := vdc.QueryVmList(ctx, types.VmQueryFilterOnlyDeployed)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,11 +1015,11 @@ func (vdc *Vdc) QueryVmById(id string) (*VM, error) {
 	if len(foundVM) > 1 {
 		return nil, fmt.Errorf("more than one VM found with ID %s", id)
 	}
-	return vdc.client.GetVMByHref(foundVM[0].HREF)
+	return vdc.client.GetVMByHref(ctx, foundVM[0].HREF)
 }
 
 // CreateStandaloneVMFromTemplateAsync starts a standalone VM creation using a template
-func (vdc *Vdc) CreateStandaloneVMFromTemplateAsync(params *types.InstantiateVmTemplateParams) (Task, error) {
+func (vdc *Vdc) CreateStandaloneVMFromTemplateAsync(ctx context.Context, params *types.InstantiateVmTemplateParams) (Task, error) {
 
 	util.Logger.Printf("[TRACE] Vdc.CreateStandaloneVMFromTemplateAsync - Creating VM")
 
@@ -1047,33 +1052,33 @@ func (vdc *Vdc) CreateStandaloneVMFromTemplateAsync(params *types.InstantiateVmT
 	}
 	params.XmlnsOvf = types.XMLNamespaceOVF
 
-	return vdc.client.ExecuteTaskRequest(href, http.MethodPost, types.MimeInstantiateVmTemplateParams, "error creating standalone VM from template: %s", params)
+	return vdc.client.ExecuteTaskRequest(ctx, href, http.MethodPost, types.MimeInstantiateVmTemplateParams, "error creating standalone VM from template: %s", params)
 }
 
 // CreateStandaloneVMFromTemplate creates a standalone VM from a template
-func (vdc *Vdc) CreateStandaloneVMFromTemplate(params *types.InstantiateVmTemplateParams) (*VM, error) {
+func (vdc *Vdc) CreateStandaloneVMFromTemplate(ctx context.Context, params *types.InstantiateVmTemplateParams) (*VM, error) {
 
-	task, err := vdc.CreateStandaloneVMFromTemplateAsync(params)
+	task, err := vdc.CreateStandaloneVMFromTemplateAsync(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return vdc.getVmFromTask(task, params.Name)
+	return vdc.getVmFromTask(ctx, task, params.Name)
 }
 
 // GetCapabilities allows to retrieve a list of VDC capabilities. It has a list of values. Some particularly useful are:
 // * networkProvider - overlay stack responsible for providing network functionality. (NSX_V or NSX_T)
 // * crossVdc - supports cross vDC network creation
-func (vdc *Vdc) GetCapabilities() ([]types.VdcCapability, error) {
+func (vdc *Vdc) GetCapabilities(ctx context.Context) ([]types.VdcCapability, error) {
 	if vdc.Vdc.ID == "" {
 		return nil, fmt.Errorf("VDC ID must be set to get capabilities")
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcCapabilities
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -1084,7 +1089,7 @@ func (vdc *Vdc) GetCapabilities() ([]types.VdcCapability, error) {
 	}
 
 	capabilities := make([]types.VdcCapability, 0)
-	err = vdc.client.OpenApiGetAllItems(minimumApiVersion, urlRef, nil, &capabilities)
+	err = vdc.client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, nil, &capabilities)
 	if err != nil {
 		return nil, err
 	}
@@ -1093,8 +1098,8 @@ func (vdc *Vdc) GetCapabilities() ([]types.VdcCapability, error) {
 
 // IsNsxt is a convenience function to check if VDC is backed by NSX-T pVdc
 // If error occurs - it returns false
-func (vdc *Vdc) IsNsxt() bool {
-	vdcCapabilities, err := vdc.GetCapabilities()
+func (vdc *Vdc) IsNsxt(ctx context.Context) bool {
+	vdcCapabilities, err := vdc.GetCapabilities(ctx)
 	if err != nil {
 		return false
 	}
@@ -1105,8 +1110,8 @@ func (vdc *Vdc) IsNsxt() bool {
 
 // IsNsxv is a convenience function to check if VDC is backed by NSX-V pVdc
 // If error occurs - it returns false
-func (vdc *Vdc) IsNsxv() bool {
-	vdcCapabilities, err := vdc.GetCapabilities()
+func (vdc *Vdc) IsNsxv(ctx context.Context) bool {
+	vdcCapabilities, err := vdc.GetCapabilities(ctx)
 	if err != nil {
 		return false
 	}

--- a/govcd/vdccomputepolicy.go
+++ b/govcd/vdccomputepolicy.go
@@ -5,6 +5,7 @@ package govcd
  */
 
 import (
+	"context"
 	"fmt"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
@@ -20,19 +21,19 @@ type VdcComputePolicy struct {
 }
 
 // GetVdcComputePolicyById retrieves VDC compute policy by given ID
-func (org *AdminOrg) GetVdcComputePolicyById(id string) (*VdcComputePolicy, error) {
-	return getVdcComputePolicyById(org.client, id)
+func (org *AdminOrg) GetVdcComputePolicyById(ctx context.Context, id string) (*VdcComputePolicy, error) {
+	return getVdcComputePolicyById(ctx, org.client, id)
 }
 
 // GetVdcComputePolicyById retrieves VDC compute policy by given ID
-func (org *Org) GetVdcComputePolicyById(id string) (*VdcComputePolicy, error) {
-	return getVdcComputePolicyById(org.client, id)
+func (org *Org) GetVdcComputePolicyById(ctx context.Context, id string) (*VdcComputePolicy, error) {
+	return getVdcComputePolicyById(ctx, org.client, id)
 }
 
 // getVdcComputePolicyById retrieves VDC compute policy by given ID
-func getVdcComputePolicyById(client *Client, id string) (*VdcComputePolicy, error) {
+func getVdcComputePolicyById(ctx context.Context, client *Client, id string) (*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func getVdcComputePolicyById(client *Client, id string) (*VdcComputePolicy, erro
 		client:           client,
 	}
 
-	err = client.OpenApiGetItem(minimumApiVersion, urlRef, nil, vdcComputePolicy.VdcComputePolicy)
+	err = client.OpenApiGetItem(ctx, minimumApiVersion, urlRef, nil, vdcComputePolicy.VdcComputePolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -63,21 +64,21 @@ func getVdcComputePolicyById(client *Client, id string) (*VdcComputePolicy, erro
 
 // GetAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
-func (org *AdminOrg) GetAllVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
-	return getAllVdcComputePolicies(org.client, queryParameters)
+func (org *AdminOrg) GetAllVdcComputePolicies(ctx context.Context, queryParameters url.Values) ([]*VdcComputePolicy, error) {
+	return getAllVdcComputePolicies(ctx, org.client, queryParameters)
 }
 
 // GetAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
-func (org *Org) GetAllVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
-	return getAllVdcComputePolicies(org.client, queryParameters)
+func (org *Org) GetAllVdcComputePolicies(ctx context.Context, queryParameters url.Values) ([]*VdcComputePolicy, error) {
+	return getAllVdcComputePolicies(ctx, org.client, queryParameters)
 }
 
 // getAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
-func getAllVdcComputePolicies(client *Client, queryParameters url.Values) ([]*VdcComputePolicy, error) {
+func getAllVdcComputePolicies(ctx context.Context, client *Client, queryParameters url.Values) ([]*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +90,7 @@ func getAllVdcComputePolicies(client *Client, queryParameters url.Values) ([]*Vd
 
 	responses := []*types.VdcComputePolicy{{}}
 
-	err = client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &responses)
+	err = client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &responses)
 	if err != nil {
 		return nil, err
 	}
@@ -107,9 +108,9 @@ func getAllVdcComputePolicies(client *Client, queryParameters url.Values) ([]*Vd
 }
 
 // CreateVdcComputePolicy creates a new VDC Compute Policy using OpenAPI endpoint
-func (org *AdminOrg) CreateVdcComputePolicy(newVdcComputePolicy *types.VdcComputePolicy) (*VdcComputePolicy, error) {
+func (org *AdminOrg) CreateVdcComputePolicy(ctx context.Context, newVdcComputePolicy *types.VdcComputePolicy) (*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := org.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := org.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +125,7 @@ func (org *AdminOrg) CreateVdcComputePolicy(newVdcComputePolicy *types.VdcComput
 		client:           org.client,
 	}
 
-	err = org.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newVdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy)
+	err = org.client.OpenApiPostItem(ctx, minimumApiVersion, urlRef, nil, newVdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VDC compute policy: %s", err)
 	}
@@ -133,9 +134,9 @@ func (org *AdminOrg) CreateVdcComputePolicy(newVdcComputePolicy *types.VdcComput
 }
 
 // Update existing VDC compute policy
-func (vdcComputePolicy *VdcComputePolicy) Update() (*VdcComputePolicy, error) {
+func (vdcComputePolicy *VdcComputePolicy) Update(ctx context.Context) (*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := vdcComputePolicy.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdcComputePolicy.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +155,7 @@ func (vdcComputePolicy *VdcComputePolicy) Update() (*VdcComputePolicy, error) {
 		client:           vdcComputePolicy.client,
 	}
 
-	err = vdcComputePolicy.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, vdcComputePolicy.VdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy)
+	err = vdcComputePolicy.client.OpenApiPutItem(ctx, minimumApiVersion, urlRef, nil, vdcComputePolicy.VdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy)
 	if err != nil {
 		return nil, fmt.Errorf("error updating VDC compute policy: %s", err)
 	}
@@ -163,9 +164,9 @@ func (vdcComputePolicy *VdcComputePolicy) Update() (*VdcComputePolicy, error) {
 }
 
 // Delete deletes VDC compute policy
-func (vdcComputePolicy *VdcComputePolicy) Delete() error {
+func (vdcComputePolicy *VdcComputePolicy) Delete(ctx context.Context) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := vdcComputePolicy.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdcComputePolicy.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return err
 	}
@@ -179,7 +180,7 @@ func (vdcComputePolicy *VdcComputePolicy) Delete() error {
 		return err
 	}
 
-	err = vdcComputePolicy.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+	err = vdcComputePolicy.client.OpenApiDeleteItem(ctx, minimumApiVersion, urlRef, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting VDC compute policy: %s", err)
@@ -190,9 +191,9 @@ func (vdcComputePolicy *VdcComputePolicy) Delete() error {
 
 // GetAllAssignedVdcComputePolicies retrieves all VDC assigned compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
-func (vdc *AdminVdc) GetAllAssignedVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
+func (vdc *AdminVdc) GetAllAssignedVdcComputePolicies(ctx context.Context, queryParameters url.Values) ([]*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcAssignedComputePolicies
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +205,7 @@ func (vdc *AdminVdc) GetAllAssignedVdcComputePolicies(queryParameters url.Values
 
 	responses := []*types.VdcComputePolicy{{}}
 
-	err = vdc.client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &responses)
+	err = vdc.client.OpenApiGetAllItems(ctx, minimumApiVersion, urlRef, queryParameters, &responses)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func (vdc *AdminVdc) GetAllAssignedVdcComputePolicies(queryParameters url.Values
 }
 
 // SetAssignedComputePolicies assign(set) compute policies.
-func (vdc *AdminVdc) SetAssignedComputePolicies(computePolicyReferences types.VdcComputePolicyReferences) (*types.VdcComputePolicyReferences, error) {
+func (vdc *AdminVdc) SetAssignedComputePolicies(ctx context.Context, computePolicyReferences types.VdcComputePolicyReferences) (*types.VdcComputePolicyReferences, error) {
 	util.Logger.Printf("[TRACE] Set Compute Policies started")
 
 	if !vdc.client.IsSysAdmin {
@@ -243,7 +244,7 @@ func (vdc *AdminVdc) SetAssignedComputePolicies(computePolicyReferences types.Vd
 	returnedVdcComputePolicies := &types.VdcComputePolicyReferences{}
 	computePolicyReferences.Xmlns = types.XMLNamespaceVCloud
 
-	_, err = vdc.client.ExecuteRequest(adminVdcPolicyHREF.String(), http.MethodPut,
+	_, err = vdc.client.ExecuteRequest(ctx, adminVdcPolicyHREF.String(), http.MethodPut,
 		types.MimeVdcComputePolicyReferences, "error setting compute policies for VDC: %s", computePolicyReferences, returnedVdcComputePolicies)
 	if err != nil {
 		return nil, err

--- a/govcd/vm_concurrent_test.go
+++ b/govcd/vm_concurrent_test.go
@@ -26,7 +26,7 @@ func (vcd *TestVCD) Test_VMRefreshConcurrent(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -37,7 +37,7 @@ func (vcd *TestVCD) Test_VMRefreshConcurrent(check *C) {
 	for counter := 0; counter < 5; counter++ {
 		waitgroup.Add(1)
 		go func() {
-			_ = vm.Refresh()
+			_ = vm.Refresh(ctx)
 			waitgroup.Done()
 			// check.Assert(err, IsNil)
 		}()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -8,6 +8,7 @@
 package govcd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -27,9 +28,10 @@ func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	if vapp.VApp.Name == "" {
 		check.Skip("Disabled: No suitable vApp found in vDC")
 	}
@@ -38,7 +40,7 @@ func (vcd *TestVCD) Test_FindVMByHREF(check *C) {
 		check.Skip("Disabled: No suitable VM found in vDC")
 	}
 
-	newVM, err := vcd.client.Client.GetVMByHref(vm.HREF)
+	newVM, err := vcd.client.Client.GetVMByHref(ctx, vm.HREF)
 	check.Assert(err, IsNil)
 	check.Assert(newVM.VM.Name, Equals, vmName)
 	check.Assert(newVM.VM.VirtualHardwareSection.Item, NotNil)
@@ -55,7 +57,8 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -68,9 +71,9 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 
 	// Ensure vApp and VM are suitable for this test
 	// Disk attach and detach operations are not working if VM is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -84,7 +87,7 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -93,43 +96,43 @@ func (vcd *TestVCD) Test_VMAttachOrDetachDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.attachOrDetachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.attachOrDetachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	}, types.RelDiskAttach)
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Get attached VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
 	// Detach disk
-	detachDiskTask, err := vm.attachOrDetachDisk(&types.DiskAttachOrDetachParams{
+	detachDiskTask, err := vm.attachOrDetachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	}, types.RelDiskDetach)
 	check.Assert(err, IsNil)
 
-	err = detachDiskTask.WaitTaskCompletion()
+	err = detachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 }
@@ -148,9 +151,10 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	// Find VM
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -163,9 +167,9 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 
 	// Discard vApp suspension
 	// Disk attach and detach operations are not working if vApp is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -179,7 +183,7 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -188,43 +192,43 @@ func (vcd *TestVCD) Test_VMAttachDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.AttachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.AttachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Get attached VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
 	// Cleanup: Detach disk
-	detachDiskTask, err := vm.attachOrDetachDisk(&types.DiskAttachOrDetachParams{
+	detachDiskTask, err := vm.attachOrDetachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	}, types.RelDiskDetach)
 	check.Assert(err, IsNil)
 
-	err = detachDiskTask.WaitTaskCompletion()
+	err = detachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 }
@@ -239,9 +243,10 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	// Find VM
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -254,9 +259,9 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 
 	// Ensure vApp and VM are suitable for this test
 	// Disk attach and detach operations are not working if VM is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -270,7 +275,7 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -280,43 +285,43 @@ func (vcd *TestVCD) Test_VMDetachDisk(check *C) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.AttachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.AttachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Get attached VM
-	vmRef, err := disk.AttachedVM()
+	vmRef, err := disk.AttachedVM(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmRef, NotNil)
 	check.Assert(vmRef.Name, Equals, vm.VM.Name)
 
 	// Detach disk
-	detachDiskTask, err := vm.DetachDisk(&types.DiskAttachOrDetachParams{
+	detachDiskTask, err := vm.DetachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = detachDiskTask.WaitTaskCompletion()
+	err = detachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 }
@@ -335,7 +340,8 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -345,37 +351,37 @@ func (vcd *TestVCD) Test_HandleInsertOrEjectMedia(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_HandleInsertOrEjectMedia")
 
-	catalog, err = vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err = vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	media, err := catalog.GetMediaByName(itemName, false)
+	media, err := catalog.GetMediaByName(ctx, itemName, false)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 
-	insertMediaTask, err := vm.HandleInsertMedia(vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	insertMediaTask, err := vm.HandleInsertMedia(ctx, vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
 
-	err = insertMediaTask.WaitTaskCompletion()
+	err = insertMediaTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, true)
 
-	vm, err = vm.HandleEjectMediaAndAnswer(vcd.org, vcd.config.VCD.Catalog.Name, itemName, true)
+	vm, err = vm.HandleEjectMediaAndAnswer(ctx, vcd.org, vcd.config.VCD.Catalog.Name, itemName, true)
 	check.Assert(err, IsNil)
 
 	//verify
@@ -389,9 +395,10 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
+	ctx := context.Background()
 
 	// Skipping this test due to a bug in vCD. VM refresh status returns old state, though eject task is finished.
-	if vcd.client.Client.APIVCDMaxVersionIs(">= 32.0, <= 33.0") {
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, ">= 32.0, <= 33.0") {
 		check.Skip("Skipping test because this vCD version has a bug")
 	}
 
@@ -402,7 +409,7 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -414,27 +421,27 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_InsertOrEjectMedia")
 
-	catalog, err = vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err = vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	media, err := catalog.GetMediaByName(itemName, false)
+	media, err := catalog.GetMediaByName(ctx, itemName, false)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 
 	// Insert Media
-	insertMediaTask, err := vm.insertOrEjectMedia(&types.MediaInsertOrEjectParams{
+	insertMediaTask, err := vm.insertOrEjectMedia(ctx, &types.MediaInsertOrEjectParams{
 		Media: &types.Reference{
 			HREF: media.Media.HREF,
 			Name: media.Media.Name,
@@ -444,28 +451,28 @@ func (vcd *TestVCD) Test_InsertOrEjectMedia(check *C) {
 	}, types.RelMediaInsertMedia)
 	check.Assert(err, IsNil)
 
-	err = insertMediaTask.WaitTaskCompletion()
+	err = insertMediaTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, true)
 
 	// Insert Media
-	ejectMediaTask, err := vm.insertOrEjectMedia(&types.MediaInsertOrEjectParams{
+	ejectMediaTask, err := vm.insertOrEjectMedia(ctx, &types.MediaInsertOrEjectParams{
 		Media: &types.Reference{
 			HREF: media.Media.HREF,
 		},
 	}, types.RelMediaEjectMedia)
 	check.Assert(err, IsNil)
 
-	err = ejectMediaTask.WaitTaskCompletion()
+	err = ejectMediaTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
@@ -485,7 +492,8 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 		check.Skip("skipping test because no vApp is found")
 	}
 
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -495,58 +503,58 @@ func (vcd *TestVCD) Test_AnswerVmQuestion(check *C) {
 	vm.VM = &vmType
 
 	// Upload Media
-	catalog, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
+	uploadTask, err := catalog.UploadMediaImage(ctx, itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
 	check.Assert(err, IsNil)
-	err = uploadTask.WaitTaskCompletion()
+	err = uploadTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_AnswerVmQuestion")
 
-	catalog, err = vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	catalog, err = vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	media, err := catalog.GetMediaByName(itemName, false)
+	media, err := catalog.GetMediaByName(ctx, itemName, false)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	insertMediaTask, err := vm.HandleInsertMedia(vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	insertMediaTask, err := vm.HandleInsertMedia(ctx, vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
 
-	err = insertMediaTask.WaitTaskCompletion()
+	err = insertMediaTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, true)
 
-	ejectMediaTask, err := vm.HandleEjectMedia(vcd.org, vcd.config.VCD.Catalog.Name, itemName)
+	ejectMediaTask, err := vm.HandleEjectMedia(ctx, vcd.org, vcd.config.VCD.Catalog.Name, itemName)
 	check.Assert(err, IsNil)
 
 	for i := 0; i < 10; i++ {
-		question, err := vm.GetQuestion()
+		question, err := vm.GetQuestion(ctx)
 		check.Assert(err, IsNil)
 
 		if question.QuestionId != "" && strings.Contains(question.Question, "Disconnect anyway and override the lock?") {
-			err = vm.AnswerQuestion(question.QuestionId, 0)
+			err = vm.AnswerQuestion(ctx, question.QuestionId, 0)
 			check.Assert(err, IsNil)
 		}
 		time.Sleep(time.Second * 3)
 	}
 
-	err = ejectMediaTask.Task.WaitTaskCompletion()
+	err = ejectMediaTask.Task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(isMediaInjected(vm.VM.VirtualHardwareSection.Item), Equals, false)
 }
@@ -556,7 +564,8 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
 
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -579,19 +588,19 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	check.Assert(0, Not(Equals), currentCpus)
 	check.Assert(0, Not(Equals), currentCores)
 
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 
 	cores := 2
 	cpuCount := int64(4)
 
-	task, err := vm.ChangeCPUCountWithCore(int(cpuCount), &cores)
+	task, err := vm.ChangeCPUCountWithCore(ctx, int(cpuCount), &cores)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	foundItem := false
 	if nil != vm.VM.VirtualHardwareSection.Item {
@@ -607,9 +616,9 @@ func (vcd *TestVCD) Test_VMChangeCPUCountWithCore(check *C) {
 	}
 
 	// return to previous value
-	task, err = vm.ChangeCPUCountWithCore(int(currentCpus), &currentCores)
+	task, err = vm.ChangeCPUCountWithCore(ctx, int(currentCpus), &currentCores)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
@@ -618,7 +627,8 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -627,45 +637,45 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	nestingStatus := existingVm.NestedHypervisorEnabled
 	check.Assert(nestingStatus, Equals, false)
 
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 
 	// PowerOn
-	task, err := vm.PowerOn()
+	task, err := vm.PowerOn(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Try to change the setting on powered on VM to fail
-	_, err = vm.ToggleHardwareVirtualization(true)
+	_, err = vm.ToggleHardwareVirtualization(ctx, true)
 	check.Assert(err, ErrorMatches, ".*hardware virtualization can be changed from powered off state.*")
 
 	// PowerOf
-	task, err = vm.PowerOff()
+	task, err = vm.PowerOff(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
 	// Perform steps on powered off VM
-	task, err = vm.ToggleHardwareVirtualization(true)
+	task, err = vm.ToggleHardwareVirtualization(ctx, true)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, true)
 
-	task, err = vm.ToggleHardwareVirtualization(false)
+	task, err = vm.ToggleHardwareVirtualization(ctx, false)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, false)
 }
@@ -674,45 +684,46 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 
 	// Ensure VM is not powered on
-	vmStatus, err := vm.GetStatus()
+	vmStatus, err := vm.GetStatus(ctx)
 	check.Assert(err, IsNil)
 	if vmStatus != "POWERED_OFF" {
-		task, err := vm.PowerOff()
+		task, err := vm.PowerOff(ctx)
 		check.Assert(err, IsNil)
-		err = task.WaitTaskCompletion()
+		err = task.WaitTaskCompletion(ctx)
 		check.Assert(err, IsNil)
 		check.Assert(task.Task.Status, Equals, "success")
 	}
 
-	task, err := vm.PowerOn()
+	task, err := vm.PowerOn(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
-	vmStatus, err = vm.GetStatus()
+	vmStatus, err = vm.GetStatus(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmStatus, Equals, "POWERED_ON")
 
 	// Power off again
-	task, err = vm.PowerOff()
+	task, err = vm.PowerOff(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
-	vmStatus, err = vm.GetStatus()
+	vmStatus, err = vm.GetStatus(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmStatus, Equals, "POWERED_OFF")
 }
@@ -721,23 +732,23 @@ func (vcd *TestVCD) Test_GetNetworkConnectionSection(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
 
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 
-	networkBefore, err := vm.GetNetworkConnectionSection()
+	networkBefore, err := vm.GetNetworkConnectionSection(ctx)
 	check.Assert(err, IsNil)
 
-	err = vm.UpdateNetworkConnectionSection(networkBefore)
+	err = vm.UpdateNetworkConnectionSection(ctx, networkBefore)
 	check.Assert(err, IsNil)
 
-	networkAfter, err := vm.GetNetworkConnectionSection()
+	networkAfter, err := vm.GetNetworkConnectionSection(ctx)
 	check.Assert(err, IsNil)
 
 	// Filter out always differing fields and do deep comparison of objects
@@ -758,15 +769,15 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
-
+	ctx := context.Background()
 	fmt.Printf("Running: %s\n", check.TestName())
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
 
-	vm, err := vcd.client.Client.GetVMByHref(vmType.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, vmType.HREF)
 	check.Assert(err, IsNil)
 
 	// It may be that prebuilt VM was not booted before in the test vApp and it would still have
@@ -774,62 +785,62 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	// but while this flag is here the test cannot actually check if vm.PowerOnAndForceCustomization()
 	// gives any effect therefore we must "wait through" initial guest customization if it is in
 	// 'GC_PENDING' state.
-	custStatus, err := vm.GetGuestCustomizationStatus()
+	custStatus, err := vm.GetGuestCustomizationStatus(ctx)
 	check.Assert(err, IsNil)
 	if custStatus == types.GuestCustStatusPending {
-		vmStatus, err := vm.GetStatus()
+		vmStatus, err := vm.GetStatus(ctx)
 		check.Assert(err, IsNil)
 		// If VM is POWERED OFF - let's power it on before waiting for its status to change
 		if vmStatus == "POWERED_OFF" {
-			task, err := vm.PowerOn()
+			task, err := vm.PowerOn(ctx)
 			check.Assert(err, IsNil)
-			err = task.WaitTaskCompletion()
+			err = task.WaitTaskCompletion(ctx)
 			check.Assert(err, IsNil)
 			check.Assert(task.Task.Status, Equals, "success")
 		}
 
-		err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
+		err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, 300)
 		check.Assert(err, IsNil)
 	}
 
 	// Check that VM is deployed
-	vmIsDeployed, err := vm.IsDeployed()
+	vmIsDeployed, err := vm.IsDeployed(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmIsDeployed, Equals, true)
 
 	// Try to force operation on deployed VM and expect an error
-	err = vm.PowerOnAndForceCustomization()
+	err = vm.PowerOnAndForceCustomization(ctx)
 	check.Assert(err, NotNil)
 
 	// VM _must_ be un-deployed because PowerOnAndForceCustomization task will never finish (and
 	// probably not triggered) if it is not un-deployed.
-	task, err := vm.Undeploy()
+	task, err := vm.Undeploy(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Check that VM is un-deployed
-	vmIsDeployed, err = vm.IsDeployed()
+	vmIsDeployed, err = vm.IsDeployed(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmIsDeployed, Equals, false)
 
-	err = vm.PowerOnAndForceCustomization()
+	err = vm.PowerOnAndForceCustomization(ctx)
 	check.Assert(err, IsNil)
 
 	// Ensure that VM has the status set to "GC_PENDING" after forced re-customization
-	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus()
+	recustomizedVmStatus, err := vm.GetGuestCustomizationStatus(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(recustomizedVmStatus, Equals, types.GuestCustStatusPending)
 
 	// Check that VM is deployed
-	vmIsDeployed, err = vm.IsDeployed()
+	vmIsDeployed, err = vm.IsDeployed(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(vmIsDeployed, Equals, true)
 
 	// Wait until the VM exists GC_PENDING status again. At the moment this is the only simple way
 	// to see that the customization really worked as there is no API in vCD to execute remote
 	// commands on guest VMs
-	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, 300)
 	check.Assert(err, IsNil)
 }
 
@@ -837,36 +848,36 @@ func (vcd *TestVCD) Test_BlockWhileGuestCustomizationStatus(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
-
+	ctx := context.Background()
 	fmt.Printf("Running: %s\n", check.TestName())
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
 
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 
 	// Attempt to set invalid timeout values and expect validation error
-	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 0)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, 0)
 	check.Assert(err, ErrorMatches, "timeOutAfterSeconds must be in range 4<X<7200")
-	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 4)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, 4)
 	check.Assert(err, ErrorMatches, "timeOutAfterSeconds must be in range 4<X<7200")
-	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, -30)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, -30)
 	check.Assert(err, ErrorMatches, "timeOutAfterSeconds must be in range 4<X<7200")
-	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 7201)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, types.GuestCustStatusPending, 7201)
 	check.Assert(err, ErrorMatches, "timeOutAfterSeconds must be in range 4<X<7200")
 
-	vmCustStatus, err := vm.GetGuestCustomizationStatus()
+	vmCustStatus, err := vm.GetGuestCustomizationStatus(ctx)
 	check.Assert(err, IsNil)
 
 	// Use current value to trigger timeout
-	err = vm.BlockWhileGuestCustomizationStatus(vmCustStatus, 5)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, vmCustStatus, 5)
 	check.Assert(err, ErrorMatches, "timed out waiting for VM guest customization status to exit state GC_PENDING after 5 seconds")
 
 	// Use unreal value to trigger instant unblocking
-	err = vm.BlockWhileGuestCustomizationStatus("invalid_GC_STATUS", 5)
+	err = vm.BlockWhileGuestCustomizationStatus(ctx, "invalid_GC_STATUS", 5)
 	check.Assert(err, IsNil)
 }
 
@@ -876,12 +887,13 @@ func (vcd *TestVCD) Test_VMSetProductSectionList(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 	propertyTester(vcd, check, vm)
 }
@@ -891,12 +903,13 @@ func (vcd *TestVCD) Test_VMSetGetGuestCustomizationSection(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
-	vapp := vcd.findFirstVapp()
+	ctx := context.Background()
+	vapp := vcd.findFirstVapp(ctx)
 	existingVm, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
 	}
-	vm, err := vcd.client.Client.GetVMByHref(existingVm.HREF)
+	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
 	guestCustomizationPropertyTester(vcd, check, vm)
 }
@@ -909,14 +922,14 @@ func (vcd *TestVCD) Test_AddInternalDisk(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-
+	ctx := context.Background()
 	vmName := "Test_AddInternalDisk"
 
-	vm, storageProfile, diskSettings, diskId, previousProvisioningValue, err := vcd.createInternalDisk(check, vmName, 1)
+	vm, storageProfile, diskSettings, diskId, previousProvisioningValue, err := vcd.createInternalDisk(ctx, check, vmName, 1)
 	check.Assert(err, IsNil)
 
 	//verify
-	disk, err := vm.GetInternalDiskById(diskId, true)
+	disk, err := vm.GetInternalDiskById(ctx, diskId, true)
 	check.Assert(err, IsNil)
 
 	check.Assert(disk.StorageProfile.HREF, Equals, storageProfile.HREF)
@@ -930,19 +943,19 @@ func (vcd *TestVCD) Test_AddInternalDisk(check *C) {
 	check.Assert(disk.AdapterType, Equals, diskSettings.AdapterType)
 
 	//cleanup
-	err = vm.DeleteInternalDisk(diskId)
+	err = vm.DeleteInternalDisk(ctx, diskId)
 	check.Assert(err, IsNil)
 
 	// disable fast provisioning if needed
-	updateVdcFastProvisioning(vcd, check, previousProvisioningValue)
+	updateVdcFastProvisioning(ctx, vcd, check, previousProvisioningValue)
 
 	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
+	deleteVapp(ctx, vcd, vmName)
 }
 
 // createInternalDisk Finds available VM and creates internal Disk in it.
 // returns VM, storage profile, disk settings, disk id and error.
-func (vcd *TestVCD) createInternalDisk(check *C, vmName string, busNumber int) (*VM, types.Reference, *types.DiskSettings, string, string, error) {
+func (vcd *TestVCD) createInternalDisk(ctx context.Context, check *C, vmName string, busNumber int) (*VM, types.Reference, *types.DiskSettings, string, string, error) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
@@ -959,16 +972,16 @@ func (vcd *TestVCD) createInternalDisk(check *C, vmName string, busNumber int) (
 	}
 
 	// disables fast provisioning if needed
-	previousVdcFastProvisioningValue := updateVdcFastProvisioning(vcd, check, "disable")
+	previousVdcFastProvisioningValue := updateVdcFastProvisioning(ctx, vcd, check, "disable")
 	AddToCleanupList(previousVdcFastProvisioningValue, "fastProvisioning", vcd.config.VCD.Org+"|"+vcd.config.VCD.Vdc, "createInternalDisk")
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(ctx, check, vmName)
 	check.Assert(err, IsNil)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
+	vm, err := spawnVM(ctx, "FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
 	check.Assert(err, IsNil)
 
-	storageProfile, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	storageProfile, err := vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 	check.Assert(err, IsNil)
 	isThinProvisioned := true
 	iops := int64(0)
@@ -983,19 +996,19 @@ func (vcd *TestVCD) createInternalDisk(check *C, vmName string, busNumber int) (
 		Iops:              &iops,
 	}
 
-	diskId, err := vm.AddInternalDisk(diskSettings)
+	diskId, err := vm.AddInternalDisk(ctx, diskSettings)
 	check.Assert(err, IsNil)
 	check.Assert(diskId, NotNil)
 	return &vm, storageProfile, diskSettings, diskId, previousVdcFastProvisioningValue, err
 }
 
 // updateVdcFastProvisioning Enables or Disables fast provisioning if needed
-func updateVdcFastProvisioning(vcd *TestVCD, check *C, enable string) string {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+func updateVdcFastProvisioning(ctx context.Context, vcd *TestVCD, check *C, enable string) string {
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.config.VCD.Vdc, true)
+	adminVdc, err := adminOrg.GetAdminVDCByName(ctx, vcd.config.VCD.Vdc, true)
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
 
@@ -1016,7 +1029,7 @@ func updateVdcFastProvisioning(vcd *TestVCD, check *C, enable string) string {
 		valuePt = true
 	}
 	adminVdc.AdminVdc.UsesFastProvisioning = &valuePt
-	_, err = adminVdc.Update()
+	_, err = adminVdc.Update(ctx)
 	check.Assert(err, IsNil)
 	return vdcFastProvisioningValue
 }
@@ -1029,28 +1042,28 @@ func (vcd *TestVCD) Test_DeleteInternalDisk(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
-
+	ctx := context.Background()
 	vmName := "Test_DeleteInternalDisk"
 
-	vm, _, _, diskId, previousProvisioningValue, err := vcd.createInternalDisk(check, vmName, 2)
+	vm, _, _, diskId, previousProvisioningValue, err := vcd.createInternalDisk(ctx, check, vmName, 2)
 	check.Assert(err, IsNil)
 
 	//verify
-	err = vm.Refresh()
+	err = vm.Refresh(ctx)
 	check.Assert(err, IsNil)
 
-	err = vm.DeleteInternalDisk(diskId)
+	err = vm.DeleteInternalDisk(ctx, diskId)
 	check.Assert(err, IsNil)
 
-	disk, err := vm.GetInternalDiskById(diskId, true)
+	disk, err := vm.GetInternalDiskById(ctx, diskId, true)
 	check.Assert(err, Equals, ErrorEntityNotFound)
 	check.Assert(disk, IsNil)
 
 	// enable fast provisioning if needed
-	updateVdcFastProvisioning(vcd, check, previousProvisioningValue)
+	updateVdcFastProvisioning(ctx, vcd, check, previousProvisioningValue)
 
 	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
+	deleteVapp(ctx, vcd, vmName)
 }
 
 // Test update internal disk for VM which has independent disk
@@ -1061,12 +1074,13 @@ func (vcd *TestVCD) Test_UpdateInternalDisk(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
+	ctx := context.Background()
 	vmName := "Test_UpdateInternalDisk"
-	vm, storageProfile, diskSettings, diskId, previousProvisioningValue, err := vcd.createInternalDisk(check, vmName, 1)
+	vm, storageProfile, diskSettings, diskId, previousProvisioningValue, err := vcd.createInternalDisk(ctx, check, vmName, 1)
 	check.Assert(err, IsNil)
 
 	//verify
-	disk, err := vm.GetInternalDiskById(diskId, true)
+	disk, err := vm.GetInternalDiskById(ctx, diskId, true)
 	check.Assert(err, IsNil)
 	check.Assert(disk, NotNil)
 
@@ -1081,11 +1095,11 @@ func (vcd *TestVCD) Test_UpdateInternalDisk(check *C) {
 
 	vmSpecSection.DiskSection.DiskSettings = changeDiskSettings
 
-	vmSpecSection, err = vm.UpdateInternalDisks(vmSpecSection)
+	vmSpecSection, err = vm.UpdateInternalDisks(ctx, vmSpecSection)
 	check.Assert(err, IsNil)
 	check.Assert(vmSpecSection, NotNil)
 
-	disk, err = vm.GetInternalDiskById(diskId, true)
+	disk, err = vm.GetInternalDiskById(ctx, diskId, true)
 	check.Assert(err, IsNil)
 	check.Assert(disk, NotNil)
 
@@ -1101,24 +1115,24 @@ func (vcd *TestVCD) Test_UpdateInternalDisk(check *C) {
 	check.Assert(disk.AdapterType, Equals, diskSettings.AdapterType)
 
 	// attach independent disk
-	independentDisk, err := attachIndependentDisk(vcd, check)
+	independentDisk, err := attachIndependentDisk(ctx, vcd, check)
 	check.Assert(err, IsNil)
 
 	//cleanup
-	err = vm.DeleteInternalDisk(diskId)
+	err = vm.DeleteInternalDisk(ctx, diskId)
 	check.Assert(err, IsNil)
-	detachIndependentDisk(vcd, check, independentDisk)
+	detachIndependentDisk(ctx, vcd, check, independentDisk)
 
 	// disable fast provisioning if needed
-	updateVdcFastProvisioning(vcd, check, previousProvisioningValue)
+	updateVdcFastProvisioning(ctx, vcd, check, previousProvisioningValue)
 
 	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
+	deleteVapp(ctx, vcd, vmName)
 }
 
-func attachIndependentDisk(vcd *TestVCD, check *C) (*Disk, error) {
+func attachIndependentDisk(ctx context.Context, vcd *TestVCD, check *C) (*Disk, error) {
 	// Find VM
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	vmType, vmName := vcd.findFirstVm(vapp)
 	if vmName == "" {
 		check.Skip("skipping test because no VM is found")
@@ -1129,9 +1143,9 @@ func attachIndependentDisk(vcd *TestVCD, check *C) (*Disk, error) {
 
 	// Ensure vApp and VM are suitable for this test
 	// Disk attach and detach operations are not working if VM is suspended
-	err := vcd.ensureVappIsSuitableForVMTest(vapp)
+	err := vcd.ensureVappIsSuitableForVMTest(ctx, vapp)
 	check.Assert(err, IsNil)
-	err = vcd.ensureVMIsSuitableForVMTest(vm)
+	err = vcd.ensureVMIsSuitableForVMTest(ctx, vm)
 	check.Assert(err, IsNil)
 
 	// Create disk
@@ -1145,7 +1159,7 @@ func attachIndependentDisk(vcd *TestVCD, check *C) (*Disk, error) {
 		Disk: diskCreateParamsDisk,
 	}
 
-	task, err := vcd.vdc.CreateDisk(diskCreateParams)
+	task, err := vcd.vdc.CreateDisk(ctx, diskCreateParams)
 	check.Assert(err, IsNil)
 
 	check.Assert(task.Task.Owner.Type, Equals, types.MimeDisk)
@@ -1154,32 +1168,32 @@ func attachIndependentDisk(vcd *TestVCD, check *C) (*Disk, error) {
 	PrependToCleanupList(diskHREF, "disk", "", check.TestName())
 
 	// Wait for disk creation complete
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	// Verify created disk
 	check.Assert(diskHREF, Not(Equals), "")
-	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
+	disk, err := vcd.vdc.GetDiskByHref(ctx, diskHREF)
 	check.Assert(err, IsNil)
 	check.Assert(disk.Disk.Name, Equals, diskCreateParamsDisk.Name)
 	check.Assert(disk.Disk.Size, Equals, diskCreateParamsDisk.Size)
 	check.Assert(disk.Disk.Description, Equals, diskCreateParamsDisk.Description)
 
 	// Attach disk
-	attachDiskTask, err := vm.AttachDisk(&types.DiskAttachOrDetachParams{
+	attachDiskTask, err := vm.AttachDisk(ctx, &types.DiskAttachOrDetachParams{
 		Disk: &types.Reference{
 			HREF: disk.Disk.HREF,
 		},
 	})
 	check.Assert(err, IsNil)
 
-	err = attachDiskTask.WaitTaskCompletion()
+	err = attachDiskTask.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	return disk, err
 }
 
-func detachIndependentDisk(vcd *TestVCD, check *C, disk *Disk) {
-	err := vcd.detachIndependentDisk(Disk{disk.Disk, &vcd.client.Client})
+func detachIndependentDisk(ctx context.Context, vcd *TestVCD, check *C, disk *Disk) {
+	err := vcd.detachIndependentDisk(ctx, Disk{disk.Disk, &vcd.client.Client})
 	check.Assert(err, IsNil)
 }
 
@@ -1187,9 +1201,10 @@ func (vcd *TestVCD) Test_VmGetParentvAppAndVdc(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vapp wasn't properly created")
 	}
+	ctx := context.Background()
 
 	fmt.Printf("Running: %s\n", check.TestName())
-	vapp := vcd.findFirstVapp()
+	vapp := vcd.findFirstVapp(ctx)
 	if vapp.VApp.Name == "" {
 		check.Skip("Disabled: No suitable vApp found in vDC")
 	}
@@ -1198,16 +1213,16 @@ func (vcd *TestVCD) Test_VmGetParentvAppAndVdc(check *C) {
 		check.Skip("Disabled: No suitable VM found in vDC")
 	}
 
-	newVM, err := vcd.client.Client.GetVMByHref(vm.HREF)
+	newVM, err := vcd.client.Client.GetVMByHref(ctx, vm.HREF)
 	check.Assert(err, IsNil)
 	check.Assert(newVM.VM.Name, Equals, vmName)
 	check.Assert(newVM.VM.VirtualHardwareSection.Item, NotNil)
 
-	parentvApp, err := newVM.GetParentVApp()
+	parentvApp, err := newVM.GetParentVApp(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(parentvApp.VApp.HREF, Equals, vapp.VApp.HREF)
 
-	parentVdc, err := newVM.GetParentVdc()
+	parentVdc, err := newVM.GetParentVdc(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(parentVdc.Vdc.Name, Equals, vcd.config.VCD.Vdc)
 }
@@ -1223,8 +1238,9 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 	if vcd.vapp.VApp == nil {
 		check.Skip("skipping test because no vApp is found")
 	}
+	ctx := context.Background()
 
-	vapp, err := createVappForTest(vcd, "Test_AddNewEmptyVMMultiNIC")
+	vapp, err := createVappForTest(ctx, vcd, "Test_AddNewEmptyVMMultiNIC")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
 
@@ -1247,9 +1263,9 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 	// Test with two different networks if we have them
 	if config.VCD.Network.Net2 != "" {
 		// Attach second vdc network to vApp
-		vdcNetwork2, err := vcd.vdc.GetOrgVdcNetworkByName(vcd.config.VCD.Network.Net2, false)
+		vdcNetwork2, err := vcd.vdc.GetOrgVdcNetworkByName(ctx, vcd.config.VCD.Network.Net2, false)
 		check.Assert(err, IsNil)
-		_, err = vapp.AddOrgNetwork(&VappNetworkSettings{}, vdcNetwork2.OrgVDCNetwork, false)
+		_, err = vapp.AddOrgNetwork(ctx, &VappNetworkSettings{}, vdcNetwork2.OrgVDCNetwork, false)
 		check.Assert(err, IsNil)
 
 		desiredNetConfig.NetworkConnection = append(desiredNetConfig.NetworkConnection,
@@ -1264,11 +1280,11 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 		fmt.Println("Skipping adding another vdc network as network2 was not specified")
 	}
 
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(cat, NotNil)
 
-	media, err := cat.GetMediaByName(vcd.config.Media.Media, false)
+	media, err := cat.GetMediaByName(ctx, vcd.config.Media.Media, false)
 	check.Assert(err, IsNil)
 	check.Assert(media, NotNil)
 
@@ -1277,7 +1293,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 	var customSP = false
 
 	if vcd.config.VCD.StorageProfile.SP1 != "" {
-		sp, _ = vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+		sp, _ = vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 	}
 
 	newDisk := types.DiskSettings{
@@ -1313,12 +1329,12 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 		AllEULAsAccepted: true,
 	}
 
-	createdVm, err := vapp.AddEmptyVm(requestDetails)
+	createdVm, err := vapp.AddEmptyVm(ctx, requestDetails)
 	check.Assert(err, IsNil)
 	check.Assert(createdVm, NotNil)
 
 	// Ensure network config was valid
-	actualNetConfig, err := createdVm.GetNetworkConnectionSection()
+	actualNetConfig, err := createdVm.GetNetworkConnectionSection(ctx)
 	check.Assert(err, IsNil)
 
 	if customSP {
@@ -1328,17 +1344,17 @@ func (vcd *TestVCD) Test_AddNewEmptyVMMultiNIC(check *C) {
 	verifyNetworkConnectionSection(check, actualNetConfig, desiredNetConfig)
 
 	// Cleanup
-	err = vapp.RemoveVM(*createdVm)
+	err = vapp.RemoveVM(ctx, *createdVm)
 	check.Assert(err, IsNil)
 
 	// Ensure network is detached from vApp to avoid conflicts in other tests
-	task, err = vapp.RemoveAllNetworks()
+	task, err = vapp.RemoveAllNetworks(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	task, err = vapp.Delete()
+	task, err = vapp.Delete(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
@@ -1351,16 +1367,17 @@ func (vcd *TestVCD) Test_UpdateVmSpecSection(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(ctx, check, vmName)
 	check.Assert(err, IsNil)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
+	vm, err := spawnVM(ctx, "FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
 	check.Assert(err, IsNil)
 
-	task, err := vm.PowerOff()
+	task, err := vm.PowerOff(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	vmSpecSection := vm.VM.VmSpecSection
@@ -1370,7 +1387,7 @@ func (vcd *TestVCD) Test_UpdateVmSpecSection(check *C) {
 	vmSpecSection.NumCoresPerSocket = takeIntAddress(2)
 	vmSpecSection.MemoryResourceMb = &types.MemoryResourceMb{Configured: 768}
 
-	updatedVm, err := vm.UpdateVmSpecSection(vmSpecSection, "updateDescription")
+	updatedVm, err := vm.UpdateVmSpecSection(ctx, vmSpecSection, "updateDescription")
 	check.Assert(err, IsNil)
 	check.Assert(updatedVm, NotNil)
 
@@ -1382,7 +1399,7 @@ func (vcd *TestVCD) Test_UpdateVmSpecSection(check *C) {
 	check.Assert(updatedVm.VM.Description, Equals, "updateDescription")
 
 	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
+	deleteVapp(ctx, vcd, vmName)
 }
 
 func (vcd *TestVCD) Test_QueryVmList(check *C) {
@@ -1391,9 +1408,10 @@ func (vcd *TestVCD) Test_QueryVmList(check *C) {
 		check.Skip("Test_QueryVmList needs an existing vApp to run")
 		return
 	}
+	ctx := context.Background()
 
 	// Get the setUp vApp using traditional methods
-	vapp, err := vcd.vdc.GetVAppByName(TestSetUpSuite, true)
+	vapp, err := vcd.vdc.GetVAppByName(ctx, TestSetUpSuite, true)
 	check.Assert(err, IsNil)
 	vmName := ""
 	for _, vm := range vapp.VApp.Children.VM {
@@ -1406,7 +1424,7 @@ func (vcd *TestVCD) Test_QueryVmList(check *C) {
 	}
 
 	for filter := range []types.VmQueryFilter{types.VmQueryFilterOnlyDeployed, types.VmQueryFilterAll} {
-		list, err := vcd.vdc.QueryVmList(types.VmQueryFilter(filter))
+		list, err := vcd.vdc.QueryVmList(ctx, types.VmQueryFilter(filter))
 		check.Assert(err, IsNil)
 		check.Assert(list, NotNil)
 		foundVm := false
@@ -1430,22 +1448,23 @@ func (vcd *TestVCD) Test_UpdateVmCpuAndMemoryHotAdd(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp wasn't properly created")
 	}
+	ctx := context.Background()
 
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
+	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(ctx, check, vmName)
 	check.Assert(err, IsNil)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
+	vm, err := spawnVM(ctx, "FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
 	check.Assert(err, IsNil)
 
-	task, err := vm.PowerOff()
+	task, err := vm.PowerOff(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 
 	check.Assert(vm.VM.VMCapabilities.MemoryHotAddEnabled, Equals, false)
 	check.Assert(vm.VM.VMCapabilities.CPUHotAddEnabled, Equals, false)
 
-	updatedVm, err := vm.UpdateVmCpuAndMemoryHotAdd(true, true)
+	updatedVm, err := vm.UpdateVmCpuAndMemoryHotAdd(ctx, true, true)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVm, NotNil)
 
@@ -1454,20 +1473,20 @@ func (vcd *TestVCD) Test_UpdateVmCpuAndMemoryHotAdd(check *C) {
 	check.Assert(updatedVm.VM.VMCapabilities.CPUHotAddEnabled, Equals, true)
 
 	// delete Vapp early to avoid env capacity issue
-	deleteVapp(vcd, vmName)
+	deleteVapp(ctx, vcd, vmName)
 }
 
 func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
-
-	if vcd.client.Client.APIVCDMaxVersionIs("< 33.0") {
+	ctx := context.Background()
+	if vcd.client.Client.APIVCDMaxVersionIs(ctx, "< 33.0") {
 		check.Skip(fmt.Sprintf("Test %s requires VCD 10.0 (API version 33) or higher", check.TestName()))
 	}
 
-	vapp, err := createVappForTest(vcd, "Test_AddNewEmptyVMWithVmComputePolicy")
+	vapp, err := createVappForTest(ctx, vcd, "Test_AddNewEmptyVMWithVmComputePolicy")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
 
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(cat, NotNil)
 
@@ -1489,19 +1508,19 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 	}
 
 	// Create and assign compute policy
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.vdc.Vdc.Name, false)
+	adminVdc, err := adminOrg.GetAdminVDCByName(ctx, vcd.vdc.Vdc.Name, false)
 	if adminVdc == nil || err != nil {
 		vcd.infoCleanup(notFoundMsg, "vdc", vcd.vdc.Vdc.Name)
 	}
 
-	createdPolicy, err := adminOrg.CreateVdcComputePolicy(newComputePolicy.VdcComputePolicy)
+	createdPolicy, err := adminOrg.CreateVdcComputePolicy(ctx, newComputePolicy.VdcComputePolicy)
 	check.Assert(err, IsNil)
 
-	createdPolicy2, err := adminOrg.CreateVdcComputePolicy(newComputePolicy2.VdcComputePolicy)
+	createdPolicy2, err := adminOrg.CreateVdcComputePolicy(ctx, newComputePolicy2.VdcComputePolicy)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(createdPolicy.VdcComputePolicy.ID, "vdcComputePolicy", vcd.org.Org.Name, "Test_AddNewEmptyVMWithVmComputePolicyAndUpdate")
@@ -1511,7 +1530,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 	check.Assert(err, IsNil)
 
 	// Get policy to existing ones (can be only default one)
-	allAssignedComputePolicies, err := adminVdc.GetAllAssignedVdcComputePolicies(nil)
+	allAssignedComputePolicies, err := adminVdc.GetAllAssignedVdcComputePolicies(ctx, nil)
 	check.Assert(err, IsNil)
 	var policyReferences []*types.Reference
 	for _, assignedPolicy := range allAssignedComputePolicies {
@@ -1520,7 +1539,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 	policyReferences = append(policyReferences, &types.Reference{HREF: vdcComputePolicyHref.String() + createdPolicy.VdcComputePolicy.ID})
 	policyReferences = append(policyReferences, &types.Reference{HREF: vdcComputePolicyHref.String() + createdPolicy2.VdcComputePolicy.ID})
 
-	assignedVdcComputePolicies, err := adminVdc.SetAssignedComputePolicies(types.VdcComputePolicyReferences{VdcComputePolicyReference: policyReferences})
+	assignedVdcComputePolicies, err := adminVdc.SetAssignedComputePolicies(ctx, types.VdcComputePolicyReferences{VdcComputePolicyReference: policyReferences})
 	check.Assert(err, IsNil)
 	check.Assert(len(allAssignedComputePolicies)+2, Equals, len(assignedVdcComputePolicies.VdcComputePolicyReference))
 	// end
@@ -1530,7 +1549,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 	var customSP = false
 
 	if vcd.config.VCD.StorageProfile.SP1 != "" {
-		sp, _ = vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+		sp, _ = vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 	}
 
 	newDisk := types.DiskSettings{
@@ -1566,7 +1585,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 		AllEULAsAccepted: true,
 	}
 
-	createdVm, err := vapp.AddEmptyVm(requestDetails)
+	createdVm, err := vapp.AddEmptyVm(ctx, requestDetails)
 	check.Assert(err, IsNil)
 	check.Assert(createdVm, NotNil)
 	check.Assert(createdVm.VM.ComputePolicy, NotNil)
@@ -1577,7 +1596,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 		check.Assert(createdVm.VM.StorageProfile.HREF, Equals, sp.HREF)
 	}
 
-	updatedVm, err := createdVm.UpdateComputePolicy(createdPolicy2.VdcComputePolicy)
+	updatedVm, err := createdVm.UpdateComputePolicy(ctx, createdPolicy2.VdcComputePolicy)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVm, NotNil)
 	check.Assert(updatedVm.VM.ComputePolicy, NotNil)
@@ -1587,17 +1606,17 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 	check.Assert(updatedVm.VM.VmSpecSection.MemoryResourceMb.Configured, Equals, int64(2048))
 
 	// Cleanup
-	err = vapp.RemoveVM(*createdVm)
+	err = vapp.RemoveVM(ctx, *createdVm)
 	check.Assert(err, IsNil)
 
 	// Ensure network is detached from vApp to avoid conflicts in other tests
-	task, err = vapp.RemoveAllNetworks()
+	task, err = vapp.RemoveAllNetworks(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	task, err = vapp.Delete()
+	task, err = vapp.Delete(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 
@@ -1607,7 +1626,7 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 		beforeTestPolicyReferences = append(beforeTestPolicyReferences, &types.Reference{HREF: vdcComputePolicyHref.String() + assignedPolicy.VdcComputePolicy.ID})
 	}
 
-	_, err = adminVdc.SetAssignedComputePolicies(types.VdcComputePolicyReferences{VdcComputePolicyReference: beforeTestPolicyReferences})
+	_, err = adminVdc.SetAssignedComputePolicies(ctx, types.VdcComputePolicyReferences{VdcComputePolicyReference: beforeTestPolicyReferences})
 	check.Assert(err, IsNil)
 }
 
@@ -1616,43 +1635,44 @@ func (vcd *TestVCD) Test_VMUpdateStorageProfile(check *C) {
 	if config.VCD.StorageProfile.SP1 == "" || config.VCD.StorageProfile.SP2 == "" {
 		check.Skip("Skipping test because both storage profiles have to be configured")
 	}
+	ctx := context.Background()
 
-	vapp, err := createVappForTest(vcd, "Test_VMUpdateStorageProfile")
+	vapp, err := createVappForTest(ctx, vcd, "Test_VMUpdateStorageProfile")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
 
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
+	cat, err := vcd.org.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(cat, NotNil)
 
 	var storageProfile types.Reference
 
-	storageProfile, _ = vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	storageProfile, _ = vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP1)
 
-	createdVm, err := makeEmptyVm(vapp, "Test_VMUpdateStorageProfile")
+	createdVm, err := makeEmptyVm(ctx, vapp, "Test_VMUpdateStorageProfile")
 	check.Assert(err, IsNil)
 	check.Assert(createdVm, NotNil)
 	check.Assert(createdVm.VM.StorageProfile.HREF, Equals, storageProfile.HREF)
 
-	storageProfile2, _ := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP2)
-	updatedVm, err := createdVm.UpdateStorageProfile(storageProfile2.HREF)
+	storageProfile2, _ := vcd.vdc.FindStorageProfileReference(ctx, vcd.config.VCD.StorageProfile.SP2)
+	updatedVm, err := createdVm.UpdateStorageProfile(ctx, storageProfile2.HREF)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVm, NotNil)
 	check.Assert(createdVm.VM.StorageProfile.HREF, Equals, storageProfile2.HREF)
 
 	// Cleanup
 	var task Task
-	err = vapp.RemoveVM(*createdVm)
+	err = vapp.RemoveVM(ctx, *createdVm)
 	check.Assert(err, IsNil)
 
 	// Ensure network is detached from vApp to avoid conflicts in other tests
-	task, err = vapp.RemoveAllNetworks()
+	task, err = vapp.RemoveAllNetworks(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
-	task, err = vapp.Delete()
+	task, err = vapp.Delete(ctx)
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	err = task.WaitTaskCompletion(ctx)
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 }
@@ -1681,11 +1701,12 @@ func (vcd *TestVCD) getNetworkConnection() *types.NetworkConnectionSection {
 }
 
 func (vcd *TestVCD) Test_CreateStandaloneVM(check *C) {
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	ctx := context.Background()
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	vdc, err := adminOrg.GetVDCByName(vcd.vdc.Vdc.Name, false)
+	vdc, err := adminOrg.GetVDCByName(ctx, vcd.vdc.Vdc.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 	description := "created by " + check.TestName()
@@ -1735,50 +1756,50 @@ func (vcd *TestVCD) Test_CreateStandaloneVM(check *C) {
 	}
 	vappList := vdc.GetVappList()
 	vappNum := len(vappList)
-	vm, err := vdc.CreateStandaloneVm(&params)
+	vm, err := vdc.CreateStandaloneVm(ctx, &params)
 	check.Assert(err, IsNil)
 	check.Assert(vm, NotNil)
 	AddToCleanupList(vm.VM.ID, "standaloneVm", "", check.TestName())
 	check.Assert(vm.VM.Description, Equals, description)
 
-	_ = vdc.Refresh()
+	_ = vdc.Refresh(ctx)
 	vappList = vdc.GetVappList()
 	check.Assert(len(vappList), Equals, vappNum+1)
 	for _, vapp := range vappList {
 		printVerbose("vapp: %s\n", vapp.Name)
 	}
-	err = vm.Delete()
+	err = vm.Delete(ctx)
 	check.Assert(err, IsNil)
-	_ = vdc.Refresh()
+	_ = vdc.Refresh(ctx)
 	vappList = vdc.GetVappList()
 	check.Assert(len(vappList), Equals, vappNum)
 }
 
 func (vcd *TestVCD) Test_CreateStandaloneVMFromTemplate(check *C) {
-
 	if vcd.config.VCD.Catalog.Name == "" {
 		check.Skip("no catalog was defined")
 	}
 	if vcd.config.VCD.Catalog.CatalogItem == "" {
 		check.Skip("no catalog item was defined")
 	}
-	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	ctx := context.Background()
+	adminOrg, err := vcd.client.GetAdminOrgByName(ctx, vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	vdc, err := adminOrg.GetVDCByName(vcd.vdc.Vdc.Name, false)
+	vdc, err := adminOrg.GetVDCByName(ctx, vcd.vdc.Vdc.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(vdc, NotNil)
 
-	catalog, err := adminOrg.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
+	catalog, err := adminOrg.GetCatalogByName(ctx, vcd.config.VCD.Catalog.Name, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	catalogItem, err := catalog.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
+	catalogItem, err := catalog.GetCatalogItemByName(ctx, vcd.config.VCD.Catalog.CatalogItem, false)
 	check.Assert(err, IsNil)
 	check.Assert(catalogItem, NotNil)
 
-	vappTemplate, err := catalog.GetVappTemplateByHref(catalogItem.CatalogItem.Entity.HREF)
+	vappTemplate, err := catalog.GetVappTemplateByHref(ctx, catalogItem.CatalogItem.Entity.HREF)
 	check.Assert(err, IsNil)
 	check.Assert(vappTemplate, NotNil)
 	check.Assert(vappTemplate.VAppTemplate.Children, NotNil)
@@ -1812,21 +1833,21 @@ func (vcd *TestVCD) Test_CreateStandaloneVMFromTemplate(check *C) {
 	vappList := vdc.GetVappList()
 	vappNum := len(vappList)
 	util.Logger.Printf("%# v", pretty.Formatter(params))
-	vm, err := vdc.CreateStandaloneVMFromTemplate(&params)
+	vm, err := vdc.CreateStandaloneVMFromTemplate(ctx, &params)
 	check.Assert(err, IsNil)
 	check.Assert(vm, NotNil)
 	AddToCleanupList(vm.VM.ID, "standaloneVm", "", check.TestName())
 
-	_ = vdc.Refresh()
+	_ = vdc.Refresh(ctx)
 	vappList = vdc.GetVappList()
 	check.Assert(len(vappList), Equals, vappNum+1)
 	for _, vapp := range vappList {
 		printVerbose("vapp: %s\n", vapp.Name)
 	}
 
-	err = vm.Delete()
+	err = vm.Delete(ctx)
 	check.Assert(err, IsNil)
-	_ = vdc.Refresh()
+	_ = vdc.Refresh(ctx)
 	vappList = vdc.GetVappList()
 	check.Assert(len(vappList), Equals, vappNum)
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -895,7 +895,7 @@ func (vcd *TestVCD) Test_VMSetProductSectionList(check *C) {
 	}
 	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
-	propertyTester(vcd, check, vm)
+	propertyTester(ctx, vcd, check, vm)
 }
 
 // Test_VMSetGetGuestCustomizationSection sets and when retrieves guest customization and checks if properties are right.
@@ -911,7 +911,7 @@ func (vcd *TestVCD) Test_VMSetGetGuestCustomizationSection(check *C) {
 	}
 	vm, err := vcd.client.Client.GetVMByHref(ctx, existingVm.HREF)
 	check.Assert(err, IsNil)
-	guestCustomizationPropertyTester(vcd, check, vm)
+	guestCustomizationPropertyTester(ctx, vcd, check, vm)
 }
 
 // Test create internal disk For VM

--- a/samples/saml_auth_adfs/main.go
+++ b/samples/saml_auth_adfs/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/url"
@@ -45,6 +46,8 @@ func main() {
 		os.Exit(2)
 	}
 
+	ctx := context.Background()
+
 	// Create VCD client allowing insecure TLS connection and using SAML auth.
 	// WithSamlAdfs() allows SAML authentication when vCD uses Microsoft Active Directory
 	// Federation Services (ADFS) as SAML IdP. The code below allows to authenticate ADFS using
@@ -56,7 +59,7 @@ func main() {
 	// customAdfsRptId - override relaying party trust ID. If it is empty - vCD Entity ID will be used
 	// as Relaying Party Trust ID.
 	vcdCli := govcd.NewVCDClient(*vcdURL, true, govcd.WithSamlAdfs(true, customAdfsRptId))
-	err = vcdCli.Authenticate(username, password, org)
+	err = vcdCli.Authenticate(ctx, username, password, org)
 	if err != nil {
 
 		fmt.Println(err)
@@ -64,7 +67,7 @@ func main() {
 	}
 
 	// To prove authentication worked - just fetch all edge gateways and dump them on the screen
-	edgeGatewayResults, err := vcdCli.Query(map[string]string{"type": "edgeGateway"})
+	edgeGatewayResults, err := vcdCli.Query(ctx, map[string]string{"type": "edgeGateway"})
 	if err != nil {
 		fmt.Printf("Error retrieving Edge Gateways: %s\n", err)
 		os.Exit(4)


### PR DESCRIPTION
## Description

Related issue: #362 

I switched out the two `http.NewRequest` calls with `http.NewRequestWithContext` and then just started passing `context.Context` down through all the functions.

This will allow users to set timeouts on the http operations or cancel them manually such as ctrl-c on a command line or graceful server shutdown.