### PR TITLE
Utility scripts

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -1,0 +1,30 @@
+# Handling of CHANGELOG entries
+
+## PR operations
+
+* All PRs, instead of updating CHANGELOG.md directly, will create individual files in a directory .changes/$version 
+* The files will be named `xxx-section_name.md`, where xxx is the PR number, and `section_name` is one of 
+    * features
+    * improvements
+    * bug-fixes
+    * deprecations
+    * notes
+    * removals
+
+* The changes files must NOT contain the header
+
+* You can update the file `.changes/sections` to add more headers
+* To see the full change set for the current version (or an old one), use `./scripts/make-changelog.sh [version]`
+
+
+## Post release initialization
+   
+After a release, the changelog will be initialized with the following template:
+ 
+```
+    ## $VERSION (Unreleased)
+
+    Changes in progress for v$VERSION are available at [.changes/v$VERSION](https://github.com/vmware/go-vcloud-director/tree/master/.changes/v$VERSION) until the release.
+```
+
+Run `.changes/init.sh version` to get the needed text

--- a/.changes/init.sh
+++ b/.changes/init.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+VERSION=$1
+
+if [ -z "$VERSION" ]
+then
+    echo "Syntax: $0 VERSION (without initial 'v')"
+
+    exit 1
+fi
+
+starts_with_v=$(echo $VERSION | grep '^v')
+if [ -n "$starts_with_v" ]
+then
+    echo "The version should be without the initial 'v'"
+    exit 1
+fi
+
+echo "Copy the following lines at the top of CHANGELOG.md"
+echo ""
+echo ""
+echo "## $VERSION (Unreleased)"
+echo ""
+echo "Changes in progress for v$VERSION are available at [.changes/v$VERSION](https://github.com/vmware/go-vcloud-director/tree/master/.changes/v$VERSION) until the release."
+echo ""
+

--- a/.changes/sections
+++ b/.changes/sections
@@ -1,0 +1,7 @@
+features
+improvements
+bug-fixes
+deprecations
+notes
+removals
+breaking-changes

--- a/.changes/v2.12.0/364-deprecations.md
+++ b/.changes/v2.12.0/364-deprecations.md
@@ -1,0 +1,2 @@
+* Deprecated `vdc.GetEdgeGatewayRecordsType` [GH-364]
+

--- a/.changes/v2.12.0/364-features.md
+++ b/.changes/v2.12.0/364-features.md
@@ -1,0 +1,2 @@
+* Added method `vdc.QueryEdgeGateway` [GH-364]
+

--- a/.changes/v2.12.0/367-improvements.md
+++ b/.changes/v2.12.0/367-improvements.md
@@ -1,0 +1,3 @@
+* Only send xml.Header when payload is not empty (some WAFs block empty requests with XML header) 
+  [GH-367]
+

--- a/.changes/v2.12.0/368-features.md
+++ b/.changes/v2.12.0/368-features.md
@@ -1,0 +1,14 @@
+* Added NSX-T Firewall Group type (which represents a Security Group or an IP Set) support by using
+  structures `NsxtFirewallGroup` and `NsxtFirewallGroupMemberVms`. The following methods are
+  introduced for managing Security Groups and Ip Sets: `Vdc.CreateNsxtFirewallGroup`,
+  `NsxtEdgeGateway.CreateNsxtFirewallGroup`, `Org.GetAllNsxtFirewallGroups`,
+  `Vdc.GetAllNsxtFirewallGroups`, `Org.GetNsxtFirewallGroupByName`,
+  `Vdc.GetNsxtFirewallGroupByName`, `NsxtEdgeGateway.GetNsxtFirewallGroupByName`,
+  `Org.GetNsxtFirewallGroupById`, `Vdc.GetNsxtFirewallGroupById`,
+  `NsxtEdgeGateway.GetNsxtFirewallGroupById`, `NsxtFirewallGroup.Update`,
+  `NsxtFirewallGroup.Delete`, `NsxtFirewallGroup.GetAssociatedVms`,
+  `NsxtFirewallGroup.IsSecurityGroup`, `NsxtFirewallGroup.IsIpSet`
+  [GH-368]
+* Added methods Org.QueryVmList and Org.QueryVmById to find VM by ID in an Org
+  [GH-368]
+

--- a/.changes/v2.12.0/368-improvements.md
+++ b/.changes/v2.12.0/368-improvements.md
@@ -1,0 +1,5 @@
+* Improved test entity cleanup to find standalone VMs in any VDC (not only default NSX-V one)
+  [GH-368]
+* Improved test entity cleanup to allow specifying parent VDC for vApp removals
+  [GH-368]
+

