### PR TITLE
Fix broken request payload logging

### DIFF
--- a/.changes/v2.14.0/408-improvements.md
+++ b/.changes/v2.14.0/408-improvements.md
@@ -1,1 +1,1 @@
-* Remove Coverity warnings from code [GH-408]
+* Remove Coverity warnings from code [GH-408, GH-412]

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -634,8 +634,9 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	// If the body contains data - try to read all contents for logging and re-create another
 	// io.Reader with all contents to use it down the line
 	var readBody []byte
+	var err error
 	if body != nil {
-		readBody, err := ioutil.ReadAll(body)
+		readBody, err = ioutil.ReadAll(body)
 		if err != nil {
 			util.Logger.Printf("[DEBUG - newOpenApiRequest] error reading body: %s", err)
 		}


### PR DESCRIPTION
While fixing unhandled errors we accidentally masked one variable. More details in https://github.com/vmware/go-vcloud-director/pull/412/files#r759886479