### PR TITLE
Add more convenience methods for Org Vdc network DHCP handling

### DIFF
--- a/.changes/v2.16.0/469-improvements.md
+++ b/.changes/v2.16.0/469-improvements.md
@@ -1,3 +1,3 @@
 * Add additional methods for convenience of NSX-T Org Network DHCP handling
   `OpenApiOrgVdcNetwork.GetOpenApiOrgVdcNetworkDhcp`, `OpenApiOrgVdcNetwork.DeletNetworkDhcp`
-  `OpenApiOrgVdcNetwork.UpdateDhcp` [GH-YYY]
+  `OpenApiOrgVdcNetwork.UpdateDhcp` [GH-469]

--- a/.changes/v2.16.0/yyy-improvements.md
+++ b/.changes/v2.16.0/yyy-improvements.md
@@ -1,0 +1,3 @@
+* Add additional methods for convenience of NSX-T Org Network DHCP handling
+  `OpenApiOrgVdcNetwork.GetOpenApiOrgVdcNetworkDhcp`, `OpenApiOrgVdcNetwork.DeletNetworkDhcp`
+  `OpenApiOrgVdcNetwork.UpdateDhcp` [GH-YYY]

--- a/govcd/openapi_org_network.go
+++ b/govcd/openapi_org_network.go
@@ -132,41 +132,12 @@ func (vdcGroup *VdcGroup) CreateOpenApiOrgVdcNetwork(orgVdcNetworkConfig *types.
 	return createOpenApiOrgVdcNetwork(vdcGroup.client, orgVdcNetworkConfig)
 }
 