--- a/.changes/v2.12.0/371-breaking-changes.md
+++ b/.changes/v2.12.0/371-breaking-changes.md
@@ -1,0 +1,5 @@
+* Field `types.Disk.Size` is replaced with `types.Disk.SizeMb` as size in Kilobytes is not supported in V33.0
+  [GH-371]
+* Field `types.DiskRecordType.SizeB` is replaced with `types.DiskRecordType.SizeMb` as size in Kilobytes is not
+  supported in V33.0 [GH-371]
+

--- a/.changes/v2.12.0/371-improvements.md
+++ b/.changes/v2.12.0/371-improvements.md
@@ -1,0 +1,5 @@
+* Methods `GetVDCById` and `GetVDCByName` for `Org` now use queries behind the scenes because Org 
+  structure does not list child VDCs anymore  [GH-371], [GH-376], [GH-382]
+* Methods `GetCatalogById` and `GetCatalogByName` for `Org`  now use queries behind the scenes because Org
+  structure does not list child Catalogs anymore  [GH-371] [GH-376]
+

--- a/.changes/v2.12.0/371-notes.md
+++ b/.changes/v2.12.0/371-notes.md
@@ -1,0 +1,5 @@
+* Dropped support for VCD 9.7 which is EOL now [GH-371]
+* Bumped Default API Version to V33.0  [GH-371]
+* Drop legacy authentication mechanism (vcdAuthorize) and use only new Cloud API provided (vcdCloudApiAuthorize) as
+  API V33.0 is sufficient for it [GH-371]
+

--- a/.changes/v2.12.0/372-breaking-changes.md
+++ b/.changes/v2.12.0/372-breaking-changes.md
@@ -1,0 +1,3 @@
+* Added parameter `description` to method `vdc.ComposeRawVapp` [GH-372]
+* Added methods `vapp.Rename`, `vapp.UpdateDescription`, `vapp.UpdateNameDescription` [GH-372]
+

--- a/.changes/v2.12.0/378-features.md
+++ b/.changes/v2.12.0/378-features.md
@@ -1,0 +1,3 @@
+* Added `NsxtAppPortProfile` and `types.NsxtAppPortProfile` for NSX-T Application Port Profile management 
+  [GH-378]  
+

--- a/.changes/v2.12.0/378-improvements.md
+++ b/.changes/v2.12.0/378-improvements.md
@@ -1,0 +1,5 @@
+* Improved `OpenApiGetAllItems` to still follow pages in VCD endpoints with BUG which don't return 'nextPage' link for
+  pagination [GH-378]
+* Improved LDAP container related tests to use correct port mapping for latest LDAP container version 
+  [GH-378]
+

--- a/.changes/v2.12.0/380-breaking-changes.md
+++ b/.changes/v2.12.0/380-breaking-changes.md
@@ -1,0 +1,6 @@
+* Added parameter `additionalHeader map[string]string` to functions `Client.OpenApiDeleteItem`, `Client.OpenApiGetAllItems`,
+  `Client.OpenApiGetItem`, `Client.OpenApiPostItem`, `Client.OpenApiPutItem`, `Client.OpenApiPutItemAsync`,
+  `Client.OpenApiPutItemSync` [GH-380]
+* Renamed functions `GetOpenApiRoleById` -> `GetRoleById`, `GetOpenApiRoleByName` -> `GetRoleByName`, 
+  `GetAllOpenApiRoles` -> `GetAllRoles` [GH-380]
+

--- a/.changes/v2.12.0/380-deprecations.md
+++ b/.changes/v2.12.0/380-deprecations.md
@@ -1,0 +1,2 @@
+* Removed deprecated method `adminOrg.GetRole` [GH-380] 
+

