### PR TITLE
Change owner to VdcComputePolicy functions

### DIFF
--- a/.changes/v2.16.0/468-improvements.md
+++ b/.changes/v2.16.0/468-improvements.md
@@ -1,0 +1,3 @@
+* Add methods `client.CreateVdcComputePolicy`, `client.GetVdcComputePolicyById`, `client.GetAllVdcComputePolicies`
+* Deprecate `org.GetVdcComputePolicyById`, `adminOrg.GetVdcComputePolicyById`
+* Deprecate `org.GetAllVdcComputePolicies`, `adminOrg.GetAllVdcComputePolicies`, `org.CreateVdcComputePolicy`

--- a/.changes/v2.16.0/468-improvements.md
+++ b/.changes/v2.16.0/468-improvements.md
@@ -1,3 +1,3 @@
-* Add methods `client.CreateVdcComputePolicy`, `client.GetVdcComputePolicyById`, `client.GetAllVdcComputePolicies`
-* Deprecate `org.GetVdcComputePolicyById`, `adminOrg.GetVdcComputePolicyById`
-* Deprecate `org.GetAllVdcComputePolicies`, `adminOrg.GetAllVdcComputePolicies`, `org.CreateVdcComputePolicy`
+* Add methods `client.CreateVdcComputePolicy`, `client.GetVdcComputePolicyById`, `client.GetAllVdcComputePolicies` [GH-468]
+* Deprecate `org.GetVdcComputePolicyById`, `adminOrg.GetVdcComputePolicyById` [GH-468]
+* Deprecate `org.GetAllVdcComputePolicies`, `adminOrg.GetAllVdcComputePolicies`, `org.CreateVdcComputePolicy` [GH-468]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1529,16 +1529,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		return
 
 	case "vdcComputePolicy":
-		if entity.Parent == "" {
-			vcd.infoCleanup("removeLeftoverEntries: [ERROR] No ORG provided for vdcComputePolicy '%s'\n", entity.Name)
-			return
-		}
-		org, err := vcd.client.GetAdminOrgByName(entity.Parent)
-		if err != nil {
-			vcd.infoCleanup(notFoundMsg, "org", entity.Parent)
-			return
-		}
-		policy, err := org.GetVdcComputePolicyById(entity.Name)
+		policy, err := vcd.client.Client.GetVdcComputePolicyById(entity.Name)
 		if policy == nil || err != nil {
 			vcd.infoCleanup(notFoundMsg, "vdcComputePolicy", entity.Name)
 			return

--- a/govcd/vdccomputepolicy.go
+++ b/govcd/vdccomputepolicy.go
@@ -1,15 +1,16 @@
 package govcd
 
 /*
- * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	"github.com/vmware/go-vcloud-director/v2/util"
 	"net/http"
 	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // In UI called VM sizing policy. In API VDC compute policy
@@ -20,11 +21,18 @@ type VdcComputePolicy struct {
 }
 
 // GetVdcComputePolicyById retrieves VDC compute policy by given ID
+func (client *Client) GetVdcComputePolicyById(id string) (*VdcComputePolicy, error) {
+	return getVdcComputePolicyById(client, id)
+}
+
+// GetVdcComputePolicyById retrieves VDC compute policy by given ID
+// Deprecated: use client.GetVdcComputePolicyById
 func (org *AdminOrg) GetVdcComputePolicyById(id string) (*VdcComputePolicy, error) {
 	return getVdcComputePolicyById(org.client, id)
 }
 
 // GetVdcComputePolicyById retrieves VDC compute policy by given ID
+// Deprecated: use client.GetVdcComputePolicyById
 func (org *Org) GetVdcComputePolicyById(id string) (*VdcComputePolicy, error) {
 	return getVdcComputePolicyById(org.client, id)
 }
@@ -63,12 +71,20 @@ func getVdcComputePolicyById(client *Client, id string) (*VdcComputePolicy, erro
 
 // GetAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
+func (client *Client) GetAllVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
+	return getAllVdcComputePolicies(client, queryParameters)
+}
+
+// GetAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
+// filtering
+// Deprecated: use client.GetAllVdcComputePolicies
 func (org *AdminOrg) GetAllVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
 	return getAllVdcComputePolicies(org.client, queryParameters)
 }
 
 // GetAllVdcComputePolicies retrieves all VDC compute policies using OpenAPI endpoint. Query parameters can be supplied to perform additional
 // filtering
+// Deprecated: use client.GetAllVdcComputePolicies
 func (org *Org) GetAllVdcComputePolicies(queryParameters url.Values) ([]*VdcComputePolicy, error) {
 	return getAllVdcComputePolicies(org.client, queryParameters)
 }
@@ -107,24 +123,30 @@ func getAllVdcComputePolicies(client *Client, queryParameters url.Values) ([]*Vd
 }
 
 // CreateVdcComputePolicy creates a new VDC Compute Policy using OpenAPI endpoint
+// Deprecated: use client.CreateVdcComputePolicy
 func (org *AdminOrg) CreateVdcComputePolicy(newVdcComputePolicy *types.VdcComputePolicy) (*VdcComputePolicy, error) {
+	return org.client.CreateVdcComputePolicy(newVdcComputePolicy)
+}
+
+// CreateVdcComputePolicy creates a new VDC Compute Policy using OpenAPI endpoint
+func (client *Client) CreateVdcComputePolicy(newVdcComputePolicy *types.VdcComputePolicy) (*VdcComputePolicy, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies
-	minimumApiVersion, err := org.client.checkOpenApiEndpointCompatibility(endpoint)
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	urlRef, err := org.client.OpenApiBuildEndpoint(endpoint)
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	returnVdcComputePolicy := &VdcComputePolicy{
 		VdcComputePolicy: &types.VdcComputePolicy{},
-		client:           org.client,
+		client:           client,
 	}
 
-	err = org.client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newVdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy, nil)
+	err = client.OpenApiPostItem(minimumApiVersion, urlRef, nil, newVdcComputePolicy, returnVdcComputePolicy.VdcComputePolicy, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VDC compute policy: %s", err)
 	}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1490,10 +1490,10 @@ func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
 		vcd.infoCleanup(notFoundMsg, "vdc", vcd.vdc.Vdc.Name)
 	}
 
-	createdPolicy, err := adminOrg.CreateVdcComputePolicy(newComputePolicy.VdcComputePolicy)
+	createdPolicy, err := adminOrg.client.CreateVdcComputePolicy(newComputePolicy.VdcComputePolicy)
 	check.Assert(err, IsNil)
 
-	createdPolicy2, err := adminOrg.CreateVdcComputePolicy(newComputePolicy2.VdcComputePolicy)
+	createdPolicy2, err := adminOrg.client.CreateVdcComputePolicy(newComputePolicy2.VdcComputePolicy)
 	check.Assert(err, IsNil)
 
 	AddToCleanupList(createdPolicy.VdcComputePolicy.ID, "vdcComputePolicy", vcd.org.Org.Name, "Test_AddNewEmptyVMWithVmComputePolicyAndUpdate")


### PR DESCRIPTION
* Add `client.CreateVdcComputePolicy`
* Add `client.GetVdcComputePolicyById`
* Add `client.GetAllVdcComputePolicies`
* Deprecate `org.GetVdcComputePolicyById`
* Deprecate `adminOrg.GetVdcComputePolicyById`
* Deprecate `org.GetAllVdcComputePolicies`
* Deprecate `adminOrg.GetAllVdcComputePolicies`
* Deprecate `org.CreateVdcComputePolicy`

VDC compute policy should not belong to any organization. It is a Provider entity.
