### PR TITLE
bugfix: Do not send Weight in ChangeCPUCountWithCore

### DIFF
--- a/.changes/v2.14.0/419-bug-fixes.md
+++ b/.changes/v2.14.0/419-bug-fixes.md
@@ -1,0 +1,1 @@
+* Remove hardcoded 0 value for Weight field in `ChangeCPUCountWithCore` function to avoid overriding shares [GH-419] 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -245,8 +245,7 @@ func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (
 		Reservation:     0,
 		ResourceType:    types.ResourceTypeProcessor,
 		VirtualQuantity: int64(virtualCpuCount),
-		//Weight:          0,
-		CoresPerSocket: coresPerSocket,
+		CoresPerSocket:  coresPerSocket,
 		Link: &types.Link{
 			HREF: vm.VM.HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -245,8 +245,8 @@ func (vm *VM) ChangeCPUCountWithCore(virtualCpuCount int, coresPerSocket *int) (
 		Reservation:     0,
 		ResourceType:    types.ResourceTypeProcessor,
 		VirtualQuantity: int64(virtualCpuCount),
-		Weight:          0,
-		CoresPerSocket:  coresPerSocket,
+		//Weight:          0,
+		CoresPerSocket: coresPerSocket,
 		Link: &types.Link{
 			HREF: vm.VM.HREF + "/virtualHardwareSection/cpu",
 			Rel:  "edit",

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1597,9 +1597,10 @@ type OVFItem struct {
 	Reservation     int      `xml:"rasd:Reservation"`
 	ResourceType    int      `xml:"rasd:ResourceType"`
 	VirtualQuantity int64    `xml:"rasd:VirtualQuantity"`
-	Weight          int      `xml:"rasd:Weight,omitempty"`
-	CoresPerSocket  *int     `xml:"vmw:CoresPerSocket,omitempty"`
-	Link            *Link    `xml:"vcloud:Link"`
+	// Weight corresponds to Shares when used for CPU and/or memory settings
+	Weight         int   `xml:"rasd:Weight,omitempty"`
+	CoresPerSocket *int  `xml:"vmw:CoresPerSocket,omitempty"`
+	Link           *Link `xml:"vcloud:Link"`
 }
 
 // DeployVAppParams are the parameters to a deploy vApp request

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1597,7 +1597,7 @@ type OVFItem struct {
 	Reservation     int      `xml:"rasd:Reservation"`
 	ResourceType    int      `xml:"rasd:ResourceType"`
 	VirtualQuantity int64    `xml:"rasd:VirtualQuantity"`
-	Weight          int      `xml:"rasd:Weight"`
+	Weight          int      `xml:"rasd:Weight,omitempty"`
 	CoresPerSocket  *int     `xml:"vmw:CoresPerSocket,omitempty"`
 	Link            *Link    `xml:"vcloud:Link"`
 }


### PR DESCRIPTION
`ChangeCPUCountWithCore` sends a hardocded `Weight` field with value 0. This might override shares in some cases. This PR adjusts `ChangeCPUCountWithCore` function to avoid sending Weight field at all.