### PR TITLE
Add admin VDC metadata CRUD functions

### DIFF
--- a/.changes/v2.15.0/453-improvements.md
+++ b/.changes/v2.15.0/453-improvements.md
@@ -1,0 +1,3 @@
+* Added support to set, get and delete metadata to Admin VDC with the methods
+  `AdminVdc.AddMetadataEntry`, `AdminVdc.AddMetadataEntryAsync`, `AdminVdc.GetMetadata`,
+  `AdminVdc.DeleteMetadataEntry` and `AdminVdc.DeleteMetadataEntryAsync` [GH-453]

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -444,6 +444,45 @@ func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, erro
 	return addMetadata(vdc.client, typedValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
 }
 
+
+// GetMetadata returns AdminVdc metadata.
+func (adminVdc *AdminVdc) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(adminVdc.client, adminVdc.AdminVdc.HREF)
+}
+
+// AddMetadataEntry adds AdminVdc metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (adminVdc *AdminVdc) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := adminVdc.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryAsync adds AdminVdc metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (adminVdc *AdminVdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(adminVdc.client, typedValue, key, value, adminVdc.AdminVdc.HREF)
+}
+
+// DeleteMetadataEntry deletes AdminVdc metadata depending on key provided as input
+// and waits for the task to finish.
+func (adminVdc *AdminVdc) DeleteMetadataEntry(key string) error {
+	task, err := adminVdc.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntryAsync deletes AdminVdc metadata depending on key provided as input
+// and returns a task.
+func (adminVdc *AdminVdc) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(adminVdc.client, key, adminVdc.AdminVdc.HREF)
+}
+
 // DeleteMetadataEntry deletes VApp metadata by key provided as input and waits for
 // the task to finish.
 func (vapp *VApp) DeleteMetadataEntry(key string) error {

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -444,7 +444,6 @@ func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, erro
 	return addMetadata(vdc.client, typedValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
 }
 
-
 // GetMetadata returns AdminVdc metadata.
 func (adminVdc *AdminVdc) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(adminVdc.client, adminVdc.AdminVdc.HREF)


### PR DESCRIPTION
Not needed as regular `Vdc` has already the methods to create and delete.