### PR TITLE
Fix vapp description and add vapp.Rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added method `vdc.QueryEdgeGateway` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
 * Deprecated `vdc.GetEdgeGatewayRecordsType` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
+* Added parameter `description` to method `vdc.ComposeRawVapp`
+* Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription`
 
 ## 2.11.0 (March 10, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Added method `vdc.QueryEdgeGateway` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
 * Deprecated `vdc.GetEdgeGatewayRecordsType` [#364](https://github.com/vmware/go-vcloud-director/pull/364)
-* Added parameter `description` to method `vdc.ComposeRawVapp`
-* Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription`
+* Added parameter `description` to method `vdc.ComposeRawVapp` [#372](https://github.com/vmware/go-vcloud-director/pull/372)
+* Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription` [#372](https://github.com/vmware/go-vcloud-director/pull/372)
 
 ## 2.11.0 (March 10, 2021)
 

--- a/govcd/access_control_vapp_test.go
+++ b/govcd/access_control_vapp_test.go
@@ -54,7 +54,7 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 	}
 
 	// Create a new vApp
-	vapp, err := makeEmptyVapp(vdc, vappName)
+	vapp, err := makeEmptyVapp(vdc, vappName, "")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
 	AddToCleanupList(vappName, "vapp", vcd.config.VCD.Org+"|"+vcd.config.VCD.Vdc, "Test_VappAccessControl")

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -197,7 +197,7 @@ func createLdapServer(vcd *TestVCD, check *C, directNetworkName string) (string,
 	vappTemplate, err := catalogItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
 	// Compose Raw vApp
-	err = vdc.ComposeRawVApp(vAppName)
+	err = vdc.ComposeRawVApp(vAppName, "")
 	check.Assert(err, IsNil)
 	vapp, err := vdc.GetVAppByName(vAppName, true)
 	check.Assert(err, IsNil)

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -1,7 +1,7 @@
 // +build api functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user nsxv affinity ALL
 
 /*
- * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -672,7 +672,7 @@ func deleteVapp(vcd *TestVCD, name string) error {
 // makeEmptyVapp creates a given vApp without any VM
 func makeEmptyVapp(vdc *Vdc, name string) (*VApp, error) {
 
-	err := vdc.ComposeRawVApp(name, "")
+	err := vdc.ComposeRawVApp(name, name)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -670,9 +670,9 @@ func deleteVapp(vcd *TestVCD, name string) error {
 }
 
 // makeEmptyVapp creates a given vApp without any VM
-func makeEmptyVapp(vdc *Vdc, name string) (*VApp, error) {
+func makeEmptyVapp(vdc *Vdc, name string, description string) (*VApp, error) {
 
-	err := vdc.ComposeRawVApp(name, "description of "+name)
+	err := vdc.ComposeRawVApp(name, description)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -672,7 +672,7 @@ func deleteVapp(vcd *TestVCD, name string) error {
 // makeEmptyVapp creates a given vApp without any VM
 func makeEmptyVapp(vdc *Vdc, name string) (*VApp, error) {
 
-	err := vdc.ComposeRawVApp(name, name)
+	err := vdc.ComposeRawVApp(name, "description of "+name)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -55,7 +55,7 @@ func (vcd *TestVCD) createAndGetResourcesForVmCreation(check *C, vmName string) 
 	vappTemplate, err := catalogItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
 	// Compose Raw vApp
-	err = vdc.ComposeRawVApp(vmName)
+	err = vdc.ComposeRawVApp(vmName, "")
 	check.Assert(err, IsNil)
 	vapp, err := vdc.GetVAppByName(vmName, true)
 	check.Assert(err, IsNil)
@@ -672,7 +672,7 @@ func deleteVapp(vcd *TestVCD, name string) error {
 // makeEmptyVapp creates a given vApp without any VM
 func makeEmptyVapp(vdc *Vdc, name string) (*VApp, error) {
 
-	err := vdc.ComposeRawVApp(name)
+	err := vdc.ComposeRawVApp(name, "")
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1378,14 +1378,14 @@ func (vapp *VApp) getOrgInfo() (orgInfoType, error) {
 }
 
 // UpdateNameDescription can change the name and the description of a vApp
-// If name or description are empty, they are not changed.
+// If name is empty, it is left unchanged.
 func (vapp *VApp) UpdateNameDescription(newName, newDescription string) error {
 	if vapp == nil || vapp.VApp.HREF == "" {
 		return fmt.Errorf("vapp or href cannot be empty")
 	}
 
 	// Skip update if we are using the original values
-	if (newName == vapp.VApp.Name || newName == "") && (newDescription == vapp.VApp.Description || newDescription == "") {
+	if (newName == vapp.VApp.Name || newName == "") && (newDescription == vapp.VApp.Description) {
 		return nil
 	}
 
@@ -1406,11 +1406,8 @@ func (vapp *VApp) UpdateNameDescription(newName, newDescription string) error {
 	if newName == "" {
 		newName = vapp.VApp.Name
 	}
-	if newDescription == "" {
-		newDescription = vapp.VApp.Description
-	}
 
-	recomposeParams := &types.ReComposeVAppParams{
+	recomposeParams := &types.SmallRecomposeVappParams{
 		XMLName:     xml.Name{},
 		Ovf:         types.XMLNamespaceOVF,
 		Xsi:         types.XMLNamespaceXSI,
@@ -1418,7 +1415,6 @@ func (vapp *VApp) UpdateNameDescription(newName, newDescription string) error {
 		Name:        newName,
 		Description: newDescription,
 		Deploy:      vapp.VApp.Deployed,
-		VAppParent:  vapp.VApp.VAppParent,
 	}
 
 	task, err := vapp.client.ExecuteTaskRequest(href, http.MethodPost,
@@ -1442,5 +1438,5 @@ func (vapp *VApp) UpdateDescription(newDescription string) error {
 
 // Rename changes the name of a vApp
 func (vapp *VApp) Rename(newName string) error {
-	return vapp.UpdateNameDescription(newName, "")
+	return vapp.UpdateNameDescription(newName, vapp.VApp.Description)
 }

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1381,7 +1381,7 @@ func (vapp *VApp) getOrgInfo() (orgInfoType, error) {
 // If name is empty, it is left unchanged.
 func (vapp *VApp) UpdateNameDescription(newName, newDescription string) error {
 	if vapp == nil || vapp.VApp.HREF == "" {
-		return fmt.Errorf("vapp or href cannot be empty")
+		return fmt.Errorf("vApp or href cannot be empty")
 	}
 
 	// Skip update if we are using the original values
@@ -1389,7 +1389,7 @@ func (vapp *VApp) UpdateNameDescription(newName, newDescription string) error {
 		return nil
 	}
 
-	opType := "application/vnd.vmware.vcloud.recomposeVAppParams+xml"
+	opType := types.MimeRecomposeVappParams
 
 	href := ""
 	for _, link := range vapp.VApp.Link {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,7 +1,7 @@
 // +build vapp functional ALL
 
 /*
- * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -9,6 +9,7 @@ package govcd
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -1555,5 +1556,103 @@ func (vcd *TestVCD) Test_AddNewVMWithComputeCapacity(check *C) {
 	}
 
 	_, err = adminVdc.SetAssignedComputePolicies(types.VdcComputePolicyReferences{VdcComputePolicyReference: beforeTestPolicyReferences})
+	check.Assert(err, IsNil)
+}
+
+func (vcd *TestVCD) testUpdateVapp(check *C, vapp *VApp, name, description string, vms []string) {
+
+	var err error
+
+	// Make sure that at least one value was set
+	bothEmpty := description == "" && name == ""
+	check.Assert(bothEmpty, Equals, false)
+
+	if name == "" && description != "" {
+		printVerbose("testing vapp.UpdateDescription(%s)\n", description)
+		err = vapp.UpdateDescription(description)
+		check.Assert(err, IsNil)
+	}
+	if description == "" && name != "" {
+		printVerbose("testing vapp.Rename(%s)\n", name)
+		err = vapp.Rename(name)
+		check.Assert(err, IsNil)
+	}
+	if description != "" && name != "" {
+		printVerbose("testing vapp.UpdateNameDescription(%s, %s)\n", name, description)
+		err = vapp.UpdateNameDescription(name, description)
+		check.Assert(err, IsNil)
+	}
+
+	if name == "" {
+		name = vapp.VApp.Name
+	}
+	if description == "" {
+		description = vapp.VApp.Description
+	}
+
+	// Get a fresh copy of the vApp
+	vapp, err = vcd.vdc.GetVAppByName(name, true)
+	check.Assert(err, IsNil)
+
+	check.Assert(vapp.VApp.Name, Equals, name)
+	check.Assert(vapp.VApp.Description, Equals, description)
+	// check that the VMs still exist after vApp update
+	for _, vm := range vms {
+		printVerbose("checking VM %s\n", vm)
+		_, err = vapp.GetVMByName(vm, true)
+		check.Assert(err, IsNil)
+	}
+}
+
+func (vcd *TestVCD) Test_UpdateVappNameDescription(check *C) {
+
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vappName := check.TestName()
+	vappDescription := vappName
+	newVappName := vappName + "_new"
+
+	newVappDescription := vappName + " desc"
+	// Compose VApp (the description, by default, is the vapp name)
+	vapp, err := makeEmptyVapp(vcd.vdc, vappName)
+	check.Assert(err, IsNil)
+	AddToCleanupList(vappName, "vapp", "", "Test_RenameVapp")
+
+	check.Assert(vapp.VApp.Name, Equals, vappName)
+	check.Assert(vapp.VApp.Description, Equals, vappName)
+
+	// Need a slight delay for the vApp to get the links that are needed for renaming
+	time.Sleep(time.Second)
+
+	// change description
+	vcd.testUpdateVapp(check, vapp, "", newVappDescription, nil)
+	// restore original
+	vcd.testUpdateVapp(check, vapp, vappName, vappDescription, nil)
+
+	// change name
+	vcd.testUpdateVapp(check, vapp, newVappName, "", nil)
+	AddToCleanupList(newVappName, "vapp", "", "Test_RenameVapp")
+	// restore original
+	vcd.testUpdateVapp(check, vapp, vappName, vappDescription, nil)
+
+	// Add two VMs
+	_, err = makeEmptyVm(vapp, "vm1")
+	check.Assert(err, IsNil)
+	_, err = makeEmptyVm(vapp, "vm2")
+	check.Assert(err, IsNil)
+
+	vms := []string{"vm1", "vm2"}
+	// change description after adding VMs
+	vcd.testUpdateVapp(check, vapp, "", newVappDescription, vms)
+	// restore original
+	vcd.testUpdateVapp(check, vapp, vappName, vappDescription, vms)
+
+	// change name after adding VMs
+	vcd.testUpdateVapp(check, vapp, newVappName, "", vms)
+	// restore original
+	vcd.testUpdateVapp(check, vapp, vappName, vappDescription, vms)
+
+	// Remove VM
+	err = deleteVapp(vcd, vappName)
 	check.Assert(err, IsNil)
 }

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1652,7 +1652,7 @@ func (vcd *TestVCD) Test_UpdateVappNameDescription(check *C) {
 	// restore original
 	vcd.testUpdateVapp(check, vapp, vappName, vappDescription, vms)
 
-	// Remove VM
+	// Remove vApp
 	err = deleteVapp(vcd, vappName)
 	check.Assert(err, IsNil)
 }

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1602,17 +1602,17 @@ func (vcd *TestVCD) Test_UpdateVappNameDescription(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	vappName := check.TestName()
-	vappDescription := vappName
+	vappDescription := vappName + " description"
 	newVappName := vappName + "_new"
 
 	newVappDescription := vappName + " desc"
-	// Compose VApp (the description, by default, is the vapp name)
-	vapp, err := makeEmptyVapp(vcd.vdc, vappName)
+	// Compose VApp
+	vapp, err := makeEmptyVapp(vcd.vdc, vappName, vappDescription)
 	check.Assert(err, IsNil)
 	AddToCleanupList(vappName, "vapp", "", "Test_RenameVapp")
 
 	check.Assert(vapp.VApp.Name, Equals, vappName)
-	check.Assert(vapp.VApp.Description, Equals, vappName)
+	check.Assert(vapp.VApp.Description, Equals, vappDescription)
 
 	// Need a slight delay for the vApp to get the links that are needed for renaming
 	time.Sleep(time.Second)

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -464,14 +464,15 @@ func (vdc *Vdc) GetEdgeGatewayByNameOrId(identifier string, refresh bool) (*Edge
 	return entity.(*EdgeGateway), err
 }
 
-func (vdc *Vdc) ComposeRawVApp(name string) error {
+func (vdc *Vdc) ComposeRawVApp(name string, description string) error {
 	vcomp := &types.ComposeVAppParams{
-		Ovf:     types.XMLNamespaceOVF,
-		Xsi:     types.XMLNamespaceXSI,
-		Xmlns:   types.XMLNamespaceVCloud,
-		Deploy:  false,
-		Name:    name,
-		PowerOn: false,
+		Ovf:         types.XMLNamespaceOVF,
+		Xsi:         types.XMLNamespaceXSI,
+		Xmlns:       types.XMLNamespaceVCloud,
+		Deploy:      false,
+		Name:        name,
+		PowerOn:     false,
+		Description: description,
 	}
 
 	vdcHref, err := url.ParseRequestURI(vdc.Vdc.HREF)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -217,6 +217,22 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 
 }
 
+func (vcd *TestVCD) Test_ComposeRawVApp(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vappName := check.TestName()
+	vappDescription := vappName + " desc"
+	// Compose VApp
+	err := vcd.vdc.ComposeRawVApp(vappName, vappDescription)
+	check.Assert(err, IsNil)
+	// Get VApp
+	vapp, err := vcd.vdc.GetVAppByName(vappName, true)
+	check.Assert(err, IsNil)
+	AddToCleanupList(vappName, "vapp", "", "Test_ComposeRawVApp")
+	check.Assert(vapp.VApp.Name, Equals, vappName)
+	check.Assert(vapp.VApp.Description, Equals, vappDescription)
+}
+
 func (vcd *TestVCD) Test_FindVApp(check *C) {
 
 	if vcd.skipVappTests {

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,13 +1,14 @@
 // +build vdc functional ALL
 
 /*
- * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -225,12 +226,26 @@ func (vcd *TestVCD) Test_ComposeRawVApp(check *C) {
 	// Compose VApp
 	err := vcd.vdc.ComposeRawVApp(vappName, vappDescription)
 	check.Assert(err, IsNil)
+
+	// Need a slight delay for the vApp to get the links that are needed for renaming
+	time.Sleep(time.Second)
 	// Get VApp
 	vapp, err := vcd.vdc.GetVAppByName(vappName, true)
 	check.Assert(err, IsNil)
 	AddToCleanupList(vappName, "vapp", "", "Test_ComposeRawVApp")
 	check.Assert(vapp.VApp.Name, Equals, vappName)
 	check.Assert(vapp.VApp.Description, Equals, vappDescription)
+	newVappName := vappName + "_new"
+	newVappDescription := vappDescription + " description"
+
+	err = vapp.UpdateNameDescription(newVappName, newVappDescription)
+	check.Assert(err, IsNil)
+	AddToCleanupList(newVappName, "vapp", "", "Test_ComposeRawVApp")
+	check.Assert(vapp.VApp.Name, Equals, newVappName)
+	check.Assert(vapp.VApp.Description, Equals, newVappDescription)
+
+	err = deleteVapp(vcd, newVappName)
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_FindVApp(check *C) {

--- a/govcd/vm_affinity_rule_test.go
+++ b/govcd/vm_affinity_rule_test.go
@@ -306,7 +306,7 @@ func makeVappGroup(label string, vdc *Vdc, groupDefinition map[string][]string) 
 		if testVerbose {
 			fmt.Printf("Creating vApp %s\n", vappName)
 		}
-		vapp, err := makeEmptyVapp(vdc, vappName)
+		vapp, err := makeEmptyVapp(vdc, vappName, "")
 		if err != nil {
 			return nil, err
 		}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1186,6 +1186,18 @@ type ReComposeVAppParams struct {
 	DeleteItem          *DeleteItem                  `xml:"DeleteItem,omitempty"`
 }
 
+// SmallRecomposeVappParams is used to update name and description of a vApp
+// Using the full definition (ReComposeVAppParams), the description can be changed but not removed
+type SmallRecomposeVappParams struct {
+	XMLName     xml.Name `xml:"RecomposeVAppParams"`
+	Ovf         string   `xml:"xmlns:ovf,attr"`
+	Xsi         string   `xml:"xmlns:xsi,attr"`
+	Xmlns       string   `xml:"xmlns,attr"`
+	Name        string   `xml:"name,attr"`
+	Deploy      bool     `xml:"deploy,attr"`
+	Description string   `xml:"Description"`
+}
+
 type DeleteItem struct {
 	HREF string `xml:"href,attr,omitempty"`
 }


### PR DESCRIPTION
* Added parameter `description` to method `vdc.ComposeRawVapp` (This method is used in `terraform-provider-vcd` to create a vApp.)
* Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription`. This make it possible to update the vApp's name and description in Terraform.

