### PR TITLE
Openapi TestConnection new method

### DIFF
--- a/.changes/v2.15.0/447-features.md
+++ b/.changes/v2.15.0/447-features.md
@@ -1,1 +1,3 @@
-* Add `Client.OpenApiTestConnection` method to check remote VCD endpoints [GH-447]
+* Add `Client.TestConnection` method to check remote VCD endpoints [GH-447]
+* Change behavior of `Client.OpenApiPostItem` and `Client.OpenApiPostItemSync` so they accept response code 200 OK as valid. The reason is `TestConnection` endpoint requires a POST request and returns a 200OK when successful [GH-447]
+

--- a/.changes/v2.15.0/447-features.md
+++ b/.changes/v2.15.0/447-features.md
@@ -1,3 +1,4 @@
 * Add `Client.TestConnection` method to check remote VCD endpoints [GH-447]
+* Add `Client.TestConnectionWithDefaults` method that uses `Client.TestConnection` with some default values [GH-447]
 * Change behavior of `Client.OpenApiPostItem` and `Client.OpenApiPostItemSync` so they accept response code 200 OK as valid. The reason is `TestConnection` endpoint requires a POST request and returns a 200OK when successful [GH-447]
 

--- a/.changes/v2.15.0/447-features.md
+++ b/.changes/v2.15.0/447-features.md
@@ -1,0 +1,1 @@
+* Add `Client.OpenApiTestConnection` method to check remote VCD endpoints [GH-447]

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -772,17 +772,9 @@ func (client *Client) RemoveProvidedCustomHeaders(values map[string]string) {
 func (client *Client) TestConnection(testConnection types.TestConnection) (*types.TestConnectionResult, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTestConnection
 
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
-	}
-
-	// TestConnection in versions lower than 36.0 doesn't support sending these fields in the POST payload and
-	// fails if they are included. These code snippet avoid sending them in case they are set in those versions.
-	if client.APIVCDMaxVersionIs("< 36.0") {
-		testConnection.HostnameVerificationAlgorithm = ""
-		testConnection.AdditionalCAIssuers = nil
-		testConnection.PreConfiguredProxy = ""
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
@@ -795,7 +787,7 @@ func (client *Client) TestConnection(testConnection types.TestConnection) (*type
 		ProxyProbe:  &types.ProbeResult{},
 	}
 
-	err = client.OpenApiPostItem(minimumApiVersion, urlRef, nil, testConnection, returnTestConnectionResult, nil)
+	err = client.OpenApiPostItem(apiVersion, urlRef, nil, testConnection, returnTestConnectionResult, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error performing test connection: %s", err)
 	}

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -768,7 +768,7 @@ func (client *Client) RemoveProvidedCustomHeaders(values map[string]string) {
 	}
 }
 
-// TestConnection Tests a connection against a VCD, including SSL handshake and hostname verification.
+// TestConnection calls API to test a connection against a VCD, including SSL handshake and hostname verification.
 func (client *Client) TestConnection(testConnection types.TestConnection) (*types.TestConnectionResult, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTestConnection
 

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -267,7 +267,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 		return err
 	}
 
-	// Handle two cases of API behaviour - synchronous (response status code is 201) and asynchronous (response status
+	// Handle two cases of API behaviour - synchronous (response status code is 200 or 201) and asynchronous (response status
 	// code 202)
 	switch resp.StatusCode {
 	// Asynchronous case - must track task and get item HREF from there

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -293,7 +293,7 @@ func (client *Client) OpenApiPostItem(apiVersion string, urlRef *url.URL, params
 
 		// Synchronous task - new item body is returned in response of HTTP POST request
 	case http.StatusCreated, http.StatusOK:
-		util.Logger.Printf("[TRACE] Synchronous task detected, marshalling outType '%s'", reflect.TypeOf(outType))
+		util.Logger.Printf("[TRACE] Synchronous task detected (HTTP Status %d), marshalling outType '%s'", resp.StatusCode, reflect.TypeOf(outType))
 		if err = decodeBody(types.BodyTypeJSON, resp, outType); err != nil {
 			return fmt.Errorf("error decoding JSON response after POST: %s", err)
 		}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -82,6 +82,11 @@ var endpointElevatedApiVersions = map[string][]string{
 		"35.0", // Deprecates field BackingType in favor of BackingTypeValue
 		"36.0", // Adds support new type of BackingTypeValue - IMPORTED_T_LOGICAL_SWITCH (backed by NSX-T segment)
 	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTestConnection: {
+		//"34.0", Basic minimun required version
+		"36.0", // Adds fields hostnameVerificationAlgorithm and additionalCAIssuers to Connection
+		"36.1", // Adds preConfiguredProxy to Connection
+	},
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with
@@ -116,7 +121,7 @@ func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string
 // supported API versions just like client.checkOpenApiEndpointCompatibility().
 //
 // The advantage of this functions is that it provides a controlled API elevation instead of just picking the highest
-// which could be risky and untested (especially if new API version is released after release of package consuming this
+// which could be risky and untested (especially if new API version hich could be risky and untested (especially if new API version is released after release of package consuming this
 // SDK)
 func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string, error) {
 	util.Logger.Printf("[DEBUG] Checking if elevated API versions are defined for endpoint '%s'", endpoint)

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -26,6 +26,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRoles + types.OpenApiEndpointRights: "31.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAuditTrail:                          "33.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointImportableTier0Routers:              "32.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTestConnection:                      "34.0",
 	// OpenApiEndpointExternalNetworks endpoint support was introduced with version 32.0 however it was still not stable
 	// enough to be used. (i.e. it did not support update "PUT")
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks:                   "33.0",

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -116,13 +116,12 @@ func (client *Client) checkOpenApiEndpointCompatibility(endpoint string) (string
 	return minimumApiVersion, nil
 }
 
-// getOpenApiHighestElevatedVersion returns highest supported API version for particular endpoint
+// getOpenApiHighestElevatedVersion returns the highest supported API version for particular endpoint
 // These API versions must be defined in endpointElevatedApiVersions. If none are there - it will return minimum
 // supported API versions just like client.checkOpenApiEndpointCompatibility().
 //
-// The advantage of this functions is that it provides a controlled API elevation instead of just picking the highest
-// which could be risky and untested (especially if new API version hich could be risky and untested (especially if new API version is released after release of package consuming this
-// SDK)
+// The advantage of this function is that it provides a controlled API elevation instead of just picking the highest version
+// which could be risky and untested (especially if new API version is released after release of package consuming this SDK)
 func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string, error) {
 	util.Logger.Printf("[DEBUG] Checking if elevated API versions are defined for endpoint '%s'", endpoint)
 

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -290,30 +290,27 @@ func (vcd *TestVCD) Test_OpenApiTestConnection(check *C) {
 	}{
 		{
 			TestConnection: types.TestConnection{
-				Host:                          vcd.client.Client.VCDHREF.Host,
-				Port:                          443,
-				Secure:                        takeBoolPointer(true),
-				Timeout:                       10,
-				HostnameVerificationAlgorithm: "HTTPS",
+				Host:    vcd.client.Client.VCDHREF.Host,
+				Port:    443,
+				Secure:  takeBoolPointer(true),
+				Timeout: 10,
 			},
 			WantedCanConnect: true,
 		},
 		{
 			TestConnection: types.TestConnection{
-				Host:                          vcd.client.Client.VCDHREF.Host,
-				Port:                          443,
-				Secure:                        takeBoolPointer(false),
-				Timeout:                       10,
-				HostnameVerificationAlgorithm: "HTTPS",
+				Host:    vcd.client.Client.VCDHREF.Host,
+				Port:    443,
+				Secure:  takeBoolPointer(false),
+				Timeout: 10,
 			},
 			WantedCanConnect: true,
 		},
 		{
 			TestConnection: types.TestConnection{
-				Host:                          fmt.Sprintf("%s.io", vcd.client.Client.VCDHREF.Host),
-				Port:                          443,
-				Timeout:                       10,
-				HostnameVerificationAlgorithm: "HTTPS",
+				Host:    fmt.Sprintf("%s.io", vcd.client.Client.VCDHREF.Host),
+				Port:    443,
+				Timeout: 10,
 			},
 			WantedCanConnect: false,
 		},

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -370,6 +370,7 @@ const (
 	OpenApiEndpointVdcGroupsCandidateVdcs             = "vdcGroups/networkingCandidateVdcs"
 	OpenApiEndpointVdcGroupsDfwPolicies               = "vdcGroups/%s/dfwPolicies"
 	OpenApiEndpointVdcGroupsDfwDefaultPolicies        = "vdcGroups/%s/dfwPolicies/default"
+	OpenApiEndpointTestConnection                     = "testConnection/"
 
 	// NSX-T ALB related endpoints
 

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -368,21 +368,39 @@ type VersionField struct {
 
 // TestConnection defines the parameters used when testing a connection, including SSL handshake and hostname verification.
 type TestConnection struct {
-	Host                          string           `json:"host"`                                    // The host (or IP address) to connect to.
-	Port                          int              `json:"port"`                                    // The port to use when connecting.
-	Secure                        bool             `json:"secure,omitempty"`                        // If the connection should use https.
-	Timeout                       int              `json:"timeout,omitempty"`                       // Maximum time (in seconds) any step in the test should wait for a response.
-	HostnameVerificationAlgorithm string           `json:"hostnameVerificationAlgorithm,omitempty"` // Endpoint/Hostname verification algorithm to be used during SSL/TLS/DTLS handshake.
-	AdditionalCAIssuers           []string         `json:"additionalCAIssuers,omitempty"`           // A list of URLs being authorized by the user to retrieve additional CA certificates from, if necessary, to complete the certificate chain to its trust anchor.
-	ProxyConnection               *ProxyConnection `json:"proxyConnection,omitempty"`               // Proxy connection to use for test. Only one of proxyConnection and preConfiguredProxy can be specified.
-	PreConfiguredProxy            string           `json:"preConfiguredProxy,omitempty"`            // The URN of a ProxyConfiguration to use for the test. Only one of proxyConnection or preConfiguredProxy can be specified. If neither is specified then no proxy is used to test the connection.
+	Host                          string               `json:"host"`                                    // The host (or IP address) to connect to.
+	Port                          int                  `json:"port"`                                    // The port to use when connecting.
+	Secure                        *bool                `json:"secure,omitempty"`                        // If the connection should use https.
+	Timeout                       int                  `json:"timeout,omitempty"`                       // Maximum time (in seconds) any step in the test should wait for a response.
+	HostnameVerificationAlgorithm string               `json:"hostnameVerificationAlgorithm,omitempty"` // Endpoint/Hostname verification algorithm to be used during SSL/TLS/DTLS handshake.
+	AdditionalCAIssuers           []string             `json:"additionalCAIssuers,omitempty"`           // A list of URLs being authorized by the user to retrieve additional CA certificates from, if necessary, to complete the certificate chain to its trust anchor.
+	ProxyConnection               *ProxyTestConnection `json:"proxyConnection,omitempty"`               // Proxy connection to use for test. Only one of proxyConnection and preConfiguredProxy can be specified.
+	PreConfiguredProxy            string               `json:"preConfiguredProxy,omitempty"`            // The URN of a ProxyConfiguration to use for the test. Only one of proxyConnection or preConfiguredProxy can be specified. If neither is specified then no proxy is used to test the connection.
 }
 
-// ProxyConnection defines the proxy connection to use for TestConnection (if any).
-type ProxyConnection struct {
+// ProxyTestConnection defines the proxy connection to use for TestConnection (if any).
+type ProxyTestConnection struct {
 	ProxyHost     string `json:"proxyHost"`               // The host (or IP address) of the proxy.
 	ProxyPort     int    `json:"proxyPort"`               // The port to use when connecting to the proxy.
 	ProxyUsername string `json:"proxyUsername,omitempty"` // Username to authenticate to the proxy.
 	ProxyPassword string `json:"proxyPassword,omitempty"` // Password to authenticate to the proxy.
 	ProxySecure   *bool  `json:"proxySecure,omitempty"`   // If the connection to the proxy should use https.
+}
+
+// TestConnectionResult is the result of a connection test.
+type TestConnectionResult struct {
+	TargetProbe *ProbeResult `json:"targetProbe,omitempty"` // Results of a connection test to a specific endpoint.
+	ProxyProbe  *ProbeResult `json:"proxyProbe,omitempty"`  // Results of a connection test to a specific endpoint.
+}
+
+// ProbeResult results of a connection test to a specific endpoint.
+type ProbeResult struct {
+	Result              string   `json:"result,omitempty"`              // Localized message describing the connection result stating success or an error message with a brief summary.
+	ResolvedIp          string   `json:"resolvedIp,omitempty"`          // The IP address the host was resolved to, if not going through a proxy.
+	CanConnect          bool     `json:"canConnect,omitempty"`          // If vCD can establish a connection on the specified port.
+	SSLHandshake        bool     `json:"sslHandshake,omitempty"`        // If an SSL Handshake succeeded (secure requests only).
+	ConnectionResult    string   `json:"connectionResult,omitempty"`    // A code describing the result of establishing a connection. It can be either SUCCESS, ERROR_CANNOT_RESOLVE_IP or ERROR_CANNOT_CONNECT.
+	SSLResult           string   `json:"sslResult,omitempty"`           // A code describing the result of the SSL handshake. It can be either SUCCESS, ERROR_SSL_ERROR, ERROR_UNTRUSTED_CERTIFICATE, ERROR_CANNOT_VERIFY_HOSTNAME or null.
+	CertificateChain    string   `json:"certificateChain,omitempty"`    // The SSL certificate chain presented by the server if a secure connection was made.
+	AdditionalCAIssuers []string `json:"additionalCAIssuers,omitempty"` // URLs supplied by Certificate Authorities to retrieve signing certificates, when those certificates are not included in the chain.
 }

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -365,3 +365,24 @@ type DefaultPolicy struct {
 type VersionField struct {
 	Version int `json:"version"`
 }
+
+// TestConnection defines the parameters used when testing a connection, including SSL handshake and hostname verification.
+type TestConnection struct {
+	Host                          string           `json:"host"`                                    // The host (or IP address) to connect to.
+	Port                          int              `json:"port"`                                    // The port to use when connecting.
+	Secure                        bool             `json:"secure,omitempty"`                        // If the connection should use https.
+	Timeout                       int              `json:"timeout,omitempty"`                       // Maximum time (in seconds) any step in the test should wait for a response.
+	HostnameVerificationAlgorithm string           `json:"hostnameVerificationAlgorithm,omitempty"` // Endpoint/Hostname verification algorithm to be used during SSL/TLS/DTLS handshake.
+	AdditionalCAIssuers           []string         `json:"additionalCAIssuers,omitempty"`           // A list of URLs being authorized by the user to retrieve additional CA certificates from, if necessary, to complete the certificate chain to its trust anchor.
+	ProxyConnection               *ProxyConnection `json:"proxyConnection,omitempty"`               // Proxy connection to use for test. Only one of proxyConnection and preConfiguredProxy can be specified.
+	PreConfiguredProxy            string           `json:"preConfiguredProxy,omitempty"`            // The URN of a ProxyConfiguration to use for the test. Only one of proxyConnection or preConfiguredProxy can be specified. If neither is specified then no proxy is used to test the connection.
+}
+
+// ProxyConnection defines the proxy connection to use for TestConnection (if any).
+type ProxyConnection struct {
+	ProxyHost     string `json:"proxyHost"`               // The host (or IP address) of the proxy.
+	ProxyPort     int    `json:"proxyPort"`               // The port to use when connecting to the proxy.
+	ProxyUsername string `json:"proxyUsername,omitempty"` // Username to authenticate to the proxy.
+	ProxyPassword string `json:"proxyPassword,omitempty"` // Password to authenticate to the proxy.
+	ProxySecure   *bool  `json:"proxySecure,omitempty"`   // If the connection to the proxy should use https.
+}


### PR DESCRIPTION
This PR does not have any issue associated.

# Description
When creating a catalog and subscribing to an external one, VCD uses the endpoint `/cloudapi/1.0.0/testConnection/` to check before hand if the endpoint where the user is trying to subscribe the external catalog from exists.

# Detailed description
In order to implement the external catalog subscription in the Terraform provider for VCD when creating a catalog, TestConnection functionality needs to be implemented since before subscribing, VCD does this previous sanity check.  
  
This has been implemented as a `Client` method, since it doesn't belong to any VCD resource and it's a client helping tool.  
  
Also, I propose a slight change to `Client.OpenApiPostItem` since to use TestConnection, I had to do a POST request against `/cloudapi/1.0.0/testConnection/`. This results in a `200OK`, instead of 201 or 202. 
`Client.OpenApiPostItem` wasn't covering this case, so the function worked but it wasn't unmarshalling the response into the needed struct.
This last point is open to discussion, as it might be a better way to handle this.

🚀 