### PR TITLE
Add support External Network backed NSX-T Segment

### DIFF
--- a/.changes/v2.13.0/339-improvements.md
+++ b/.changes/v2.13.0/339-improvements.md
@@ -1,3 +1,4 @@
-* External network type ExternalNetworkV2 uses elevated API (maximum available from 33.0, 35.0 and 36.0) [GH-339]
+* External network type ExternalNetworkV2 automatically elevates API version to maximum available from 33.0, 35.0 and
+  36.0 so that new functionality can be consumed [GH-339]
 * Added new field BackingTypeValue in favor of deprecated BackingType to types.ExternalNetworkV2Backing [GH-339]
 * Add new function `GetFilteredNsxtImportableSwitches` to query NSX-T Importable Switches (Segments) [GH-339] 

--- a/.changes/v2.13.0/339-improvements.md
+++ b/.changes/v2.13.0/339-improvements.md
@@ -1,4 +1,6 @@
-* External network type ExternalNetworkV2 automatically elevates API version to maximum available from 33.0, 35.0 and
-  36.0 so that new functionality can be consumed [GH-339]
+* External network type ExternalNetworkV2 automatically elevates API version to maximum available out of 33.0, 35.0 and
+  36.0, so that new functionality can be consumed. It uses a controlled version elevation mechanism to consume the newer
+  features, but at the same time remain tested by not choosing the latest untested version blindly (more information in
+  openapi_endpoints.go) [GH-339]
 * Added new field BackingTypeValue in favor of deprecated BackingType to types.ExternalNetworkV2Backing [GH-339]
 * Add new function `GetFilteredNsxtImportableSwitches` to query NSX-T Importable Switches (Segments) [GH-339] 

--- a/.changes/v2.13.0/339-improvements.md
+++ b/.changes/v2.13.0/339-improvements.md
@@ -1,0 +1,3 @@
+* External network type ExternalNetworkV2 uses elevated API (maximum available from 33.0, 35.0 and 36.0) [GH-339]
+* Added new field BackingTypeValue in favor of deprecated BackingType to types.ExternalNetworkV2Backing [GH-339]
+* Add new function `GetFilteredNsxtImportableSwitches` to query NSX-T Importable Switches (Segments) [GH-339] 

--- a/.changes/v2.13.0/YYY-improvements.md
+++ b/.changes/v2.13.0/YYY-improvements.md
@@ -1,3 +1,0 @@
-* External network type ExternalNetworkV2 uses elevated API (maximum available from 33.0, 35.0 and 36.0) [GH-YYY]
-* Added new field BackingTypeValue in favor of deprecated BackingType to types.ExternalNetworkV2Backing [GH-YYY]
-* Add new function `GetFilteredNsxtImportableSwitches` to query NSX-T Importable Switches (Segments) [GH-YYY] 

--- a/.changes/v2.13.0/YYY-improvements.md
+++ b/.changes/v2.13.0/YYY-improvements.md
@@ -1,0 +1,3 @@
+* External network type ExternalNetworkV2 uses elevated API (maximum available from 33.0, 35.0 and 36.0) [GH-YYY]
+* Added new field BackingTypeValue in favor of deprecated BackingType to types.ExternalNetworkV2Backing [GH-YYY]
+* Add new function `GetFilteredNsxtImportableSwitches` to query NSX-T Importable Switches (Segments) [GH-YYY] 

--- a/govcd/external_network_v2.go
+++ b/govcd/external_network_v2.go
@@ -23,7 +23,7 @@ type ExternalNetworkV2 struct {
 // provided. types.ExternalNetworkV2 has documented fields.
 func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetworkV2) (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetw
 		client:          &vcdClient.Client,
 	}
 
-	err = vcdClient.Client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newExtNet, returnExtNet.ExternalNetwork, nil)
+	err = vcdClient.Client.OpenApiPostItem(apiVersion, urlRef, nil, newExtNet, returnExtNet.ExternalNetwork, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating external network: %s", err)
 	}