--- a/.changes/v2.12.0/380-features.md
+++ b/.changes/v2.12.0/380-features.md
@@ -1,0 +1,22 @@
+* Added Tenant Context management functions `Client.RemoveCustomHeader`, `Client.SetCustomHeader`, `WithHttpHeader`, 
+  and many private methods to retrieve tenant context down the hierarchy. More details in `CODING_GUIDELINES.md`
+  [GH-380]
+* Added Rights management methods `AdminOrg.GetAllRights`, `AdminOrg.GetAllRightsCategories`, `AdminOrg.GetRightById`, 
+  `AdminOrg.GetRightByName`, `Client.GetAllRights`, `Client.GetAllRightsCategories`, `Client.GetRightById`, 
+  `Client.GetRightByName`, `client.GetRightsCategoryById`, `AdminOrg.GetRightsCategoryById` [GH-380]
+* Added Global Role management methods `Client.GetAllGlobalRoles`, `Client.CreateGlobalRole`, `Client.GetGlobalRoleById`,
+  `Client.GetGlobalRoleByName`, `GlobalRole.AddRights`, `GlobalRole.Delete`, `GlobalRole.GetRights`,
+  `GlobalRole.GetTenants`, `GlobalRole.PublishAllTenants`, `GlobalRole.PublishTenants`, `GlobalRole.RemoveAllRights`,
+  `GlobalRole.RemoveRights`, `GlobalRole.ReplacePublishedTenants`, `GlobalRole.UnpublishAllTenants`, 
+  `GlobalRole.UnpublishTenants`, `GlobalRole.Update`, `GlobalRole.UpdateRights` [GH-380]
+* Added Rights Bundle management methods `Client.CreateRightsBundle`, `Client.GetAllRightsBundles`, 
+  `Client.GetRightsBundleById`, `Client.GetRightsBundleByName`, `RightsBundle.AddRights`, `RightsBundle.Delete`, 
+  `RightsBundle.GetRights`, `RightsBundle.GetTenants`, `RightsBundle.PublishAllTenants`, `RightsBundle.PublishTenants`, 
+  `RightsBundle.RemoveAllRights`, `RightsBundle.RemoveRights`, `RightsBundle.ReplacePublishedTenants`, 
+  `RightsBundle.UnpublishAllTenants`, `RightsBundle.UnpublishTenants`, `RightsBundle.Update`, `RightsBundle.UpdateRights`
+  [GH-380]
+* Added Role managemnt methods `AdminOrg.GetAllRoles`, `AdminOrg.GetRoleById`, `AdminOrg.GetRoleByName`, 
+  `Client.GetAllRoles`, `Role.AddRights`, `Role.GetRights`, `Role.RemoveAllRights`, `Role.RemoveRights`, `Role.UpdateRights`
+  [GH-380]
+* Added convenience function `FindMissingImpliedRights` [GH-380]
+

--- a/.changes/v2.12.0/381-features.md
+++ b/.changes/v2.12.0/381-features.md
@@ -1,0 +1,3 @@
+* Added methods `NsxtEdgeGateway.UpdateNsxtFirewall()`, `NsxtEdgeGateway.GetNsxtFirewall()`, `nsxtFirewall.DeleteAllRules()`,
+  `nsxtFirewall.DeleteRuleById` [GH-381]
+

--- a/.changes/v2.12.0/381-improvements.md
+++ b/.changes/v2.12.0/381-improvements.md
@@ -1,0 +1,3 @@
+* Cleanup a few unnecessary type conversions detected by new staticcheck version 
+  [GH-381]
+

--- a/.changes/v2.12.0/382-features.md
+++ b/.changes/v2.12.0/382-features.md
@@ -1,0 +1,4 @@
+* Added NSX-T NAT support with types `NsxtNatRule` and `types.NsxtNatRule` as well as methods `edge.GetAllNsxtNatRules`,
+  `edge.GetNsxtNatRuleByName`, `edge.GetNsxtNatRuleById`, `edge.CreateNatRule`, `nsxtNatRule.Update`, `nsxtNatRule.Delete`,
+  `nsxtNatRule.IsEqualTo` [GH-382]
+

--- a/.changes/v2.12.0/385-features.md
+++ b/.changes/v2.12.0/385-features.md
@@ -1,0 +1,3 @@
+* Added `NsxtIpSecVpnTunnel` and `types.NsxtIpSecVpnTunnel` for NSX-T IPsec VPN Tunnel configuration
+  [GH-385]
+

