### PR TITLE
Do not send  'org' filter when used with Org users (fixes `queryCatalogByX` and `queryVDCByX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 * Dropped support for VCD 9.7 which is EOL now [#371](https://github.com/vmware/go-vcloud-director/pull/371)
 * Bumped Default API Version to V33.0  [#371](https://github.com/vmware/go-vcloud-director/pull/371)
 * Methods `GetVDCById` and `GetVDCByName` for `Org` now use queries behind the scenes because Org 
-  structure does not list child VDCs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371)
+  structure does not list child VDCs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371), 
+  [#376](https://github.com/vmware/go-vcloud-director/pull/376)
 * Methods `GetCatalogById` and `GetCatalogByName` for `Org`  now use queries behind the scenes because Org
-  structure does not list child Catalogs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371)
+  structure does not list child Catalogs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371), 
+  [#376](https://github.com/vmware/go-vcloud-director/pull/376)
 * Drop legacy authentication mechanism (vcdAuthorize) and use only new Cloud API provided (vcdCloudApiAuthorize) as
   API V33.0 is sufficient for it [#371](https://github.com/vmware/go-vcloud-director/pull/371)
 * Added NSX-T Firewall Group type (which represents a Security Group or an IP Set) support by using

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -472,11 +472,15 @@ func queryOrgVdcList(client *Client, filterFields map[string]string) ([]*types.Q
 		filterSlice := make([]string, 0)
 
 		for filterFieldName, filterFieldValue := range filterFields {
+			// Do not inject 'org' filter for System user as API returns an error
+			if !client.IsSysAdmin && filterFieldName == "org" {
+				continue
+			}
+
 			if filterFieldName != "" && filterFieldValue != "" {
 				filterText := fmt.Sprintf("%s==%s", filterFieldName, url.QueryEscape(filterFieldValue))
 				filterSlice = append(filterSlice, filterText)
 			}
-
 		}
 
 		if len(filterSlice) > 0 {
@@ -510,11 +514,15 @@ func queryCatalogList(client *Client, filterFields map[string]string) ([]*types.
 		filterSlice := make([]string, 0)
 
 		for filterFieldName, filterFieldValue := range filterFields {
+			// Do not inject 'org' filter for System user as API returns an error
+			if !client.IsSysAdmin && filterFieldName == "org" {
+				continue
+			}
+
 			if filterFieldName != "" && filterFieldValue != "" {
 				filterText := fmt.Sprintf("%s==%s", filterFieldName, url.QueryEscape(filterFieldValue))
 				filterSlice = append(filterSlice, filterText)
 			}
-
 		}
 
 		if len(filterSlice) > 0 {


### PR DESCRIPTION
After API V33.0 bump (#371) `GetCatalogById`, `GetCatalogByName`, `GetVDCById`, `GetVDCByName` started using queries behind the scenes. Apparently query filters do not accept `org` filter when being used by Org user. (it does work and is useful with System user).

This PR adjusts filtering to avoid sending `org` filter when used by Org user.