@@ -49,7 +49,7 @@ func CreateExternalNetworkV2(vcdClient *VCDClient, newExtNet *types.ExternalNetw
 // GetExternalNetworkV2ById retrieves external network by given ID using OpenAPI endpoint
 func GetExternalNetworkV2ById(vcdClient *VCDClient, id string) (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func GetExternalNetworkV2ById(vcdClient *VCDClient, id string) (*ExternalNetwork
 		client:          &vcdClient.Client,
 	}
 
-	err = vcdClient.Client.OpenApiGetItem(minimumApiVersion, urlRef, nil, extNet.ExternalNetwork, nil)
+	err = vcdClient.Client.OpenApiGetItem(apiVersion, urlRef, nil, extNet.ExternalNetwork, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func GetExternalNetworkV2ByName(vcdClient *VCDClient, name string) (*ExternalNet
 // perform additional filtering
 func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) ([]*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := vcdClient.Client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) 
 	}
 
 	typeResponses := []*types.ExternalNetworkV2{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &typeResponses, nil)
+	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func GetAllExternalNetworksV2(vcdClient *VCDClient, queryParameters url.Values) 
 // Update updates existing external network using OpenAPI endpoint
 func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := extNet.client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
 		client:          extNet.client,
 	}
 
-	err = extNet.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, extNet.ExternalNetwork, returnExtNet.ExternalNetwork, nil)
+	err = extNet.client.OpenApiPutItem(apiVersion, urlRef, nil, extNet.ExternalNetwork, returnExtNet.ExternalNetwork, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error updating external network: %s", err)
 	}
@@ -168,7 +168,7 @@ func (extNet *ExternalNetworkV2) Update() (*ExternalNetworkV2, error) {
 // Delete deletes external network using OpenAPI endpoint
 func (extNet *ExternalNetworkV2) Delete() error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
-	minimumApiVersion, err := extNet.client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := extNet.client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (extNet *ExternalNetworkV2) Delete() error {
 		return err
 	}
 
-	err = extNet.client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil, nil)
+	err = extNet.client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting extNet: %s", err)

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -191,7 +191,7 @@ func testExternalNetworkV2(vcd *TestVCD, name, backingType, backingId, NetworkPr
 		}},
 	}
 
-	// Starting with VCD 10.2 field BackingType is deprecated in favor of BackingTypeValue, and only it accepts new values
+	// Starting with VCD 10.2 field BackingType is deprecated in favor of BackingTypeValue, and it only accepts new values
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 35.0") {
 		net.NetworkBackings.Values[0].BackingTypeValue = backingType
 	} else {

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -30,7 +30,14 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2NsxtVrf(check *C) {
 	vcd.testCreateExternalNetworkV2Nsxt(check, vcd.config.VCD.Nsxt.Tier0routerVrf, types.ExternalNetworkBackingTypeNsxtTier0Router)
 }
 
-func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, backingType string) {
+func (vcd *TestVCD) Test_CreateExternalNetworkV2NsxtSegment(check *C) {
+	if vcd.client.Client.APIVCDMaxVersionIs("< 36") {
+		check.Skip("NSX-T segment backed external networks are supported only in 10.3.0+")
+	}
+	vcd.testCreateExternalNetworkV2Nsxt(check, vcd.config.VCD.Nsxt.NsxtImportSegment, types.ExternalNetworkBackingTypeNsxtSegment)
+}
+
+func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, backingName, backingType string) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
 	skipOpenApiEndpointTest(vcd, check, endpoint)
 	skipNoNsxtConfiguration(vcd, check)
@@ -43,11 +50,10 @@ func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, b
 	nsxtManagerId, err := BuildUrnWithUuid("urn:vcloud:nsxtmanager:", extractUuid(man[0].HREF))
 	check.Assert(err, IsNil)
 
-	tier0RouterVrf, err := vcd.client.GetImportableNsxtTier0RouterByName(nsxtTier0Router, nsxtManagerId)
-	check.Assert(err, IsNil)
+	backingId := getBackingIdByNameAndType(check, backingName, backingType, vcd, nsxtManagerId)
 
 	// Create network and test CRUD capabilities
-	netNsxt := testExternalNetworkV2(check.TestName(), backingType, tier0RouterVrf.NsxtTier0Router.ID, nsxtManagerId)
+	netNsxt := testExternalNetworkV2(vcd, check.TestName(), backingType, backingId, nsxtManagerId)
 	createdNet, err := CreateExternalNetworkV2(vcd.client, netNsxt)
 	check.Assert(err, IsNil)
 
@@ -86,6 +92,26 @@ func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, nsxtTier0Router, b
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
+// getBackingIdByNameAndType looks up Backing ID by name and type
+func getBackingIdByNameAndType(check *C, backingName string, backingType string, vcd *TestVCD, nsxtManagerId string) string {
+	var backingId string
+	switch backingType {
+	case types.ExternalNetworkBackingTypeNsxtTier0Router: // Lookup T0 router ID
+		tier0RouterVrf, err := vcd.client.GetImportableNsxtTier0RouterByName(backingName, nsxtManagerId)
+		check.Assert(err, IsNil)
+		backingId = tier0RouterVrf.NsxtTier0Router.ID
+	case types.ExternalNetworkBackingTypeNsxtSegment: // Lookup segment ID
+		bareNsxtManagerId, err := getBareEntityUuid(nsxtManagerId)
+		check.Assert(err, IsNil)
+		filter := map[string]string{"nsxTManager": bareNsxtManagerId}
+
+		nsxtSegment, err := vcd.client.GetFilteredNsxtImportableSwitches(filter)
+		check.Assert(err, IsNil)
+		backingId = nsxtSegment[0].NsxtImportableSwitch.ID
+	}
+	return backingId
+}
+
 func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
 	skipOpenApiEndpointTest(vcd, check, endpoint)
