### PR TITLE
Fix bug Test_VdcUpdateStorageProfile test

### DIFF
--- a/govcd/adminvdc_test.go
+++ b/govcd/adminvdc_test.go
@@ -302,7 +302,7 @@ func (vcd *TestVCD) Test_VdcUpdateStorageProfile(check *C) {
 	check.Assert(updatedStorageProfile, Not(Equals), types.VdcStorageProfile{})
 	check.Assert(updatedStorageProfile, NotNil)
 
-	check.Assert(updatedStorageProfile.Enabled, Equals, true)
+	check.Assert(*updatedStorageProfile.Enabled, Equals, true)
 	check.Assert(updatedStorageProfile.Limit, Equals, int64(9081))
 	check.Assert(updatedStorageProfile.Default, Equals, true)
 	check.Assert(updatedStorageProfile.Units, Equals, "MB")


### PR DESCRIPTION
No PR associated with this bug. 
@adambarreiro and myself found this while running the test suite.

## Description
There is a bug in `Test_VdcUpdateStorageProfile` that compares a type bool against a pointer. The test fails because of this.

## Detailed description
In test ´Test_VdcUpdateStorageProfile´, one of the checks is wrong as it tries to compare a `bool` type against a `pointer`type:
```
check.Assert(updatedStorageProfile.Enabled, Equals, true)
```

We must deference the pointer, so it looks like:
```
check.Assert(*updatedStorageProfile.Enabled, Equals, true)
```