### PR TITLE
Add NSX-T NAT rule support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
 * Added methods Org.QueryVmList and Org.QueryVmById to find VM by ID in an Org
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
+* Added NSX-T NAT support with types `NsxtNat` and `types.NsxtNatRule` as well as methods `edge.GetAllNsxtNatRules`,
+  `edge.GetNsxtNatRuleByName`, `edge.GetNsxtNatRuleById`, `edge.CreateNatRule`, `nsxtNatRule.Update`, `nsxtNatRule.Delete`,
+  `nsxtNatRule.IsEqualTo` [#382](https://github.com/vmware/go-vcloud-director/pull/382)
+
   
 BREAKING CHANGES:
 * Added parameter `description` to method `vdc.ComposeRawVapp` [#372](https://github.com/vmware/go-vcloud-director/pull/372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Bumped Default API Version to V33.0  [#371](https://github.com/vmware/go-vcloud-director/pull/371)
 * Methods `GetVDCById` and `GetVDCByName` for `Org` now use queries behind the scenes because Org 
   structure does not list child VDCs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371), 
-  [#376](https://github.com/vmware/go-vcloud-director/pull/376)
+  [#376](https://github.com/vmware/go-vcloud-director/pull/376), [#382](https://github.com/vmware/go-vcloud-director/pull/382)
 * Methods `GetCatalogById` and `GetCatalogByName` for `Org`  now use queries behind the scenes because Org
   structure does not list child Catalogs anymore  [#371](https://github.com/vmware/go-vcloud-director/pull/371), 
   [#376](https://github.com/vmware/go-vcloud-director/pull/376)

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -721,9 +721,14 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		// to lookup used API version this ID must not be present therefore below we remove suffix ID.
 		// This is done by splitting whole path by "/" and rebuilding path again without last element in slice (which is
 		// expected to be the ID)
+		// Sometimes API endpoint path might contain URNs in the middle (e.g. OpenApiEndpointNsxtNatRules). They are
+		// replaced back to string placeholder %s to match original definitions
 		endpointSlice := strings.Split(entity.OpenApiEndpoint, "/")
-		endpoint := strings.Join(endpointSlice[:len(endpointSlice)-1], "/") + "/"
-		apiVersion, _ := vcd.client.Client.checkOpenApiEndpointCompatibility(endpoint)
+		endpointWithUuid := strings.Join(endpointSlice[:len(endpointSlice)-1], "/") + "/"
+		// replace any "urns" (e.g. 'urn:vcloud:gateway:64966c36-e805-44e2-980b-c1077ab54956') with '%s' to match API definitions
+		re := regexp.MustCompile(`urn[^\/]+`) // Regexp matches from 'urn' up to next '/' in the path
+		endpointRemovedUuids := re.ReplaceAllString(endpointWithUuid, "%s")
+		apiVersion, _ := vcd.client.Client.checkOpenApiEndpointCompatibility(endpointRemovedUuids)
 
 		// Build UP complete endpoint address
 		urlRef, err := vcd.client.Client.OpenApiBuildEndpoint(entity.OpenApiEndpoint)

--- a/govcd/nsxt_nat_rule.go
+++ b/govcd/nsxt_nat_rule.go
@@ -259,9 +259,15 @@ func natRulesEqual(first, second *types.NsxtNatRule) bool {
 		first.Description == second.Description &&
 		first.ExternalAddresses == second.ExternalAddresses &&
 		first.InternalAddresses == second.InternalAddresses &&
-		// Match either both application profiles being empty/nil, or both having the same value
-		((first.ApplicationPortProfile == second.ApplicationPortProfile) ||
-			(first.ApplicationPortProfile != nil && second.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == second.ApplicationPortProfile.ID)) {
+
+		// Match both application profiles being nil (types cannot be equal as they are pointers, not values)
+		((first.ApplicationPortProfile == nil && second.ApplicationPortProfile == nil) ||
+			// Or both being not nil and having the same IDs
+			(first.ApplicationPortProfile != nil && second.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == second.ApplicationPortProfile.ID) ||
+			// Or first Application profile is nil and second is not nil, but has empty ID
+			(first.ApplicationPortProfile == nil && second.ApplicationPortProfile != nil && second.ApplicationPortProfile.ID == "") ||
+			// Or first Application Profile  is not nil, but has empty ID, while second application port profile is nil
+			(first.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == "" && second.ApplicationPortProfile == nil)) {
 
 		return true
 	}

--- a/govcd/nsxt_nat_rule.go
+++ b/govcd/nsxt_nat_rule.go
@@ -236,6 +236,14 @@ func (nsxtNat *NsxtNatRule) Delete() error {
 }
 
 // IsEqualTo allows to check if a rule has exactly the same fields (except ID) to the supplied rule
+// This validation is very tricky because minor version changes impact how fields are return.
+// This function relies on most common and stable fields:
+// * Name
+// * Enabled
+// * Description
+// * ExternalAddresses
+// * InternalAddresses
+// * ApplicationPortProfile.ID
 func (nsxtNat *NsxtNatRule) IsEqualTo(rule *types.NsxtNatRule) bool {
 	return natRulesEqual(nsxtNat.NsxtNatRule, rule)
 }
@@ -247,13 +255,18 @@ func natRulesEqual(first, second *types.NsxtNatRule) bool {
 	util.Logger.Println("against:")
 	util.Logger.Printf("%+v\n", second)
 
+	// Being an org user always returns logging as false - therefore cannot compare it.
+	// first.Logging == second.Logging &&
+
+	// These fields are returned or not returned depending on version and it is impossible to be 100% sure a minor
+	// patch does not break such comparison
+	// first.DnatExternalPort == second.DnatExternalPort &&
+	// first.SnatDestinationAddresses == second.SnatDestinationAddresses &&
+	//
 	if first.Name == second.Name &&
-		// Being an org user always returns logging as false - therefore cannot compare it.
-		//first.Logging == second.Logging &&
 		first.Enabled == second.Enabled &&
 		first.Description == second.Description &&
-		first.DnatExternalPort == second.DnatExternalPort &&
-		first.SnatDestinationAddresses == second.SnatDestinationAddresses &&
+
 		first.ExternalAddresses == second.ExternalAddresses &&
 		first.InternalAddresses == second.InternalAddresses &&
 		// Match either both application profiles being empty/nil, or both having the same value

--- a/govcd/nsxt_nat_rule.go
+++ b/govcd/nsxt_nat_rule.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// NsxtNatRule describes a single NAT rule of 4 different RuleTypes - DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`.
+//
+// A SNAT or a DNAT rule on an Edge Gateway in the VMware Cloud Director environment is always configured from the
+// perspective of your organization VDC.
+// DNAT and NO_DNAT - outside traffic going inside
+// SNAT and NO_SNAT - inside traffic going outside
+// More docs in https://docs.vmware.com/en/VMware-Cloud-Director/10.2/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-9E43E3DC-C028-47B3-B7CA-59F0ED40E0A6.html
+//
+// Note. This structure and all its API calls will require at least API version 34.0, but will elevate it to 35.2 if
+// possible because API 35.2 introduces support for 2 new fields FirewallMatch and Priority.
+type NsxtNatRule struct {
+	NsxtNatRule *types.NsxtNatRule
+	client      *Client
+	// edgeGatewayId is stored here so that pointer receiver functions can embed edge gateway ID into path
+	edgeGatewayId string
+}
+
+// GetAllNatRules retrieves all NAT rules with an optional queryParameters filter.
+func (egw *NsxtEdgeGateway) GetAllNatRules(queryParameters url.Values) ([]*NsxtNatRule, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fields FirewallMatch and Priority require API version 35.2 to be set therefore version is elevated if API supports
+	if client.APIVCDMaxVersionIs(">= 35.2") {
+		apiVersion = "35.2"
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	typeResponses := []*types.NsxtNatRule{{}}
+	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap all typeResponses into NsxtNatRule types with client
+	wrappedResponses := make([]*NsxtNatRule, len(typeResponses))
+	for sliceIndex := range typeResponses {
+		wrappedResponses[sliceIndex] = &NsxtNatRule{
+			NsxtNatRule:   typeResponses[sliceIndex],
+			client:        client,
+			edgeGatewayId: egw.EdgeGateway.ID,
+		}
+	}
+
+	return wrappedResponses, nil
+}
+
+// GetNatRuleByName finds a NAT rule by Name and returns it
+//
+// Note. API does not enforce name uniqueness therefore an error will be thrown if two rules with the same name exist
+func (egw *NsxtEdgeGateway) GetNatRuleByName(name string) (*NsxtNatRule, error) {
+	// Ideally this function would use OpenAPI filters to perform server side filtering, but this endpoint does not
+	// support any filters - even ID. Therefore one must retrieve all items and look if there is an item with the same ID
+	allNatRules, err := egw.GetAllNatRules(nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retriving all NSX-T NAT rules: %s", err)
+	}
+
+	var allResults []*NsxtNatRule
+
+	for _, natRule := range allNatRules {
+		if natRule.NsxtNatRule.Name == name {
+			allResults = append(allResults, natRule)
+		}
+	}
+
+	if len(allResults) > 1 {
+		return nil, fmt.Errorf("error - found %d NSX-T NAT rules with name '%s'. Expected 1", len(allResults), name)
+	}
+
+	if len(allResults) == 0 {
+		return nil, ErrorEntityNotFound
+	}
+
+	return allResults[0], nil
+}
+
+// GetNatRuleById finds a NAT rule by ID and returns it
+func (egw *NsxtEdgeGateway) GetNatRuleById(id string) (*NsxtNatRule, error) {
+	// Ideally this function would use OpenAPI filters to perform server side filtering, but this endpoint does not
+	// support any filters - even ID. Therefore one must retrieve all items and look if there is an item with the same ID
+	allNatRules, err := egw.GetAllNatRules(nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retriving all NSX-T NAT rules: %s", err)
+	}
+
+	for _, natRule := range allNatRules {
+		if natRule.NsxtNatRule.ID == id {
+			return natRule, nil
+		}
+	}
+
+	return nil, ErrorEntityNotFound
+}
+
+// CreateNatRule creates a NAT rule and returns it.
+//
+// Note. API has a limitation, that it does not return ID for created rule. To work around it this function creates
+// a NAT rule, fetches all rules and finds a rule with exactly the same field values and returns it (including ID)
+// There is still a slight risk to retrieve wrong ID if exactly the same rule already exists.
+func (egw *NsxtEdgeGateway) CreateNatRule(natRuleConfig *types.NsxtNatRule) (*NsxtNatRule, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fields FirewallMatch and Priority require API version 35.2 to be set therefore version is elevated if API supports
+	if client.APIVCDMaxVersionIs(">= 35.2") {
+		apiVersion = "35.2"
+	}
+
+	// Insert Edge Gateway ID into endpoint path edgeGateways/%s/nat/rules
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	// Creating NAT rule must follow different way than usual OpenAPI one because this item has an API bug and
+	// NAT rule ID is not returned after this object is created. The only way to find its ID afterwards is to GET all
+	// items, and manually match it based on rule name, etc.
+	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, natRuleConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T NAT rule: %s", err)
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("task failed while creating NSX-T NAT rule: %s", err)
+	}
+
+	// queryParameters (API side filtering) are not used because pretty much nothing is accepted as filter (such fields as
+	// name, description, ruleType and even ID are not allowed
+	allNatRules, err := egw.GetAllNatRules(nil)
+
+	for index, singleRule := range allNatRules {
+		// Look for a matching rule
+		if singleRule.IsEqualTo(natRuleConfig) {
+			return allNatRules[index], nil
+
+		}
+	}
+	return nil, fmt.Errorf("rule '%s' of type '%s' not found after creation", natRuleConfig.Name, natRuleConfig.RuleType)
+}
+
+// Update allows users to update NSX-T NAT rule
+func (nsxtNat *NsxtNatRule) Update(natRuleConfig *types.NsxtNatRule) (*NsxtNatRule, error) {
+	client := nsxtNat.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fields FirewallMatch and Priority require API version 35.2 to be set therefore version is elevated if API supports
+	if client.APIVCDMaxVersionIs(">= 35.2") {
+		apiVersion = "35.2"
+	}
+
+	if nsxtNat.NsxtNatRule.ID == "" {
+		return nil, fmt.Errorf("cannot update NSX-T NAT Rule without ID")
+	}
+
+	urlRef, err := nsxtNat.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, nsxtNat.edgeGatewayId), nsxtNat.NsxtNatRule.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &NsxtNatRule{
+		NsxtNatRule:   &types.NsxtNatRule{},
+		client:        client,
+		edgeGatewayId: nsxtNat.edgeGatewayId,
+	}
+
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, natRuleConfig, returnObject.NsxtNatRule)
+	if err != nil {
+		return nil, fmt.Errorf("error updating NSX-T NAT Rule: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+// Delete deletes NSX-T NAT rule
+func (nsxtNat *NsxtNatRule) Delete() error {
+	client := nsxtNat.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	// Fields FirewallMatch and Priority require API version 35.2 to be set therefore version is elevated if API supports
+	if client.APIVCDMaxVersionIs(">= 35.2") {
+		apiVersion = "35.2"
+	}
+
+	if nsxtNat.NsxtNatRule.ID == "" {
+		return fmt.Errorf("cannot delete NSX-T NAT rule without ID")
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, nsxtNat.edgeGatewayId), nsxtNat.NsxtNatRule.ID)
+	if err != nil {
+		return err
+	}
+
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting NSX-T NAT Rule: %s", err)
+	}
+
+	return nil
+}
+
+// IsEqualTo allows to check if a rule has exactly the same fields (except ID) to the supplied rule
+func (nsxtNat *NsxtNatRule) IsEqualTo(rule *types.NsxtNatRule) bool {
+	return natRulesEqual(nsxtNat.NsxtNatRule, rule)
+}
+
+// natRulesEqual is a helper to check if first and second supplied rules are exactly the same (except ID)
+func natRulesEqual(first, second *types.NsxtNatRule) bool {
+	if first.Name == second.Name &&
+		first.Logging == second.Logging &&
+		first.Enabled == second.Enabled &&
+		first.Description == second.Description &&
+		first.DnatExternalPort == second.DnatExternalPort &&
+		first.SnatDestinationAddresses == second.SnatDestinationAddresses &&
+		first.ExternalAddresses == second.ExternalAddresses &&
+		first.InternalAddresses == second.InternalAddresses &&
+		// Match either both application profiles being empty/nil, or both having the same value
+		(first.ApplicationPortProfile == second.ApplicationPortProfile) ||
+		(first.ApplicationPortProfile != nil && second.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == second.ApplicationPortProfile.ID) {
+
+		return true
+	}
+
+	return false
+}

--- a/govcd/nsxt_nat_rule.go
+++ b/govcd/nsxt_nat_rule.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // NsxtNatRule describes a single NAT rule of 4 different RuleTypes - DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`.
@@ -241,8 +242,14 @@ func (nsxtNat *NsxtNatRule) IsEqualTo(rule *types.NsxtNatRule) bool {
 
 // natRulesEqual is a helper to check if first and second supplied rules are exactly the same (except ID)
 func natRulesEqual(first, second *types.NsxtNatRule) bool {
+	util.Logger.Println("comparing NAT rule:")
+	util.Logger.Printf("%+v\n", first)
+	util.Logger.Println("against:")
+	util.Logger.Printf("%+v\n", second)
+
 	if first.Name == second.Name &&
-		first.Logging == second.Logging &&
+		// Being an org user always returns logging as false - therefore cannot compare it.
+		//first.Logging == second.Logging &&
 		first.Enabled == second.Enabled &&
 		first.Description == second.Description &&
 		first.DnatExternalPort == second.DnatExternalPort &&
@@ -250,8 +257,8 @@ func natRulesEqual(first, second *types.NsxtNatRule) bool {
 		first.ExternalAddresses == second.ExternalAddresses &&
 		first.InternalAddresses == second.InternalAddresses &&
 		// Match either both application profiles being empty/nil, or both having the same value
-		(first.ApplicationPortProfile == second.ApplicationPortProfile) ||
-		(first.ApplicationPortProfile != nil && second.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == second.ApplicationPortProfile.ID) {
+		((first.ApplicationPortProfile == second.ApplicationPortProfile) ||
+			(first.ApplicationPortProfile != nil && second.ApplicationPortProfile != nil && first.ApplicationPortProfile.ID == second.ApplicationPortProfile.ID)) {
 
 		return true
 	}

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -25,12 +25,18 @@ func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
 	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "dnat",
 		Description:       "description",
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 		InternalAddresses: "11.11.11.2",
 		ApplicationPortProfile: &types.OpenApiReference{
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
@@ -63,12 +69,18 @@ func (vcd *TestVCD) Test_NsxtNatDnatInternalPort(check *C) {
 	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "dnat",
 		Description:       "description",
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 		InternalAddresses: "11.11.11.2",
 		ApplicationPortProfile: &types.OpenApiReference{
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
@@ -101,12 +113,18 @@ func (vcd *TestVCD) Test_NsxtNatDnatExternalPortPort(check *C) {
 	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "dnat",
 		Description:       "description",
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 		InternalAddresses: "11.11.11.2",
 		ApplicationPortProfile: &types.OpenApiReference{
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
@@ -139,12 +157,18 @@ func (vcd *TestVCD) Test_NsxtNatDnatFirewallMatchPriority(check *C) {
 	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "dnat",
 		Description:       "description",
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 		InternalAddresses: "11.11.11.2",
 		ApplicationPortProfile: &types.OpenApiReference{
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
@@ -171,12 +195,18 @@ func (vcd *TestVCD) Test_NsxtNatNoDnat(check *C) {
 	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "no-dnat",
 		Description:       "description",
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeNoDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 	}
 
 	nsxtNatRuleChecks(natRuleDefinition, edge, check, vcd)
@@ -198,12 +228,18 @@ func (vcd *TestVCD) Test_NsxtNatSnat(check *C) {
 	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:                     check.TestName() + "snat",
 		Description:              "description",
 		Enabled:                  true,
 		RuleType:                 types.NsxtNatRuleTypeSnat,
-		ExternalAddresses:        edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses:        edgeGatewayPrimaryIp,
 		InternalAddresses:        "11.11.11.2",
 		SnatDestinationAddresses: "11.11.11.4",
 		ApplicationPortProfile: &types.OpenApiReference{
@@ -256,12 +292,18 @@ func (vcd *TestVCD) Test_NsxtNatPriorityAndFirewallMatch(check *C) {
 	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:                     check.TestName() + "dnat",
 		Description:              "description",
 		Enabled:                  true,
 		RuleType:                 types.NsxtNatRuleTypeDnat,
-		ExternalAddresses:        edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses:        edgeGatewayPrimaryIp,
 		InternalAddresses:        "11.11.11.2",
 		SnatDestinationAddresses: "",
 		Logging:                  true,
@@ -291,13 +333,19 @@ func (vcd *TestVCD) Test_NsxtNatReflexive(check *C) {
 	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
+	edgeGatewayPrimaryIp := ""
+	if edge.EdgeGateway != nil && len(edge.EdgeGateway.EdgeGatewayUplinks) > 0 && len(edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values) > 0 {
+		edgeGatewayPrimaryIp = edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP
+	}
+	check.Assert(edgeGatewayPrimaryIp, Not(Equals), "")
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:        check.TestName() + "reflexive",
 		Description: "description",
 		Enabled:     true,
 		//RuleType:          types.NsxtNatRuleTypeReflexive,
 		Type:              types.NsxtNatRuleTypeReflexive,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		ExternalAddresses: edgeGatewayPrimaryIp,
 		InternalAddresses: "11.11.11.2",
 		Priority:          takeIntAddress(100),
 		FirewallMatch:     types.NsxtNatRuleFirewallMatchExternalAddress,

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -319,6 +319,7 @@ func nsxtNatRuleChecks(natRuleDefinition *types.NsxtNatRule, edge *NsxtEdgeGatew
 	natRuleDefinition.ID = createdNatRule.NsxtNatRule.ID                       // ID is always the difference
 	natRuleDefinition.Priority = createdNatRule.NsxtNatRule.Priority           // Priority returns default value (0) for VCD 10.2.2+
 	natRuleDefinition.FirewallMatch = createdNatRule.NsxtNatRule.FirewallMatch // FirewallMatch returns default value (MATCH_INTERNAL_ADDRESS) for VCD 10.2.2+
+	natRuleDefinition.Version = createdNatRule.NsxtNatRule.Version             // Version will always be populated afterwards
 
 	// In API V36.0 expect the Type field to have the same value as specified RuleType
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 36.0") {

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -22,6 +22,9 @@ func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
 	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
+	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
+	check.Assert(err, IsNil)
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:              check.TestName() + "dnat",
 		Description:       "description",
@@ -29,8 +32,9 @@ func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
 		RuleType:          types.NsxtNatRuleTypeDnat,
 		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
 		InternalAddresses: "11.11.11.2",
-		// To fill once it is in master
-		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+		ApplicationPortProfile: &types.OpenApiReference{
+			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
+			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
 		SnatDestinationAddresses: "",
 		Logging:                  true,
 		DnatExternalPort:         "",
@@ -58,8 +62,6 @@ func (vcd *TestVCD) Test_NsxtNatNoDnat(check *C) {
 		Enabled:           true,
 		RuleType:          types.NsxtNatRuleTypeNoDnat,
 		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
-		// To fill once it is in master
-		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
 	}
 
 	nsxtNatRuleChecks(natRuleDefinition, edge, check)
@@ -78,6 +80,9 @@ func (vcd *TestVCD) Test_NsxtNatSnat(check *C) {
 	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
 
+	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
+	check.Assert(err, IsNil)
+
 	natRuleDefinition := &types.NsxtNatRule{
 		Name:                     check.TestName() + "snat",
 		Description:              "description",
@@ -86,8 +91,9 @@ func (vcd *TestVCD) Test_NsxtNatSnat(check *C) {
 		ExternalAddresses:        edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
 		InternalAddresses:        "11.11.11.2",
 		SnatDestinationAddresses: "11.11.11.4",
-		// To fill once it is in master
-		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+		ApplicationPortProfile: &types.OpenApiReference{
+			ID:   appPortProfiles[1].NsxtAppPortProfile.ID,
+			Name: appPortProfiles[1].NsxtAppPortProfile.Name},
 	}
 
 	nsxtNatRuleChecks(natRuleDefinition, edge, check)
@@ -136,14 +142,12 @@ func (vcd *TestVCD) Test_NsxtNatPriorityAndFirewallMatch(check *C) {
 	check.Assert(err, IsNil)
 
 	natRuleDefinition := &types.NsxtNatRule{
-		Name:              check.TestName() + "dnat",
-		Description:       "description",
-		Enabled:           true,
-		RuleType:          types.NsxtNatRuleTypeDnat,
-		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
-		InternalAddresses: "11.11.11.2",
-		// To fill once it is in master
-		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+		Name:                     check.TestName() + "dnat",
+		Description:              "description",
+		Enabled:                  true,
+		RuleType:                 types.NsxtNatRuleTypeDnat,
+		ExternalAddresses:        edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses:        "11.11.11.2",
 		SnatDestinationAddresses: "",
 		Logging:                  true,
 		DnatExternalPort:         "",

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -43,6 +43,121 @@ func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
 	nsxtNatRuleChecks(natRuleDefinition, edge, check)
 }
 
+func (vcd *TestVCD) Test_NsxtNatDnatInternalPort(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 35.2") {
+		check.Skip("InternalPort field is only used in older API versions (replaced by 'DnatExternalPort' field)")
+	}
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses: "11.11.11.2",
+		ApplicationPortProfile: &types.OpenApiReference{
+			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
+			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
+		SnatDestinationAddresses: "",
+		Logging:                  true,
+		InternalPort:             "9898",
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatDnatExternalPortPort(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	if vcd.client.Client.APIVCDMaxVersionIs("< 35.2") {
+		check.Skip("DnatExternalPort field is only used in API V35.2 (previously 'InternalPort' field)")
+	}
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses: "11.11.11.2",
+		ApplicationPortProfile: &types.OpenApiReference{
+			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
+			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
+		SnatDestinationAddresses: "",
+		Logging:                  true,
+		DnatExternalPort:         "9898",
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatDnatFirewallMatchPriority(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	if vcd.client.Client.APIVCDMaxVersionIs("< 35.2") {
+		check.Skip("FirewallMatch and Priority fields are only supported in API V35.2")
+	}
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	appPortProfiles, err := org.GetAllNsxtAppPortProfiles(nil, types.ApplicationPortProfileScopeSystem)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses: "11.11.11.2",
+		ApplicationPortProfile: &types.OpenApiReference{
+			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
+			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
+		SnatDestinationAddresses: "",
+		Logging:                  true,
+		FirewallMatch:            types.NsxtNatRuleFirewallMatchExternalAddress,
+		Priority:                 takeIntAddress(248),
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
 func (vcd *TestVCD) Test_NsxtNatNoDnat(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -1,0 +1,195 @@
+// +build network nsxt functional openapi ALL
+
+package govcd
+
+import (
+	"fmt"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses: "11.11.11.2",
+		// To fill once it is in master
+		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+		SnatDestinationAddresses: "",
+		Logging:                  true,
+		DnatExternalPort:         "",
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatNoDnat(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "no-dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeNoDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		// To fill once it is in master
+		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatSnat(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:                     check.TestName() + "snat",
+		Description:              "description",
+		Enabled:                  true,
+		RuleType:                 types.NsxtNatRuleTypeSnat,
+		ExternalAddresses:        edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses:        "11.11.11.2",
+		SnatDestinationAddresses: "11.11.11.4",
+		// To fill once it is in master
+		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatNoSnat(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "no-snat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeNoSnat,
+		ExternalAddresses: "",
+		InternalAddresses: "11.11.11.2",
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func (vcd *TestVCD) Test_NsxtNatPriorityAndFirewallMatch(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	if vcd.client.Client.APIVCDMaxVersionIs("< 35.2") {
+		check.Skip("testing 'Priority' and 'FirewallMatch' fields requires at least VCD 10.2.2")
+	}
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	natRuleDefinition := &types.NsxtNatRule{
+		Name:              check.TestName() + "dnat",
+		Description:       "description",
+		Enabled:           true,
+		RuleType:          types.NsxtNatRuleTypeDnat,
+		ExternalAddresses: edge.EdgeGateway.EdgeGatewayUplinks[0].Subnets.Values[0].PrimaryIP,
+		InternalAddresses: "11.11.11.2",
+		// To fill once it is in master
+		//ApplicationPortProfile:   &types.OpenApiReference{ID: "urn:vcloud:applicationPortProfile:c03eef76-9f6b-4758-9281-b9b21e0aeb08"},
+		SnatDestinationAddresses: "",
+		Logging:                  true,
+		DnatExternalPort:         "",
+		Priority:                 takeIntAddress(100),
+		FirewallMatch:            types.NsxtNatRuleFirewallMatchExternalAddress,
+	}
+
+	nsxtNatRuleChecks(natRuleDefinition, edge, check)
+}
+
+func nsxtNatRuleChecks(natRuleDefinition *types.NsxtNatRule, edge *NsxtEdgeGateway, check *C) {
+	createdNatRule, err := edge.CreateNatRule(natRuleDefinition)
+	check.Assert(err, IsNil)
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + fmt.Sprintf(types.OpenApiEndpointNsxtNatRules, edge.EdgeGateway.ID) + createdNatRule.NsxtNatRule.ID
+	AddToCleanupListOpenApi(createdNatRule.NsxtNatRule.Name, check.TestName(), openApiEndpoint)
+
+	// check if created rule matches definition
+	check.Assert(createdNatRule.IsEqualTo(natRuleDefinition), Equals, true)
+
+	// Validate that supplied values are the same as read values
+	natRuleDefinition.ID = createdNatRule.NsxtNatRule.ID                       // ID is always the difference
+	natRuleDefinition.Priority = createdNatRule.NsxtNatRule.Priority           // Priority returns default value (0) for VCD 10.2.2+
+	natRuleDefinition.FirewallMatch = createdNatRule.NsxtNatRule.FirewallMatch // FirewallMatch returns default value (MATCH_INTERNAL_ADDRESS) for VCD 10.2.2+
+	check.Assert(createdNatRule.NsxtNatRule, DeepEquals, natRuleDefinition)
+
+	// Try to get NAT rules by name and by ID
+	natRuleById, err := edge.GetNatRuleById(createdNatRule.NsxtNatRule.ID)
+	check.Assert(err, IsNil)
+	natRuleByName, err := edge.GetNatRuleByName(createdNatRule.NsxtNatRule.Name)
+	check.Assert(err, IsNil)
+
+	check.Assert(natRuleById.NsxtNatRule, DeepEquals, natRuleDefinition)
+	check.Assert(natRuleByName.NsxtNatRule, DeepEquals, natRuleDefinition)
+
+	// Try to update value
+	createdNatRule.NsxtNatRule.Name = check.TestName() + "updated"
+	updatedNatRule, err := createdNatRule.Update(createdNatRule.NsxtNatRule)
+	check.Assert(err, IsNil)
+
+	// validate that supplied values are new, but ID stays the same
+	check.Assert(updatedNatRule.NsxtNatRule.ID, Equals, createdNatRule.NsxtNatRule.ID)
+	check.Assert(updatedNatRule.NsxtNatRule.RuleType, Equals, createdNatRule.NsxtNatRule.RuleType)
+
+	err = createdNatRule.Delete()
+	check.Assert(err, IsNil)
+
+	_, err = edge.GetNatRuleById(createdNatRule.NsxtNatRule.ID)
+	check.Assert(ContainsNotFound(err), Equals, true)
+}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -23,6 +23,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups:             "34.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks:             "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp:         "32.0", // VCD 9.7+ for NSX-V, 10.1+ for NSX-T
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcCapabilities:            "32.0",

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -1,11 +1,17 @@
 package govcd
 
 /*
- * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/util"
+
+	"github.com/hashicorp/go-version"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
@@ -36,6 +42,19 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAppPortProfiles:            "34.0", // VCD 10.1+
 }
 
+// elevateNsxtNatRuleApiVersion helps to elevate API version to consume newer NSX-T NAT Rule features
+// API V35.2+ support new fields FirewallMatch and Priority
+// API V36.0+ supports new RuleType - REFLEXIVE
+
+// endpointElevatedApiVersions endpoint elevated API versions
+var endpointElevatedApiVersions = map[string][]string{
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules: {
+		//"34.0", // Basic minimum required version
+		"35.2", // Introduces support for new fields FirewallMatch and Priority
+		"36.0", // Adds support for new NAT Rule Type - REFLEXIVE (field Type must be used instead of RuleType)
+	},
+}
+
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with
 // specified OpenAPI endpoint and returns either an error or the Api version to use for calling that endpoint. This Api
 // version can then be supplied to low level OpenAPI client functions.
@@ -61,4 +80,69 @@ func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string
 	}
 
 	return minimumApiVersion, nil
+}
+
+// getOpenApiHighestElevatedVersion returns highest supported API version for particular endpoint
+// These API versions must be defined in endpointElevatedApiVersions. If none are there - it will return minimum
+// supported API versions just like client.checkOpenApiEndpointCompatibility().
+//
+// The advantage of this functions is that it provides a controlled API elevation instead of just picking the highest
+// which could be risky and untested (especially if new API version is released after release of package consuming this
+// SDK)
+func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string, error) {
+	util.Logger.Printf("[DEBUG] Checking if elevated API versions are defined for endpoint '%s'", endpoint)
+
+	// At first get minimum API version and check if it can be supported
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("error getting minimum required API version: %s", err)
+	}
+
+	// If no elevated versions are defined - return minimumApiVersion
+	elevatedVersionSlice, elevatedVersionsDefined := endpointElevatedApiVersions[endpoint]
+	if !elevatedVersionsDefined {
+		util.Logger.Printf("[DEBUG] No elevated API versions are defined for endpoint '%s'. Using minimum '%s'",
+			endpoint, minimumApiVersion)
+		return minimumApiVersion, nil
+	}
+
+	util.Logger.Printf("[DEBUG] Found '%d' (%s) elevated API versions for endpoint '%s' ",
+		len(elevatedVersionSlice), strings.Join(elevatedVersionSlice, ", "), endpoint)
+
+	// Reverse sort (highest to lowest) slice of elevated API versions so that we can start by highest supported and go down
+	versionsRaw := elevatedVersionSlice
+	versions := make([]*version.Version, len(versionsRaw))
+	for i, raw := range versionsRaw {
+		v, _ := version.NewVersion(raw)
+		versions[i] = v
+	}
+	sort.Sort(sort.Reverse(version.Collection(versions)))
+
+	var supportedElevatedVersion string
+	// Loop highest to lowest elevated versions and try to find highest from the list of supported ones
+	for _, elevatedVersion := range versions {
+
+		util.Logger.Printf("[DEBUG] Checking if elevated version '%s' is supported by VCD instance for endpoint '%s'",
+			elevatedVersion.Original(), endpoint)
+		// Check if maximum VCD API version supported is greater or equal to elevated version
+		if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) {
+			util.Logger.Printf("[DEBUG] Elevated version '%s' is supported by VCD instance for endpoint '%s'",
+				elevatedVersion.Original(), endpoint)
+			// highest version found - store it and abort the loop
+			supportedElevatedVersion = elevatedVersion.Original()
+			break
+		}
+		util.Logger.Printf("[DEBUG] API version '%s' is not supported by VCD instance for endpoint '%s'",
+			elevatedVersion.Original(), endpoint)
+	}
+
+	if supportedElevatedVersion == "" {
+		util.Logger.Printf("[DEBUG] No elevated API versions are supported for endpoint '%s'. Will use minimum "+
+			"required version '%s'", endpoint, minimumApiVersion)
+		return minimumApiVersion, nil
+	}
+
+	util.Logger.Printf("[DEBUG] Will use elevated version '%s for endpoint '%s'",
+		supportedElevatedVersion, endpoint)
+	return supportedElevatedVersion, nil
 }

--- a/govcd/openapi_endpoints_unit_test.go
+++ b/govcd/openapi_endpoints_unit_test.go
@@ -1,0 +1,146 @@
+// +build unit ALL
+
+package govcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// TestClient_getOpenApiHighestElevatedVersion aims to test out capabilities of getOpenApiHighestElevatedVersion
+// It consists of:
+// * A few manually defined tests for known endpoints
+// * Automatically generated tests for each entry in endpointMinApiVersions to ensure it returns correct version
+// * Automatically generated tests where available VCD version does not satisfy it
+// * Automatically generated tests to check if each elevated API version is returned for endpoints that have it defined
+func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
+	type testCase struct {
+		name              string
+		supportedVersions SupportedVersions
+		endpoint          string
+		wantVersion       string
+		wantErr           bool
+	}
+
+	// Start with some statically defined tests for known endpoints
+	tests := []testCase{
+		{
+			name:              "VCD_does_not_support_minimum_required_version",
+			supportedVersions: renderSupportedVersions([]string{"27.0", "28.0", "29.0", "30.0", "31.0", "32.0", "33.0"}),
+			endpoint:          types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules,
+			wantVersion:       "",
+			wantErr:           true, // NAT requires at least version 34.0
+		},
+		{
+			name:              "VCD_minimum_required_version_only",
+			supportedVersions: renderSupportedVersions([]string{"28.0", "29.0", "30.0", "31.0", "32.0", "33.0", "34.0"}),
+			endpoint:          types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules,
+			wantVersion:       "34.0",
+			wantErr:           false, // NAT minimum requirement is version 34.0
+		},
+		{
+			name: "VCD_minimum_required_version_only_unordered",
+			// Explicitly pass in unordered VCD API supported versions to ensure that ordering and matching works well
+			supportedVersions: renderSupportedVersions([]string{"33.0", "34.0", "30.0", "31.0", "32.0", "28.0", "29.0"}),
+			endpoint:          types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules,
+			wantVersion:       "34.0",
+			wantErr:           false, // NAT minimum requirement is version 34.0
+		},
+	}
+
+	// Generate unit tests for each defined endpoint in endpointMinApiVersions which does not have an elevated
+	// version entry in endpointElevatedApiVersions.
+	// Always expect to get minimal version returned without error
+	for endpointName, minimumRequiredVersion := range endpointMinApiVersions {
+		// Do not create a test case for those endpoints which explicitly have elevated versions defined in
+		// endpointElevatedApiVersions
+		if _, hasEntry := endpointElevatedApiVersions[endpointName]; hasEntry {
+			continue
+		}
+
+		tCase := testCase{
+			name: fmt.Sprintf("%s_minimum_version_%s", minimumRequiredVersion, endpointName),
+			// Put a list of versions which always satisfied minimum requirement
+			supportedVersions: renderSupportedVersions([]string{
+				"27.0", "28.0", "29.0", "30.0", "31.0", "32.0", "33.0", "34.0", "35.0", "35.1", "35.2", "36.0", "37.0", "38.0",
+			}),
+			endpoint:    endpointName,
+			wantVersion: minimumRequiredVersion,
+			wantErr:     false,
+		}
+		tests = append(tests, tCase)
+	}
+
+	// Generate unit tests for each defined endpoint in endpointMinApiVersions which does not have supported version at all
+	// Always expect an error and empty version
+	for endpointName, minimumRequiredVersion := range endpointMinApiVersions {
+		tCase := testCase{
+			name: fmt.Sprintf("%s_unsatisfied_minimum_version_%s", minimumRequiredVersion, endpointName),
+			supportedVersions: renderSupportedVersions([]string{
+				"25.0",
+			}),
+			endpoint:    endpointName,
+			wantVersion: "",
+			wantErr:     true,
+		}
+		tests = append(tests, tCase)
+	}
+
+	// Generate tests for each elevated API version in endpoints which do have elevated rights defined
+	for endpointName := range endpointMinApiVersions {
+		// Do not create a test case for those endpoints which do not have endpointElevatedApiVersions specified
+		if _, hasEntry := endpointElevatedApiVersions[endpointName]; !hasEntry {
+			continue
+		}
+
+		// generate tests for all elevated rights and expect to get
+		for _, singleElevatedApiVerion := range endpointElevatedApiVersions[endpointName] {
+
+			tCase := testCase{
+				name: fmt.Sprintf("elevated_up_to_%s_for_%s", singleElevatedApiVerion, endpointName),
+				// Insert some older versions and make it so that the highest elevated API version matches
+				supportedVersions: renderSupportedVersions([]string{
+					"27.0", singleElevatedApiVerion, "23.0", "30.0",
+				}),
+				endpoint:    endpointName,
+				wantVersion: singleElevatedApiVerion,
+				wantErr:     false,
+			}
+			tests = append(tests, tCase)
+		}
+	}
+
+	// Run all defined tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				supportedVersions: tt.supportedVersions,
+			}
+			got, err := client.getOpenApiHighestElevatedVersion(tt.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOpenApiHighestElevatedVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.wantVersion {
+				t.Errorf("getOpenApiHighestElevatedVersion() got = %v, wantVersion %v", got, tt.wantVersion)
+			}
+		})
+	}
+}
+
+// renderSupportedVersions is a helper to create fake `SupportedVersions` type out of given VCD API version list
+func renderSupportedVersions(versions []string) SupportedVersions {
+	supportedVersions := SupportedVersions{}
+
+	for _, version := range versions {
+		supportedVersions.VersionInfos = append(supportedVersions.VersionInfos,
+			VersionInfo{
+				Version:    version,
+				LoginUrl:   "https://fake-host/api/sessions",
+				Deprecated: false,
+			})
+	}
+	return supportedVersions
+}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -368,8 +368,9 @@ func (org *Org) GetTaskList() (*types.TasksList, error) {
 // queryOrgVdcByName returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryOrgVdcByName(vdcName string) (*types.QueryResultOrgVdcRecordType, error) {
 	filterFields := map[string]string{
-		"org":  org.Org.HREF,
-		"name": vdcName,
+		"org":     org.Org.HREF,
+		"orgName": org.Org.Name,
+		"name":    vdcName,
 	}
 	allVdcs, err := queryOrgVdcList(org.client, filterFields)
 	if err != nil {
@@ -390,8 +391,9 @@ func (org *Org) queryOrgVdcByName(vdcName string) (*types.QueryResultOrgVdcRecor
 // queryOrgVdcById returns a single Org VDC query result
 func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordType, error) {
 	filterMap := map[string]string{
-		"org": org.Org.HREF,
-		"id":  vdcId,
+		"org":     org.Org.HREF,
+		"orgName": org.Org.Name,
+		"id":      vdcId,
 	}
 	allVdcs, err := queryOrgVdcList(org.client, filterMap)
 
@@ -409,8 +411,9 @@ func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordTyp
 // queryCatalogByName returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		"org":  org.Org.HREF,
-		"name": catalogName,
+		"org":     org.Org.HREF, // Org ID is not allowed for non System
+		"orgName": org.Org.Name,
+		"name":    catalogName,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)
 	if err != nil {
@@ -428,11 +431,12 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 	return allCatalogs[0], nil
 }
 
-// queryCatalogById returns a single Org VDC query result
+// queryCatalogById returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryCatalogById(catalogId string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		"org": org.Org.HREF,
-		"id":  catalogId,
+		"org":     org.Org.HREF,
+		"orgName": org.Org.Name,
+		"id":      catalogId,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)
 

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -388,7 +388,7 @@ func (org *Org) queryOrgVdcByName(vdcName string) (*types.QueryResultOrgVdcRecor
 	return allVdcs[0], nil
 }
 
-// queryOrgVdcById returns a single Org VDC query result
+// queryOrgVdcById returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordType, error) {
 	filterMap := map[string]string{
 		"org":     org.Org.HREF,
@@ -408,7 +408,7 @@ func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordTyp
 	return allVdcs[0], nil
 }
 
-// queryCatalogByName returns a single QueryResultOrgVdcRecordType
+// queryCatalogByName returns a single CatalogRecord
 func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
 		"org":     org.Org.HREF, // Org ID is not allowed for non System

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -398,10 +398,11 @@ const (
 
 // These constants can be used to pick type of NSX-T NAT Rule
 const (
-	NsxtNatRuleTypeDnat   = "DNAT"
-	NsxtNatRuleTypeNoDnat = "NO_DNAT"
-	NsxtNatRuleTypeSnat   = "SNAT"
-	NsxtNatRuleTypeNoSnat = "NO_SNAT"
+	NsxtNatRuleTypeDnat      = "DNAT"
+	NsxtNatRuleTypeNoDnat    = "NO_DNAT"
+	NsxtNatRuleTypeSnat      = "SNAT"
+	NsxtNatRuleTypeNoSnat    = "NO_SNAT"
+	NsxtNatRuleTypeReflexive = "REFLEXIVE" // Only in VCD 10.3+ (API V36.0)
 )
 
 // In VCD versions 10.2.2+ (API V35.2+) there is a FirewallMatch field in NAT rule with these

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -346,6 +346,7 @@ const (
 	OpenApiEndpointFirewallGroups             = "firewallGroups/"
 	OpenApiEndpointOrgVdcNetworks             = "orgVdcNetworks/"
 	OpenApiEndpointOrgVdcNetworksDhcp         = "orgVdcNetworks/%s/dhcp"
+	OpenApiEndpointNsxtNatRules               = "edgeGateways/%s/nat/rules/"
 )
 
 // Header keys to run operations in tenant context
@@ -392,4 +393,16 @@ const (
 	// FirewallGroupTypeIpSet can be used in types.NsxtFirewallGroup for 'type' field to create IP
 	// Set
 	FirewallGroupTypeIpSet = "IP_SET"
+)
+
+// These constants can be used to pick type of NSX-T NAT Rule and FirewallMatch (for VCD 10.2.2+)
+const (
+	NsxtNatRuleTypeDnat   = "DNAT"
+	NsxtNatRuleTypeNoDnat = "NO_DNAT"
+	NsxtNatRuleTypeSnat   = "SNAT"
+	NsxtNatRuleTypeNoSnat = "NO_SNAT"
+
+	NsxtNatRuleFirewallMatchInternalAddress = "MATCH_INTERNAL_ADDRESS"
+	NsxtNatRuleFirewallMatchExternalAddress = "MATCH_EXTERNAL_ADDRESS"
+	NsxtNatRuleFirewallMatchBypass          = "BYPASS"
 )

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -439,7 +439,7 @@ type NsxtNatRule struct {
 	// Logging enabled or disabled logging of that rule
 	Logging bool `json:"logging"`
 
-	// Below two fields are only supported in VCD 10.2.2+
+	// Below two fields are only supported in VCD 10.2.2+ (API v35.2)
 
 	// FirewallMatch determines how the firewall matches the address during NATing if firewall stage is not skipped.
 	// * MATCH_INTERNAL_ADDRESS indicates the firewall will be applied to internal address of a NAT rule. For SNAT, the

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -355,7 +355,10 @@ type NsxtNatRule struct {
 	// * A DNAT rule translates the external IP to an internal IP and is used for inbound traffic.
 	// * A NO DNAT rule prevents the translation of the external IP address of packets received by an organization VDC
 	// from an external network or from another organization VDC network.
-	RuleType string `json:"ruleType"`
+	// Deprecated in API V36.0
+	RuleType string `json:"ruleType,omitempty"`
+	// Type replaces RuleType in V36.0 and adds a new Rule - REFLEXIVE
+	Type string `json:"type,omitempty"`
 
 	// ExternalAddresses
 	// * SNAT - enter the public IP address of the edge gateway for which you are configuring the SNAT rule.

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -376,6 +376,11 @@ type NsxtNatRule struct {
 	InternalAddresses      string            `json:"internalAddresses"`
 	ApplicationPortProfile *OpenApiReference `json:"applicationPortProfile,omitempty"`
 
+	// InternalPort specifies port number or port range for incoming network traffic. If Any Traffic is selected for the
+	// Application Port Profile, the default internal port is "ANY".
+	// Deprecated since API V35.0 and is replaced by DnatExternalPort
+	InternalPort string `json:"internalPort,omitempty"`
+
 	// DnatExternalPort can set a port into which the DNAT rule is translating for the packets inbound to the virtual
 	// machines.
 	DnatExternalPort string `json:"dnatExternalPort,omitempty"`

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -341,11 +341,11 @@ type NsxtAppPortProfilePort struct {
 // More docs in https://docs.vmware.com/en/VMware-Cloud-Director/10.2/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-9E43E3DC-C028-47B3-B7CA-59F0ED40E0A6.html
 type NsxtNatRule struct {
 	ID string `json:"id,omitempty"`
-	// Name holds a meaningful name for the rule
+	// Name holds a meaningful name for the rule. (API does not enforce uniqueness)
 	Name string `json:"name"`
 	// Description holds optional description for the rule
 	Description string `json:"description"`
-	// Enabled sets if the rule is active
+	// Enabled defines if the rule is active
 	Enabled bool `json:"enabled"`
 
 	// RuleType - one of the following: `DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`
@@ -355,7 +355,7 @@ type NsxtNatRule struct {
 	// * A DNAT rule translates the external IP to an internal IP and is used for inbound traffic.
 	// * A NO DNAT rule prevents the translation of the external IP address of packets received by an organization VDC
 	// from an external network or from another organization VDC network.
-	RuleType string `json:"ruleType,omitempty"`
+	RuleType string `json:"ruleType"`
 
 	// ExternalAddresses
 	// * SNAT - enter the public IP address of the edge gateway for which you are configuring the SNAT rule.

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -290,3 +290,80 @@ type NsxtFirewallGroupMemberVms struct {
 	VdcRef  *OpenApiReference `json:"vdcRef"`
 	OrgRef  *OpenApiReference `json:"orgRef"`
 }
+
+// NsxtNatRule describes a single NAT rule of 4 diferent RuleTypes - DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`.
+//
+// A SNAT or a DNAT rule on an Edge Gateway in the VMware Cloud Director environment, you always configure the rule
+// from the perspective of your organization VDC.
+// DNAT and NO_DNAT - outside traffic going inside
+// SNAT and NO_SNAT - inside traffic going outside
+// More docs in https://docs.vmware.com/en/VMware-Cloud-Director/10.2/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-9E43E3DC-C028-47B3-B7CA-59F0ED40E0A6.html
+type NsxtNatRule struct {
+	ID string `json:"id,omitempty"`
+	// Name holds a meaningful name for the rule
+	Name string `json:"name"`
+	// Description holds optional description for the rule
+	Description string `json:"description"`
+	// Enabled sets if the rule is active
+	Enabled bool `json:"enabled"`
+
+	// RuleType - one of the following: `DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`
+	// * An SNAT rule translates an internal IP to an external IP and is used for outbound traffic
+	// * A NO SNAT rule prevents the translation of the internal IP address of packets sent from an organization VDC out
+	// to an external network or to another organization VDC network.
+	// * A DNAT rule translates the external IP to an internal IP and is used for inbound traffic.
+	// * A NO DNAT rule prevents the translation of the external IP address of packets received by an organization VDC
+	// from an external network or from another organization VDC network.
+	RuleType string `json:"ruleType,omitempty"`
+
+	// ExternalAddresses
+	// * SNAT - enter the public IP address of the edge gateway for which you are configuring the SNAT rule.
+	// * NO_SNAT - leave empty (but field cannot be skipped at all, therefore it does not have 'omitempty' tag)
+	//
+	// * DNAT - public IP address of the edge gateway for which you are configuring the DNAT rule. The IP
+	// addresses that you enter must belong to the suballocated IP range of the edge gateway.
+	// * NO_DNAT - leave empty
+	ExternalAddresses string `json:"externalAddresses"`
+
+	// InternalAddresses
+	// * SNAT - the IP address or a range of IP addresses of the virtual machines for which you are configuring SNAT, so
+	// that they can send traffic to the external network.
+	//
+	// * DNAT - enter the IP address or a range of IP addresses of the virtual machines for which you are configuring
+	// DNAT, so that they can receive traffic from the external network.
+	// * NO_DNAT - leave empty
+	InternalAddresses      string            `json:"internalAddresses"`
+	ApplicationPortProfile *OpenApiReference `json:"applicationPortProfile,omitempty"`
+
+	// DnatExternalPort can set a port into which the DNAT rule is translating for the packets inbound to the virtual
+	// machines.
+	DnatExternalPort string `json:"dnatExternalPort,omitempty"`
+
+	// SnatDestinationAddresses applies only for RuleTypes `SNAT`, `NO_SNAT`
+	// If you want the rule to apply only for traffic to a specific domain, enter an IP address for this domain or an IP
+	// address range in CIDR format. If you leave this text box blank, the SNAT rule applies to all destinations outside
+	// of the local subnet.
+	SnatDestinationAddresses string `json:"snatDestinationAddresses,omitempty"`
+
+	// Logging enabled or disabled logging of that rule
+	Logging bool `json:"logging"`
+
+	// Below two fields are only supported in VCD 10.2.2+
+
+	// FirewallMatch determines how the firewall matches the address during NATing if firewall stage is not skipped.
+	// * MATCH_INTERNAL_ADDRESS indicates the firewall will be applied to internal address of a NAT rule. For SNAT, the
+	// internal address is the original source address before NAT is done. For DNAT, the internal address is the translated
+	// destination address after NAT is done. For REFLEXIVE, to egress traffic, the internal address is the original
+	// source address before NAT is done; to ingress traffic, the internal address is the translated destination address
+	// after NAT is done.
+	// * MATCH_EXTERNAL_ADDRESS indicates the firewall will be applied to external address of a NAT rule. For SNAT, the
+	// external address is the translated source address after NAT is done. For DNAT, the external address is the original
+	// destination address before NAT is done. For REFLEXIVE, to egress traffic, the external address is the translated
+	// internal address after NAT is done; to ingress traffic, the external address is the original destination address
+	// before NAT is done.
+	// * BYPASS firewall stage will be skipped.
+	FirewallMatch string `json:"firewallMatch,omitempty"`
+	// Priority helps to select rule with highest priority if an address has multiple NAT rules. A lower value means a
+	// higher precedence for this rule. Maximum value 2147481599
+	Priority *int `json:"priority,omitempty"`
+}

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -415,4 +415,10 @@ type NsxtNatRule struct {
 	// Priority helps to select rule with highest priority if an address has multiple NAT rules. A lower value means a
 	// higher precedence for this rule. Maximum value 2147481599
 	Priority *int `json:"priority,omitempty"`
+
+	// Version of NAT rule. Must not be set when creating.
+	Version *struct {
+		// Version is incremented after each update
+		Version *int `json:"version,omitempty"`
+	} `json:"version,omitempty"`
 }

--- a/util/logging.go
+++ b/util/logging.go
@@ -296,12 +296,13 @@ func ProcessRequestOutput(caller, operation, url, payload string, req *http.Requ
 	if isBinary(payload, req) {
 		payload = "[binary data]"
 	}
-	if dataSize > 0 {
-		Logger.Printf("Request data: [%d]\n%s\n", dataSize, hidePasswords(payload, false))
-	}
+	// Request header should be shown before Request data
 	Logger.Printf("Req header:\n")
 	logSanitizedHeader(req.Header)
 
+	if dataSize > 0 {
+		Logger.Printf("Request data: [%d]\n%s\n", dataSize, hidePasswords(payload, false))
+	}
 }
 
 // Logs the essentials of a HTTP response


### PR DESCRIPTION
Implements NSX-T NAT rule support by adding `NsxtNatRule` and `types.NsxtNatRule` as well as methods `edge.GetAllNsxtNatRules`,`edge.GetNsxtNatRuleByName`, `edge.GetNsxtNatRuleById`, `edge.CreateNatRule`, `nsxtNatRule.Update`, `nsxtNatRule.Delete`, `nsxtNatRule.IsEqualTo`

A few caveats:
* API does not return ID of created object therefore it must be manually looked up by comparing as much fields as it is possible. To aid this `nsxtNatRule.IsEqualTo` is introduced to perform additional validations. `edge.CreateNatRule` also has non-standard task tracking and then uses `nsxtNatRule.IsEqualTo` internally to find ID of newly created rule.
* There are two new fields introduced in API V35.2+ (VCD 10.2.2+) - `FirewalMatch` and `Priority`. In order to support these fields all methods above will elevevate API version to exactly V35.2 (not higher) so that those fields can be used. There is a specific check `Test_NsxtNatDnatFirewallMatchPriority` to test exactly that
* New NAT rule type `REFLEXIVE` is supported in API V36.0. It also requires rule type to be specified in `Type` field instead of `RuleType`
* There is one field which was deprecated `InternalPort` and was changed to `DnatExternalPort` between existing versions. Because these functions automatically elevate API - one must know which field to use. Tests `Test_NsxtNatDnatInternalPort` and `Test_NsxtNatDnatExternalPort` test out this functionality.


Additionally:
* Functions `queryOrgVdcByName`, `queryOrgVdcById`,  `queryCatalogByName` and `queryCatalogById` are improved to include `orgName` as filter (improves filtering accuracy in cases when `org` ID field is not accepted)


Note. Tests pass with `nsxt` tag on all NSX-T supported environments.