+// UpdateDhcp updates DHCP configuration for specific Org VDC network
 func (orgVdcNet *OpenApiOrgVdcNetwork) UpdateDhcp(orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	apiVersion, err := orgVdcNet.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	if orgVdcNet.client == nil || orgVdcNet.OpenApiOrgVdcNetwork == nil || orgVdcNet.OpenApiOrgVdcNetwork.ID == "" {
+		return nil, fmt.Errorf("error - Org VDC network structure must be set and have ID field available")
 	}
-
-	urlRef, err := orgVdcNet.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgVdcNet.OpenApiOrgVdcNetwork.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	orgNetDhcpResponse := &OpenApiOrgVdcNetworkDhcp{
-		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
-		client:                   orgVdcNet.client,
-	}
-
-	// From v35.0 onwards, if orgVdcNetworkDhcpConfig.LeaseTime or orgVdcNetworkDhcpConfig.Mode are not explicitly
-	// passed, the API doesn't use any defaults returning an error. Previous API versions were setting
-	// LeaseTime to 86400 seconds and Mode to EDGE if these values were not supplied. These two conditional
-	// address the situation.
-	if orgVdcNetworkDhcpConfig.LeaseTime == nil {
-		orgVdcNetworkDhcpConfig.LeaseTime = takeIntAddress(86400)
-	}
-
-	if len(orgVdcNetworkDhcpConfig.Mode) == 0 {
-		orgVdcNetworkDhcpConfig.Mode = "EDGE"
-	}
-
-	err = orgVdcNet.client.OpenApiPutItem(apiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
-	}
-
-	return orgNetDhcpResponse, nil
+	return updateOrgNetworkDhcp(orgVdcNet.client, orgVdcNet.OpenApiOrgVdcNetwork.ID, orgVdcNetworkDhcpConfig)
 }
 
 // Update allows to update Org VDC network

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -19,6 +19,10 @@ type OpenApiOrgVdcNetworkDhcp struct {
 
 // GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
 func (orgVdcNet *OpenApiOrgVdcNetwork) GetOpenApiOrgVdcNetworkDhcp() (*OpenApiOrgVdcNetworkDhcp, error) {
+	if orgVdcNet == nil || orgVdcNet.client == nil {
+		return nil, fmt.Errorf("error ")
+	}
+
 	client := orgVdcNet.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -19,6 +19,38 @@ type OpenApiOrgVdcNetworkDhcp struct {
 
 // GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
 // ID specified as orgNetworkId using OpenAPI
+func (orgVdcNet *OpenApiOrgVdcNetwork) GetOpenApiOrgVdcNetworkDhcp() (*OpenApiOrgVdcNetworkDhcp, error) {
+	client := orgVdcNet.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if orgVdcNet.OpenApiOrgVdcNetwork.ID == "" {
+		return nil, fmt.Errorf("empty Org VDC network ID")
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgVdcNet.OpenApiOrgVdcNetwork.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	orgNetDhcp := &OpenApiOrgVdcNetworkDhcp{
+		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
+		client:                   client,
+	}
+
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, orgNetDhcp.OpenApiOrgVdcNetworkDhcp, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return orgNetDhcp, nil
+}
+
+// GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
+// ID specified as orgNetworkId using OpenAPI
 func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdcNetworkDhcp, error) {
 
 	client := vdc.client
@@ -112,6 +144,33 @@ func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 	}
 
 	err = vdc.client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
+
+	if err != nil {
+		return fmt.Errorf("error deleting Org VDC network DHCP configuration: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteOpenApiOrgVdcNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for specified Org VDC
+// Network ID
+func (orgVdcNet *OpenApiOrgVdcNetwork) DeletNetworkDhcp() error {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	apiVersion, err := orgVdcNet.client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return err
+	}
+
+	if orgVdcNet.OpenApiOrgVdcNetwork.ID == "" {
+		return fmt.Errorf("cannot delete Org VDC network DHCP configuration without ID")
+	}
+
+	urlRef, err := orgVdcNet.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgVdcNet.OpenApiOrgVdcNetwork.ID))
+	if err != nil {
+		return err
+	}
+
+	err = orgVdcNet.client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
 
 	if err != nil {
 		return fmt.Errorf("error deleting Org VDC network DHCP configuration: %s", err)

--- a/govcd/openapi_org_network_dhcp.go
+++ b/govcd/openapi_org_network_dhcp.go
@@ -18,7 +18,6 @@ type OpenApiOrgVdcNetworkDhcp struct {
 }
 
 // GetOpenApiOrgVdcNetworkDhcp allows to retrieve DHCP configuration for specific Org VDC network
-// ID specified as orgNetworkId using OpenAPI
 func (orgVdcNet *OpenApiOrgVdcNetwork) GetOpenApiOrgVdcNetworkDhcp() (*OpenApiOrgVdcNetworkDhcp, error) {
 	client := orgVdcNet.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
@@ -89,40 +88,7 @@ func (vdc *Vdc) GetOpenApiOrgVdcNetworkDhcp(orgNetworkId string) (*OpenApiOrgVdc
 // UpdateOpenApiOrgVdcNetworkDhcp allows to update DHCP configuration for specific Org VDC network
 // ID specified as orgNetworkId using OpenAPI
 func (vdc *Vdc) UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
-	apiVersion, err := vdc.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	urlRef, err := vdc.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgNetworkId))
-	if err != nil {
-		return nil, err
-	}
-
-	orgNetDhcpResponse := &OpenApiOrgVdcNetworkDhcp{
-		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
-		client:                   vdc.client,
-	}
-
-	// From v35.0 onwards, if orgVdcNetworkDhcpConfig.LeaseTime or orgVdcNetworkDhcpConfig.Mode are not explicitly
-	// passed, the API doesn't use any defaults returning an error. Previous API versions were setting
-	// LeaseTime to 86400 seconds and Mode to EDGE if these values were not supplied. These two conditional
-	// address the situation.
-	if orgVdcNetworkDhcpConfig.LeaseTime == nil {
-		orgVdcNetworkDhcpConfig.LeaseTime = takeIntAddress(86400)
-	}
-
-	if len(orgVdcNetworkDhcpConfig.Mode) == 0 {
-		orgVdcNetworkDhcpConfig.Mode = "EDGE"
-	}
-
-	err = vdc.client.OpenApiPutItem(apiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
-	}
-
-	return orgNetDhcpResponse, nil
+	return updateOrgNetworkDhcp(vdc.client, orgNetworkId, orgVdcNetworkDhcpConfig)
 }
 
 // DeleteOpenApiOrgVdcNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for specified Org VDC
@@ -152,8 +118,7 @@ func (vdc *Vdc) DeleteOpenApiOrgVdcNetworkDhcp(orgNetworkId string) error {
 	return nil
 }
 
-// DeleteOpenApiOrgVdcNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for specified Org VDC
-// Network ID
+// DeletNetworkDhcp allows to perform HTTP DELETE request on DHCP pool configuration for Org network
 func (orgVdcNet *OpenApiOrgVdcNetwork) DeletNetworkDhcp() error {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
 	apiVersion, err := orgVdcNet.client.getOpenApiHighestElevatedVersion(endpoint)
@@ -177,4 +142,41 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) DeletNetworkDhcp() error {
 	}
 
 	return nil
+}
+
+func updateOrgNetworkDhcp(client *Client, orgNetworkId string, orgVdcNetworkDhcpConfig *types.OpenApiOrgVdcNetworkDhcp) (*OpenApiOrgVdcNetworkDhcp, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgNetworkId))
+	if err != nil {
+		return nil, err
+	}
+
+	orgNetDhcpResponse := &OpenApiOrgVdcNetworkDhcp{
+		OpenApiOrgVdcNetworkDhcp: &types.OpenApiOrgVdcNetworkDhcp{},
+		client:                   client,
+	}
+
+	// From v35.0 onwards, if orgVdcNetworkDhcpConfig.LeaseTime or orgVdcNetworkDhcpConfig.Mode are not explicitly
+	// passed, the API doesn't use any defaults returning an error. Previous API versions were setting
+	// LeaseTime to 86400 seconds and Mode to EDGE if these values were not supplied. These two conditional
+	// address the situation.
+	if orgVdcNetworkDhcpConfig.LeaseTime == nil {
+		orgVdcNetworkDhcpConfig.LeaseTime = takeIntAddress(86400)
+	}
+
+	if len(orgVdcNetworkDhcpConfig.Mode) == 0 {
+		orgVdcNetworkDhcpConfig.Mode = "EDGE"
+	}
+
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, orgVdcNetworkDhcpConfig, orgNetDhcpResponse.OpenApiOrgVdcNetworkDhcp, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error updating Org VDC network DHCP configuration: %s", err)
+	}
+
+	return orgNetDhcpResponse, nil
 }

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -431,6 +431,11 @@ func nsxtRoutedDhcpConfig(check *C, vcd *TestVCD, vdc *Vdc, orgNetId string) {
 	err = orgVdcNetwork.DeletNetworkDhcp()
 	check.Assert(err, IsNil)
 
+	deletedDhcp, err := orgVdcNetwork.GetOpenApiOrgVdcNetworkDhcp()
+	check.Assert(err, IsNil)
+	check.Assert(len(deletedDhcp.OpenApiOrgVdcNetworkDhcp.DhcpPools), Equals, 0)
+	check.Assert(len(deletedDhcp.OpenApiOrgVdcNetworkDhcp.DnsServers), Equals, 0)
+
 }
 
 func runOpenApiOrgVdcNetworkWithVdcGroupTest(check *C, vcd *TestVCD, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, expectNetworkType string, dhcpFunc dhcpConfigFunc) {

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -54,7 +54,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
 	runOpenApiOrgVdcNetworkWithVdcGroupTest(check, vcd, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
 }
 
@@ -115,7 +115,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nsxtRoutedDhcpConfig)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nsxtRoutedDhcpConfig)
 	runOpenApiOrgVdcNetworkWithVdcGroupTest(check, vcd, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nsxtRoutedDhcpConfig)
 }
 
