### PR TITLE
Add Vdc.GetNsxtAppPortProfileByName and VdcGroup.GetNsxtAppPortProfileByName for convenience

### DIFF
--- a/.changes/v2.15.0/460-improvements.md
+++ b/.changes/v2.15.0/460-improvements.md
@@ -1,0 +1,2 @@
+* Added `Vdc.GetNsxtAppPortProfileByName` and `VdcGroup.GetNsxtAppPortProfileByName` for NSX-T
+  Application Port Profile lookup [GH-460]

--- a/govcd/nsxt_application_profile.go
+++ b/govcd/nsxt_application_profile.go
@@ -78,6 +78,35 @@ func (org *Org) GetNsxtAppPortProfileByName(name, scope string) (*NsxtAppPortPro
 	return getNsxtAppPortProfileByName(org.client, name, queryParameters)
 }
 
+// GetNsxtAppPortProfileByName allows users to retrieve Application Port Profiles for specific scope.
+// More details in documentation for types.NsxtAppPortProfile
+//
+// Note. Names are enforced to be unique per scope
+func (vdc *Vdc) GetNsxtAppPortProfileByName(name, scope string) (*NsxtAppPortProfile, error) {
+	queryParameters := copyOrNewUrlValues(nil)
+	queryParameters = queryParameterFilterAnd("_context=="+vdc.Vdc.ID, queryParameters)
+	if scope != "" {
+		queryParameters = queryParameterFilterAnd("scope=="+scope, queryParameters)
+	}
+
+	return getNsxtAppPortProfileByName(vdc.client, name, queryParameters)
+}
+
+// GetNsxtAppPortProfileByName allows users to retrieve Application Port Profiles for specific scope.
+// More details in documentation for types.NsxtAppPortProfile
+//
+// Note. Names are enforced to be unique per scope
+func (vdcGroup *VdcGroup) GetNsxtAppPortProfileByName(name, scope string) (*NsxtAppPortProfile, error) {
+	queryParameters := copyOrNewUrlValues(nil)
+	queryParameters = queryParameterFilterAnd("_context=="+vdcGroup.VdcGroup.Id, queryParameters)
+
+	if scope != "" {
+		queryParameters = queryParameterFilterAnd("scope=="+scope, queryParameters)
+	}
+
+	return getNsxtAppPortProfileByName(vdcGroup.client, name, queryParameters)
+}
+
 // GetNsxtAppPortProfileById retrieves NSX-T Application Port Profile by ID
 func (org *Org) GetNsxtAppPortProfileById(id string) (*NsxtAppPortProfile, error) {
 	return getNsxtAppPortProfileById(org.client, id)

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -17,7 +17,6 @@ func (vcd *TestVCD) Test_NsxtApplicationPortProfileProvider(check *C) {
 
 	appPortProfileConfig := getAppProfileProvider(vcd, check)
 	testAppPortProfile(appPortProfileConfig, types.ApplicationPortProfileScopeProvider, vcd, check)
-
 }
 
 func (vcd *TestVCD) Test_NsxtApplicationPortProfileTenant(check *C) {
@@ -26,7 +25,6 @@ func (vcd *TestVCD) Test_NsxtApplicationPortProfileTenant(check *C) {
 
 	appPortProfileConfig := getAppProfileTenant(vcd, check)
 	testAppPortProfile(appPortProfileConfig, types.ApplicationPortProfileScopeTenant, vcd, check)
-
 }
 
 func (vcd *TestVCD) Test_NsxtApplicationPortProfileReadSystem(check *C) {
@@ -104,6 +102,10 @@ func testAppPortProfile(appPortProfileConfig *types.NsxtAppPortProfile, scope st
 	appProfile, err := org.CreateNsxtAppPortProfile(appPortProfileConfig)
 	check.Assert(err, IsNil)
 
+	// vdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	// check.Assert(err, IsNil)
+	// check.Assert(vdc, NotNil)
+
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAppPortProfiles + appProfile.NsxtAppPortProfile.ID
 	AddToCleanupListOpenApi(appProfile.NsxtAppPortProfile.Name, check.TestName(), openApiEndpoint)
 
@@ -125,6 +127,26 @@ func testAppPortProfile(appPortProfileConfig *types.NsxtAppPortProfile, scope st
 	foundAppProfileByName, err := org.GetNsxtAppPortProfileByName(appProfile.NsxtAppPortProfile.Name, scope)
 	check.Assert(err, IsNil)
 	check.Assert(foundAppProfileByName.NsxtAppPortProfile, DeepEquals, foundAppProfileById.NsxtAppPortProfile)
+
+	// Check VDC and VDC Group lookup
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+	vdc, vdcGroup := test_CreateVdcGroup(check, adminOrg, vcd)
+
+	// Lookup by VDC
+	foundAppProfileByNameInVdc, err := vdc.GetNsxtAppPortProfileByName(appProfile.NsxtAppPortProfile.Name, scope)
+	check.Assert(err, IsNil)
+	check.Assert(foundAppProfileByNameInVdc.NsxtAppPortProfile, DeepEquals, foundAppProfileById.NsxtAppPortProfile)
+
+	foundAppProfileByNameInVdcGroup, err := vdcGroup.GetNsxtAppPortProfileByName(appProfile.NsxtAppPortProfile.Name, scope)
+	check.Assert(err, IsNil)
+	check.Assert(foundAppProfileByNameInVdcGroup.NsxtAppPortProfile, DeepEquals, foundAppProfileById.NsxtAppPortProfile)
+	// Remove VDC group
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	err = vdc.DeleteWait(true, true)
+	check.Assert(err, IsNil)
 
 	err = appProfile.Delete()
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -102,10 +102,6 @@ func testAppPortProfile(appPortProfileConfig *types.NsxtAppPortProfile, scope st
 	appProfile, err := org.CreateNsxtAppPortProfile(appPortProfileConfig)
 	check.Assert(err, IsNil)
 
-	// vdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
-	// check.Assert(err, IsNil)
-	// check.Assert(vdc, NotNil)
-
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAppPortProfiles + appProfile.NsxtAppPortProfile.ID
 	AddToCleanupListOpenApi(appProfile.NsxtAppPortProfile.Name, check.TestName(), openApiEndpoint)
 


### PR DESCRIPTION
This PR adds two additional methods `Vdc.GetNsxtAppPortProfileByName` and `VdcGroup.GetNsxtAppPortProfileByName` for easier NSX-T Application Port Profile lookup.

Additionally it improves tests to test out lookup using VDC and VDC Group 

This will be used to improve https://github.com/vmware/terraform-provider-vcd/pull/812