### PR TITLE
Add session info to govcd logs

### DIFF
--- a/.changes/v2.14.0/409-improvements.md
+++ b/.changes/v2.14.0/409-improvements.md
@@ -1,0 +1,1 @@
+* Add session info to go-vcloud-director logs [GH-409]

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -102,7 +102,6 @@ func printVerbose(format string, args ...interface{}) {
 	}
 }
 
-//lint:ignore U1000 this function is used on request for debugging purposes
 func logVerbose(t *testing.T, format string, args ...interface{}) {
 	if testVerbose {
 		t.Logf(format, args...)

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -169,6 +169,7 @@ func (vcdCli *VCDClient) GetAuthResponse(username, password, org string) (*http.
 		}
 	}
 
+	vcdCli.LogSessionInfo()
 	return resp, nil
 }
 
@@ -205,6 +206,7 @@ func (vcdCli *VCDClient) SetToken(org, authHeader, token string) error {
 	if err != nil {
 		return err
 	}
+	vcdCli.LogSessionInfo()
 	return nil
 }
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -169,7 +169,7 @@ func (vcdClient *VCDClient) GetAuthResponse(username, password, org string) (*ht
 		}
 	}
 
-	vcdCli.LogSessionInfo()
+	vcdClient.LogSessionInfo()
 	return resp, nil
 }
 
