### PR TITLE
Publish to external VCD ORG and subscribe attributes on OrgGeneralSettings struct

### DIFF
--- a/.changes/v2.15.0/444-improvements.md
+++ b/.changes/v2.15.0/444-improvements.md
@@ -1,0 +1,1 @@
+* Add `CanPublishExternally` and `CanSubscribe` attributes to `OrgGeneralSettings` struct. [GH-444]

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -787,6 +787,8 @@ type OrgGeneralSettings struct {
 	Link LinkList `xml:"Link,omitempty"`      // A reference to an entity or operation associated with this object.
 
 	CanPublishCatalogs       bool `xml:"CanPublishCatalogs,omitempty"`
+	CanPublishExternally     bool `xml:"CanPublishExternally,omitempty"`
+	CanSubscribe             bool `xml:"CanSubscribe,omitempty"`
 	DeployedVMQuota          int  `xml:"DeployedVMQuota,omitempty"`
 	StoredVMQuota            int  `xml:"StoredVmQuota,omitempty"`
 	UseServerBootSequence    bool `xml:"UseServerBootSequence,omitempty"`


### PR DESCRIPTION
## Description

In order to fulfill the issue from the Terraform provider for VCD https://github.com/vmware/terraform-provider-vcd/issues/775 we needed to add a couple of attributes to `OrgGeneralSettings`. These are `CanPublishExternally` and `CanSubscribe`.

## Detailed description
The current go-vcd SDK lacks of functionality for reading and changing some ORG values regarding catalogs. At the moment it is possible to read and change the option "Share catalogs to other organizations" through the attribute ´AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs´ but for options "Publish external catalogs" and "Subscribe to external catalogs" is not possible.  
  
This PR adds support for both options through the attributes `CanPublishExternally` and `CanSubscribe` from `OrgGeneralSettings` struct.

![image](https://user-images.githubusercontent.com/6768988/157062335-2e59fcd6-efa6-4bae-aee9-387f59bea52f.png)