--- a/.changes/v2.12.0/387-bug-fixes.md
+++ b/.changes/v2.12.0/387-bug-fixes.md
@@ -1,0 +1,3 @@
+* Deprecated methods `vdc.ComposeRawVApp` and `vdc.ComposeVApp` [#387](https://github.com/vmware/go-vcloud-director/pull/387)
+* Added method `vdc.CreateRawVApp` [#387](https://github.com/vmware/go-vcloud-director/pull/387)
+

--- a/.changes/v2.12.1/389-bug-fixes.md
+++ b/.changes/v2.12.1/389-bug-fixes.md
@@ -1,0 +1,3 @@
+* org.GetCatalogByName and org.GetCatalogById could not retrieve shared catalogs from different Orgs 
+  [GH-389]
+

--- a/.changes/v2.13.0/391-bug-fixes.md
+++ b/.changes/v2.13.0/391-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fix handling of `staticcheck` in GitGub Actions [GH-391]
+

--- a/.changes/v2.13.0/391-improvements.md
+++ b/.changes/v2.13.0/391-improvements.md
@@ -1,0 +1,2 @@
+* Add `.changes` directory for changelog items [GH-391]
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.13.0 (Unreleased)
+
+Changes in progress for v2.13.0 are available at [.changes/v2.13.0](https://github.com/vmware/go-vcloud-director/tree/master/.changes/v2.13.0) until the release.
+
 ## 2.12.1 (5 July, 2021)
 
 BUGS FIXED:

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -102,6 +102,7 @@ func printVerbose(format string, args ...interface{}) {
 	}
 }
 
+//lint:ignore U1000 this function is used on request for debugging purposes
 func logVerbose(t *testing.T, format string, args ...interface{}) {
 	if testVerbose {
 		t.Logf(format, args...)

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script rewrites [GH-nnnn]-style references in the CHANGELOG.md file to
+# be Markdown links to the given github issues.
+#
+# This is run during releases so that the issue references in all of the
+# released items are presented as clickable links, but we can just use the
+# easy [GH-nnnn] shorthand for quickly adding items to the "Unrelease" section
+# while merging things between releases.
+
+set -e
+
+if [[ ! -f CHANGELOG.md ]]; then
+  echo "ERROR: CHANGELOG.md not found in pwd."
+  echo "Please run this from the root of the go-vcloud-director repository"
+  exit 1
+fi
+
+if [[ `uname` == "Darwin" ]]; then
+  echo "Using BSD sed"
+  SED="sed -i.bak -E -e"
+else
+  echo "Using GNU sed"
+  SED="sed -i.bak -r -e"
+fi
+
+GOVCD_URL="https:\/\/github.com\/vmware\/go-vcloud-director\/pull"
+
+$SED "s/GH-([0-9]+)/\[#\1\]\($GOVCD_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
+if [ "$?" != "0" ] ; then exit 1 ; fi
+rm CHANGELOG.md.bak

--- a/scripts/make-changelog.sh
+++ b/scripts/make-changelog.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# This script collects the single change files and generates CHANGELOG entries
+# for the whole release
+
+# .changes is the directory where the change files are
+sources=.changes
+
+if [ ! -d $sources ]
+then
+    echo "Directory $sources not found"
+    exit 1
+fi
+
+# We must indicate a version on the command line
+version=$1
+
+# If no version was provided, we use the current release version
+if [  -z "$version" ] 
+then
+    echo "No version was provided"
+    exit 1
+fi
+
+
+# If the provided version does not exist, there is nothing to do
+if [ ! -d  $sources/$version ]
+then
+    echo "# Changes directory $sources/$version not found"
+    exit 1
+fi
+
+# The "sections" file contains the CHANGELOG headers
+if [ ! -f $sources/sections ]
+then
+    echo "File $sources/sections not found"
+    exit 1
+fi
+sections=$(cat $sources/sections)
+
+cd $sources/$version
+
+for section in $sections
+do
+    # Check whether we have any file for this section
+    num=$(ls | grep "\-${section}.md" | wc -l | tr -d ' \t')
+    # if there are no files for this section, we skip
+    if [ "$num" == "0" ]
+    then
+        continue
+    fi
+
+    # Generate the header
+    echo "## $(echo $section | tr 'a-z' 'A-Z' | tr '-' ' ')"
+
+    # Print the changes files, sorted by PR number
+    for f in $(ls *${section}.md | sort -n)
+    do
+        cat $f
+    done
+    echo ""
+done
+

--- a/scripts/staticcheck.sh
+++ b/scripts/staticcheck.sh
@@ -27,7 +27,7 @@ function exists_in_path {
 
 function get_check_static {
     static_check=$(exists_in_path staticcheck)
-    if [  -z "$staticcheck" -a -n "$TRAVIS" ]
+    if [  -z "$staticcheck" -a -n "$GITHUB_ACTIONS" ]
     then
         # Variables found in staticcheck-config.sh
         # STATICCHECK_URL


### PR DESCRIPTION
###  Add .changes folder 

Add a folder `.changes' and `scripts/make-changelog.sh` to avoid `CHANGELOG` confilcts .
This is similar to the organization of terraform-provider-vcd.
To re-assemble the CHANGELOG, use `./scripts-make-changelog.sh VERSION`.

To show how the CHANGELOG would be organized, I added the items for v2.12.0 and v2.12.1.

###  Allow staticcheck to run in GitHub Actions

The test with `staticcheck` had stopped working when we transitioned from Travis to GitHub Actions. Changing the trigger variable fixed it. I also added a skip comment for a function that is used on demand for debugging.
