### PR TITLE
Solve bug that prevented sending StoredVmQuota and DeployedVmQuota when creating/updating Org User

### DIFF
--- a/govcd/user_test.go
+++ b/govcd/user_test.go
@@ -184,6 +184,19 @@ func (vcd *TestVCD) Test_UserCRUD(check *C) {
 		check.Assert(user.User.DeployedVmQuota, Equals, userDefinition.DeployedVmQuota)
 		check.Assert(user.User.IsExternal, Equals, userDefinition.IsExternal)
 
+		// change DeployedVmQuota and StoredVmQuota to 0 and assert
+		// this will make DeployedVmQuota and StoredVmQuota unlimited
+		user.User.DeployedVmQuota = 0
+		user.User.StoredVmQuota = 0
+		err = user.Update()
+		check.Assert(err, IsNil)
+
+		// Get the user from API again
+		user, err = adminOrg.GetUserByHref(user.User.Href)
+		check.Assert(err, IsNil)
+		check.Assert(user.User.DeployedVmQuota, Equals, 0)
+		check.Assert(user.User.StoredVmQuota, Equals, 0)
+
 		err = user.Disable()
 		check.Assert(err, IsNil)
 		check.Assert(user.User.IsEnabled, Equals, false)

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2873,8 +2873,8 @@ type User struct {
 	IsExternal      bool             `xml:"IsExternal,omitempty"`
 	ProviderType    string           `xml:"ProviderType,omitempty"`
 	IsGroupRole     bool             `xml:"IsGroupRole,omitempty"`
-	StoredVmQuota   int              `xml:"StoredVmQuota,omitempty"`
-	DeployedVmQuota int              `xml:"DeployedVmQuota,omitempty"`
+	StoredVmQuota   int              `xml:"StoredVmQuota"`
+	DeployedVmQuota int              `xml:"DeployedVmQuota"`
 	Role            *Reference       `xml:"Role,omitempty"`
 	GroupReferences *GroupReference  `xml:"GroupReferences,omitempty"`
 	Password        string           `xml:"Password,omitempty"`


### PR DESCRIPTION
This PR is related https://github.com/vmware/terraform-provider-vcd/issues/799

## Description
This PR aims to solve a bug reported on https://github.com/vmware/terraform-provider-vcd/issues/799. When trying to update a user from whatever quota to 0 (unlimited), it wasn't working. Creating was working.

## Detailed description
VCD Terraform provider, when updating an user it was using the method `OrgUser.Update()`. Turns out that after doing some troubleshooting, I've spotted that on struct `types.User` the attributes `StoredVmQuota` and `DeployedVmQuota` had the `omitempty` tag, which was preventing to send these fields on the PUT HTTP request when updating if they were set to 0, because Go recognizes this as the empty value and doesn't sent it. 
  
The outcome of this was the API returning a 200 OK but these fields not being set to 0 (unlimited quota) because everything else was being update but those two fields, since they were not included in the request.

When creating a user it was working if set to 0, because if the API receives a POST request without these two fields, it set them to 0 (unlimited) by default.
  
To solve this, those two fields were removed that xml tag, so this fields is always sent in all PUT requests:
```
...
StoredVmQuota   int              `xml:"StoredVmQuota"`
DeployedVmQuota int              `xml:"DeployedVmQuota"`
...
```

Also `Test_UserCRUD` has been updated to test `OrgUser.Update()` and check this edge case.