### PR TITLE
Bump staticcheck to 2022.1 with Go 1.18 support

### DIFF
--- a/.changes/v2.15.0/457-notes.md
+++ b/.changes/v2.15.0/457-notes.md
@@ -1,0 +1,1 @@
+* Bump `staticcheck` version to 2022.1 with Go 1.18 support [GH-457]

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -233,7 +233,7 @@ func (client *Client) newRequest(params map[string]string, notEncodedParams map[
 
 	// Merge in additional headers before logging if any where specified in additionalHeader
 	// parameter
-	if additionalHeader != nil && len(additionalHeader) > 0 {
+	if len(additionalHeader) > 0 {
 		for headerName, headerValueSlice := range additionalHeader {
 			for _, singleHeaderValue := range headerValueSlice {
 				req.Header.Add(headerName, singleHeaderValue)

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,4 +1,4 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=2021.1.1
+export STATICCHECK_VERSION=2022.1
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
 


### PR DESCRIPTION
Github actions introduced Go 1.18 environment and our used `staticcheck` version does not support it. This PR bumps `staticcheck` to 2022.1 with Go 1.18 support.

This new `staticheck` version discovered one error to fix:
```sh
api.go:236:5: should omit nil check; len() for net/http.Header is defined as zero (S1009)
```

This PR also patches it.