### PR TITLE
add OwnerRef to OpenAPIEdgeGateway

### DIFF
--- a/.changes/v2.13.0/397-bug-fixes.md
+++ b/.changes/v2.13.0/397-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fixes Issue #395 "BUG: can't update EGW - there is no ownerRef field"

--- a/.changes/v2.13.0/397-bug-fixes.md
+++ b/.changes/v2.13.0/397-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fixes Issue #395 "BUG: can't update EGW - there is no ownerRef field"
+* Fixes Issue #395 "BUG: can't update EGW - there is no ownerRef field" [GH-397]

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -14,8 +14,6 @@ type OpenAPIEdgeGateway struct {
 	// provider, the Org VDC network is automatically connected to the distributed router associated with the VDC Group
 	// and the "connection" field does not need to be set. For API version 35.0 and above, this field should be set for
 	// network creation.
-	//
-	// Note. In lower API versions (i.e. 32.0) this field is not recognized and OrgVdc should be used instead
 	OwnerRef *OpenApiReference `json:"ownerRef,omitempty"`
 	// OrgVdc holds the organization vDC or vDC Group that this edge gateway belongs to. If the ownerRef is set to a VDC
 	// Group, this gateway will be available across all the participating Organization vDCs in the VDC Group.

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -9,6 +9,14 @@ type OpenAPIEdgeGateway struct {
 	Name string `json:"name"`
 	// Description of edge gateway
 	Description string `json:"description"`
+	// OwnerRef defines Org VDC or VDC Group that this network belongs to. If the ownerRef is set to a VDC Group, this
+	// network will be available across all the VDCs in the vDC Group. If the VDC Group is backed by a NSX-V network
+	// provider, the Org VDC network is automatically connected to the distributed router associated with the VDC Group
+	// and the "connection" field does not need to be set. For API version 35.0 and above, this field should be set for
+	// network creation.
+	//
+	// Note. In lower API versions (i.e. 32.0) this field is not recognized and OrgVdc should be used instead
+	OwnerRef *OpenApiReference `json:"ownerRef,omitempty"`
 	// OrgVdc holds the organization vDC or vDC Group that this edge gateway belongs to. If the ownerRef is set to a VDC
 	// Group, this gateway will be available across all the participating Organization vDCs in the VDC Group.
 	OrgVdc *OpenApiReference `json:"orgVdc,omitempty"`


### PR DESCRIPTION
Fixes Issue https://github.com/vmware/go-vcloud-director/issues/395 "BUG: can't update EGW - there is no ownerRef field"

Add `OwnerRef` field to `OpenAPIEdgeGateway`

@Didainius

