### PR TITLE
Fix catalog delete

### DIFF
--- a/.changes/v2.13.0/392-bug-fixes.md
+++ b/.changes/v2.13.0/392-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fix Issue #390: `catalog.Delete()` ignores task [GH-392]
+* Fix Issue #390: `catalog.Delete()` ignores returned task and responds immediately which could have caused failures [GH-392]
 

--- a/.changes/v2.13.0/392-bug-fixes.md
+++ b/.changes/v2.13.0/392-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fix Issue #390: `catalog.Delete()` ignores task
+* Fix Issue #390: `catalog.Delete()` ignores task [GH-392]
 

--- a/.changes/v2.13.0/392-bug-fixes.md
+++ b/.changes/v2.13.0/392-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fix Issue #390: `catalog.Delete()` ignores task
+

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -29,7 +29,7 @@ func NewAdminCatalog(client *Client) *AdminCatalog {
 	}
 }
 
-// Deletes the Catalog, returning an error if the vCD call fails.
+// Delete deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
 func (adminCatalog *AdminCatalog) Delete(force, recursive bool) error {
 	catalog := NewCatalog(adminCatalog.client)

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -70,7 +70,7 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 	if task.Task.Status == "error" {
-		return fmt.Errorf("catalog not properly destroyed")
+		return fmt.Errorf(combinedTaskErrorMessage(task.Task, fmt.Errorf("catalog %s not properly destroyed", catalog.Catalog.Name)))
 	}
 	return task.WaitTaskCompletion()
 }

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -42,7 +42,7 @@ func NewCatalog(client *Client) *Catalog {
 	}
 }
 
-// Deletes the Catalog, returning an error if the vCD call fails.
+// Delete deletes the Catalog, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Catalog.html
 func (catalog *Catalog) Delete(force, recursive bool) error {
 
@@ -52,7 +52,7 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 		return err
 	}
 	if catalogID == "" {
-		return fmt.Errorf("empty ID returned for catalog ID %s", catalog.Catalog.ID)
+		return fmt.Errorf("empty ID returned for catalog %s", catalog.Catalog.Name)
 	}
 	adminCatalogHREF.Path += "/admin/catalog/" + catalogID
 
@@ -61,13 +61,18 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 		"recursive": strconv.FormatBool(recursive),
 	}, http.MethodDelete, adminCatalogHREF, nil)
 
-	_, err = checkResp(catalog.client.Http.Do(req))
-
+	resp, err := checkResp(catalog.client.Http.Do(req))
 	if err != nil {
-		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.ID, err)
+		return fmt.Errorf("error deleting Catalog %s: %s", catalog.Catalog.Name, err)
 	}
-
-	return nil
+	task := NewTask(catalog.client)
+	if err = decodeBody(types.BodyTypeXML, resp, task.Task); err != nil {
+		return fmt.Errorf("error decoding task response: %s", err)
+	}
+	if task.Task.Status == "error" {
+		return fmt.Errorf("catalog not properly destroyed")
+	}
+	return task.WaitTaskCompletion()
 }
 
 // Envelope is a ovf description root element. File contains information for vmdk files.

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -772,9 +772,6 @@ func cleanupCatalogOrgVdc(check *C, sharedCatalog Catalog, vdc *Vdc, vcd *TestVC
 	err := sharedCatalog.Delete(true, true)
 	check.Assert(err, IsNil)
 
-	// There are cases where it just takes a a few seconds after catalog deletion when one can delete VDC
-	time.Sleep(2 * time.Second)
-
 	err = vdc.DeleteWait(true, true)
 	check.Assert(err, IsNil)
 

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -37,7 +37,7 @@ func (catalogItem *CatalogItem) GetVAppTemplate() (VAppTemplate, error) {
 
 }
 
-// Deletes the Catalog Item, returning an error if the vCD call fails.
+// Delete deletes the Catalog Item, returning an error if the vCD call fails.
 // Link to API call: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-CatalogItem.html
 func (catalogItem *CatalogItem) Delete() error {
 	util.Logger.Printf("[TRACE] Deleting catalog item: %#v", catalogItem.CatalogItem)


### PR DESCRIPTION
Fix Issue #390: `catalog.Delete()` ignores task

Note: the file in `.changes/...` will be processed correctly after PR #391 is merged.