### PR TITLE
Catalog and LDAP tests fix

### DIFF
--- a/.changes/v2.15.0/458-improvements.md
+++ b/.changes/v2.15.0/458-improvements.md
@@ -1,0 +1,2 @@
+* Add workaround to tests for Org Catalog publishing bug when dealing with LDAP [GH-458]
+* Add clean-up actions to some tests that were uploading vAppTemplates/medias to catalogs [GH-458]

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -35,12 +35,33 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 	if vcd.config.VCD.ExternalNetwork == "" {
 		check.Skip("[" + check.TestName() + "] external network not provided")
 	}
+	// Due to a bug in VCD, when configuring LDAP service, Org publishing catalog settings `Publish external catalogs` and
+	// `Subscribe to external catalogs ` gets disabled. For that reason we are getting the current values from those vars
+	// to set them at the end of the test, to avoid interference with other tests.
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+
+	publishExternalCatalogs := adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally
+	subscribeToExternalCatalogs := adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe
 
 	fmt.Println("Setting up LDAP")
 	networkName, vappName, vmName := vcd.configureLdap(check)
 	defer func() {
 		fmt.Println("Unconfiguring LDAP")
 		vcd.unconfigureLdap(check, networkName, vappName, vmName)
+
+		// Due to the VCD bug mentioned above, we need to set the previous state from the publishing settings vars
+		check.Assert(adminOrg.Refresh(), IsNil)
+
+		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally = publishExternalCatalogs
+		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe = subscribeToExternalCatalogs
+
+		task, err := adminOrg.Update()
+		check.Assert(err, IsNil)
+
+		err = task.WaitTaskCompletion()
+		check.Assert(err, IsNil)
 	}()
 
 	// Run tests requiring LDAP from here.

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -133,7 +133,7 @@ func (vcd *TestVCD) Test_DeleteCatalog(check *C) {
 	AddToCleanupList(TestDeleteCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestDeleteCatalog)
 
-	checkUploadOvf(vcd, check, vcd.config.OVA.OvaPath, TestDeleteCatalog, TestUploadOvf+"_"+check.TestName())
+	checkUploadOvf(vcd, check, vcd.config.OVA.OvaPath, TestDeleteCatalog, TestUploadOvf+"_"+check.TestName(), false)
 	err = adminCatalog.Delete(false, false)
 	check.Assert(err, NotNil)
 	// Catalog is not empty. An attempt to delete without recursion will fail
@@ -164,7 +164,7 @@ func (vcd *TestVCD) Test_UploadOvf(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	skipWhenOvaPathMissing(vcd.config.OVA.OvaPath, check)
-	checkUploadOvf(vcd, check, vcd.config.OVA.OvaPath, vcd.config.VCD.Catalog.Name, TestUploadOvf)
+	checkUploadOvf(vcd, check, vcd.config.OVA.OvaPath, vcd.config.VCD.Catalog.Name, TestUploadOvf, true)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -173,7 +173,7 @@ func (vcd *TestVCD) Test_UploadOvf_chunked(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	skipWhenOvaPathMissing(vcd.config.OVA.OvaChunkedPath, check)
-	checkUploadOvf(vcd, check, vcd.config.OVA.OvaChunkedPath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"2")
+	checkUploadOvf(vcd, check, vcd.config.OVA.OvaChunkedPath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"2", true)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -309,7 +309,7 @@ func (vcd *TestVCD) Test_UploadOvfFile(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	skipWhenOvaPathMissing(vcd.config.OVA.OvfPath, check)
-	checkUploadOvf(vcd, check, vcd.config.OVA.OvfPath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"7")
+	checkUploadOvf(vcd, check, vcd.config.OVA.OvfPath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"7", true)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -318,7 +318,7 @@ func (vcd *TestVCD) Test_UploadOvf_withoutVMDKSize(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	skipWhenOvaPathMissing(vcd.config.OVA.OvaWithoutSizePath, check)
-	checkUploadOvf(vcd, check, vcd.config.OVA.OvaWithoutSizePath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"8")
+	checkUploadOvf(vcd, check, vcd.config.OVA.OvaWithoutSizePath, vcd.config.VCD.Catalog.Name, TestUploadOvf+"8", true)
 }
 
 func countFolders() int {
@@ -335,7 +335,7 @@ func countFolders() int {
 	return count
 }
 
-func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName string) {
+func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName string, deleteItemAtTheEnd bool) {
 	catalog, org := findCatalog(vcd, check, catalogName)
 
 	uploadTask, err := catalog.UploadOvf(ovaFileName, itemName, "upload from test", 1024)
@@ -350,7 +350,9 @@ func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName s
 	verifyCatalogItemUploaded(check, catalog, itemName)
 
 	// Delete testing catalog item
-	deleteCatalogItem(check, catalog, itemName)
+	if deleteItemAtTheEnd {
+		deleteCatalogItem(check, catalog, itemName)
+	}
 }
 
 func verifyCatalogItemUploaded(check *C, catalog *Catalog, itemName string) {
@@ -387,7 +389,7 @@ func skipWhenOvaPathMissing(ovaPath string, check *C) {
 }
 
 func deleteCatalogItem(check *C, catalog *Catalog, itemName string) {
-	catalogItem, err := catalog.GetCatalogItemByName(itemName, false)
+	catalogItem, err := catalog.GetCatalogItemByName(itemName, true)
 	check.Assert(err, IsNil)
 	check.Assert(catalogItem, NotNil)
 

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -203,6 +203,9 @@ func (vcd *TestVCD) Test_UploadOvf_progress_works(check *C) {
 	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -241,6 +244,9 @@ func (vcd *TestVCD) Test_UploadOvf_ShowUploadProgress_works(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadOvf by creating catalog, creating catalog item
@@ -265,6 +271,9 @@ func (vcd *TestVCD) Test_UploadOvf_error_withSameItem(check *C) {
 	catalog, _ = findCatalog(vcd, check, vcd.config.VCD.Catalog.Name)
 	_, err3 := catalog.UploadOvf(vcd.config.OVA.OvaPath, itemName, "upload from test", 1024)
 	check.Assert(err3.Error(), Matches, ".*already exists. Upload with different name.*")
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadOvf by creating catalog, uploading file and verifying
@@ -290,6 +299,8 @@ func (vcd *TestVCD) Test_UploadOvf_cleaned_extracted_files(check *C) {
 
 	check.Assert(oldFolderCount, Equals, countFolders())
 
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadOvf by creating catalog and
@@ -337,6 +348,9 @@ func checkUploadOvf(vcd *TestVCD, check *C, ovaFileName, catalogName, itemName s
 	catalog, err = org.GetCatalogByName(catalogName, false)
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 func verifyCatalogItemUploaded(check *C, catalog *Catalog, itemName string) {
@@ -372,6 +386,15 @@ func skipWhenOvaPathMissing(ovaPath string, check *C) {
 	}
 }
 
+func deleteCatalogItem(check *C, catalog *Catalog, itemName string) {
+	catalogItem, err := catalog.GetCatalogItemByName(itemName, false)
+	check.Assert(err, IsNil)
+	check.Assert(catalogItem, NotNil)
+
+	err = catalogItem.Delete()
+	check.Assert(err, IsNil)
+}
+
 // Tests System function UploadMediaImage by checking if provided standard iso file uploaded.
 func (vcd *TestVCD) Test_CatalogUploadMediaImage(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
@@ -392,6 +415,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, TestCatalogUploadMedia)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, TestCatalogUploadMedia)
 }
 
 // Tests System function UploadMediaImage by checking UploadTask.GetUploadProgress returns values of progress.
@@ -421,6 +447,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_progress_works(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadMediaImage by checking UploadTask.ShowUploadProgress writes values of progress to stdin.
@@ -457,6 +486,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_ShowUploadProgress_works(check 
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function UploadMediaImage by creating media item and expecting specific error
@@ -475,6 +507,9 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_error_withSameItem(check *C) {
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_CatalogUploadMediaImage_error_withSameItem")
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 // Tests System function Delete by creating media item and
@@ -896,6 +931,9 @@ func (vcd *TestVCD) Test_UploadOvfByLink_progress_works(check *C) {
 	catalog, err = org.GetCatalogByName(vcd.config.VCD.Catalog.Name, true)
 	check.Assert(err, IsNil)
 	verifyCatalogItemUploaded(check, catalog, itemName)
+
+	// Delete testing catalog item
+	deleteCatalogItem(check, catalog, itemName)
 }
 
 func (vcd *TestVCD) Test_CatalogQueryMediaList(check *C) {


### PR DESCRIPTION
This PR is not associated with any issue.

## Description

Fix issues with Catalog tests, as well as LDAP test framework.

## Detailed description
This PR addresses two issues that were impacting tests. 

### Issues solved related Catalog
There were some Catalog tests that were not removing the CatalogItems being upload to Catalogs. These tests were leveraging the function `AddToCleanupList` to delete those CatalogItems. This was leading to issues because the clean-up function is executed at the end of the test framework, and other tests might not be aware about the changes being done there.
The fix introduced here is to make every tests responsible of cleaning up whatever it has uploaded to Catalogs after the testing part has been done and right before the test returns. Hence, the `AddToCleanupList` function lays as last resort for cleaning-up the environment at the end of the tests if something fails.

### Issues solved related LDAP
Turns out that when configuring LDAP settings, for whatever reason, two Org catalog publishing vars gets disable (these are `Publish external catalogs` and `Subscribe to external catalogs`). This is a know issue and VCD team is addressing it to be solved. This interference with more tests as it makes the environment non-consistent.
In the meantime, this workaround what it does is, before doing any configuration, it grabs those two values, and when all LDAP testing sub-framework is closing up, is sets those vars again to the Org and finishes.

Tested and working in VCD 10.2.2 and 10.3.2