### PR TITLE
Add method AdminOrg.FindCatalogRecords 

### DIFF
--- a/.changes/v2.15.0/450-features.md
+++ b/.changes/v2.15.0/450-features.md
@@ -1,0 +1,1 @@
+* Add method `AdminOrg.FindCatalogRecords` that allows to query `types.CatalogRecord` by their catalog name  [GH-450]

--- a/.changes/v2.15.0/450-features.md
+++ b/.changes/v2.15.0/450-features.md
@@ -1,1 +1,2 @@
-* Add method `AdminOrg.FindCatalogRecords` that allows to query `types.CatalogRecord` by their catalog name  [GH-450]
+* Add method `AdminOrg.FindCatalogRecords` that allows to query `types.CatalogRecord` by their catalog name. [GH-450]
+* Add methods `Client.QueryWithNotEncodedParamsWithHeaders` and `Client.QueryWithNotEncodedParamsWithApiVersionWithHeaders` so HTTP headers can be added now when doing API queries. [GH-450]

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -764,13 +764,14 @@ func (adminOrg *AdminOrg) QueryCatalogList() ([]*types.CatalogRecord, error) {
 func (adminOrg *AdminOrg) FindCatalogRecords(name string) ([]*types.CatalogRecord, error) {
 	util.Logger.Printf("[DEBUG] QueryCatalogList with org name %s", adminOrg.AdminOrg.Name)
 
+	var tenantHeaders map[string]string
+
 	if adminOrg.client.IsSysAdmin {
-		// Set tenant context
-		adminOrg.client.SetCustomHeader(map[string]string{
+		// Set tenant context headers just for the query
+		tenantHeaders = map[string]string{
 			types.HeaderAuthContext:   adminOrg.TenantContext.OrgName,
 			types.HeaderTenantContext: adminOrg.TenantContext.OrgId,
-		})
-		defer adminOrg.client.RemoveCustomHeader()
+		}
 	}
 
 	var filter string
@@ -779,11 +780,11 @@ func (adminOrg *AdminOrg) FindCatalogRecords(name string) ([]*types.CatalogRecor
 		filter = fmt.Sprintf("%s;name==%s", filter, name)
 	}
 
-	results, err := adminOrg.client.cumulativeQuery(types.QtCatalog, nil, map[string]string{
+	results, err := adminOrg.client.cumulativeQueryWithHeaders(types.QtCatalog, nil, map[string]string{
 		"type":          types.QtCatalog,
 		"filter":        filter,
 		"filterEncoded": "true",
-	})
+	}, tenantHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -789,6 +789,9 @@ func (adminOrg *AdminOrg) FindCatalogRecords(name string) ([]*types.CatalogRecor
 	}
 
 	catalogs := results.Results.CatalogRecord
+	if catalogs == nil {
+		return nil, ErrorEntityNotFound
+	}
 
 	util.Logger.Printf("[DEBUG] QueryCatalogList returned with : %#v and error: %s", catalogs, err)
 	return catalogs, nil

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -757,14 +757,26 @@ func (adminOrg *AdminOrg) GetVdcByName(vdcname string) (Vdc, error) {
 
 // QueryCatalogList returns a list of catalogs for this organization
 func (adminOrg *AdminOrg) QueryCatalogList() ([]*types.CatalogRecord, error) {
+	return adminOrg.FindCatalogRecords("")
+}
+
+// FindCatalogRecords given a catalog name, retrieves the catalogRecords for a given organization
+func (adminOrg *AdminOrg) FindCatalogRecords(name string) ([]*types.CatalogRecord, error) {
 	util.Logger.Printf("[DEBUG] QueryCatalogList with org name %s", adminOrg.AdminOrg.Name)
 	queryType := types.QtCatalog
 	if adminOrg.client.IsSysAdmin {
 		queryType = types.QtAdminCatalog
 	}
+
+	var filter string
+	filter = fmt.Sprintf("orgName==%s", url.QueryEscape(adminOrg.AdminOrg.Name))
+	if name != "" {
+		filter = fmt.Sprintf("%s;name==%s", filter, name)
+	}
+
 	results, err := adminOrg.client.cumulativeQuery(queryType, nil, map[string]string{
 		"type":          queryType,
-		"filter":        fmt.Sprintf("orgName==%s", url.QueryEscape(adminOrg.AdminOrg.Name)),
+		"filter":        filter,
 		"filterEncoded": "true",
 	})
 	if err != nil {

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -190,6 +190,11 @@ func (vcd *TestVCD) TestOrg_AdminOrg_QueryCatalogList(check *C) {
 	catalogsInAdminOrg, err := adminOrg.QueryCatalogList()
 	check.Assert(err, IsNil)
 
+	// gets a specific catalog as an adminOrg
+	singleCatalogInAdminOrg, err := adminOrg.FindCatalogRecords(vcd.config.VCD.Catalog.Name)
+	check.Assert(err, IsNil)
+	check.Assert(len(singleCatalogInAdminOrg), Equals, 1)
+
 	// gets the catalog list as an Org
 	catalogsInOrg, err := org.QueryCatalogList()
 	check.Assert(err, IsNil)

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -193,6 +193,7 @@ func (vcd *TestVCD) TestOrg_AdminOrg_QueryCatalogList(check *C) {
 	// gets a specific catalog as an adminOrg
 	singleCatalogInAdminOrg, err := adminOrg.FindCatalogRecords(vcd.config.VCD.Catalog.Name)
 	check.Assert(err, IsNil)
+	check.Assert(singleCatalogInAdminOrg, NotNil)
 	check.Assert(len(singleCatalogInAdminOrg), Equals, 1)
 
 	// gets the catalog list as an Org

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -196,6 +196,11 @@ func (vcd *TestVCD) TestOrg_AdminOrg_QueryCatalogList(check *C) {
 	check.Assert(singleCatalogInAdminOrg, NotNil)
 	check.Assert(len(singleCatalogInAdminOrg), Equals, 1)
 
+	// try to get a non-existent catalog
+	nonExistentCatalog, err := adminOrg.FindCatalogRecords("iCompletelyMadeThisUp")
+	check.Assert(nonExistentCatalog, IsNil)
+	check.Assert(err, Equals, ErrorEntityNotFound)
+
 	// gets the catalog list as an Org
 	catalogsInOrg, err := org.QueryCatalogList()
 	check.Assert(err, IsNil)

--- a/govcd/query.go
+++ b/govcd/query.go
@@ -45,13 +45,25 @@ func (client *Client) QueryWithNotEncodedParams(params map[string]string, notEnc
 	return client.QueryWithNotEncodedParamsWithApiVersion(params, notEncodedParams, client.APIVersion)
 }
 
+func (client *Client) QueryWithNotEncodedParamsWithHeaders(params map[string]string, notEncodedParams map[string]string, headers map[string]string) (Results, error) {
+	return client.QueryWithNotEncodedParamsWithApiVersionWithHeaders(params, notEncodedParams, client.APIVersion, headers)
+}
+
 // QueryWithNotEncodedParams uses Query API to search for requested data
 func (client *Client) QueryWithNotEncodedParamsWithApiVersion(params map[string]string, notEncodedParams map[string]string, apiVersion string) (Results, error) {
+	return client.QueryWithNotEncodedParamsWithApiVersionWithHeaders(params, notEncodedParams, apiVersion, nil)
+}
+
+func (client *Client) QueryWithNotEncodedParamsWithApiVersionWithHeaders(params map[string]string, notEncodedParams map[string]string, apiVersion string, headers map[string]string) (Results, error) {
 	queryUrl := client.VCDHREF
 	queryUrl.Path += "/query"
 
 	req := client.NewRequestWitNotEncodedParamsWithApiVersion(params, notEncodedParams, http.MethodGet, queryUrl, nil, apiVersion)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version="+apiVersion)
+
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
 
 	return getResult(client, req)
 }

--- a/govcd/query_metadata.go
+++ b/govcd/query_metadata.go
@@ -166,6 +166,11 @@ func addResults(queryType string, cumulativeResults, newResults Results) (Result
 
 // cumulativeQuery runs a paginated query and collects all elements until the total number of records is retrieved
 func (client *Client) cumulativeQuery(queryType string, params, notEncodedParams map[string]string) (Results, error) {
+	return client.cumulativeQueryWithHeaders(queryType, params, notEncodedParams, nil)
+}
+
+// cumulativeQueryWithHeaders is the same as cumulativeQuery() but let you add headers to the query
+func (client *Client) cumulativeQueryWithHeaders(queryType string, params, notEncodedParams map[string]string, headers map[string]string) (Results, error) {
 	var supportedQueryTypes = []string{
 		types.QtVappTemplate,
 		types.QtAdminVappTemplate,
@@ -198,7 +203,7 @@ func (client *Client) cumulativeQuery(queryType string, params, notEncodedParams
 		return Results{}, fmt.Errorf("[cumulativeQuery] query type %s not supported", queryType)
 	}
 
-	result, err := client.QueryWithNotEncodedParams(params, notEncodedParams)
+	result, err := client.QueryWithNotEncodedParamsWithHeaders(params, notEncodedParams, headers)
 	if err != nil {
 		return Results{}, err
 	}
@@ -221,7 +226,7 @@ func (client *Client) cumulativeQuery(queryType string, params, notEncodedParams
 		page++
 		notEncodedParams["page"] = fmt.Sprintf("%d", page)
 		var size int
-		newResult, err := client.QueryWithNotEncodedParams(params, notEncodedParams)
+		newResult, err := client.QueryWithNotEncodedParamsWithHeaders(params, notEncodedParams, headers)
 		if err != nil {
 			return Results{}, err
 		}

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2927,7 +2927,7 @@ type CatalogRecord struct {
 	CreationDate            string    `xml:"creationDate,attr,omitempty"`
 	OrgName                 string    `xml:"orgName,attr,omitempty"`
 	OwnerName               string    `xml:"ownerName,attr,omitempty"`
-	NumberOfVAppTemplates   int64     `xml:"numberOfVAppTemplates,attr,omitempty"`
+	NumberOfVAppTemplates   int64     `xml:"numberOfTemplates,attr,omitempty"`
 	NumberOfMedia           int64     `xml:"numberOfMedia,attr,omitempty"`
 	Owner                   string    `xml:"owner,attr,omitempty"`
 	PublishSubscriptionType string    `xml:"publishSubscriptionType,attr,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2927,7 +2927,7 @@ type CatalogRecord struct {
 	CreationDate            string    `xml:"creationDate,attr,omitempty"`
 	OrgName                 string    `xml:"orgName,attr,omitempty"`
 	OwnerName               string    `xml:"ownerName,attr,omitempty"`
-	NumberOfVAppTemplates   int64     `xml:"numberOfTemplates,attr,omitempty"`
+	NumberOfVAppTemplates   int64     `xml:"numberOfVAppTemplates,attr,omitempty"`
 	NumberOfMedia           int64     `xml:"numberOfMedia,attr,omitempty"`
 	Owner                   string    `xml:"owner,attr,omitempty"`
 	PublishSubscriptionType string    `xml:"publishSubscriptionType,attr,omitempty"`


### PR DESCRIPTION
There is no issue associated with this PR.
The purpose of this PR is to provide the right method to retrieve information about catalog records. This method will be used for the Terraform provider to set more information about catalogs.

## Description
govcd lacks of methods to query catalogRecords by name. This PR provides the method `AdminOrg.FindCatalogRecords` that does that.

## Detailed description
Previously there was just one method called `AdminOrg.QueryCatalogList` that was returning all catalog records for a given AdminOrg. There was no way to query catalog/s using their name.
With `AdminOrg.FindCatalogRecords`, given a name, the SDK can retrieve just the specific catalog record.
This is usefull for Terraform provider for VCD. Please check PR https://github.com/vmware/terraform-provider-vcd/pull/800 