### PR TITLE
Vapp creation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   [#368](https://github.com/vmware/go-vcloud-director/pull/368)
 * Added `NsxtAppPortProfile` and `types.NsxtAppPortProfile` for NSX-T Application Port Profile management 
   [#378](https://github.com/vmware/go-vcloud-director/pull/378)  
+* Deprecated methods `vdc.ComposeRawVApp` and `vdc.ComposeVApp` [#387](https://github.com/vmware/go-vcloud-director/pull/387)
+* Added method `vdc.CreateRawVApp` [#387](https://github.com/vmware/go-vcloud-director/pull/387)
 
   
 BREAKING CHANGES:

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -206,10 +206,9 @@ func createLdapServer(vcd *TestVCD, check *C, directNetworkName string) (string,
 	vappTemplate, err := catalogItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
 	// Compose Raw vApp
-	err = vdc.ComposeRawVApp(vAppName, "")
+	vapp, err := vdc.CreateRawVApp(vAppName, "", false, false)
 	check.Assert(err, IsNil)
-	vapp, err := vdc.GetVAppByName(vAppName, true)
-	check.Assert(err, IsNil)
+	check.Assert(vapp, NotNil)
 	// vApp was created - adding it to cleanup list (using prepend to remove it before direct
 	// network removal)
 	PrependToCleanupList(vAppName, "vapp", "", check.TestName())

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -206,7 +206,7 @@ func createLdapServer(vcd *TestVCD, check *C, directNetworkName string) (string,
 	vappTemplate, err := catalogItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
 	// Compose Raw vApp
-	vapp, err := vdc.CreateRawVApp(vAppName, "", false, false)
+	vapp, err := vdc.CreateRawVApp(vAppName, "")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
 	// vApp was created - adding it to cleanup list (using prepend to remove it before direct

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -55,10 +55,9 @@ func (vcd *TestVCD) createAndGetResourcesForVmCreation(check *C, vmName string) 
 	vappTemplate, err := catalogItem.GetVAppTemplate()
 	check.Assert(err, IsNil)
 	// Compose Raw vApp
-	err = vdc.ComposeRawVApp(vmName, "")
+	vapp, err := vdc.CreateRawVApp(vmName, "")
 	check.Assert(err, IsNil)
-	vapp, err := vdc.GetVAppByName(vmName, true)
-	check.Assert(err, IsNil)
+	check.Assert(vapp, NotNil)
 	// vApp was created - let's add it to cleanup list
 	AddToCleanupList(vmName, "vapp", "", "createTestVapp")
 	// Wait until vApp becomes configurable
@@ -672,13 +671,12 @@ func deleteVapp(vcd *TestVCD, name string) error {
 // makeEmptyVapp creates a given vApp without any VM
 func makeEmptyVapp(vdc *Vdc, name string, description string) (*VApp, error) {
 
-	err := vdc.ComposeRawVApp(name, description)
+	vapp, err := vdc.CreateRawVApp(name, description)
 	if err != nil {
 		return nil, err
 	}
-	vapp, err := vdc.GetVAppByName(name, true)
-	if err != nil {
-		return nil, err
+	if vapp == nil {
+		return nil, fmt.Errorf("[makeEmptyVapp] unexpected nil vApp returned")
 	}
 	initialVappStatus, err := vapp.GetStatus()
 	if err != nil {

--- a/govcd/nsxt_firewall_group_security_group_test.go
+++ b/govcd/nsxt_firewall_group_security_group_test.go
@@ -270,11 +270,10 @@ func createStandaloneVm(check *C, vcd *TestVCD, vdc *Vdc, net *OpenApiOrgVdcNetw
 }
 
 func createVappVmAndAttachNetwork(check *C, vcd *TestVCD, vdc *Vdc, net *OpenApiOrgVdcNetwork) (*VApp, *VM) {
-	err := vdc.ComposeRawVApp(check.TestName(), check.TestName()+"description")
+	vapp, err := vdc.CreateRawVApp(check.TestName(), check.TestName()+"description")
 	check.Assert(err, IsNil)
 
-	vapp, err := vdc.GetVAppByName(check.TestName(), true)
-	check.Assert(err, IsNil)
+	check.Assert(vapp, NotNil)
 
 	// Attach network to vApp
 	orgVdcNetworkWithHREF, err := vdc.GetOrgVdcNetworkById(net.OpenApiOrgVdcNetwork.ID, true)

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -528,7 +528,6 @@ func (vdc *Vdc) CreateRawVApp(name string, description string) (*VApp, error) {
 	if vAppContents.Tasks != nil {
 		for _, innerTask := range vAppContents.Tasks.Task {
 			if innerTask != nil {
-
 				task := NewTask(vdc.client)
 				task.Task = innerTask
 				err = task.WaitTaskCompletion()

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -557,6 +557,7 @@ func (vdc *Vdc) CreateRawVApp(name string, description string) (*VApp, error) {
 // that uses the storageprofile and networks given. If you want all eulas
 // to be accepted set acceptalleulas to true. Returns a successful task
 // if completed successfully, otherwise returns an error and an empty task.
+// Deprecated: bad implementation
 func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate VAppTemplate, storageprofileref types.Reference, name string, description string, acceptalleulas bool) (Task, error) {
 	if vapptemplate.VAppTemplate.Children == nil || orgvdcnetworks == nil {
 		return Task{}, fmt.Errorf("can't compose a new vApp, objects passed are not valid")
@@ -638,6 +639,9 @@ func (vdc *Vdc) ComposeVApp(orgvdcnetworks []*types.OrgVDCNetwork, vapptemplate 
 	}
 	vdcHref.Path += "/action/composeVApp"
 
+	// Like ComposeRawVApp, this function returns a task, while it should be returning a vApp
+	// Since we don't use this function in terraform-provider-vcd, we are not going to
+	// replace it.
 	return vdc.client.ExecuteTaskRequest(vdcHref.String(), http.MethodPost,
 		types.MimeComposeVappParams, "error instantiating a new vApp: %s", vcomp)
 }

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -481,4 +481,8 @@ func (vcd *TestVCD) TestCreateRawVapp(check *C) {
 
 	check.Assert(vapp.VApp.Name, Equals, name)
 	check.Assert(vapp.VApp.Description, Equals, description)
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }


### PR DESCRIPTION
Deprecate `vdc.ComposeRawVApp` (returns task) and replace it with `vdc.CreateRawVApp` (returns vApp)

Addresses #386