### PR TITLE
go fmt with Go 1.17 

### DIFF
--- a/.changes/v2.13.0/396-improvements.md
+++ b/.changes/v2.13.0/396-improvements.md
@@ -1,0 +1,2 @@
+* Align build tags to match go fmt with Go 1.17 [GH-396]
+* 

--- a/.changes/v2.13.0/396-improvements.md
+++ b/.changes/v2.13.0/396-improvements.md
@@ -1,2 +1,2 @@
 * Align build tags to match go fmt with Go 1.17 [GH-396]
-* 
+* Improve `test-tags.sh` script to handle new build tag format [GH-396]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.17
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/govcd/access_control_catalog_test.go
+++ b/govcd/access_control_catalog_test.go
@@ -1,3 +1,4 @@
+//go:build functional || catalog || ALL
 // +build functional catalog ALL
 
 /*

--- a/govcd/access_control_test.go
+++ b/govcd/access_control_test.go
@@ -1,3 +1,4 @@
+//go:build functional || vapp || catalog || ALL
 // +build functional vapp catalog ALL
 
 /*

--- a/govcd/access_control_vapp_test.go
+++ b/govcd/access_control_vapp_test.go
@@ -1,3 +1,4 @@
+//go:build functional || vapp || ALL
 // +build functional vapp ALL
 
 /*

--- a/govcd/adminorg_administration_test.go
+++ b/govcd/adminorg_administration_test.go
@@ -1,3 +1,4 @@
+//go:build org || functional || ALL
 // +build org functional ALL
 
 /*

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -1,3 +1,4 @@
+//go:build (user || functional || ALL) && !skipLong
 // +build user functional ALL
 // +build !skipLong
 

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -1,3 +1,4 @@
+//go:build org || functional || ALL
 // +build org functional ALL
 
 /*

--- a/govcd/adminorg_unit_test.go
+++ b/govcd/adminorg_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/adminvdc_nsxt_test.go
+++ b/govcd/adminvdc_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build org || functional || nsxt || ALL
 // +build org functional nsxt ALL
 
 /*

--- a/govcd/adminvdc_test.go
+++ b/govcd/adminvdc_test.go
@@ -1,3 +1,4 @@
+//go:build org || functional || ALL
 // +build org functional ALL
 
 /*

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,3 +1,4 @@
+//go:build api || openapi || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || search || nsxv || nsxt || auth || affinity || role || ALL
 // +build api openapi functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user search nsxv nsxt auth affinity role ALL
 
 /*

--- a/govcd/api_vcd_test_unit.go
+++ b/govcd/api_vcd_test_unit.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -1,3 +1,4 @@
+//go:build api || functional || ALL
 // +build api functional ALL
 
 /*

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || functional || ALL
 // +build catalog functional ALL
 
 /*

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || functional || ALL
 // +build catalog functional ALL
 
 /*

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -1,3 +1,4 @@
+//go:build api || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || nsxv || nsxt || openapi || affinity || search || ALL
 // +build api functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user nsxv nsxt openapi affinity search ALL
 
 /*

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -1,3 +1,4 @@
+//go:build disk || functional || ALL
 // +build disk functional ALL
 
 /*

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || functional || ALL
 // +build gateway functional ALL
 
 /*

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -1,3 +1,4 @@
+//go:build api || functional || catalog || org || extnetwork || vm || vdc || system || user || nsxv || network || vapp || vm || affinity || ALL
 // +build api functional catalog org extnetwork vm vdc system user nsxv network vapp vm affinity ALL
 
 /*

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -1,3 +1,4 @@
+//go:build extnetwork || network || functional || openapi || ALL
 // +build extnetwork network functional openapi ALL
 
 /*

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -1,3 +1,4 @@
+//go:build extnetwork || network || functional || ALL
 // +build extnetwork network functional ALL
 
 /*

--- a/govcd/filter_engine_test.go
+++ b/govcd/filter_engine_test.go
@@ -1,3 +1,4 @@
+//go:build search || functional || ALL
 // +build search functional ALL
 
 /*

--- a/govcd/filter_engine_unit_test.go
+++ b/govcd/filter_engine_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 /*

--- a/govcd/filter_util_unit_test.go
+++ b/govcd/filter_util_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/global_role_test.go
+++ b/govcd/global_role_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || role || ALL
 // +build functional openapi role ALL
 
 /*

--- a/govcd/group_test.go
+++ b/govcd/group_test.go
@@ -1,3 +1,4 @@
+//go:build user || functional || ALL
 // +build user functional ALL
 
 /*

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -1,3 +1,4 @@
+//go:build (lb || functional || integration || ALL) && !skipLong
 // +build lb functional integration ALL
 // +build !skipLong
 

--- a/govcd/lb_unit_test.go
+++ b/govcd/lb_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || lb || lbAppProfile || functional || ALL
 // +build unit lb lbAppProfile functional ALL
 
 /*

--- a/govcd/lbappprofile_test.go
+++ b/govcd/lbappprofile_test.go
@@ -1,3 +1,4 @@
+//go:build lb || lbAppProfile || nsxv || functional || ALL
 // +build lb lbAppProfile nsxv functional ALL
 
 /*

--- a/govcd/lbapprule_test.go
+++ b/govcd/lbapprule_test.go
@@ -1,3 +1,4 @@
+//go:build lb || lbAppRule || nsxv || functional || ALL
 // +build lb lbAppRule nsxv functional ALL
 
 /*

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -1,3 +1,4 @@
+//go:build lb || lbServerPool || nsxv || functional || ALL
 // +build lb lbServerPool nsxv functional ALL
 
 /*

--- a/govcd/lbservicemonitor_test.go
+++ b/govcd/lbservicemonitor_test.go
@@ -1,3 +1,4 @@
+//go:build lb || lbServiceMonitor || nsxv || functional || ALL
 // +build lb lbServiceMonitor nsxv functional ALL
 
 /*

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -1,3 +1,4 @@
+//go:build lb || lbVirtualServer || nsxv || functional || ALL
 // +build lb lbVirtualServer nsxv functional ALL
 
 /*

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || functional || ALL
 // +build catalog functional ALL
 
 /*

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vdc || metadata || functional || ALL
 // +build vapp vdc metadata functional ALL
 
 /*

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_edge_cluster_test.go
+++ b/govcd/nsxt_edge_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 /*

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_firewall_group_ip_set_test.go
+++ b/govcd/nsxt_firewall_group_ip_set_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_firewall_group_security_group_test.go
+++ b/govcd/nsxt_firewall_group_security_group_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_importable_switch_test.go
+++ b/govcd/nsxt_importable_switch_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || ALL
 // +build network nsxt functional ALL
 
 /*

--- a/govcd/nsxt_ipsec_vpn_tunnel_test.go
+++ b/govcd/nsxt_ipsec_vpn_tunnel_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 package govcd

--- a/govcd/nsxt_test.go
+++ b/govcd/nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || openapi || functional || nsxt
 // +build ALL openapi functional nsxt
 
 /*

--- a/govcd/nsxv_dhcprelay_test.go
+++ b/govcd/nsxv_dhcprelay_test.go
@@ -1,3 +1,4 @@
+//go:build nsxv || functional || ALL
 // +build nsxv functional ALL
 
 /*

--- a/govcd/nsxv_firewall_test.go
+++ b/govcd/nsxv_firewall_test.go
@@ -1,3 +1,4 @@
+//go:build nsxv || edge || firewall || functional || ALL
 // +build nsxv edge firewall functional ALL
 
 /*

--- a/govcd/nsxv_ipset_test.go
+++ b/govcd/nsxv_ipset_test.go
@@ -1,3 +1,4 @@
+//go:build nsxv || functional || ALL
 // +build nsxv functional ALL
 
 /*

--- a/govcd/nsxv_nat_test.go
+++ b/govcd/nsxv_nat_test.go
@@ -1,3 +1,4 @@
+//go:build edge || nat || nsxv || functional || ALL
 // +build edge nat nsxv functional ALL
 
 /*

--- a/govcd/openapi_endpoints_unit_test.go
+++ b/govcd/openapi_endpoints_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 package govcd

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || functional || openapi || ALL
 // +build network nsxt functional openapi ALL
 
 /*

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || ALL
 // +build functional openapi ALL
 
 /*

--- a/govcd/openapi_unit_test.go
+++ b/govcd/openapi_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 package govcd

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1,3 +1,4 @@
+//go:build org || functional || ALL
 // +build org functional ALL
 
 /*

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -1,3 +1,4 @@
+//go:build network || functional || ALL
 // +build network functional ALL
 
 /*

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -1,3 +1,4 @@
+//go:build query || functional || ALL
 // +build query functional ALL
 
 /*

--- a/govcd/rights_bundle_test.go
+++ b/govcd/rights_bundle_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || role || ALL
 // +build functional openapi role ALL
 
 /*

--- a/govcd/rights_test.go
+++ b/govcd/rights_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || role || ALL
 // +build functional openapi role ALL
 
 /*

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || role || ALL
 // +build functional openapi role ALL
 
 /*

--- a/govcd/saml_auth_test.go
+++ b/govcd/saml_auth_test.go
@@ -1,3 +1,4 @@
+//go:build auth || functional || ALL
 // +build auth functional ALL
 
 /*

--- a/govcd/saml_auth_unit_test.go
+++ b/govcd/saml_auth_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,3 +1,4 @@
+//go:build system || functional || ALL
 // +build system functional ALL
 
 /*

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 /*

--- a/govcd/task_test.go
+++ b/govcd/task_test.go
@@ -1,3 +1,4 @@
+//go:build task || functional || ALL
 // +build task functional ALL
 
 /*

--- a/govcd/tenant_context_test.go
+++ b/govcd/tenant_context_test.go
@@ -1,3 +1,4 @@
+//go:build functional || openapi || ALL
 // +build functional openapi ALL
 
 package govcd

--- a/govcd/user_test.go
+++ b/govcd/user_test.go
@@ -1,3 +1,4 @@
+//go:build user || functional || ALL
 // +build user functional ALL
 
 /*

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -1,3 +1,4 @@
+//go:build concurrent
 // +build concurrent
 
 /*

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || functional || ALL
 // +build vapp functional ALL
 
 /*

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || functional || ALL
 // +build vapp functional ALL
 
 /*

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || functional || ALL
 // +build vapp vm functional ALL
 
 /*

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || functional || ALL
 // +build vapp functional ALL
 
 /*

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || functional || ALL
 // +build vdc functional ALL
 
 /*

--- a/govcd/vdccomputepolicy_test.go
+++ b/govcd/vdccomputepolicy_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || functional || openapi || ALL
 // +build vdc functional openapi ALL
 
 /*

--- a/govcd/vm_affinity_rule_test.go
+++ b/govcd/vm_affinity_rule_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || affinity || functional || ALL
 // +build vdc affinity functional ALL
 
 /*

--- a/govcd/vm_concurrent_test.go
+++ b/govcd/vm_concurrent_test.go
@@ -1,3 +1,4 @@
+//go:build concurrent
 // +build concurrent
 
 /*

--- a/govcd/vm_dhcp_test.go
+++ b/govcd/vm_dhcp_test.go
@@ -1,3 +1,4 @@
+//go:build nsxv || vm || functional || ALL
 // +build nsxv vm functional ALL
 
 /*

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1,3 +1,4 @@
+//go:build vm || functional || ALL
 // +build vm functional ALL
 
 /*

--- a/govcd/vm_unit_test.go
+++ b/govcd/vm_unit_test.go
@@ -1,3 +1,4 @@
+//go:build vm || unit || ALL
 // +build vm unit ALL
 
 /*

--- a/scripts/test-tags.sh
+++ b/scripts/test-tags.sh
@@ -17,7 +17,7 @@ then
 fi
 
 start=$(date +%s)
-tags=$(head -n 1 api_vcd_test.go | sed -e 's/^.*build //')
+tags=$(head -n 1 api_vcd_test.go | sed -e 's/^.*build //;s/|| //g')
 
 echo "=== RUN TagsTest"
 for tag in $tags


### PR DESCRIPTION
Go 1.17 introduced changes to how build tags are defined. `gofmt` automatically fixes that and this PR is just to make sure we are 1.17 compatible so that `make build` works.

Additionally it tunes `sed` command in `test-tags.sh` so that it gathers all tags and ignores or `||` sign in new build tag format.

_A longer description._
Go 1.17 started to use new format of build tags (which we use to separate test cases). In Go 1.17 `go fmt` command automatically maintains two types of build tags - new and old one. That way the code is still compatible with older Go versions. `go fmt` (in Go 1.17) will also keep these build directives in sync (older format with newer one). Additionally `go vet` will capture if these tags are not in sync. Our  GitHub workflow will run on Go 1.17 now and it will capture if any of submitted tags are not in sync.

Example of how new build directive looks (line1) and older one (line2)
```go
//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbServiceMonitor || lbServerPool || lbAppProfile || lbAppRule || lbVirtualServer || access_control || user || standaloneVm || search || auth || nsxt || role || ALL
// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool lbAppProfile lbAppRule lbVirtualServer access_control user standaloneVm search auth nsxt role ALL
```