@@ -221,7 +221,7 @@ func (vcdClient *VCDClient) SetToken(org, authHeader, token string) error {
 	if err != nil {
 		return err
 	}
-	vcdCli.LogSessionInfo()
+	vcdClient.LogSessionInfo()
 	return nil
 }
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -397,7 +397,6 @@ func AddToCleanupListOpenApi(name, createdBy, openApiEndpoint string) {
 
 // PrependToCleanupListOpenApi prepends an OpenAPI entity OpenApi objects `entityType=OpenApiEntity` and
 // `openApiEndpoint`should be set in format "types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks + ID"
-//lint:ignore U1000 Not yet used
 func PrependToCleanupListOpenApi(name, createdBy, openApiEndpoint string) {
 	for _, item := range cleanupEntityList {
 		// avoid adding the same item twice

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -31,6 +31,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks:                   "33.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies:                 "32.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcAssignedComputePolicies:         "33.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent:                     "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:                       "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:                       "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups:                     "34.0",

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -1,8 +1,8 @@
-package govcd
-
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
+
+package govcd
 
 import (
 	"fmt"

--- a/govcd/session_info.go
+++ b/govcd/session_info.go
@@ -15,11 +15,12 @@ import (
 
 // ExtendedSessionInfo collects data regarding a VCD connection
 type ExtendedSessionInfo struct {
-	User    string
-	Org     string
-	Roles   []string
-	Version string
-	Rights  []string
+	User           string
+	Org            string
+	Roles          []string
+	Rights         []string
+	Version        string
+	ConnectionType string
 }
 
 // GetSessionInfo collects the basic session information for a VCD connection
@@ -55,6 +56,14 @@ func (vcdClient *VCDClient) GetExtendedSessionInfo() (*ExtendedSessionInfo, erro
 	sessionInfo, err := vcdClient.Client.GetSessionInfo()
 	if err != nil {
 		return nil, err
+	}
+	switch {
+	case vcdClient.Client.UsingBearerToken:
+		extendedSessionInfo.ConnectionType = "Bearer token"
+	case vcdClient.Client.UsingAccessToken:
+		extendedSessionInfo.ConnectionType = "API Access token"
+	default:
+		extendedSessionInfo.ConnectionType = "Username + password"
 	}
 	version, err := vcdClient.Client.GetVcdFullVersion()
 	if err == nil {

--- a/govcd/session_info.go
+++ b/govcd/session_info.go
@@ -73,9 +73,7 @@ func (vcdClient *VCDClient) GetExtendedSessionInfo() (*ExtendedSessionInfo, erro
 	if len(sessionInfo.Roles) == 0 {
 		return &extendedSessionInfo, nil
 	}
-	for _, roleName := range sessionInfo.Roles {
-		extendedSessionInfo.Roles = append(extendedSessionInfo.Roles, roleName)
-	}
+	extendedSessionInfo.Roles = append(extendedSessionInfo.Roles, sessionInfo.Roles...)
 	org, err := vcdClient.GetAdminOrgById(sessionInfo.Org.ID)
 	if err != nil {
 		return &extendedSessionInfo, err

--- a/govcd/session_info.go
+++ b/govcd/session_info.go
@@ -1,0 +1,122 @@
+package govcd
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
+)
+
+// ExtendedSessionInfo collects data regarding a VCD connection
+type ExtendedSessionInfo struct {
+	User    string
+	Org     string
+	Roles   []string
+	Version string
+	Rights  []string
+}
+
+// GetSessionInfo collects the basic session information for a VCD connection
+func (client *Client) GetSessionInfo() (*types.CurrentSessionInfo, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent
+
+	// We get the maximum supported version, as early versions of the API return less data
+	apiVersion, err := client.MaxSupportedVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var info types.CurrentSessionInfo
+
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, &info, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// GetExtendedSessionInfo collects extended session information for support and debugging
+// It will try to collect as much data as possible, failing only if the minimum data can't
+// be collected.
+func (vcdClient *VCDClient) GetExtendedSessionInfo() (*ExtendedSessionInfo, error) {
+	var extendedSessionInfo ExtendedSessionInfo
+	sessionInfo, err := vcdClient.Client.GetSessionInfo()
+	if err != nil {
+		return nil, err
+	}
+	version, err := vcdClient.Client.GetVcdFullVersion()
+	if err == nil {
+		extendedSessionInfo.Version = version.Version.String()
+	}
+	if sessionInfo.User.Name == "" {
+		return nil, fmt.Errorf("no user reference found")
+	}
+	extendedSessionInfo.User = sessionInfo.User.Name
+
+	if sessionInfo.Org.Name == "" {
+		return nil, fmt.Errorf("no Org reference found")
+	}
+	extendedSessionInfo.Org = sessionInfo.Org.Name
+
+	if len(sessionInfo.Roles) == 0 {
+		return &extendedSessionInfo, nil
+	}
+	for _, roleName := range sessionInfo.Roles {
+		extendedSessionInfo.Roles = append(extendedSessionInfo.Roles, roleName)
+	}
+	org, err := vcdClient.GetAdminOrgById(sessionInfo.Org.ID)
+	if err != nil {
+		return &extendedSessionInfo, err
+	}
+	for _, roleRef := range sessionInfo.RoleRefs {
+		role, err := org.GetRoleById(roleRef.ID)
+		if err != nil {
+			continue
+		}
+		rights, err := role.GetRights(nil)
+		if err != nil {
+			continue
+		}
+		for _, right := range rights {
+			extendedSessionInfo.Rights = append(extendedSessionInfo.Rights, right.Name)
+		}
+	}
+	return &extendedSessionInfo, nil
+}
+
+// LogSessionInfo prints session information into the default logs
+func (client *VCDClient) LogSessionInfo() {
+
+	// If logging is disabled, there is no point in collecting session info
+	if util.EnableLogging {
+		info, err := client.GetExtendedSessionInfo()
+		if err != nil {
+			util.Logger.Printf("no session info collected: %s\n", err)
+			return
+		}
+		text, err := json.MarshalIndent(info, " ", " ")
+		if err != nil {
+			util.Logger.Printf("error formatting session info %s\n", err)
+			return
+		}
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Println("START SESSION INFO")
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Printf("%s\n", text)
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Println("END SESSION INFO")
+		util.Logger.Println(strings.Repeat("*", 80))
+	}
+}

--- a/govcd/session_info_test.go
+++ b/govcd/session_info_test.go
@@ -1,0 +1,58 @@
+//go:build api || functional || ALL
+// +build api functional ALL
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_GetSessionInfo(check *C) {
+	info, err := vcd.client.Client.GetSessionInfo()
+	check.Assert(err, IsNil)
+	check.Assert(info, NotNil)
+
+	if testVerbose {
+		var data []byte
+		data, err = json.MarshalIndent(info, " ", " ")
+		check.Assert(err, IsNil)
+		fmt.Printf("%s\n", data)
+		org, err := vcd.client.GetAdminOrgById(info.Org.ID)
+		check.Assert(err, IsNil)
+		for _, roleRef := range info.RoleRefs {
+			role, err := org.GetRoleById(roleRef.ID)
+			check.Assert(err, IsNil)
+			fmt.Printf("%s\n", role.Role.Name)
+			rights, err := role.GetRights(nil)
+			check.Assert(err, IsNil)
+			for i, right := range rights {
+				fmt.Printf("\t%3d %s\n", i, right.Name)
+			}
+		}
+	}
+	check.Assert(info.Org, NotNil)
+	check.Assert(info.Org.Name, Not(Equals), "")
+	if vcd.client.Client.IsSysAdmin {
+		check.Assert(info.Org.Name, Equals, "System")
+	}
+	check.Assert(info.User, Not(Equals), "")
+	check.Assert(len(info.Roles), Not(Equals), 0)
+}
+
+func (vcd *TestVCD) Test_GetExtendedSessionInfo(check *C) {
+	info, err := vcd.client.GetExtendedSessionInfo()
+	check.Assert(err, IsNil)
+	check.Assert(info, NotNil)
+	if testVerbose {
+		text, err := json.MarshalIndent(info, " ", " ")
+		check.Assert(err, IsNil)
+		fmt.Printf("%s\n", text)
+	}
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -360,6 +360,7 @@ const (
 	OpenApiEndpointIpSecVpnTunnelStatus               = "edgeGateways/%s/ipsec/tunnels/%s/status"
 	OpenApiEndpointSSLCertificateLibrary              = "ssl/certificateLibrary/"
 	OpenApiEndpointSSLCertificateLibraryOld           = "ssl/cetificateLibrary/"
+	OpenApiEndpointSessionCurrent                     = "sessions/current"
 
 	// NSX-T ALB related endpoints
 	OpenApiEndpointAlbController = "loadBalancer/controllers/"

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -295,3 +295,14 @@ type CertificateLibraryItem struct {
 	PrivateKey           string `json:"privateKey,omitempty"`           // PEM encoded private key. Required if providing a certificate chain
 	PrivateKeyPassphrase string `json:"privateKeyPassphrase,omitempty"` // passphrase for the private key. Required if the private key is encrypted
 }
+
+// CurrentSessionInfo gives information about the current session
+type CurrentSessionInfo struct {
+	ID                        string            `json:"id"`                        // Session ID
+	User                      OpenApiReference  `json:"user"`                      // Name of the user associated with this session
+	Org                       OpenApiReference  `json:"org"`                       // Organization for this connection
+	Location                  string            `json:"location"`                  // Location ID: unknown usage
+	Roles                     []string          `json:"roles"`                     // Roles associated with the session user
+	RoleRefs                  OpenApiReferences `json:"roleRefs"`                  // Roles references for the session user
+	SessionIdleTimeoutMinutes int               `json:"sessionIdleTimeoutMinutes"` // session idle timeout
+}


### PR DESCRIPTION
This PR adds detailed session information to the logs.
The information recorded is:

* VCD version
* User name
* Org name
* Roles used by the connection
* Rights associated with all roles in the connection
* Connection type (using password/token/API token)

The above data gets written even if the connection uses a token

No input is required from users: if  logging is enabled, the session info gets written into the current log.

Once this PR is merged, terraform-provider-vcd will automatically benefit from it.

You can get the session information from the log using:

```
awk '/START SESSION/, /END SESSION/' go-vcloud-director.log
```
