### PR TITLE
Add support for NSX-T ALB Pools

### DIFF
--- a/.changes/v2.14.0/409-improvements.md
+++ b/.changes/v2.14.0/409-improvements.md
@@ -1,0 +1,1 @@
+* Add session info to go-vcloud-director logs [GH-409]

--- a/.changes/v2.14.0/411-features.md
+++ b/.changes/v2.14.0/411-features.md
@@ -1,0 +1,2 @@
+* Added support for ALB Pool to NSX-T Edge Gateway via type `NsxtAlbPool` and functions `GetAllAlbPools`,
+  `GetAlbPoolByName`, `GetAlbPoolById`, `CreateNsxtAlbPool`, `Update`, `Delete`  [GH-411]

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -102,7 +102,6 @@ func printVerbose(format string, args ...interface{}) {
 	}
 }
 
-//lint:ignore U1000 this function is used on request for debugging purposes
 func logVerbose(t *testing.T, format string, args ...interface{}) {
 	if testVerbose {
 		t.Logf(format, args...)

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -169,6 +169,7 @@ func (vcdClient *VCDClient) GetAuthResponse(username, password, org string) (*ht
 		}
 	}
 
+	vcdClient.LogSessionInfo()
 	return resp, nil
 }
 
@@ -220,6 +221,7 @@ func (vcdClient *VCDClient) SetToken(org, authHeader, token string) error {
 	if err != nil {
 		return err
 	}
+	vcdClient.LogSessionInfo()
 	return nil
 }
 

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -398,7 +398,6 @@ func AddToCleanupListOpenApi(name, createdBy, openApiEndpoint string) {
 
 // PrependToCleanupListOpenApi prepends an OpenAPI entity OpenApi objects `entityType=OpenApiEntity` and
 // `openApiEndpoint`should be set in format "types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworks + ID"
-//lint:ignore U1000 Not yet used
 func PrependToCleanupListOpenApi(name, createdBy, openApiEndpoint string) {
 	for _, item := range cleanupEntityList {
 		// avoid adding the same item twice

--- a/govcd/certificate_management_test.go
+++ b/govcd/certificate_management_test.go
@@ -16,14 +16,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-var (
-	//go:embed test-resources/cert.pem
-	certificate string
-
-	//go:embed test-resources/key.pem
-	privateKey string
-)
-
 func (vcd *TestVCD) Test_CertificateInLibrary(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))

--- a/govcd/certificates_embedded_test.go
+++ b/govcd/certificates_embedded_test.go
@@ -1,0 +1,20 @@
+//go:build functional || openapi || certificate || alb || nsxt || ALL
+// +build functional openapi certificate alb nsxt ALL
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	_ "embed"
+)
+
+var (
+	//go:embed test-resources/cert.pem
+	certificate string
+
+	//go:embed test-resources/key.pem
+	privateKey string
+)

--- a/govcd/nsxt_alb_pool.go
+++ b/govcd/nsxt_alb_pool.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type NsxtAlbPool struct {
+	NsxtAlbPool *types.NsxtAlbPool
+	vcdClient   *VCDClient
+}
+
+func (vcdClient *VCDClient) GetAllAlbPools(queryParameters url.Values) ([]*NsxtAlbPool, error) {
+	client := vcdClient.Client
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	typeResponses := []*types.NsxtAlbPool{{}}
+	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap all typeResponses into NsxtAlbPool types with client
+	wrappedResponses := make([]*NsxtAlbPool, len(typeResponses))
+	for sliceIndex := range typeResponses {
+		wrappedResponses[sliceIndex] = &NsxtAlbPool{
+			NsxtAlbPool: typeResponses[sliceIndex],
+			vcdClient:   vcdClient,
+		}
+	}
+
+	return wrappedResponses, nil
+}
+
+func (vcdClient *VCDClient) GetAlbPoolByName(name string) (*NsxtAlbPool, error) {
+	queryParameters := copyOrNewUrlValues(nil)
+	queryParameters.Add("filter", "name=="+name)
+
+	allAlbPools, err := vcdClient.GetAllAlbPools(queryParameters)
+	if err != nil {
+		return nil, fmt.Errorf("error reading ALB Pool with Name '%s': %s", name, err)
+	}
+
+	if len(allAlbPools) == 0 {
+		return nil, fmt.Errorf("%s: could not find ALB Pool with Name '%s'", ErrorEntityNotFound, name)
+	}
+
+	if len(allAlbPools) > 1 {
+		return nil, fmt.Errorf("found more than 1 ALB Pool with Name '%s'", name)
+	}
+
+	return allAlbPools[0], nil
+}
+
+func (vcdClient *VCDClient) GetAlbPoolById(id string) (*NsxtAlbPool, error) {
+	client := vcdClient.Client
+
+	if id == "" {
+		return nil, fmt.Errorf("ID is required to lookup NSX-T ALB Pool by ID")
+	}
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools
+	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint, id)
+	if err != nil {
+		return nil, err
+	}
+
+	typeResponse := &types.NsxtAlbPool{}
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, &typeResponse, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedResponse := &NsxtAlbPool{
+		NsxtAlbPool: typeResponse,
+		vcdClient:   vcdClient,
+	}
+
+	return wrappedResponse, nil
+}
+
+func (vcdClient *VCDClient) CreateNsxtAlbPool(albPoolConfig *types.NsxtAlbPool) (*NsxtAlbPool, error) {
+	client := vcdClient.Client
+
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &NsxtAlbPool{
+		NsxtAlbPool: &types.NsxtAlbPool{},
+		vcdClient:   vcdClient,
+	}
+
+	err = client.OpenApiPostItem(minimumApiVersion, urlRef, nil, albPoolConfig, returnObject.NsxtAlbPool, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T ALB Pool: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+func (nsxtAlbPool *NsxtAlbPool) Update(albPoolConfig *types.NsxtAlbPool) (*NsxtAlbPool, error) {
+	client := nsxtAlbPool.vcdClient.Client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if albPoolConfig.ID == "" {
+		return nil, fmt.Errorf("cannot update NSX-T ALB Pool without ID")
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint, albPoolConfig.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	responseAlbController := &NsxtAlbPool{
+		NsxtAlbPool: &types.NsxtAlbPool{},
+		vcdClient:   nsxtAlbPool.vcdClient,
+	}
+
+	err = client.OpenApiPutItem(minimumApiVersion, urlRef, nil, albPoolConfig, responseAlbController.NsxtAlbPool, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error updating NSX-T ALB Pool: %s", err)
+	}
+
+	return responseAlbController, nil
+}
+
+func (nsxtAlbPool *NsxtAlbPool) Delete() error {
+	client := nsxtAlbPool.vcdClient.Client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return err
+	}
+
+	if nsxtAlbPool.NsxtAlbPool.ID == "" {
+		return fmt.Errorf("cannot delete NSX-T ALB Pool without ID")
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint, nsxtAlbPool.NsxtAlbPool.ID)
+	if err != nil {
+		return err
+	}
+
+	err = client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting NSX-T ALB Pool: %s", err)
+	}
+
+	return nil
+}

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -1,0 +1,241 @@
+//go:build nsxt || alb || functional || ALL
+// +build nsxt alb functional ALL
+
+package govcd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_AlbPool(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+	skipNoNsxtAlbConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointAlbEdgeGateway)
+
+	// Setup prerequisites
+	controller, cloud, seGroup, edge, assignment := setupAlbPoolPrerequisites(check, vcd)
+
+	// Run various tests
+	fmt.Println("===")
+	time.Sleep(600 * time.Second)
+
+	testMinimalPoolConfig(check, edge, vcd)
+	testAdvancedPoolConfig(check, edge, vcd)
+	testPoolWithCertNoPrivateKey(check, vcd, edge.EdgeGateway.ID)
+	testPoolWithCertAndPrivateKey(check, vcd, edge.EdgeGateway.ID)
+
+	// teardown prerequisites
+	tearDownAlbPoolPrerequisites(check, assignment, edge, seGroup, cloud, controller)
+}
+
+func testMinimalPoolConfig(check *C, edge *NsxtEdgeGateway, vcd *TestVCD) {
+	poolConfigMinimal := &types.NsxtAlbPool{
+		Name:       check.TestName() + "Minimal",
+		GatewayRef: types.OpenApiReference{ID: edge.EdgeGateway.ID},
+	}
+
+	poolConfigMinimalUpdated := &types.NsxtAlbPool{
+		Name:       poolConfigMinimal.Name + "-updated",
+		GatewayRef: types.OpenApiReference{ID: edge.EdgeGateway.ID},
+	}
+
+	testAlbPoolConfig(check, vcd, "Minimal", poolConfigMinimal, poolConfigMinimalUpdated)
+}
+
+func testAdvancedPoolConfig(check *C, edge *NsxtEdgeGateway, vcd *TestVCD) {
+	poolConfigAdvanced := &types.NsxtAlbPool{
+		Name:                     check.TestName() + "-Advanced",
+		GatewayRef:               types.OpenApiReference{ID: edge.EdgeGateway.ID},
+		Algorithm:                "FEWEST_SERVERS",
+		DefaultPort:              takeIntAddress(8443),
+		GracefulTimeoutPeriod:    takeIntAddress(1),
+		PassiveMonitoringEnabled: takeBoolPointer(true),
+		HealthMonitors:           nil,
+		Members: []types.NsxtAlbPoolMember{
+			types.NsxtAlbPoolMember{
+				Enabled:   true,
+				IpAddress: "1.1.1.1",
+				Port:      takeIntAddress(8400),
+				Ratio:     takeIntAddress(2),
+			},
+			types.NsxtAlbPoolMember{
+				Enabled:   false,
+				IpAddress: "1.1.1.2",
+			},
+			types.NsxtAlbPoolMember{
+				Enabled:   true,
+				IpAddress: "1.1.1.3",
+			},
+		},
+		PersistenceProfile: &types.NsxtAlbPoolPersistenceProfile{
+			Name:  "PersistenceProfile1",
+			Type:  "CLIENT_IP",
+			Value: "",
+		},
+	}
+
+	poolConfigAdvancedUpdated := &types.NsxtAlbPool{
+		Name:                     poolConfigAdvanced.Name + "-Updated",
+		GatewayRef:               types.OpenApiReference{ID: edge.EdgeGateway.ID},
+		Algorithm:                "LEAST_LOAD",
+		GracefulTimeoutPeriod:    takeIntAddress(0),
+		PassiveMonitoringEnabled: takeBoolPointer(false),
+		HealthMonitors:           nil,
+		Members: []types.NsxtAlbPoolMember{
+			types.NsxtAlbPoolMember{
+				Enabled:   true,
+				IpAddress: "1.1.1.1",
+				Port:      takeIntAddress(8300),
+				Ratio:     takeIntAddress(3),
+			},
+			types.NsxtAlbPoolMember{
+				Enabled:   true,
+				IpAddress: "1.1.1.2",
+			},
+		},
+		PersistenceProfile: nil,
+	}
+
+	testAlbPoolConfig(check, vcd, "Advanced", poolConfigAdvanced, poolConfigAdvancedUpdated)
+}
+
+func testPoolWithCertNoPrivateKey(check *C, vcd *TestVCD, edgeGatewayId string) {
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	certificateConfigWithoutPrivateKey := &types.CertificateLibraryItem{
+		Alias:       check.TestName(),
+		Certificate: certificate,
+	}
+	openApiEndpoint, err := getEndpointByVersion(&vcd.client.Client)
+	check.Assert(err, IsNil)
+	createdCertificate, err := adminOrg.AddCertificateToLibrary(certificateConfigWithoutPrivateKey)
+	check.Assert(err, IsNil)
+	PrependToCleanupListOpenApi(createdCertificate.CertificateLibrary.Alias, check.TestName(), openApiEndpoint+createdCertificate.CertificateLibrary.Id)
+
+	poolConfigWithCert := &types.NsxtAlbPool{
+		Name:                   check.TestName() + "-complicated",
+		GatewayRef:             types.OpenApiReference{ID: edgeGatewayId},
+		Algorithm:              "FASTEST_RESPONSE",
+		CaCertificateRefs:      []types.OpenApiReference{types.OpenApiReference{ID: createdCertificate.CertificateLibrary.Id}},
+		CommonNameCheckEnabled: takeBoolPointer(true),
+		DomainNames:            []string{"one", "two", "three"},
+		DefaultPort:            takeIntAddress(1211),
+	}
+
+	testAlbPoolConfig(check, vcd, "CertificateWithNoPrivateKey", poolConfigWithCert, nil)
+
+	err = createdCertificate.Delete()
+	check.Assert(err, IsNil)
+}
+
+func testPoolWithCertAndPrivateKey(check *C, vcd *TestVCD, edgeGatewayId string) {
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	certificateConfigWithoutPrivateKey := &types.CertificateLibraryItem{
+		Alias:                check.TestName(),
+		Certificate:          certificate,
+		PrivateKey:           privateKey,
+		PrivateKeyPassphrase: "test",
+	}
+
+	openApiEndpoint, err := getEndpointByVersion(&vcd.client.Client)
+	check.Assert(err, IsNil)
+	createdCertificate, err := adminOrg.AddCertificateToLibrary(certificateConfigWithoutPrivateKey)
+	check.Assert(err, IsNil)
+	PrependToCleanupListOpenApi(createdCertificate.CertificateLibrary.Alias, check.TestName(), openApiEndpoint+createdCertificate.CertificateLibrary.Id)
+
+	poolConfigWithCertAndKey := &types.NsxtAlbPool{
+		Name:       check.TestName() + "-complicated",
+		GatewayRef: types.OpenApiReference{ID: edgeGatewayId},
+
+		Algorithm:         "FASTEST_RESPONSE",
+		CaCertificateRefs: []types.OpenApiReference{types.OpenApiReference{ID: createdCertificate.CertificateLibrary.Id}},
+		DefaultPort:       takeIntAddress(1211),
+	}
+
+	testAlbPoolConfig(check, vcd, "CertificateWithPrivateKey", poolConfigWithCertAndKey, nil)
+
+	err = createdCertificate.Delete()
+	check.Assert(err, IsNil)
+}
+
+func testAlbPoolConfig(check *C, vcd *TestVCD, name string, setupConfig *types.NsxtAlbPool, updateConfig *types.NsxtAlbPool) {
+	fmt.Printf("# Running ALB Pool test with config %s ", name)
+
+	createdPool, err := vcd.client.CreateNsxtAlbPool(setupConfig)
+	check.Assert(err, IsNil)
+
+	// Verify mandatory fields
+	check.Assert(createdPool.NsxtAlbPool.ID, NotNil)
+	check.Assert(createdPool.NsxtAlbPool.Name, NotNil)
+	check.Assert(createdPool.NsxtAlbPool.GatewayRef.ID, NotNil)
+
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools + createdPool.NsxtAlbPool.ID
+	PrependToCleanupListOpenApi(createdPool.NsxtAlbPool.Name, check.TestName(), openApiEndpoint)
+
+	if updateConfig != nil {
+		updateConfig.ID = createdPool.NsxtAlbPool.ID
+		updatedPool, err := createdPool.Update(updateConfig)
+		check.Assert(err, IsNil)
+		check.Assert(createdPool.NsxtAlbPool.ID, Equals, updatedPool.NsxtAlbPool.ID)
+		check.Assert(updatedPool.NsxtAlbPool.Name, NotNil)
+		check.Assert(updatedPool.NsxtAlbPool.GatewayRef.ID, NotNil)
+	}
+
+	err = createdPool.Delete()
+	check.Assert(err, IsNil)
+	fmt.Printf("Done.\n")
+}
+
+func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *NsxtAlbCloud, *NsxtAlbServiceEngineGroup, *NsxtEdgeGateway, *NsxtAlbServiceEngineGroupAssignment) {
+	controller, cloud, seGroup := spawnAlbControllerCloudServiceEngineGroup(vcd, check, "SHARED")
+	edge, err := vcd.nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	// Enable ALB on Edge Gateway with default ServiceNetworkDefinition
+	albSettingsConfig := &types.NsxtAlbConfig{
+		Enabled: true,
+	}
+	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
+	check.Assert(err, IsNil)
+	check.Assert(enabledSettings.Enabled, Equals, true)
+	PrependToCleanupList(check.TestName()+"-ALB-settings", "OpenApiEntityAlbSettingsDisable", edge.EdgeGateway.Name, check.TestName())
+
+	serviceEngineGroupAssignmentConfig := &types.NsxtAlbServiceEngineGroupAssignment{
+		GatewayRef:            &types.OpenApiReference{ID: edge.EdgeGateway.ID},
+		ServiceEngineGroupRef: &types.OpenApiReference{ID: seGroup.NsxtAlbServiceEngineGroup.ID},
+		MaxVirtualServices:    takeIntAddress(89),
+		MinVirtualServices:    takeIntAddress(20),
+	}
+
+	assignment, err := vcd.client.CreateAlbServiceEngineGroupAssignment(serviceEngineGroupAssignmentConfig)
+	check.Assert(err, IsNil)
+	check.Assert(assignment.NsxtAlbServiceEngineGroupAssignment.ID, Not(Equals), "")
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroupAssignments + assignment.NsxtAlbServiceEngineGroupAssignment.ID
+	PrependToCleanupListOpenApi(assignment.NsxtAlbServiceEngineGroupAssignment.ServiceEngineGroupRef.Name, check.TestName(), openApiEndpoint)
+	return controller, cloud, seGroup, edge, assignment
+}
+
+func tearDownAlbPoolPrerequisites(check *C, assignment *NsxtAlbServiceEngineGroupAssignment, edge *NsxtEdgeGateway, seGroup *NsxtAlbServiceEngineGroup, cloud *NsxtAlbCloud, controller *NsxtAlbController) {
+	err := assignment.Delete()
+	check.Assert(err, IsNil)
+	err = edge.DisableAlb()
+	check.Assert(err, IsNil)
+	err = seGroup.Delete()
+	check.Assert(err, IsNil)
+	err = cloud.Delete()
+	check.Assert(err, IsNil)
+	err = controller.Delete()
+	check.Assert(err, IsNil)
+}

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -634,8 +634,9 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	// If the body contains data - try to read all contents for logging and re-create another
 	// io.Reader with all contents to use it down the line
 	var readBody []byte
