### PR TITLE
Empty requests should not contain xml.Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Added method `vdc.QueryEdgeGateway` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
 * Deprecated `vdc.GetEdgeGatewayRecordsType` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
 
+IMPROVEMENTS:
+* Only send xml.Header when payload is not empty (some WAFs block empty requests with XML header) 
+  [#367](https://github.com/vmware/go-vcloud-director/pull/367)
+
 ## 2.11.0 (March 10, 2021)
 
 * Added structure and methods to handle Org VDC networks using OpenAPI - `OpenApiOrgVdcNetwork`. It supports VCD 9.7+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-## 2.11.0 (Unreleased)
+## 2.11.0 (March 10, 2021)
 
 * Added structure and methods to handle Org VDC networks using OpenAPI - `OpenApiOrgVdcNetwork`. It supports VCD 9.7+
 for all networks types for NSX-V and NSX-T backed VDCs [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `NsxtImportableSwitch` structure with `GetNsxtImportableSwitchByName` and `GetAllNsxtImportableSwitches` to 
 lookup NSX-T segments for use in NSX-T Imported networks [#354](https://github.com/vmware/go-vcloud-director/pull/354)
 * Added `vdc.IsNsxt` and `vdc.IsNsxv` methods to verify if VDC is backed by NSX-T or NSX-V [#354](https://github.com/vmware/go-vcloud-director/pull/354)
-* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`
-* Added Vdc methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
+* Added types `types.CreateVmParams` and `types.InstantiateVmTemplateParams`  [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `CreateStandaloneVMFromTemplate`, `CreateStandaloneVMFromTemplateAsync` `CreateStandaloneVm`, 
 `CreateStandaloneVmAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
+* Added VDC methods `QueryVmByName`, `QueryVmById`, `QueryVmList` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 * Added VM methods `Delete`, `DeleteAsync` [#356](https://github.com/vmware/go-vcloud-director/pull/356)
-* Added Vdc methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
+* Added VDC methods `GetOpenApiOrgVdcNetworkDhcp`, `UpdateOpenApiOrgVdcNetworkDhcp` and `DeleteOpenApiOrgVdcNetworkDhcp`
 for OpenAPI management of Org Network DHCP configurations [#357](https://github.com/vmware/go-vcloud-director/pull/357)
 
 BREAKING CHANGES:
@@ -18,10 +18,10 @@ BREAKING CHANGES:
 [#356](https://github.com/vmware/go-vcloud-director/pull/356)
 
 BUGS FIXED:
-* Made IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
+* Converted IPAddress field for IPAddresses struct to array [#350](https://github.com/vmware/go-vcloud-director/pull/350)
 
 IMPROVEMENTS:
-* Introduce generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
+* Added generic OpenAPI entity cleanup for tests [348](https://github.com/vmware/go-vcloud-director/pull/348)
 
 ## 2.10.0 (December 18, 2020)
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -601,8 +601,11 @@ func executeRequestCustomErr(pathURL string, params map[string]string, requestTy
 	url, _ := url.ParseRequestURI(pathURL)
 
 	var req *http.Request
-	switch requestType {
-	case http.MethodPost, http.MethodPut:
+	switch {
+	// Only send data (and xml.Header) if method is POST or PUT and the payload is actually provided to avoid sending
+	// empty body with XML header (some Web Application Firewalls block requests when empty XML header is set but not body
+  // provided)
+	case (requestType == http.MethodPost || requestType == http.MethodPut) && payload != nil:
 
 		marshaledXml, err := xml.MarshalIndent(payload, "  ", "    ")
 		if err != nil {

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -604,7 +604,7 @@ func executeRequestCustomErr(pathURL string, params map[string]string, requestTy
 	switch {
 	// Only send data (and xml.Header) if method is POST or PUT and the payload is actually provided to avoid sending
 	// empty body with XML header (some Web Application Firewalls block requests when empty XML header is set but not body
-  // provided)
+	// provided)
 	case (requestType == http.MethodPost || requestType == http.MethodPut) && payload != nil:
 
 		marshaledXml, err := xml.MarshalIndent(payload, "  ", "    ")

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -602,11 +602,9 @@ func executeRequestCustomErr(pathURL string, params map[string]string, requestTy
 
 	var req *http.Request
 	switch {
-	// Only send data (and xml.Header) if method is POST or PUT and the payload is actually provided to avoid sending
-	// empty body with XML header (some Web Application Firewalls block requests when empty XML header is set but not body
-	// provided)
-	case (requestType == http.MethodPost || requestType == http.MethodPut) && payload != nil:
-
+	// Only send data (and xml.Header) if the payload is actually provided to avoid sending empty body with XML header
+	//(some Web Application Firewalls block requests when empty XML header is set but not body provided)
+	case payload != nil:
 		marshaledXml, err := xml.MarshalIndent(payload, "  ", "    ")
 		if err != nil {
 			return &http.Response{}, fmt.Errorf("error marshalling xml data %s", err)


### PR DESCRIPTION
Closes #https://github.com/vmware/terraform-provider-vcd/issues/661 

Some WAF configurations block requests when the body is empty, but contains `xml.Header`. This PR adds improvement to only sends `xml.Header` when payload is not empty.

This had no impact on test runs.