@@ -109,14 +135,14 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 	// Query
 	vcHref, err := getVcenterHref(vcd.client, vcd.config.VCD.VimServer)
 	check.Assert(err, IsNil)
-	vcuuid := extractUuid(vcHref)
+	vcUuid := extractUuid(vcHref)
 
-	vcUrn, err := BuildUrnWithUuid("urn:vcloud:vimserver:", vcuuid)
+	vcUrn, err := BuildUrnWithUuid("urn:vcloud:vimserver:", vcUuid)
 	check.Assert(err, IsNil)
 
-	neT := testExternalNetworkV2(check.TestName(), vcd.config.VCD.ExternalNetworkPortGroupType, pgs[0].MoRef, vcUrn)
+	net := testExternalNetworkV2(vcd, check.TestName(), vcd.config.VCD.ExternalNetworkPortGroupType, pgs[0].MoRef, vcUrn)
 
-	r, err := CreateExternalNetworkV2(vcd.client, neT)
+	r, err := CreateExternalNetworkV2(vcd.client, net)
 	check.Assert(err, IsNil)
 
 	// Use generic "OpenApiEntity" resource cleanup type
@@ -132,8 +158,8 @@ func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
 	check.Assert(err, IsNil)
 }
 
-func testExternalNetworkV2(name, backingType, backingId, NetworkProviderId string) *types.ExternalNetworkV2 {
-	neT := &types.ExternalNetworkV2{
+func testExternalNetworkV2(vcd *TestVCD, name, backingType, backingId, NetworkProviderId string) *types.ExternalNetworkV2 {
+	net := &types.ExternalNetworkV2{
 		ID:          "",
 		Name:        name,
 		Description: "",
@@ -158,17 +184,21 @@ func testExternalNetworkV2(name, backingType, backingId, NetworkProviderId strin
 		NetworkBackings: types.ExternalNetworkV2Backings{[]types.ExternalNetworkV2Backing{
 			{
 				BackingID: backingId,
-				// Name:        tier0Router.NsxtTier0Router.DisplayName,
-				BackingType: backingType,
 				NetworkProvider: types.NetworkProvider{
-					// Name: vcd.config.Nsxt.Manager,
 					ID: NetworkProviderId,
 				},
 			},
 		}},
 	}
 
-	return neT
+	// Starting with VCD 10.2 field BackingType is deprecated in favor of BackingTypeValue, and only it accepts new values
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 35.0") {
+		net.NetworkBackings.Values[0].BackingTypeValue = backingType
+	} else {
+		net.NetworkBackings.Values[0].BackingType = backingType
+	}
+
+	return net
 }
 
 func getVcenterHref(vcdClient *VCDClient, name string) (string, error) {

--- a/govcd/nsxt_importable_switch.go
+++ b/govcd/nsxt_importable_switch.go
@@ -76,7 +76,7 @@ func (vdc *Vdc) GetAllNsxtImportableSwitches() ([]*NsxtImportableSwitch, error) 
 }
 
 // GetFilteredNsxtImportableSwitches returns all available importable switches.
-// One of filters is required (requires plain UUID - not URN):
+// One of the filters below is required (using plain UUID - not URN):
 // * orgVdc
 // * nsxTManager (only in VCD 10.3.0+)
 //

--- a/govcd/nsxt_importable_switch_test.go
+++ b/govcd/nsxt_importable_switch_test.go
@@ -48,3 +48,47 @@ func (vcd *TestVCD) Test_GetNsxtImportableSwitchByName(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(logicalSwitch.NsxtImportableSwitch.Name, Equals, vcd.config.VCD.Nsxt.NsxtImportSegment)
 }
+
+func (vcd *TestVCD) Test_GetFilteredNsxtImportableSwitches(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	if vcd.client.Client.APIVCDMaxVersionIs("< 34") {
+		check.Skip("At least VCD 10.1 is required")
+	}
+	skipNoNsxtConfiguration(vcd, check)
+
+	// Check that nil filter returns error. This will work as a safeguard to also detect if future versions start accepting
+	// empty filter value
+	results, err := vcd.client.GetFilteredNsxtImportableSwitches(nil)
+	check.Assert(err, Not(IsNil))
+	check.Assert(results, IsNil)
+
+	// Filter by VDC ID
+	bareVdcId, err := getBareEntityUuid(vcd.nsxtVdc.Vdc.ID)
+	check.Assert(err, IsNil)
+	filter := map[string]string{"orgVdc": bareVdcId}
+	results, err = vcd.client.GetFilteredNsxtImportableSwitches(filter)
+	check.Assert(err, IsNil)
+	check.Assert(len(results) > 0, Equals, true)
+
+	// Filter by NSX-T Manager (only VCD 10.3.0+)
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 36") {
+		nsxtManagers, err := vcd.client.QueryNsxtManagerByName(vcd.config.VCD.Nsxt.Manager)
+		check.Assert(err, IsNil)
+		check.Assert(len(nsxtManagers) > 0, Equals, true)
+
+		uuid := extractUuid(nsxtManagers[0].HREF)
+		filter := map[string]string{"nsxTManager": uuid}
+		results, err = vcd.client.GetFilteredNsxtImportableSwitches(filter)
+		check.Assert(err, IsNil)
+		check.Assert(len(results) > 0, Equals, true)
+
+		switchByName, err := vcd.client.GetFilteredNsxtImportableSwitchesByName(filter, vcd.config.VCD.Nsxt.NsxtImportSegment)
+		check.Assert(err, IsNil)
+		check.Assert(switchByName.NsxtImportableSwitch.Name, Equals, vcd.config.VCD.Nsxt.NsxtImportSegment)
+	} else {
+		fmt.Println("# Ignoring 'nsxTManager' filter for VCD < 10.3.0")
+	}
+}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -63,6 +63,11 @@ var endpointElevatedApiVersions = map[string][]string{
 		"35.2", // Introduces support for new fields FirewallMatch and Priority
 		"36.0", // Adds support for new NAT Rule Type - REFLEXIVE (field Type must be used instead of RuleType)
 	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks: {
+		//"33.0", // Basic minimum required version
+		"35.0", // Deprecates field BackingType in favor of BackingTypeValue
+		"36.0", // Adds support new type of BackingTypeValue - IMPORTED_T_LOGICAL_SWITCH (backed by NSX-T segment)
+	},
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -134,7 +134,7 @@ func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string,
 	sort.Sort(sort.Reverse(version.Collection(versions)))
 
 	var supportedElevatedVersion string
-	// Loop highest to lowest elevated versions and try to find highest from the list of supported ones
+	// Loop highest to the lowest elevated versions and try to find highest from the list of supported ones
 	for _, elevatedVersion := range versions {
 
 		util.Logger.Printf("[DEBUG] Checking if elevated version '%s' is supported by VCD instance for endpoint '%s'",

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -381,6 +381,8 @@ const (
 	ExternalNetworkBackingTypeNsxtTier0Router = "NSXT_TIER0"
 	// ExternalNetworkBackingTypeNsxtVrfTier0Router defines backing type of NSX-T Tier-0 VRF router
 	ExternalNetworkBackingTypeNsxtVrfTier0Router = "NSXT_VRF_TIER0"
+	// ExternalNetworkBackingTypeNsxtSegment defines backing type of NSX-T Segment (supported in VCD 10.3+)
+	ExternalNetworkBackingTypeNsxtSegment = "IMPORTED_T_LOGICAL_SWITCH"
 	// ExternalNetworkBackingTypeNetwork defines vSwitch portgroup
 	ExternalNetworkBackingTypeNetwork = "NETWORK"
 	// ExternalNetworkBackingDvPortgroup refers distributed switch portgroup

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -139,7 +139,12 @@ type ExternalNetworkV2Backing struct {
 	Name      string `json:"name,omitempty"`
 	// BackingType can be either ExternalNetworkBackingTypeNsxtTier0Router in case of NSX-T or one
 	// of ExternalNetworkBackingTypeNetwork or ExternalNetworkBackingDvPortgroup in case of NSX-V
-	BackingType string `json:"backingType"`
+	// Deprecated in favor of BackingTypeValue in API V35.0
+	BackingType string `json:"backingType,omitempty"`
+
+	// BackingTypeValue replaces BackingType in API V35.0 and adds support for additional network backing type
+	// ExternalNetworkBackingTypeNsxtSegment
+	BackingTypeValue string `json:"backingTypeValue,omitempty"`
 	// NetworkProvider defines backing network manager
 	NetworkProvider NetworkProvider `json:"networkProvider"`
 }


### PR DESCRIPTION
VCD 10.3 introduced a new type of NSX-T External networks - Segment backed networks which can then be consumed by Direct VDC network. This PR adds support for this type of network and related tests. 