+	var err error
 	if body != nil {
-		readBody, err := ioutil.ReadAll(body)
+		readBody, err = ioutil.ReadAll(body)
 		if err != nil {
 			util.Logger.Printf("[DEBUG - newOpenApiRequest] error reading body: %s", err)
 		}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -31,6 +31,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks:                   "33.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies:                 "32.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcAssignedComputePolicies:         "33.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent:                     "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:                       "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:                       "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups:                     "34.0",

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -54,6 +54,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbEdgeGateway:                   "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroupAssignments: "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools:                         "35.0", // VCD 10.2+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPoolSummaries:                 "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibrary:            "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibraryOld:         "35.0", // VCD 10.2+ and deprecated from 10.3
 }

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -52,6 +52,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups:           "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbEdgeGateway:                   "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroupAssignments: "35.0", // VCD 10.2+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbPools:                         "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibrary:            "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibraryOld:         "35.0", // VCD 10.2+ and deprecated from 10.3
 }

--- a/govcd/roles.go
+++ b/govcd/roles.go
@@ -1,8 +1,8 @@
-package govcd
-
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
+
+package govcd
 
 import (
 	"fmt"

--- a/govcd/session_info.go
+++ b/govcd/session_info.go
@@ -1,0 +1,129 @@
+package govcd
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
+)
+
+// ExtendedSessionInfo collects data regarding a VCD connection
+type ExtendedSessionInfo struct {
+	User           string
+	Org            string
+	Roles          []string
+	Rights         []string
+	Version        string
+	ConnectionType string
+}
+
+// GetSessionInfo collects the basic session information for a VCD connection
+func (client *Client) GetSessionInfo() (*types.CurrentSessionInfo, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent
+
+	// We get the maximum supported version, as early versions of the API return less data
+	apiVersion, err := client.MaxSupportedVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var info types.CurrentSessionInfo
+
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, &info, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// GetExtendedSessionInfo collects extended session information for support and debugging
+// It will try to collect as much data as possible, failing only if the minimum data can't
+// be collected.
+func (vcdClient *VCDClient) GetExtendedSessionInfo() (*ExtendedSessionInfo, error) {
+	var extendedSessionInfo ExtendedSessionInfo
+	sessionInfo, err := vcdClient.Client.GetSessionInfo()
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case vcdClient.Client.UsingBearerToken:
+		extendedSessionInfo.ConnectionType = "Bearer token"
+	case vcdClient.Client.UsingAccessToken:
+		extendedSessionInfo.ConnectionType = "API Access token"
+	default:
+		extendedSessionInfo.ConnectionType = "Username + password"
+	}
+	version, err := vcdClient.Client.GetVcdFullVersion()
+	if err == nil {
+		extendedSessionInfo.Version = version.Version.String()
+	}
+	if sessionInfo.User.Name == "" {
+		return nil, fmt.Errorf("no user reference found")
+	}
+	extendedSessionInfo.User = sessionInfo.User.Name
+
+	if sessionInfo.Org.Name == "" {
+		return nil, fmt.Errorf("no Org reference found")
+	}
+	extendedSessionInfo.Org = sessionInfo.Org.Name
+
+	if len(sessionInfo.Roles) == 0 {
+		return &extendedSessionInfo, nil
+	}
+	extendedSessionInfo.Roles = append(extendedSessionInfo.Roles, sessionInfo.Roles...)
+	org, err := vcdClient.GetAdminOrgById(sessionInfo.Org.ID)
+	if err != nil {
+		return &extendedSessionInfo, err
+	}
+	for _, roleRef := range sessionInfo.RoleRefs {
+		role, err := org.GetRoleById(roleRef.ID)
+		if err != nil {
+			continue
+		}
+		rights, err := role.GetRights(nil)
+		if err != nil {
+			continue
+		}
+		for _, right := range rights {
+			extendedSessionInfo.Rights = append(extendedSessionInfo.Rights, right.Name)
+		}
+	}
+	return &extendedSessionInfo, nil
+}
+
+// LogSessionInfo prints session information into the default logs
+func (client *VCDClient) LogSessionInfo() {
+
+	// If logging is disabled, there is no point in collecting session info
+	if util.EnableLogging {
+		info, err := client.GetExtendedSessionInfo()
+		if err != nil {
+			util.Logger.Printf("no session info collected: %s\n", err)
+			return
+		}
+		text, err := json.MarshalIndent(info, " ", " ")
+		if err != nil {
+			util.Logger.Printf("error formatting session info %s\n", err)
+			return
+		}
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Println("START SESSION INFO")
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Printf("%s\n", text)
+		util.Logger.Println(strings.Repeat("*", 80))
+		util.Logger.Println("END SESSION INFO")
+		util.Logger.Println(strings.Repeat("*", 80))
+	}
+}

