### PR TITLE
Catalog.QueryMediaList bugfix

### DIFF
--- a/.changes/v2.15.0/441-bug-fixes.md
+++ b/.changes/v2.15.0/441-bug-fixes.md
@@ -1,0 +1,1 @@
+* `Catalog.QueryMediaList` method was not working because fmt.Sprintf was being misused [GH-441]

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -904,7 +904,7 @@ func (catalog *Catalog) QueryMediaList() ([]*types.MediaRecordType, error) {
 		typeMedia = "adminMedia"
 	}
 
-	filter := fmt.Sprintf("catalog==" + url.QueryEscape(catalog.Catalog.HREF))
+	filter := fmt.Sprintf("catalog==%s", url.QueryEscape(catalog.Catalog.HREF))
 	results, err := catalog.client.QueryWithNotEncodedParams(nil, map[string]string{"type": typeMedia, "filter": filter, "filterEncoded": "true"})
 	if err != nil {
 		return nil, fmt.Errorf("error querying medias %s", err)

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -897,3 +897,45 @@ func (vcd *TestVCD) Test_UploadOvfByLink_progress_works(check *C) {
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
+
+// Test to be completed
+func (vcd *TestVCD) Test_QueryVappTemplateList(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	catalogName := vcd.config.VCD.Catalog.Name
+	if catalogName == "" {
+		check.Skip("Test_CatalogRefresh: Catalog name not given")
+		return
+	}
+
+	cat, err := vcd.org.GetCatalogByName(catalogName, false)
+	if err != nil {
+		check.Skip("Test_CatalogRefresh: Catalog not found")
+		return
+	}
+
+	numberOfMedias, err := cat.QueryVappTemplateList()
+	check.Assert(err, IsNil)
+	check.Assert(numberOfMedias, NotNil)
+}
+
+// Test to be completed
+func (vcd *TestVCD) Test_CatalogQueryMediaList(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	catalogName := vcd.config.VCD.Catalog.Name
+	if catalogName == "" {
+		check.Skip("Test_CatalogRefresh: Catalog name not given")
+		return
+	}
+
+	cat, err := vcd.org.GetCatalogByName(catalogName, false)
+	if err != nil {
+		check.Skip("Test_CatalogRefresh: Catalog not found")
+		return
+	}
+
+	numberOfMedias, err := cat.QueryMediaList()
+	check.Assert(err, IsNil)
+	check.Assert(numberOfMedias, NotNil)
+}

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -898,44 +898,28 @@ func (vcd *TestVCD) Test_UploadOvfByLink_progress_works(check *C) {
 	verifyCatalogItemUploaded(check, catalog, itemName)
 }
 
-// Test to be completed
-func (vcd *TestVCD) Test_QueryVappTemplateList(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-
-	catalogName := vcd.config.VCD.Catalog.Name
-	if catalogName == "" {
-		check.Skip("Test_CatalogRefresh: Catalog name not given")
-		return
-	}
-
-	cat, err := vcd.org.GetCatalogByName(catalogName, false)
-	if err != nil {
-		check.Skip("Test_CatalogRefresh: Catalog not found")
-		return
-	}
-
-	numberOfMedias, err := cat.QueryVappTemplateList()
-	check.Assert(err, IsNil)
-	check.Assert(numberOfMedias, NotNil)
-}
-
-// Test to be completed
 func (vcd *TestVCD) Test_CatalogQueryMediaList(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	catalogName := vcd.config.VCD.Catalog.Name
 	if catalogName == "" {
-		check.Skip("Test_CatalogRefresh: Catalog name not given")
+		check.Skip("Test_CatalogQueryMediaList: Catalog name not given")
 		return
 	}
 
 	cat, err := vcd.org.GetCatalogByName(catalogName, false)
 	if err != nil {
-		check.Skip("Test_CatalogRefresh: Catalog not found")
+		check.Skip("Test_CatalogQueryMediaList: Catalog not found")
 		return
 	}
 
-	numberOfMedias, err := cat.QueryMediaList()
+	medias, err := cat.QueryMediaList()
 	check.Assert(err, IsNil)
-	check.Assert(numberOfMedias, NotNil)
+	check.Assert(medias, NotNil)
+
+	// Check that number of medias is 1
+	check.Assert(len(medias), Equals, 1)
+
+	// Check that media name is what it should be
+	check.Assert(medias[0].Name, Equals, vcd.config.Media.Media)
 }

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -229,3 +229,29 @@ func (vcd *TestVCD) Test_DeleteNonEmptyCatalog(check *C) {
 	check.Assert(err, NotNil)
 	check.Assert(retrievedCatalog, IsNil)
 }
+
+func (vcd *TestVCD) Test_QueryVappTemplateList(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	catalogName := vcd.config.VCD.Catalog.Name
+	if catalogName == "" {
+		check.Skip("Test_QueryVappTemplateList: Catalog name not given")
+		return
+	}
+
+	cat, err := vcd.org.GetCatalogByName(catalogName, false)
+	if err != nil {
+		check.Skip("Test_QueryVappTemplateList: Catalog not found")
+		return
+	}
+
+	vAppTemplates, err := cat.QueryVappTemplateList()
+	check.Assert(err, IsNil)
+	check.Assert(vAppTemplates, NotNil)
+
+	// Check the number of vApp templates is one
+	check.Assert(len(vAppTemplates), Equals, 1)
+
+	// Check the name of the vApp template is what it should be
+	check.Assert(vAppTemplates[0].Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
+}


### PR DESCRIPTION
## Description
`Catalog.QueryMediaList` method has a bug which prevents from correctly retrieve media list from a given catalog.

## Detailed description
While developing some features for the Terraform provider for VCD, I've found out that the method `Catalog.QueryMediaList` was buggy. 
When executing it, it throws an error saying that the URL cannot be parsed.
After some debugging, I saw that the method fmt.Sprintf was being used wrongly:
```
filter := fmt.Sprintf("catalog==" + url.QueryEscape(catalog.Catalog.HREF))
```

This was causing that the string returned, instead of having escaped characters appropriately, it contained things like `(INVALID)` which were crashing the execution.

I fix the issue with the following change:
```
filter := fmt.Sprintf("catalog==%s", url.QueryEscape(catalog.Catalog.HREF))
``` 

Now things are working properly. Also I saw neither `Catalog.QueryMediaList` nor `Catalog.QueryVappTemplateList` had tests, so I wrote them! 🚀 

