### PR TITLE
Add DNS option to the NSX-T Segment DHCP server

### DIFF
--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -88,6 +88,10 @@ var endpointElevatedApiVersions = map[string][]string{
 		"35.2", // Deprecates Action field in favor of ActionValue
 		"36.2", // Adds 3 new fields - Comments, SourceGroupsExcluded, and DestinationGroupsExcluded
 	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp: {
+		//"32.0", // Basic minimum required version
+		"36.1", // Adds support for dnsServers
+	},
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -27,7 +27,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 	queryParameters := queryParameterFilterAnd("orgVdc.id=="+vdc.Vdc.ID, params)
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 		client:                   client,
 	}
 
-	err = client.OpenApiGetItem(minimumApiVersion, urlRef, queryParameters, orgNetDhcp.OpenApiOrgVdcNetworkDhcp, nil)
+	err = client.OpenApiGetItem(apiVersion, urlRef, queryParameters, orgNetDhcp.OpenApiOrgVdcNetworkDhcp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 // ID specified as orgNetworkId using OpenAPI
 func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := vdc.client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetwor
 		orgVdcNetworkDhcpConfig.Mode = "EDGE"
 	}
 
-	err = vdc.client.OpenApiPutItem(minimumApiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp, nil)
+	err = vdc.client.OpenApiPutItem(apiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
 	}
@@ -95,9 +95,6 @@ func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetwor
 
 // DeleteOpenApiOrgVdcNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for specified Org VDC
 // Network ID
-//
-// Note. VCD Versions before 10.2 do not allow to perform "DELETE" on DHCP pool and will return error. The way to
-// remove DHCP configuration is to recreate Org VDC network itself.
 func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
 	minimumApiVersion, err := vdc.client.checkOpenApiEndpointCompatibility(endpoint)

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -218,6 +218,9 @@ type OpenApiOrgVdcNetworkDhcp struct {
 	Mode string `json:"mode,omitempty"`
 	// IPAddress is only applicable when mode=NETWORK. This will specify IP address of DHCP server in network.
 	IPAddress string `json:"ipAddress,omitempty"`
+	// DnsServers are the IPs to be assigned by this DHCP service. The IP type must match the IP type of the subnet on
+	// which the DHCP config is being created.
+	DnsServers []string `json:"dnsServers,omitempty"`
 }
 
 // OpenApiOrgVdcNetworkDhcpIpRange is a type alias to fit naming

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -218,6 +218,9 @@ type OpenApiOrgVdcNetworkDhcp struct {
 	Mode string `json:"mode,omitempty"`
 	// IPAddress is only applicable when mode=NETWORK. This will specify IP address of DHCP server in network.
 	IPAddress string `json:"ipAddress,omitempty"`
+
+	// New fields starting with 36.1
+	
 	// DnsServers are the IPs to be assigned by this DHCP service. The IP type must match the IP type of the subnet on
 	// which the DHCP config is being created.
 	DnsServers []string `json:"dnsServers,omitempty"`


### PR DESCRIPTION

This PR addresses the needs on `go-vcloud-director` to allow later feature implementation on `terraform-provider-vcd` about DHCP DNS on NSX-T routed networks  https://github.com/vmware/terraform-provider-vcd/issues/753

## Description
This PR allows govcd to be able to set and read DNS servers to/from the Dhcp configuration of a specific Org vDC routed network.

## Detailed description
Starting from VCD 10.3.1 (API v36.1) is possible to set the DNS servers that the DHCP sends when configured in a routed NSX-T network.

To allow this, a new field `DnsServers` has been added to the struct `OpenApiOrgVdcNetworkDhcp`. Also the methods `Vdc.GetOpenApiOrgVdcNetworkDhcp` and `Vdc.UpdateOpenApiOrgVdcNetworkDhcp` have been updated to use the method `Client.getOpenApiHighestElevatedVersion` instead of `Client.checkOpenApiEndpointCompatibility`, so if VCD 10.3.1 or newer is used, DNS can be set.
