### PR TITLE
Add user list to organization groups

### DIFF
--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -44,9 +44,9 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 	}()
 
 	// Run tests requiring LDAP from here.
-	vcd.test_GroupCRUD(check)
-	vcd.test_GroupFinderGetGenericEntity(check)
-
+	//vcd.test_GroupCRUD(check)
+	//vcd.test_GroupFinderGetGenericEntity(check)
+	vcd.test_GroupUserListIsPopulated(check)
 }
 
 // configureLdap creates direct network, spawns Photon OS VM with LDAP server and configures vCD to

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2899,6 +2899,8 @@ type Group struct {
 	ProviderType string `xml:"ProviderType"`
 	// Role - reference to existing role
 	Role *Reference `xml:"Role,omitempty"`
+	// UsersList - references to existing users
+	UsersList []*Reference `xml:"UsersList,omitempty"`
 }
 
 // Type: AdminCatalogRecord


### PR DESCRIPTION
Signed-off-by: abarreiro <abarreiro@vmware.com>

## Description

This PR enhances the Group type by adding the UsersList attribute, that lists all the users that belong to the group.

Changelist:
- Added UsersList to the Group type.
- Added a new test that imports a Group from the testing LDAP, imports a user from the testing LDAP, then checks that retrieving the group returns the imported user in the list.
