### PR TITLE
Add generic CRUD metadata by href functions

### DIFF
--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -12,6 +12,45 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+
+// GetMetadataByHref returns metadata from the given resource reference.
+func (vcdClient *VCDClient) GetMetadataByHref(href string) (*types.Metadata, error) {
+	return getMetadata(&vcdClient.Client, href)
+}
+
+// AddMetadataEntryByHref adds metadata typedValue and key/value pair provided as input to the given resource reference,
+// then waits for the task to finish.
+func (vcdClient *VCDClient) AddMetadataEntryByHref(href, typedValue, key, value string) error {
+	task, err := vcdClient.AddMetadataEntryByHrefAsync(href, typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryByHrefAsync adds metadata typedValue and key/value pair provided as input to the given resource reference
+// and returns the task.
+func (vcdClient *VCDClient) AddMetadataEntryByHrefAsync(href, typedValue, key, value string) (Task, error) {
+	return addMetadata(&vcdClient.Client, typedValue, key, value, href)
+}
+
+// DeleteMetadataEntryByHref deletes metadata from the given resource reference, depending on key provided as input
+// and waits for the task to finish.
+func (vcdClient *VCDClient) DeleteMetadataEntryByHref(href, key string) error {
+	task, err := vcdClient.DeleteMetadataEntryByHrefAsync(href, key)
+	if err != nil {
+		return err
+	}
+
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntryByHrefAsync deletes metadata from the given resource reference, depending on key provided as input
+// and returns a task.
+func (vcdClient *VCDClient) DeleteMetadataEntryByHrefAsync(href, key string) (Task, error) {
+	return deleteMetadata(&vcdClient.Client, key, href)
+}
+
 // GetMetadata returns VM metadata.
 func (vm *VM) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(vm.client, vm.VM.HREF)


### PR DESCRIPTION
Signed-off-by: abarreiro <abarreiro@vmware.com>

This PR relates to https://github.com/vmware/terraform-provider-vcd/issues/372, as the goal is to provide CRUD functions for metadata to resources that **don't have an associated type**, like Storage profiles.

The functions just retrieve an HREF instead, and perform the metadata operation on it.

Another way of doing this would be changing the signature to:

```
func (reference *types.Reference) AddMetadataEntryByHrefAsync(typedValue, key, value string) {
// Use reference.HREF here
```

But I followed the approach of having this method associated to `VCDClient` instead. (This is, of course, open to discussion).