### PR TITLE
Change refresh_token to use request body

### DIFF
--- a/govcd/api_token.go
+++ b/govcd/api_token.go
@@ -5,6 +5,7 @@
 package govcd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -54,11 +55,8 @@ func (vcdClient *VCDClient) GetBearerTokenFromApiToken(org, token string) (*type
 		return nil, fmt.Errorf("error getting request URL from %s : %s", reqUrl, err)
 	}
 
-	options := map[string]string{
-		"grant_type":    "refresh_token",
-		"refresh_token": token,
-	}
-	req := vcdClient.Client.NewRequest(options, http.MethodPost, *reqHref, nil)
+	data := bytes.NewBufferString(fmt.Sprintf("grant_type=refresh_token&refresh_token=%s", token))
+	req := vcdClient.Client.NewRequest(nil, http.MethodPost, *reqHref, data)
 	req.Header.Add("Accept", "application/*;version=36.1")
 
 	resp, err := vcdClient.Client.Http.Do(req)

--- a/util/logging.go
+++ b/util/logging.go
@@ -189,6 +189,10 @@ func hideSensitive(in string, onScreen bool) string {
 	re6 := regexp.MustCompile(`(-----BEGIN ENCRYPTED PRIVATE KEY-----)(.*)(-----END ENCRYPTED PRIVATE KEY-----)`)
 	out = re6.ReplaceAllString(out, `${1}******${3}`)
 
+	// Token inside request body
+	re7 := regexp.MustCompile(`(refresh_token)=(\S+)`)
+	out = re7.ReplaceAllString(out, `${1}=*******`)
+
 	return out
 }
 

--- a/util/logging.go
+++ b/util/logging.go
@@ -261,15 +261,6 @@ func logSanitizedHeader(inputHeader http.Header) {
 	}
 }
 
-// sanitizedUrl removes sensitive API token from URL
-func sanitizedUrl(url string) string {
-	if !LogPasswords && strings.Contains(url, "refresh_token=") {
-		parts := strings.Split(url, "?")
-		return parts[0] + "?grant_type=refresh_token&refresh_token=**********"
-	}
-	return url
-}
-
 // Returns true if the caller function matches any of the functions in the include function list
 func includeFunction(caller string) bool {
 	if len(apiLogFunctions) > 0 {
@@ -303,7 +294,7 @@ func ProcessRequestOutput(caller, operation, url, payload string, req *http.Requ
 
 	Logger.Printf("%s\n", dashLine)
 	Logger.Printf("Request caller: %s\n", caller)
-	Logger.Printf("%s %s\n", operation, sanitizedUrl(url))
+	Logger.Printf("%s %s\n", operation, url)
 	Logger.Printf("%s\n", dashLine)
 	dataSize := len(payload)
 	if isBinary(payload, req) {


### PR DESCRIPTION
Although the operations in go-vcloud-director are logged
with the sensitive information filtered off, when using
the API token in the URL, it gets recorded in the VCD
logs. To avoid this logging, which may result in
token disclosure when a support bundle is generated,
we change the refresh_token operation to use the request body
instead of URL parameters.
