### PR TITLE
VDC Sharing methods

### DIFF
--- a/govcd/access_control.go
+++ b/govcd/access_control.go
@@ -71,6 +71,7 @@ func (client *Client) SetAccessControl(accessControl *types.ControlAccessParams,
 	return client.SetAccessControlWithMethod(http.MethodPost, accessControl, href, entityType, entityName, headerValues)
 }
 
+// SetAccessControlWithMethod is the same as Client.SetAccessControl but allowing passing a different HTTP method
 func (client *Client) SetAccessControlWithMethod(httpMethod string, accessControl *types.ControlAccessParams, href, entityType, entityName string, headerValues map[string]string) error {
 	href += "/action/controlAccess"
 	// Make sure that subjects in the setting list are used only once

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -1232,3 +1232,31 @@ func (vdc *Vdc) getParentOrg() (organization, error) {
 	}
 	return nil, fmt.Errorf("no parent found for VDC %s", vdc.Vdc.Name)
 }
+
+func (vdc *Vdc) GetControlAccess() (*types.ControlAccessParams, error) {
+	accessControlLink := vdc.getLinkHref(types.RelControlAccess, types.MimeControlAccess)
+	if accessControlLink == "" {
+		return nil, fmt.Errorf("control access link for VDC wasn't found")
+	}
+
+	controlAccessParams, err := vdc.client.GetAccessControl(accessControlLink, "vdc", vdc.Vdc.Name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("there was an error when retrieving VDC control access params - %s", err)
+	}
+
+	return controlAccessParams, nil
+}
+
+func (vdc *Vdc) SetControlAccess(accessControl *types.ControlAccessParams, tenanantContext bool) (*types.ControlAccessParams, error) {
+	accessControlLink := vdc.getLinkHref(types.RelControlAccess, types.MimeControlAccess)
+	if accessControlLink == "" {
+		return nil, fmt.Errorf("control access link for VDC wasn't found")
+	}
+
+	err := vdc.client.SetAccessControl(accessControl, accessControlLink, "vdc", vdc.Vdc.Name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("there was an error when setting VDC control access params - %s", err)
+	}
+
+	return vdc.GetControlAccess()
+}

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -1232,21 +1232,3 @@ func (vdc *Vdc) getParentOrg() (organization, error) {
 	}
 	return nil, fmt.Errorf("no parent found for VDC %s", vdc.Vdc.Name)
 }
-
-func (vdc *Vdc) GetControlAccess() (*types.ControlAccessParams, error) {
-	controlAccessParams, err := vdc.client.GetAccessControl(vdc.Vdc.HREF, "vdc", vdc.Vdc.Name, nil)
-	if err != nil {
-		return nil, fmt.Errorf("there was an error when retrieving VDC control access params - %s", err)
-	}
-
-	return controlAccessParams, nil
-}
-
-func (vdc *Vdc) SetControlAccess(accessControl *types.ControlAccessParams) (*types.ControlAccessParams, error) {
-	err := vdc.client.SetAccessControl(accessControl, vdc.Vdc.HREF, "vdc", vdc.Vdc.Name, nil)
-	if err != nil {
-		return nil, fmt.Errorf("there was an error when setting VDC control access params - %s", err)
-	}
-
-	return vdc.GetControlAccess()
-}

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -1234,12 +1234,7 @@ func (vdc *Vdc) getParentOrg() (organization, error) {
 }
 
 func (vdc *Vdc) GetControlAccess() (*types.ControlAccessParams, error) {
-	accessControlLink := vdc.getLinkHref(types.RelControlAccess, types.MimeControlAccess)
-	if accessControlLink == "" {
-		return nil, fmt.Errorf("control access link for VDC wasn't found")
-	}
-
-	controlAccessParams, err := vdc.client.GetAccessControl(accessControlLink, "vdc", vdc.Vdc.Name, nil)
+	controlAccessParams, err := vdc.client.GetAccessControl(vdc.Vdc.HREF, "vdc", vdc.Vdc.Name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("there was an error when retrieving VDC control access params - %s", err)
 	}
@@ -1247,13 +1242,8 @@ func (vdc *Vdc) GetControlAccess() (*types.ControlAccessParams, error) {
 	return controlAccessParams, nil
 }
 
-func (vdc *Vdc) SetControlAccess(accessControl *types.ControlAccessParams, tenanantContext bool) (*types.ControlAccessParams, error) {
-	accessControlLink := vdc.getLinkHref(types.RelControlAccess, types.MimeControlAccess)
-	if accessControlLink == "" {
-		return nil, fmt.Errorf("control access link for VDC wasn't found")
-	}
-
-	err := vdc.client.SetAccessControl(accessControl, accessControlLink, "vdc", vdc.Vdc.Name, nil)
+func (vdc *Vdc) SetControlAccess(accessControl *types.ControlAccessParams) (*types.ControlAccessParams, error) {
+	err := vdc.client.SetAccessControl(accessControl, vdc.Vdc.HREF, "vdc", vdc.Vdc.Name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("there was an error when setting VDC control access params - %s", err)
 	}

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -487,3 +487,7 @@ func (vcd *TestVCD) TestCreateRawVapp(check *C) {
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 }
+
+func (vcd *TestVCD) TestSetControlAccess(check *C) {
+	
+}

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -489,5 +489,21 @@ func (vcd *TestVCD) TestCreateRawVapp(check *C) {
 }
 
 func (vcd *TestVCD) TestSetControlAccess(check *C) {
-	
+	// Set VDC sharing to everyone
+	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+	check.Assert(err, IsNil)
+	check.Assert(vdc, NotNil)
+
+	controlAccessParams := &types.ControlAccessParams{
+		Xmlns:               types.XMLNamespaceVCloud,
+		IsSharedToEveryone:  true,
+		EveryoneAccessLevel: takeStringPointer("ReadOnly"),
+	}
+	readControlAccessParams, err := vdc.SetControlAccess(controlAccessParams)
+	check.Assert(err, IsNil)
+	check.Assert(readControlAccessParams, NotNil)
 }


### PR DESCRIPTION
This PR is aimed to implement https://github.com/vmware/terraform-provider-vcd/issues/785

## Description
This PR brings the possibility of setting AccessControl settings to VDC, allowing users to effectively share their VDC across users and groups.

## Detailed description
This PR comes with new methods to allow developers to share their VDCs. New methods are:
- `Vdc.GetControlAccess` which returns the current control access configuration
- `Vdc.SetControlAccess` which sets the control access configuration

Some code has been reused since other different entities also had this capability, but I had to tweak some things as the other entities were using the HTTP method POST for setting control access but VDC control access was using PUT. For this reason a new method called `Client.SetAccessControlWithMethod` has been created. It is the same a previous `Client.SetAccessControl` but it allows to pass the HTTP method needed. 
Now `Client.SetAccessControlWithMethod` has all the code `Client.SetAccessControl` had, and this last one is a wrapper to the first one, using POST.
