### PR TITLE
V2.12.0 regression fix for `org.GetCatalogByName` and `org.GetCatalogById`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.12.1 (TBC)
+## 2.12.1 (5 July, 2021)
 
 BUGS FIXED:
 * org.GetCatalogByName and org.GetCatalogById could not retrieve shared catalogs from different Orgs 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.12.1 (TBC)
+
+BUGS FIXED:
+* org.GetCatalogByName and org.GetCatalogById could not retrieve shared catalogs from different Orgs 
+  [#389](https://github.com/vmware/go-vcloud-director/pull/389)
+
+
 ## 2.12.0 (June 30, 2021)
 
 * Added method `vdc.QueryEdgeGateway` [#364](https://github.com/vmware/go-vcloud-director/pull/364)

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1852,7 +1852,6 @@ func skipOpenApiEndpointTest(vcd *TestVCD, check *C, endpoint string) {
 }
 
 // newOrgUserConnection creates a new Org User and returns a connection to it
-//lint:ignore U1000 For future usage - Allows writing tests that require multiple users
 func newOrgUserConnection(adminOrg *AdminOrg, userName, password, href string, insecure bool) (*VCDClient, error) {
 	u, err := url.ParseRequestURI(href)
 	if err != nil {

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -615,7 +615,7 @@ func (vcd *TestVCD) Test_GetCatalogByNameSharedCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(sharedCatalogByName.Catalog.Name, Equals, sharedCatalog.Catalog.Name)
 
-	cleanupCatalogOrgVdc(check, err, sharedCatalog, vdc, vcd, newOrg1)
+	cleanupCatalogOrgVdc(check, sharedCatalog, vdc, vcd, newOrg1)
 }
 
 // Test_GetCatalogByIdSharedCatalog creates a separate Org and VDC just to create Catalog and share it with main Org
@@ -635,7 +635,7 @@ func (vcd *TestVCD) Test_GetCatalogByIdSharedCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(sharedCatalogById.Catalog.Name, Equals, sharedCatalog.Catalog.Name)
 
-	cleanupCatalogOrgVdc(check, err, sharedCatalog, vdc, vcd, newOrg1)
+	cleanupCatalogOrgVdc(check, sharedCatalog, vdc, vcd, newOrg1)
 }
 
 // Test_GetCatalogByNamePrefersLocal tests that local catalog (in the same Org) is prioritised against shared catalogs
@@ -656,7 +656,7 @@ func (vcd *TestVCD) Test_GetCatalogByNamePrefersLocal(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(catalogByNameInNewOrg.parent.orgName(), Equals, newOrg1.Org.Name)
 
-	cleanupCatalogOrgVdc(check, err, sharedCatalog, vdc, vcd, newOrg1)
+	cleanupCatalogOrgVdc(check, sharedCatalog, vdc, vcd, newOrg1)
 }
 
 // Test_GetCatalogByNameSharedCatalogOrgUser additionally tests GetOrgByName and GetOrgById using a custom created Org
@@ -729,7 +729,7 @@ func (vcd *TestVCD) Test_GetCatalogByXSharedCatalogOrgUser(check *C) {
 	err = unsharedCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
 
-	cleanupCatalogOrgVdc(check, err, sharedCatalog, vdc, vcd, newOrg1)
+	cleanupCatalogOrgVdc(check, sharedCatalog, vdc, vcd, newOrg1)
 }
 
 func createSharedCatalogInNewOrg(vcd *TestVCD, check *C, newCatalogName string) (*Org, *Vdc, Catalog) {
@@ -767,9 +767,9 @@ func createSharedCatalogInNewOrg(vcd *TestVCD, check *C, newCatalogName string) 
 	return newOrg1, vdc, catalog
 }
 
-func cleanupCatalogOrgVdc(check *C, err error, sharedCatalog Catalog, vdc *Vdc, vcd *TestVCD, newOrg1 *Org) {
+func cleanupCatalogOrgVdc(check *C, sharedCatalog Catalog, vdc *Vdc, vcd *TestVCD, newOrg1 *Org) {
 	// Cleanup catalog, vdc and org
-	err = sharedCatalog.Delete(true, true)
+	err := sharedCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
 
 	// There are cases where it just takes a a few seconds after catalog deletion when one can delete VDC

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -793,6 +793,20 @@ func spawnTestVdc(vcd *TestVCD, check *C, adminOrgName string) *Vdc {
 	return vdc
 }
 
+// spawnTestOrg spawns an Org to be used in tests
+func spawnTestOrg(vcd *TestVCD, check *C, nameSuffix string) string {
+	newOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	newOrgName := check.TestName() + "-" + nameSuffix
+	task, err := CreateOrg(vcd.client, newOrgName, newOrgName, newOrgName, newOrg.AdminOrg.OrgSettings, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	AddToCleanupList(newOrgName, "org", "", check.TestName())
+
+	return newOrgName
+}
+
 func getVdcProviderVdcHref(vcd *TestVCD, check *C) string {
 	results, err := vcd.client.QueryWithNotEncodedParams(nil, map[string]string{
 		"type":   "providerVdc",

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -417,8 +417,8 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 	filterMap := map[string]string{
 		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have different
 		// parent Org
-		//"org":     org.Org.HREF,
-		//"orgName": org.Org.Name,
+		// "org":     org.Org.HREF,
+		// "orgName": org.Org.Name,
 		"name": catalogName,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)
@@ -432,9 +432,9 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 
 	// To conform with this API standard it would be best to return an error if more than 1 item is found, but because
 	// previous method of getting Catalog by Name returned the first result we are doing the same here
-	//if len(allCatalogs) > 1 {
-	//	return nil, fmt.Errorf("found more than 1 Catalog with Name '%s'", catalogName)
-	//}
+	// if len(allCatalogs) > 1 {
+	// 	return nil, fmt.Errorf("found more than 1 Catalog with Name '%s'", catalogName)
+	// }
 
 	var localCatalog *types.CatalogRecord
 	// if multiple results are found - return the one defined in `org` (local)
@@ -465,8 +465,8 @@ func (org *Org) queryCatalogById(catalogId string) (*types.CatalogRecord, error)
 	filterMap := map[string]string{
 		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have different
 		// parent Org
-		//"org":     org.Org.HREF,
-		//"orgName": org.Org.Name,
+		// "org":     org.Org.HREF,
+		// "orgName": org.Org.Name,
 		"id": catalogId,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -415,7 +415,7 @@ func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordTyp
 // queryCatalogByName returns a single CatalogRecord
 func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have org
+		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have different
 		// parent Org
 		//"org":     org.Org.HREF,
 		//"orgName": org.Org.Name,
@@ -463,7 +463,7 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 // queryCatalogById returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryCatalogById(catalogId string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have org
+		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have different
 		// parent Org
 		//"org":     org.Org.HREF,
 		//"orgName": org.Org.Name,

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -415,9 +415,11 @@ func (org *Org) queryOrgVdcById(vdcId string) (*types.QueryResultOrgVdcRecordTyp
 // queryCatalogByName returns a single CatalogRecord
 func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		"org":     org.Org.HREF, // Org ID is not allowed for non System
-		"orgName": org.Org.Name,
-		"name":    catalogName,
+		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have org
+		// parent Org
+		//"org":     org.Org.HREF,
+		//"orgName": org.Org.Name,
+		"name": catalogName,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)
 	if err != nil {
@@ -461,9 +463,11 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 // queryCatalogById returns a single QueryResultOrgVdcRecordType
 func (org *Org) queryCatalogById(catalogId string) (*types.CatalogRecord, error) {
 	filterMap := map[string]string{
-		"org":     org.Org.HREF,
-		"orgName": org.Org.Name,
-		"id":      catalogId,
+		// Not injecting `org` or `orgName` here because shared catalogs may also appear here and they would have org
+		// parent Org
+		//"org":     org.Org.HREF,
+		//"orgName": org.Org.Name,
+		"id": catalogId,
 	}
 	allCatalogs, err := queryCatalogList(org.client, filterMap)
 

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1107,17 +1107,3 @@ func validateQueryOrgVdcResults(vcd *TestVCD, check *C, name, orgName string, ex
 		fmt.Println()
 	}
 }
-
-// spawnTestOrg spawns an Org to be used in tests
-func spawnTestOrg(vcd *TestVCD, check *C, nameSuffix string) string {
-	newOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
-	check.Assert(err, IsNil)
-	newOrgName := check.TestName() + "-" + nameSuffix
-	task, err := CreateOrg(vcd.client, newOrgName, newOrgName, newOrgName, newOrg.AdminOrg.OrgSettings, true)
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-	AddToCleanupList(newOrgName, "org", "", check.TestName())
-
-	return newOrgName
-}


### PR DESCRIPTION
go vcloud director does not find catalogs shared from other Orgs in methods `org.GetCatalogByName` and `org.GetCatalogById`

This PR fixes that, adds some tests including a test with uses Org Admin user and adds a changelog note for `2.12.1` bugfix release.