@@ -168,7 +168,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkImported(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, nil)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.nsxtVdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, nil)
 	runOpenApiOrgVdcNetworkWithVdcGroupTest(check, vcd, orgVdcNetworkConfig, types.OrgVdcNetworkTypeOpaque, nil)
 }
 
@@ -211,7 +211,7 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkIsolated(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeIsolated, nil)
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
@@ -270,7 +270,7 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkRouted(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nil)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeRouted, nil)
 }
 
 func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
@@ -327,10 +327,10 @@ func (vcd *TestVCD) Test_NsxvOrgVdcNetworkDirect(check *C) {
 		},
 	}
 
-	runOpenApiOrgVdcNetworkTest(check, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeDirect, nil)
+	runOpenApiOrgVdcNetworkTest(check, vcd, vcd.vdc, orgVdcNetworkConfig, types.OrgVdcNetworkTypeDirect, nil)
 }
 
-func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, expectNetworkType string, dhcpFunc dhcpConfigFunc) {
+func runOpenApiOrgVdcNetworkTest(check *C, vcd *TestVCD, vdc *Vdc, orgVdcNetworkConfig *types.OpenApiOrgVdcNetwork, expectNetworkType string, dhcpFunc dhcpConfigFunc) {
 	orgVdcNet, err := vdc.CreateOpenApiOrgVdcNetwork(orgVdcNetworkConfig)
 	check.Assert(err, IsNil)
 
@@ -371,7 +371,7 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 
 	// Configure DHCP if specified
 	if dhcpFunc != nil {
-		dhcpFunc(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
+		dhcpFunc(check, vcd, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
 	}
 	// Delete
 	err = orgVdcNet.Delete()
@@ -385,9 +385,9 @@ func runOpenApiOrgVdcNetworkTest(check *C, vdc *Vdc, orgVdcNetworkConfig *types.
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
-type dhcpConfigFunc func(check *C, vdc *Vdc, orgNetId string)
+type dhcpConfigFunc func(check *C, vcd *TestVCD, vdc *Vdc, orgNetId string)
 
-func nsxtRoutedDhcpConfig(check *C, vdc *Vdc, orgNetId string) {
+func nsxtRoutedDhcpConfig(check *C, vcd *TestVCD, vdc *Vdc, orgNetId string) {
 	dhcpDefinition := &types.OpenApiOrgVdcNetworkDhcp{
 		Enabled: takeBoolPointer(true),
 		DhcpPools: []types.OpenApiOrgVdcNetworkDhcpPools{
@@ -407,7 +407,7 @@ func nsxtRoutedDhcpConfig(check *C, vdc *Vdc, orgNetId string) {
 
 	// In API versions lower than 36.1, dnsServers list does not exist
 	if vdc.client.APIVCDMaxVersionIs("< 36.1") {
-		dhcpDefinition.DnsServers = []string{}
+		dhcpDefinition.DnsServers = nil
 	}
 
 	updatedDhcp, err := vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetId, dhcpDefinition)
@@ -416,6 +416,17 @@ func nsxtRoutedDhcpConfig(check *C, vdc *Vdc, orgNetId string) {
 	check.Assert(dhcpDefinition, DeepEquals, updatedDhcp.OpenApiOrgVdcNetworkDhcp)
 
 	err = vdc.DeleteOpenApiOrgVdcNetworkDhcp(orgNetId)
+	check.Assert(err, IsNil)
+
+	orgVdcNetwork, err := vcd.org.GetOpenApiOrgVdcNetworkById(orgNetId)
+	check.Assert(err, IsNil)
+	check.Assert(orgVdcNetwork, NotNil)
+
+	updatedDhcp2, err := orgVdcNetwork.UpdateDhcp(dhcpDefinition)
+	check.Assert(err, IsNil)
+	check.Assert(updatedDhcp2, NotNil)
+
+	err = orgVdcNetwork.DeletNetworkDhcp()
 	check.Assert(err, IsNil)
 
 }
@@ -508,7 +519,7 @@ func runOpenApiOrgVdcNetworkWithVdcGroupTest(check *C, vcd *TestVCD, orgVdcNetwo
 
 	// Configure DHCP if specified
 	if dhcpFunc != nil {
-		dhcpFunc(check, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
+		dhcpFunc(check, vcd, vdc, updatedOrgVdcNet.OpenApiOrgVdcNetwork.ID)
 	}
 	// Delete
 	err = orgVdcNet.Delete()

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -426,6 +426,8 @@ func nsxtRoutedDhcpConfig(check *C, vcd *TestVCD, vdc *Vdc, orgNetId string) {
 	check.Assert(err, IsNil)
 	check.Assert(updatedDhcp2, NotNil)
 
+	check.Assert(dhcpDefinition, DeepEquals, updatedDhcp2.OpenApiOrgVdcNetworkDhcp)
+
 	err = orgVdcNetwork.DeletNetworkDhcp()
 	check.Assert(err, IsNil)
 


### PR DESCRIPTION
This PR adds a few functions for the convenience of handling Org network DHCP which are especially covenient when dealing with Org Networks in VDC Groups:
`OpenApiOrgVdcNetwork.GetOpenApiOrgVdcNetworkDhcp`, `OpenApiOrgVdcNetwork.DeletNetworkDhcp`
  `OpenApiOrgVdcNetwork.UpdateDhcp`

