### PR TITLE
Add NSX-T Firewall support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@
   `Client.GetAllRoles`, `Role.AddRights`, `Role.GetRights`, `Role.RemoveAllRights`, `Role.RemoveRights`, `Role.UpdateRights`
   [#380](https://github.com/vmware/go-vcloud-director/pull/380)
 * Added convenience function `FindMissingImpliedRights` [#380](https://github.com/vmware/go-vcloud-director/pull/380)
-* Added methods `NsxtEdgeGateway.UpdateNsxtFirewall()`, `NsxtEdgeGateway.GetNsxtFirewall()`, `nsxtFirewall.DeleteAll()`,
-  `nsxtFirewall.DeleteById` [#381](https://github.com/vmware/go-vcloud-director/pull/381)
+* Added methods `NsxtEdgeGateway.UpdateNsxtFirewall()`, `NsxtEdgeGateway.GetNsxtFirewall()`, `nsxtFirewall.DeleteAllRules()`,
+  `nsxtFirewall.DeleteRuleById` [#381](https://github.com/vmware/go-vcloud-director/pull/381)
 
   
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
 * Added methods Org.QueryVmList and Org.QueryVmById to find VM by ID in an Org
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
-  
+* Added methods `NsxtEdgeGateway.UpdateNsxtFirewall()`, `NsxtEdgeGateway.GetNsxtFirewall()`, `nsxtFirewall.DeleteAll()`,
+  `nsxtFirewall.DeleteById` [#381](https://github.com/vmware/go-vcloud-director/pull/381)
+
 BREAKING CHANGES:
 * Added parameter `description` to method `vdc.ComposeRawVapp` [#372](https://github.com/vmware/go-vcloud-director/pull/372)
 * Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription` [#372](https://github.com/vmware/go-vcloud-director/pull/372)
@@ -41,6 +43,9 @@ IMPROVEMENTS:
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
 * Improved test entity cleanup to allow specifying parent VDC for vApp removals
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
+* Cleanup a few unnecessary type conversions detected by new staticcheck version 
+  [#381](https://github.com/vmware/go-vcloud-director/pull/381)
+
 
 ## 2.11.0 (March 10, 2021)
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -282,7 +282,7 @@ func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) e
 		}
 	}
 
-	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, fmt.Sprintf("%s", body))
+	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(body))
 	if err != nil {
 		return err
 	}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -857,3 +857,13 @@ func extractIdsFromOpenApiReferences(refs []types.OpenApiReference) []string {
 
 	return resultStrings
 }
+
+// contains checks if a slice contains element
+func contains(s []string, element string) bool {
+	for _, a := range s {
+		if a == element {
+			return true
+		}
+	}
+	return false
+}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -847,3 +847,13 @@ func convertSliceOfStringsToOpenApiReferenceIds(ids []string) []types.OpenApiRef
 
 	return resultReferences
 }
+
+// extractIdsFromOpenApiReferences extracts []string with IDs from []types.OpenApiReference which contains ID and Names
+func extractIdsFromOpenApiReferences(refs []types.OpenApiReference) []string {
+	resultStrings := make([]string, len(refs))
+	for index := range refs {
+		resultStrings[index] = refs[index].ID
+	}
+
+	return resultStrings
+}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -1,4 +1,4 @@
-// +build api functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user nsxv affinity search ALL
+// +build api functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user nsxv nsxt openapi affinity search ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
@@ -835,4 +835,15 @@ func getVdcNetworkPoolHref(vcd *TestVCD, check *C) string {
 	networkPoolHref := results.Results.NetworkPoolRecord[0].HREF
 
 	return networkPoolHref
+}
+
+// convertSliceOfStringsToOpenApiReferenceIds converts []string to []types.OpenApiReference by filling
+// types.OpenApiReference.ID fields
+func convertSliceOfStringsToOpenApiReferenceIds(ids []string) []types.OpenApiReference {
+	resultReferences := make([]types.OpenApiReference, len(ids))
+	for i, v := range ids {
+		resultReferences[i].ID = v
+	}
+
+	return resultReferences
 }

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -142,7 +142,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 		check.Skip(fmt.Sprintf("testFinderGetGenericEntity: %s %s not found.", def.entityType, def.entityName))
 		return
 	}
-	entity1 := ge.(genericEntity)
+	entity1 := ge
 
 	wantedType := fmt.Sprintf("*govcd.%s", def.entityType)
 	if testVerbose {
@@ -162,7 +162,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getById(entityId, false)
 	check.Assert(err, IsNil)
 	check.Assert(ge, NotNil)
-	entity2 := ge.(genericEntity)
+	entity2 := ge
 	check.Assert(entity2, NotNil)
 	check.Assert(entity2.name(), Equals, entityName)
 	check.Assert(entity2.id(), Equals, entityId)
@@ -175,7 +175,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getByNameOrId(entityId, false)
 	check.Assert(err, IsNil)
 	check.Assert(ge, NotNil)
-	entity3 := ge.(genericEntity)
+	entity3 := ge
 	check.Assert(entity3, NotNil)
 	check.Assert(entity3.name(), Equals, entityName)
 	check.Assert(entity3.id(), Equals, entityId)
@@ -189,7 +189,7 @@ func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *
 	ge, err = def.getByNameOrId(entityName, false)
 	check.Assert(err, IsNil)
 	check.Assert(ge, NotNil)
-	entity4 := ge.(genericEntity)
+	entity4 := ge
 	check.Assert(entity4, NotNil)
 	check.Assert(entity4.name(), Equals, entityName)
 	check.Assert(entity4.id(), Equals, entityId)

--- a/govcd/filter_engine.go
+++ b/govcd/filter_engine.go
@@ -250,7 +250,7 @@ func searchByFilter(queryByMetadata queryByMetadataFunc, queryWithMetadataFields
 			util.Logger.Printf("[SearchByFilter] result %v: ", greater)
 			if greater {
 				latestDate = candidate.GetDate()
-				candidateByLatest = candidate.(QueryItem)
+				candidateByLatest = candidate
 			}
 		}
 		if candidateByLatest != nil {
@@ -281,7 +281,7 @@ func searchByFilter(queryByMetadata queryByMetadataFunc, queryWithMetadataFields
 			util.Logger.Printf("[SearchByFilter] result %v: ", greater)
 			if greater {
 				earliestDate = candidate.GetDate()
-				candidateByEarliest = candidate.(QueryItem)
+				candidateByEarliest = candidate
 			}
 		}
 		if candidateByEarliest != nil {

--- a/govcd/nsxt_firewall.go
+++ b/govcd/nsxt_firewall.go
@@ -82,8 +82,8 @@ func (egw *NsxtEdgeGateway) GetNsxtFirewall() (*NsxtFirewall, error) {
 	return returnObject, nil
 }
 
-// DeleteAll allows users to delete all NSX-T Firewall rules in a particular Edge Gateway
-func (firewall *NsxtFirewall) DeleteAll() error {
+// DeleteAllRules allows users to delete all NSX-T Firewall rules in a particular Edge Gateway
+func (firewall *NsxtFirewall) DeleteAllRules() error {
 
 	if firewall.edgeGatewayId == "" {
 		return fmt.Errorf("missing Edge Gateway ID")
@@ -109,8 +109,8 @@ func (firewall *NsxtFirewall) DeleteAll() error {
 	return nil
 }
 
-// DeleteById allows users to delete NSX-T Firewall Rule By ID
-func (firewall *NsxtFirewall) DeleteById(id string) error {
+// DeleteRuleById allows users to delete NSX-T Firewall Rule By ID
+func (firewall *NsxtFirewall) DeleteRuleById(id string) error {
 	if id == "" {
 		return fmt.Errorf("empty ID specified")
 	}

--- a/govcd/nsxt_firewall.go
+++ b/govcd/nsxt_firewall.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// NsxtFirewall contains a types.NsxtFirewallRuleContainer which encloses three types of rules -
+// system, default and user defined rules. User defined rules are the only ones that can be modified, others are
+// read-only.
+type NsxtFirewall struct {
+	NsxtFirewallRuleContainer *types.NsxtFirewallRuleContainer
+	client                    *Client
+	// edgeGatewayId is stored for usage in NsxtFirewall receiver functions
+	edgeGatewayId string
+}
+
+// UpdateNsxtFirewall allows user to set new firewall rules or update existing ones. The API does not have POST endpoint
+// and always uses PUT endpoint for creating and updating.
+func (egw *NsxtEdgeGateway) UpdateNsxtFirewall(firewallRules *types.NsxtFirewallRuleContainer) (*NsxtFirewall, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path edgeGateways/%s/firewall/rules
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &NsxtFirewall{
+		NsxtFirewallRuleContainer: &types.NsxtFirewallRuleContainer{},
+		client:                    client,
+		edgeGatewayId:             egw.EdgeGateway.ID,
+	}
+
+	err = client.OpenApiPutItem(minimumApiVersion, urlRef, nil, firewallRules, returnObject.NsxtFirewallRuleContainer)
+	if err != nil {
+		return nil, fmt.Errorf("error setting NSX-T Firewall: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+// GetNsxtFirewall retrieves all firewall rules system, default and user defined rules
+func (egw *NsxtEdgeGateway) GetNsxtFirewall() (*NsxtFirewall, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path edgeGateways/%s/firewall/rules
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &NsxtFirewall{
+		NsxtFirewallRuleContainer: &types.NsxtFirewallRuleContainer{},
+		client:                    client,
+		edgeGatewayId:             egw.EdgeGateway.ID,
+	}
+
+	err = client.OpenApiGetItem(minimumApiVersion, urlRef, nil, returnObject.NsxtFirewallRuleContainer)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Firewall rules: %s", err)
+	}
+
+	// Store Edge Gateway ID for later operations
+	returnObject.edgeGatewayId = egw.EdgeGateway.ID
+
+	return returnObject, nil
+}
+
+// DeleteAll allows users to delete all NSX-T Firewall rules in a particular Edge Gateway
+func (firewall *NsxtFirewall) DeleteAll() error {
+
+	if firewall.edgeGatewayId == "" {
+		return fmt.Errorf("missing Edge Gateway ID")
+	}
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules
+	minimumApiVersion, err := firewall.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	urlRef, err := firewall.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, firewall.edgeGatewayId))
+	if err != nil {
+		return err
+	}
+
+	err = firewall.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting all NSX-T Firewall Rules: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteById allows users to delete NSX-T Firewall Rule By ID
+func (firewall *NsxtFirewall) DeleteById(id string) error {
+	if id == "" {
+		return fmt.Errorf("empty ID specified")
+	}
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules
+	minimumApiVersion, err := firewall.client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	urlRef, err := firewall.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, firewall.edgeGatewayId), "/", id)
+	if err != nil {
+		return err
+	}
+
+	err = firewall.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting NSX-T Firewall Rule with ID '%s': %s", id, err)
+	}
+
+	return nil
+}

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -134,11 +134,10 @@ func createFirewallDefinitions(check *C, vcd *TestVCD) []*types.NsxtFirewallRule
 			Enabled:                   a%2 == 0,
 			SourceFirewallGroups:      srcValue,
 			DestinationFirewallGroups: dstValue,
-			// TODO when app port profiles are in master
-			ApplicationPortProfiles: appPortProfileReferences[0:a],
-			IpProtocol:              pickRandomString([]string{"IPV6", "IPV4", "IPV4_IPV6"}),
-			Logging:                 a%2 == 1,
-			Direction:               pickRandomString([]string{"IN", "OUT", "IN_OUT"}),
+			ApplicationPortProfiles:   appPortProfileReferences[0:a],
+			IpProtocol:                pickRandomString([]string{"IPV6", "IPV4", "IPV4_IPV6"}),
+			Logging:                   a%2 == 1,
+			Direction:                 pickRandomString([]string{"IN", "OUT", "IN_OUT"}),
 		}
 	}
 

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -1,0 +1,220 @@
+// +build network nsxt functional openapi ALL
+
+package govcd
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+// Test_NsxtFirewall creates 20 firewall rules with randomized parameters
+func (vcd *TestVCD) Test_NsxtFirewall(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	// Get existing firewall rule configuration
+	fwRules, err := edge.GetNsxtFirewall()
+	check.Assert(err, IsNil)
+
+	existingDefaultRuleCount := len(fwRules.NsxtFirewallRuleContainer.DefaultRules)
+	existingSystemRuleCount := len(fwRules.NsxtFirewallRuleContainer.SystemRules)
+
+	// Create some prerequisites and generate firewall rule configurations to feed them into config
+	randomizedFwRuleDefs := createFirewallDefinitions(check, vcd)
+	fwRules.NsxtFirewallRuleContainer.UserDefinedRules = randomizedFwRuleDefs
+
+	if testVerbose {
+		dumpFirewallRulesToScreen(randomizedFwRuleDefs)
+	}
+
+	fwCreated, err := edge.UpdateNsxtFirewall(fwRules.NsxtFirewallRuleContainer)
+	check.Assert(err, IsNil)
+
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + fmt.Sprintf(types.OpenApiEndpointNsxtFirewallRules, edge.EdgeGateway.ID)
+	PrependToCleanupList(openApiEndpoint, "OpenApiEntityFirewall", edge.EdgeGateway.Name, check.TestName())
+
+	check.Assert(fwCreated, Not(IsNil))
+	check.Assert(len(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules), Equals, len(randomizedFwRuleDefs))
+
+	// Check that all created rules are have the same attributes and order
+	for index := range fwCreated.NsxtFirewallRuleContainer.UserDefinedRules {
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Name, Equals, randomizedFwRuleDefs[index].Name)
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Direction, Equals, randomizedFwRuleDefs[index].Direction)
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].IpProtocol, Equals, randomizedFwRuleDefs[index].IpProtocol)
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Enabled, Equals, randomizedFwRuleDefs[index].Enabled)
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Action, Equals, randomizedFwRuleDefs[index].Action)
+		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Logging, Equals, randomizedFwRuleDefs[index].Logging)
+
+		for fwGroupIndex := range fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].SourceFirewallGroups {
+			check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].SourceFirewallGroups[fwGroupIndex].ID, Equals, randomizedFwRuleDefs[index].SourceFirewallGroups[fwGroupIndex].ID)
+		}
+
+		for fwGroupIndex := range fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].DestinationFirewallGroups {
+			check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].DestinationFirewallGroups[fwGroupIndex].ID, Equals, randomizedFwRuleDefs[index].DestinationFirewallGroups[fwGroupIndex].ID)
+		}
+
+		for fwGroupIndex := range fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].ApplicationPortProfiles {
+			check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].ApplicationPortProfiles[fwGroupIndex].ID, Equals, randomizedFwRuleDefs[index].ApplicationPortProfiles[fwGroupIndex].ID)
+		}
+	}
+
+	// Delete a single rule by ID and check for two things:
+	// * Rule with deleted ID should not be found in list post deletion
+	// * There should be one less rule in the list
+	deleteRuleId := fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[3].ID
+	err = fwCreated.DeleteById(deleteRuleId)
+	check.Assert(err, IsNil)
+
+	allRulesPostDeletion, err := edge.GetNsxtFirewall()
+	check.Assert(err, IsNil)
+
+	check.Assert(len(allRulesPostDeletion.NsxtFirewallRuleContainer.UserDefinedRules), Equals, len(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules)-1)
+	for _, rule := range allRulesPostDeletion.NsxtFirewallRuleContainer.UserDefinedRules {
+		check.Assert(rule.ID, Not(Equals), deleteRuleId)
+	}
+
+	err = fwRules.DeleteAll()
+	check.Assert(err, IsNil)
+
+	// Ensure no firewall rules left in user space post deletion, but the same amount of default and system rules still exist
+	postDeleteCheck, err := edge.GetNsxtFirewall()
+	check.Assert(err, IsNil)
+	check.Assert(len(postDeleteCheck.NsxtFirewallRuleContainer.UserDefinedRules), Equals, 0)
+	check.Assert(len(postDeleteCheck.NsxtFirewallRuleContainer.DefaultRules), Equals, existingDefaultRuleCount)
+	check.Assert(len(postDeleteCheck.NsxtFirewallRuleContainer.SystemRules), Equals, existingSystemRuleCount)
+
+}
+
+// createFirewallDefinitions creates some randomized firewall rule configurations to match possible configurations
+func createFirewallDefinitions(check *C, vcd *TestVCD) []*types.NsxtFirewallRule {
+	// This number does not impact performance because all rules are created at once in the API
+	numberOfRules := 20
+
+	// Pre-Create Firewall Groups (IP Set and Security Group to randomly configure them)
+	ipSet := preCreateIpSet(check, vcd)
+	secGroup := preCreateSecurityGroup(check, vcd)
+	fwGroupIds := []string{ipSet.NsxtFirewallGroup.ID, secGroup.NsxtFirewallGroup.ID}
+	fwGroupRefs := convertSliceOfStringsToOpenApiReferenceIds(fwGroupIds)
+
+	firewallRules := make([]*types.NsxtFirewallRule, numberOfRules)
+	for a := 0; a < numberOfRules; a++ {
+
+		// Feed in empty value for source and destination or a firewall group
+		src := pickRandomOpenApiRefOrEmpty(fwGroupRefs)
+		var srcValue []types.OpenApiReference
+		dst := pickRandomOpenApiRefOrEmpty(fwGroupRefs)
+		var dstValue []types.OpenApiReference
+		if src != (types.OpenApiReference{}) {
+			srcValue = []types.OpenApiReference{src}
+		}
+		if dst != (types.OpenApiReference{}) {
+			dstValue = []types.OpenApiReference{dst}
+		}
+
+		firewallRules[a] = &types.NsxtFirewallRule{
+			Name:                      check.TestName() + strconv.Itoa(a),
+			Action:                    pickRandomString([]string{"ALLOW", "DROP"}),
+			Enabled:                   a%2 == 0,
+			SourceFirewallGroups:      srcValue,
+			DestinationFirewallGroups: dstValue,
+			// TODO when app port profiles are in master
+			ApplicationPortProfiles: nil,
+			IpProtocol:              pickRandomString([]string{"IPV6", "IPV4", "IPV4_IPV6"}),
+			Logging:                 a%2 == 1,
+			Direction:               pickRandomString([]string{"IN", "OUT", "IN_OUT"}),
+		}
+	}
+
+	return firewallRules
+}
+
+func pickRandomString(in []string) string {
+	randomIndex := rand.Intn(len(in))
+	return in[randomIndex]
+}
+
+// pickRandomOpenApiRefOrEmpty picks a random OpenAPI entity or an empty one
+func pickRandomOpenApiRefOrEmpty(in []types.OpenApiReference) types.OpenApiReference {
+	// Random value can be up to len+1 (len+1 is the special case when it should return an empty reference)
+	randomIndex := rand.Intn(len(in) + 1)
+	if randomIndex == len(in) {
+		return types.OpenApiReference{}
+	}
+	return in[randomIndex]
+}
+
+func preCreateIpSet(check *C, vcd *TestVCD) *NsxtFirewallGroup {
+	nsxtVdc := vcd.nsxtVdc
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	ipSetDefinition := &types.NsxtFirewallGroup{
+		Name:           check.TestName() + "ipset",
+		Description:    check.TestName() + "-Description",
+		Type:           types.FirewallGroupTypeIpSet,
+		EdgeGatewayRef: &types.OpenApiReference{ID: edge.EdgeGateway.ID},
+
+		IpAddresses: []string{
+			"12.12.12.1",
+			"10.10.10.0/24",
+			"11.11.11.1-11.11.11.2",
+			// represents the block of IPv6 addresses from 2001:db8:0:0:0:0:0:0 to 2001:db8:0:ffff:ffff:ffff:ffff:ffff
+			"2001:db8::/48",
+			"2001:db6:0:0:0:0:0:0-2001:db6:0:ffff:ffff:ffff:ffff:ffff",
+		},
+	}
+
+	// Create IP Set and add to cleanup if it was created
+	createdIpSet, err := nsxtVdc.CreateNsxtFirewallGroup(ipSetDefinition)
+	check.Assert(err, IsNil)
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups + createdIpSet.NsxtFirewallGroup.ID
+	AddToCleanupListOpenApi(createdIpSet.NsxtFirewallGroup.Name, check.TestName(), openApiEndpoint)
+
+	return createdIpSet
+}
+
+func preCreateSecurityGroup(check *C, vcd *TestVCD) *NsxtFirewallGroup {
+	nsxtVdc := vcd.nsxtVdc
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	fwGroupDefinition := &types.NsxtFirewallGroup{
+		Name:           check.TestName() + "security-group",
+		Description:    check.TestName() + "-Description",
+		Type:           types.FirewallGroupTypeSecurityGroup,
+		EdgeGatewayRef: &types.OpenApiReference{ID: edge.EdgeGateway.ID},
+	}
+
+	// Create firewall group and add to cleanup if it was created
+	createdSecGroup, err := nsxtVdc.CreateNsxtFirewallGroup(fwGroupDefinition)
+	check.Assert(err, IsNil)
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups + createdSecGroup.NsxtFirewallGroup.ID
+	AddToCleanupListOpenApi(check.TestName()+"sec-group", check.TestName(), openApiEndpoint)
+
+	return createdSecGroup
+}
+
+func dumpFirewallRulesToScreen(rules []*types.NsxtFirewallRule) {
+	fmt.Println("# The following firewall rules will be created")
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintln(w, "Name\tDirection\tIP Protocol\tEnabled\tAction\tLogging\tSrc Count\tDst Count\tAppPortProfile Count")
+
+	for _, rule := range rules {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\t%t\t%d\t%d\t%d\n", rule.Name, rule.Direction, rule.IpProtocol,
+			rule.Enabled, rule.Action, rule.Logging, len(rule.SourceFirewallGroups), len(rule.DestinationFirewallGroups), len(rule.ApplicationPortProfiles))
+	}
+	w.Flush()
+}

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -78,7 +78,7 @@ func (vcd *TestVCD) Test_NsxtFirewall(check *C) {
 	// * Rule with deleted ID should not be found in list post deletion
 	// * There should be one less rule in the list
 	deleteRuleId := fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[3].ID
-	err = fwCreated.DeleteById(deleteRuleId)
+	err = fwCreated.DeleteRuleById(deleteRuleId)
 	check.Assert(err, IsNil)
 
 	allRulesPostDeletion, err := edge.GetNsxtFirewall()
@@ -89,7 +89,7 @@ func (vcd *TestVCD) Test_NsxtFirewall(check *C) {
 		check.Assert(rule.ID, Not(Equals), deleteRuleId)
 	}
 
-	err = fwRules.DeleteAll()
+	err = fwRules.DeleteAllRules()
 	check.Assert(err, IsNil)
 
 	// Ensure no firewall rules left in user space post deletion, but the same amount of default and system rules still exist

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -224,11 +224,6 @@ func getRandomListOfAppPortProfiles(check *C, vcd *TestVCD) []types.OpenApiRefer
 		openApiRefs[index].Name = appPortProfile.NsxtAppPortProfile.Name
 	}
 
-	// Make a subslice
-
-	//subSetLength := rand.Intn(len(openApiRefs))
-	//subOpenApiRefs := make([]types.OpenApiReference, subSetLength)
-
 	return openApiRefs
 }
 

--- a/govcd/nsxv_firewall.go
+++ b/govcd/nsxv_firewall.go
@@ -26,7 +26,7 @@ type responseEdgeFirewallRules struct {
 	EdgeFirewallRules requestEdgeFirewallRules `xml:"firewallRules"`
 }
 
-// CreateNsxvFirewallRule creates firewall rule using proxied NSX-V API. It is a synchronuous operation.
+// CreateNsxvFirewallRule creates firewall rule using proxied NSX-V API. It is a synchronous operation.
 // It returns an object with all fields populated (including ID)
 // If aboveRuleId is not empty, it will send a query parameter aboveRuleId= which instructs NSX to
 // place this rule above the specified rule ID

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -23,6 +23,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups:             "34.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules:          "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks:             "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp:         "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcCapabilities:            "32.0",

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -671,12 +671,3 @@ func (vcd *TestVCD) TestQueryAllVdcs(check *C) {
 		check.Assert(contains(foundVdcNames, knownVdcName), Equals, true)
 	}
 }
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -343,6 +343,7 @@ const (
 	OpenApiEndpointVdcAssignedComputePolicies = "vdcs/%s/computePolicies"
 	OpenApiEndpointVdcCapabilities            = "vdcs/%s/capabilities"
 	OpenApiEndpointEdgeGateways               = "edgeGateways/"
+	OpenApiEndpointNsxtFirewallRules          = "edgeGateways/%s/firewall/rules"
 	OpenApiEndpointFirewallGroups             = "firewallGroups/"
 	OpenApiEndpointOrgVdcNetworks             = "orgVdcNetworks/"
 	OpenApiEndpointOrgVdcNetworksDhcp         = "orgVdcNetworks/%s/dhcp"

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -290,3 +290,45 @@ type NsxtFirewallGroupMemberVms struct {
 	VdcRef  *OpenApiReference `json:"vdcRef"`
 	OrgRef  *OpenApiReference `json:"orgRef"`
 }
+
+// NsxtFirewallRule defines single NSX-T Firewall Rule
+type NsxtFirewallRule struct {
+	// ID contains UUID (e.g. d0bf5d51-f83a-489a-9323-1661024874b8)
+	ID string `json:"id,omitempty"`
+	// Name - API does not enforce uniqueness
+	Name string `json:"name"`
+	// Action 'ALLOW', 'DROP'
+	Action string `json:"action"`
+	// Enabled allows to enable or disable the rule
+	Enabled bool `json:"enabled"`
+	// SourceFirewallGroups contains a list of references to Firewall Groups. Empty list means 'Any'
+	SourceFirewallGroups []OpenApiReference `json:"sourceFirewallGroups,omitempty"`
+	// DestinationFirewallGroups contains a list of references to Firewall Groups. Empty list means 'Any'
+	DestinationFirewallGroups []OpenApiReference `json:"destinationFirewallGroups,omitempty"`
+	// ApplicationPortProfiles contains a list of references to Application Port Profiles. Empty list means 'Any'
+	ApplicationPortProfiles []OpenApiReference `json:"applicationPortProfiles,omitempty"`
+	// IpProtocol 'IPV4', 'IPV6', 'IPV4_IPV6'
+	IpProtocol string `json:"ipProtocol"`
+	Logging    bool   `json:"logging"`
+	// Direction 'IN_OUT', 'OUT', 'IN'
+	Direction string `json:"direction"`
+	// Version of firewall rule. Must not be set when creating.
+	Version *struct {
+		// Version is incremented after each update
+		Version *int `json:"version,omitempty"`
+	} `json:"version,omitempty"`
+}
+
+// NsxtFirewallRuleContainer wraps NsxtFirewallRule for user-defined and default and system Firewall Rules suitable for
+// API. Only UserDefinedRules are writeable. Others are read-only.
+type NsxtFirewallRuleContainer struct {
+	// SystemRules contain ordered list of system defined edge firewall rules. System rules are applied before user
+	// defined rules in the order in which they are returned.
+	SystemRules []*NsxtFirewallRule `json:"systemRules"`
+	// DefaultRules contain ordered list of user defined edge firewall rules. Users are allowed to add/modify/delete rules
+	// only to this list.
+	DefaultRules []*NsxtFirewallRule `json:"defaultRules"`
+	// UserDefinedRules ordered list of default edge firewall rules. Default rules are applied after the user defined
+	// rules in the order in which they are returned.
+	UserDefinedRules []*NsxtFirewallRule `json:"userDefinedRules"`
+}


### PR DESCRIPTION
This PR adds support for NSX-T Firewall by adding new functions and types:
`NsxtEdgeGateway.UpdateNsxtFirewall()`, `NsxtEdgeGateway.GetNsxtFirewall()`, `nsxtFirewall.DeleteAll()`,
  `nsxtFirewall.DeleteById`, `types.NsxtFirewallRule`, `types.NsxtFirewallRuleContainer`

It also fixes a few errors found by new staticheck:
```
## staticcheck 2021.1 (v0.2.0)

## Checking govcd
api.go:285:61: the argument's underlying type is a slice of bytes, should use a simple conversion instead of fmt.Sprintf (S1025)
api_vcd_test.go:762:3: this value of err is never used (SA4006)
entity_test.go:145:13: type assertion to the same type: ge already has type genericEntity (S1040)
entity_test.go:165:13: type assertion to the same type: ge already has type genericEntity (S1040)
entity_test.go:178:13: type assertion to the same type: ge already has type genericEntity (S1040)
entity_test.go:192:13: type assertion to the same type: ge already has type genericEntity (S1040)
filter_engine.go:253:25: type assertion to the same type: candidate already has type QueryItem (S1040)
filter_engine.go:284:27: type assertion to the same type: candidate already has type QueryItem (S1040)
```