--- a/govcd/session_info_test.go
+++ b/govcd/session_info_test.go
@@ -1,0 +1,58 @@
+//go:build api || functional || ALL
+// +build api functional ALL
+
+/*
+ * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_GetSessionInfo(check *C) {
+	info, err := vcd.client.Client.GetSessionInfo()
+	check.Assert(err, IsNil)
+	check.Assert(info, NotNil)
+
+	if testVerbose {
+		var data []byte
+		data, err = json.MarshalIndent(info, " ", " ")
+		check.Assert(err, IsNil)
+		fmt.Printf("%s\n", data)
+		org, err := vcd.client.GetAdminOrgById(info.Org.ID)
+		check.Assert(err, IsNil)
+		for _, roleRef := range info.RoleRefs {
+			role, err := org.GetRoleById(roleRef.ID)
+			check.Assert(err, IsNil)
+			fmt.Printf("%s\n", role.Role.Name)
+			rights, err := role.GetRights(nil)
+			check.Assert(err, IsNil)
+			for i, right := range rights {
+				fmt.Printf("\t%3d %s\n", i, right.Name)
+			}
+		}
+	}
+	check.Assert(info.Org, NotNil)
+	check.Assert(info.Org.Name, Not(Equals), "")
+	if vcd.client.Client.IsSysAdmin {
+		check.Assert(info.Org.Name, Equals, "System")
+	}
+	check.Assert(info.User, Not(Equals), "")
+	check.Assert(len(info.Roles), Not(Equals), 0)
+}
+
+func (vcd *TestVCD) Test_GetExtendedSessionInfo(check *C) {
+	info, err := vcd.client.GetExtendedSessionInfo()
+	check.Assert(err, IsNil)
+	check.Assert(info, NotNil)
+	if testVerbose {
+		text, err := json.MarshalIndent(info, " ", " ")
+		check.Assert(err, IsNil)
+		fmt.Printf("%s\n", text)
+	}
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -373,6 +373,9 @@ const (
 	OpenApiEndpointAlbCloud                         = "loadBalancer/clouds/"
 	OpenApiEndpointAlbServiceEngineGroups           = "loadBalancer/serviceEngineGroups/"
 	OpenApiEndpointAlbPools                         = "loadBalancer/pools/"
+	// OpenApiEndpointAlbPoolSummaries returns a limited subset of data provided by OpenApiEndpointAlbPools
+	// however only the summary endpoint can list all available pools for an edge gateway
+	OpenApiEndpointAlbPoolSummaries                 = "edgeGateways/%s/loadBalancer/poolSummaries" // %s contains edge gateway
 	OpenApiEndpointAlbServiceEngineGroupAssignments = "loadBalancer/serviceEngineGroups/assignments/"
 	OpenApiEndpointAlbEdgeGateway                   = "edgeGateways/%s/loadBalancer"
 )

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -371,6 +371,7 @@ const (
 	OpenApiEndpointAlbImportableServiceEngineGroups = "nsxAlbResources/importableServiceEngineGroups"
 	OpenApiEndpointAlbCloud                         = "loadBalancer/clouds/"
 	OpenApiEndpointAlbServiceEngineGroups           = "loadBalancer/serviceEngineGroups/"
+	OpenApiEndpointAlbPools                         = "loadBalancer/pools/"
 	OpenApiEndpointAlbServiceEngineGroupAssignments = "loadBalancer/serviceEngineGroups/assignments/"
 	OpenApiEndpointAlbEdgeGateway                   = "edgeGateways/%s/loadBalancer"
 )

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -361,6 +361,7 @@ const (
 	OpenApiEndpointIpSecVpnTunnelStatus               = "edgeGateways/%s/ipsec/tunnels/%s/status"
 	OpenApiEndpointSSLCertificateLibrary              = "ssl/certificateLibrary/"
 	OpenApiEndpointSSLCertificateLibraryOld           = "ssl/cetificateLibrary/"
+	OpenApiEndpointSessionCurrent                     = "sessions/current"
 
 	// NSX-T ALB related endpoints
 

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -891,7 +891,7 @@ type NsxtAlbPool struct {
 	// GracefulTimeoutPeriod sets maximum time (in minutes) to gracefully disable a member. Virtual service waits for the
 	// specified time before terminating the existing connections to the pool members that are disabled.
 	//
-	//Special values: 0 represents Immediate, -1 represents Infinite.
+	// Special values: 0 represents Immediate, -1 represents Infinite.
 	GracefulTimeoutPeriod *int `json:"gracefulTimeoutPeriod,omitempty"`
 
 	// PassiveMonitoringEnabled sets if client traffic should be used to check if pool member is up or down.
@@ -903,7 +903,7 @@ type NsxtAlbPool struct {
 		Name          string `json:"name"`
 		SystemDefined bool   `json:"systemDefined,omitempty"`
 		Type          string `json:"type"`
-	} `json:"healthMonitors"`
+	} `json:"healthMonitors,omitempty"`
 
 	// Members field defines list of destination servers which are used by the Load Balancer Pool to direct load balanced
 	// traffic.
@@ -928,10 +928,10 @@ type NsxtAlbPoolMember struct {
 	IpAddress string `json:"ipAddress"`
 
 	// Port number of the Load Balancer Pool member. If unset, the port that the client used to connect will be used.
-	Port *int `json:"port"`
+	Port *int `json:"port,omitempty"`
 
 	// Ratio of selecting eligible servers in the pool.
-	Ratio *int `json:"ratio"`
+	Ratio *int `json:"ratio,omitempty"`
 
 	// MarkedDownBy gives the names of the health monitors that marked the member as down when it is DOWN. If a monitor
 	// cannot be determined, the value will be UNKNOWN.

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -850,3 +850,124 @@ type NsxtAlbServiceEngineGroupAssignment struct {
 	// NumDeployedVirtualServices is a read only value
 	NumDeployedVirtualServices int `json:"numDeployedVirtualServices,omitempty"`
 }
+
+// NsxtAlbPool defines configuration of a single NSX-T ALB Pool
+type NsxtAlbPool struct {
+	ID string `json:"id,omitempty"`
+	// Name is mandatory
+	Name string `json:"name"`
+	// GatewayRef is mandatory and associates NSX-T Edge Gateway with this Load Balancer Pool.
+	GatewayRef OpenApiReference `json:"gatewayRef"`
+
+	// Algorithm for choosing a member within the pools list of available members for each new connection.
+	// Default value is LEAST_CONNECTIONS
+	// Supported algorithms are:
+	// * LEAST_CONNECTIONS
+	// * ROUND_ROBIN
+	// * CONSISTENT_HASH (uses Source IP Address hash)
+	// * FASTEST_RESPONSE
+	// * LEAST_LOAD
+	// * FEWEST_SERVERS
+	// * RANDOM
+	// * FEWEST_TASKS
+	// * CORE_AFFINITY
+	Algorithm string `json:"algorithm,omitempty"`
+
+	// CaCertificateRefs point to root certificates to use when validating certificates presented by the pool members.
+	CaCertificateRefs []OpenApiReference `json:"caCertificateRefs,omitempty"`
+	// CommonNameCheckEnabled specifies whether to check the common name of the certificate presented by the pool member.
+	// This cannot be enabled if no caCertificateRefs are specified.
+	CommonNameCheckEnabled *bool `json:"commonNameCheckEnabled,omitempty"`
+
+	// DefaultPort defines destination server port used by the traffic sent to the member.
+	DefaultPort *int `json:"defaultPort,omitempty"`
+
+	// DomainNames holds a list of domain names which will be used to verify the common names or subject alternative
+	// names presented by the pool member certificates. It is performed only when common name check
+	// (CommonNameCheckEnabled) is enabled. If common name check is enabled, but domain names are not specified then the
+	// incoming host header will be used to check the certificate.
+	DomainNames []string `json:"domainNames,omitempty"`
+
+	// GracefulTimeoutPeriod sets maximum time (in minutes) to gracefully disable a member. Virtual service waits for the
+	// specified time before terminating the existing connections to the pool members that are disabled.
+	//
+	//Special values: 0 represents Immediate, -1 represents Infinite.
+	GracefulTimeoutPeriod *int `json:"gracefulTimeoutPeriod,omitempty"`
+
+	// PassiveMonitoringEnabled sets if client traffic should be used to check if pool member is up or down.
+	PassiveMonitoringEnabled *bool `json:"passiveMonitoringEnabled,omitempty"`
+
+	// HealthMonitors check member servers health. It can be monitored by using one or more health monitors. Active
+	// monitors generate synthetic traffic and mark a server up or down based on the response.
+	HealthMonitors []struct {
+		Name          string `json:"name"`
+		SystemDefined bool   `json:"systemDefined,omitempty"`
+		Type          string `json:"type"`
+	} `json:"healthMonitors"`
+
+	// Members field defines list of destination servers which are used by the Load Balancer Pool to direct load balanced
+	// traffic.
+	Members []NsxtAlbPoolMember `json:"members,omitempty"`
+
+	// PersistenceProfile of a Load Balancer Pool. Persistence profile will ensure that the same user sticks to the same
+	// server for a desired duration of time. If the persistence profile is unmanaged by Cloud Director, updates that
+	// leave the values unchanged will continue to use the same unmanaged profile. Any changes made to the persistence
+	// profile will cause Cloud Director to switch the pool to a profile managed by Cloud Director.
+	PersistenceProfile *NsxtAlbPoolPersistenceProfile `json:"persistenceProfile,omitempty"`
+
+	// VirtualServiceRefs holds list of Load Balancer Virtual Services associated with this Load balancer Pool.
+	VirtualServiceRefs []OpenApiReference `json:"virtualServiceRefs,omitempty"`
+}
+
+// NsxtAlbPoolMember defines a single destination server which is used by the Load Balancer Pool to direct load balanced
+// traffic.
+type NsxtAlbPoolMember struct {
+	// Enabled defines if member is enabled (will receive incoming requests) or not
+	Enabled bool `json:"enabled"`
+	// IpAddress of the Load Balancer Pool member.
+	IpAddress string `json:"ipAddress"`
+
+	// Port number of the Load Balancer Pool member. If unset, the port that the client used to connect will be used.
+	Port *int `json:"port"`
+
+	// Ratio of selecting eligible servers in the pool.
+	Ratio *int `json:"ratio"`
+
+	// MarkedDownBy gives the names of the health monitors that marked the member as down when it is DOWN. If a monitor
+	// cannot be determined, the value will be UNKNOWN.
+	MarkedDownBy []string `json:"markedDownBy"`
+
+	// HealthStatus of the pool member. Possible values are:
+	// * UP - The member is operational
+	// * DOWN - The member is down
+	// * DISABLED - The member is disabled
+	// * UNKNOWN - The state is unknown
+	HealthStatus string `json:"healthStatus"`
+
+	// DetailedHealthMessage contains non-localized detailed message on the health of the pool member.
+	DetailedHealthMessage string `json:"detailedHealthMessage"`
+}
+
+// NsxtAlbPoolPersistenceProfile holds Persistence Profile of a Load Balancer Pool. Persistence profile will ensure that
+// the same user sticks to the same server for a desired duration of time. If the persistence profile is unmanaged by
+// Cloud Director, updates that leave the values unchanged will continue to use the same unmanaged profile. Any changes
+// made to the persistence profile will cause Cloud Director to switch the pool to a profile managed by Cloud Director.
+type NsxtAlbPoolPersistenceProfile struct {
+	// Name of persistence profile
+	Name string `json:"name"`
+
+	// Type of persistence strategy to use. Supported values are:
+	//  * CLIENT_IP - The clients IP is used as the identifier and mapped to the server
+	//  * HTTP_COOKIE - Load Balancer inserts a cookie into HTTP responses. Cookie name must be provided as value
+	//  * CUSTOM_HTTP_HEADER - Custom, static mappings of header values to specific servers are used. Header name must be provided as value
+	//  * APP_COOKIE - Load Balancer reads existing server cookies or URI embedded data such as JSessionID. Cookie name must be provided as value
+	//  * TLS - Information is embedded in the client?s SSL/TLS ticket ID. This will use default system profile System-Persistence-TLS
+	Type string `json:"type"`
+
+	// Value of attribute based on selected persistence type.
+	// This is required for HTTP_COOKIE, CUSTOM_HTTP_HEADER and APP_COOKIE persistence types.
+	//
+	// HTTP_COOKIE, APP_COOKIE must have cookie name set as the value and CUSTOM_HTTP_HEADER must have header name set as
+	// the value.
+	Value string `json:"value,omitempty"`
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -295,3 +295,14 @@ type CertificateLibraryItem struct {
 	PrivateKey           string `json:"privateKey,omitempty"`           // PEM encoded private key. Required if providing a certificate chain
 	PrivateKeyPassphrase string `json:"privateKeyPassphrase,omitempty"` // passphrase for the private key. Required if the private key is encrypted
 }
+
+// CurrentSessionInfo gives information about the current session
+type CurrentSessionInfo struct {
+	ID                        string            `json:"id"`                        // Session ID
+	User                      OpenApiReference  `json:"user"`                      // Name of the user associated with this session
+	Org                       OpenApiReference  `json:"org"`                       // Organization for this connection
+	Location                  string            `json:"location"`                  // Location ID: unknown usage
+	Roles                     []string          `json:"roles"`                     // Roles associated with the session user
+	RoleRefs                  OpenApiReferences `json:"roleRefs"`                  // Roles references for the session user
+	SessionIdleTimeoutMinutes int               `json:"sessionIdleTimeoutMinutes"` // session idle timeout
+}


### PR DESCRIPTION
This PR adds support for NSX-T ALB Pools via type NsxtAlbPool and its relevant functions.


* Moves embedded certificates to separate file so that they can be shared with multiple tests (tags)