### PR TITLE
Refactor metadata CRUD functions to simplify code

### DIFF
--- a/.changes/v2.16.0/473-features.md
+++ b/.changes/v2.16.0/473-features.md
@@ -4,4 +4,5 @@
 `Media.MergeMetadataAsync`, `MediaRecord.MergeMetadata`, `MediaRecord.MergeMetadataAsync`, `OpenAPIOrgVdcNetwork.MergeMetadata`, 
 `OpenAPIOrgVdcNetwork.MergeMetadataAsync`, `OrgVDCNetwork.MergeMetadata`, `OrgVDCNetwork.MergeMetadataAsync`, 
 `VApp.MergeMetadata`, `VApp.MergeMetadataAsync`, `VAppTemplate.MergeMetadata`, `VAppTemplate.MergeMetadataAsync`, 
-`VM.MergeMetadata`, `VM.MergeMetadataAsync`, `Vdc.MergeMetadata`, `Vdc.MergeMetadataAsync` to merge current metadata with new one [GH-473]
+`VM.MergeMetadata`, `VM.MergeMetadataAsync`, `Vdc.MergeMetadata`, `Vdc.MergeMetadataAsync` to merge metadata, 
+which both updates existing metadata with same key and adds new entries for the non-existent ones [GH-473]

--- a/.changes/v2.16.0/473-features.md
+++ b/.changes/v2.16.0/473-features.md
@@ -1,0 +1,7 @@
+* Added metadata interface `MetadataCompatible` to manage uniformly all metadata-compatible resources [GH-473]
+* Added `AdminCatalog.MergeMetadata`,`AdminCatalog.MergeMetadataAsync`, `AdminOrg.MergeMetadata`, `AdminOrg.MergeMetadataAsync`, 
+`CatalogItem.MergeMetadata`, `CatalogItem.MergeMetadataAsync`, `Disk.MergeMetadata`, `Disk.MergeMetadataAsync`, `Media.MergeMetadata`, 
+`Media.MergeMetadataAsync`, `MediaRecord.MergeMetadata`, `MediaRecord.MergeMetadataAsync`, `OpenAPIOrgVdcNetwork.MergeMetadata`, 
+`OpenAPIOrgVdcNetwork.MergeMetadataAsync`, `OrgVDCNetwork.MergeMetadata`, `OrgVDCNetwork.MergeMetadataAsync`, 
+`VApp.MergeMetadata`, `VApp.MergeMetadataAsync`, `VAppTemplate.MergeMetadata`, `VAppTemplate.MergeMetadataAsync`, 
+`VM.MergeMetadata`, `VM.MergeMetadataAsync`, `Vdc.MergeMetadata`, `Vdc.MergeMetadataAsync` to merge current metadata with new one [GH-473]

--- a/.changes/v2.16.0/473-features.md
+++ b/.changes/v2.16.0/473-features.md
@@ -1,4 +1,3 @@
-* Added metadata interface `MetadataCompatible` to manage uniformly all metadata-compatible resources [GH-473]
 * Added `AdminCatalog.MergeMetadata`,`AdminCatalog.MergeMetadataAsync`, `AdminOrg.MergeMetadata`, `AdminOrg.MergeMetadataAsync`, 
 `CatalogItem.MergeMetadata`, `CatalogItem.MergeMetadataAsync`, `Disk.MergeMetadata`, `Disk.MergeMetadataAsync`, `Media.MergeMetadata`, 
 `Media.MergeMetadataAsync`, `MediaRecord.MergeMetadata`, `MediaRecord.MergeMetadataAsync`, `OpenAPIOrgVdcNetwork.MergeMetadata`, 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -768,6 +768,11 @@ func (client *Client) RemoveProvidedCustomHeaders(values map[string]string) {
 	}
 }
 
+// Retrieves the administrator URL of a given HREF
+func getAdminURL(href string) string {
+	return strings.ReplaceAll(href, "/api/", "/api/admin/")
+}
+
 // ---------------------------------------------------------------------
 // The following functions are needed to avoid strict Coverity warnings
 // ---------------------------------------------------------------------

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1702,28 +1702,21 @@ func (vcd *TestVCD) findFirstVapp() VApp {
 		return VApp{}
 	}
 	wantedVapp := vcd.vapp.VApp.Name
-	vappName := ""
-	for _, res := range vdc.Vdc.ResourceEntities {
-		for _, item := range res.ResourceEntity {
-			// Finding a named vApp, if it was defined in config
-			if wantedVapp != "" {
-				if item.Name == wantedVapp {
-					vappName = item.Name
-					break
-				}
-			} else {
-				// Otherwise, we get the first vApp from the vDC list
+	if wantedVapp == "" {
+		// As no vApp is defined in config, we search for one randomly
+		for _, res := range vdc.Vdc.ResourceEntities {
+			for _, item := range res.ResourceEntity {
 				if item.Type == "application/vnd.vmware.vcloud.vApp+xml" {
-					vappName = item.Name
+					wantedVapp = item.Name
 					break
 				}
 			}
 		}
 	}
-	if wantedVapp == "" {
+	vapp, err := vdc.GetVAppByName(wantedVapp, false)
+	if err != nil {
 		return VApp{}
 	}
-	vapp, _ := vdc.GetVAppByName(vappName, false)
 	return *vapp
 }
 

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -17,7 +17,7 @@ import (
 type MetadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error
-	MergeMetadata(typedValue, metadata map[string]string) error
+	MergeMetadata(typedValue string, metadata map[string]interface{}) error
 	DeleteMetadataEntry(key string) error
 }
 
@@ -47,13 +47,13 @@ func (vcdClient *VCDClient) AddMetadataEntryByHrefAsync(href, typedValue, key, v
 
 // MergeMetadataByHrefAsync merges metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // and returns the task.
-func (vcdClient *VCDClient) MergeMetadataByHrefAsync(href, typedValue string, metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(&vcdClient.Client, typedValue, typedValue, metadata, href)
+func (vcdClient *VCDClient) MergeMetadataByHrefAsync(href, typedValue string, metadata map[string]interface{}) (Task, error) {
+	return mergeAllMetadata(&vcdClient.Client, typedValue, metadata, href)
 }
 
 // MergeMetadataByHref merges metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vcdClient *VCDClient) MergeMetadataByHref(href, typedValue string, metadata map[string]types.TypedValue) error {
+func (vcdClient *VCDClient) MergeMetadataByHref(href, typedValue string, metadata map[string]interface{}) error {
 	task, err := vcdClient.MergeMetadataByHrefAsync(href, typedValue, metadata)
 	if err != nil {
 		return err
@@ -112,13 +112,13 @@ func (vm *VM) AddMetadataEntryAsync(typedValue, key, value string) (Task, error)
 
 // MergeMetadataAsync merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then returns the task.
-func (vm *VM) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (vm *VM) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(vm.client, typedValue, metadata, vm.VM.HREF)
 }
 
 // MergeMetadata merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vm *VM) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (vm *VM) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := vm.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -189,14 +189,14 @@ func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, erro
 // MergeMetadataAsync merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (vdc *Vdc) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (vdc *Vdc) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(vdc.client, typedValue, metadata, getAdminURL(vdc.Vdc.HREF))
 }
 
 // MergeMetadata merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (vdc *Vdc) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (vdc *Vdc) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := vdc.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -265,13 +265,13 @@ func (vapp *VApp) AddMetadataEntryAsync(typedValue, key, value string) (Task, er
 
 // MergeMetadataAsync merges VApp metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vapp *VApp) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (vapp *VApp) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(vapp.client, typedValue, metadata, vapp.VApp.HREF)
 }
 
 // MergeMetadata merges VApp metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vapp *VApp) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (vapp *VApp) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := vapp.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -338,13 +338,13 @@ func (vAppTemplate *VAppTemplate) AddMetadataEntryAsync(typedValue, key, value s
 
 // MergeMetadataAsync merges VAppTemplate metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vAppTemplate *VAppTemplate) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (vAppTemplate *VAppTemplate) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(vAppTemplate.client, typedValue, metadata, vAppTemplate.VAppTemplate.HREF)
 }
 
 // MergeMetadata merges VAppTemplate metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vAppTemplate *VAppTemplate) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (vAppTemplate *VAppTemplate) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := vAppTemplate.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -412,13 +412,13 @@ func (mediaRecord *MediaRecord) AddMetadataEntryAsync(typedValue, key, value str
 
 // MergeMetadataAsync merges MediaRecord metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (mediaRecord *MediaRecord) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (mediaRecord *MediaRecord) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(mediaRecord.client, typedValue, metadata, mediaRecord.MediaRecord.HREF)
 }
 
 // MergeMetadata merges MediaRecord metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (mediaRecord *MediaRecord) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (mediaRecord *MediaRecord) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := mediaRecord.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -485,13 +485,13 @@ func (media *Media) AddMetadataEntryAsync(typedValue, key, value string) (Task, 
 
 // MergeMetadataAsync merges Media metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (media *Media) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (media *Media) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(media.client, typedValue, metadata, media.Media.HREF)
 }
 
 // MergeMetadata merges Media metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (media *Media) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (media *Media) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := media.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -564,13 +564,13 @@ func (adminCatalog *AdminCatalog) AddMetadataEntryAsync(typedValue, key, value s
 
 // MergeMetadataAsync merges AdminCatalog metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminCatalog *AdminCatalog) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (adminCatalog *AdminCatalog) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(adminCatalog.client, typedValue, metadata, adminCatalog.AdminCatalog.HREF)
 }
 
 // MergeMetadata merges AdminCatalog metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminCatalog *AdminCatalog) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (adminCatalog *AdminCatalog) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := adminCatalog.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -633,13 +633,13 @@ func (adminOrg *AdminOrg) AddMetadataEntryAsync(typedValue, key, value string) (
 
 // MergeMetadataAsync merges AdminOrg metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminOrg *AdminOrg) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (adminOrg *AdminOrg) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(adminOrg.client, typedValue, metadata, adminOrg.AdminOrg.HREF)
 }
 
 // MergeMetadata merges AdminOrg metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminOrg *AdminOrg) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (adminOrg *AdminOrg) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := adminOrg.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -688,13 +688,13 @@ func (disk *Disk) AddMetadataEntryAsync(typedValue, key, value string) (Task, er
 
 // MergeMetadataAsync merges Disk metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (disk *Disk) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (disk *Disk) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(disk.client, typedValue, metadata, disk.Disk.HREF)
 }
 
 // MergeMetadata merges Disk metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (disk *Disk) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (disk *Disk) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := disk.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -748,14 +748,14 @@ func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntryAsync(typedValue, key, value
 // MergeMetadataAsync merges OrgVDCNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (orgVdcNetwork *OrgVDCNetwork) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(orgVdcNetwork.client, typedValue, metadata, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
 }
 
 // MergeMetadata merges OrgVDCNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (orgVdcNetwork *OrgVDCNetwork) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := orgVdcNetwork.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -805,13 +805,13 @@ func (catalogItem *CatalogItem) AddMetadataEntryAsync(typedValue, key, value str
 
 // MergeMetadataAsync merges CatalogItem metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (catalogItem *CatalogItem) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+func (catalogItem *CatalogItem) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(catalogItem.client, typedValue, metadata, catalogItem.CatalogItem.HREF)
 }
 
 // MergeMetadata merges CatalogItem metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (catalogItem *CatalogItem) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (catalogItem *CatalogItem) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := catalogItem.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
@@ -859,7 +859,7 @@ func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) AddMetadataEntry(typedValue, k
 // MergeMetadata merges OpenApiOrgVdcNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // and waits for the task to finish.
 // TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
-func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) MergeMetadata(typedValue string, metadata map[string]string) error {
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
 	task, err := mergeAllMetadata(openApiOrgVdcNetwork.client, typedValue, metadata, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
 	if err != nil {
 		return err
@@ -916,15 +916,15 @@ func addMetadata(client *Client, typedValue, key, value, requestUri string) (Tas
 }
 
 // mergeAllMetadata merges the metadata key-values provided as parameter with existing entity metadata
-func mergeAllMetadata(client *Client, typedValue string, metadata map[string]string, requestUri string) (Task, error) {
+func mergeAllMetadata(client *Client, typedValue string, metadata map[string]interface{}, requestUri string) (Task, error) {
 	var metadataToMerge []*types.MetadataEntry
 	for _, value := range metadata {
 		metadataToMerge = append(metadataToMerge, &types.MetadataEntry{
-			Xmlns:      types.XMLNamespaceVCloud,
-			Xsi:        types.XMLNamespaceXSI,
+			Xmlns: types.XMLNamespaceVCloud,
+			Xsi:   types.XMLNamespaceXSI,
 			TypedValue: &types.TypedValue{
 				XsiType: typedValue,
-				Value:   value,
+				Value:   value.(string),
 			},
 		})
 	}

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -920,15 +920,15 @@ func mergeAllMetadata(client *Client, metadata map[string]types.TypedValue, requ
 	var metadataList []*types.MetadataEntry
 	for _, typedValue := range metadata {
 		metadataList = append(metadataList, &types.MetadataEntry{
-			Xmlns: types.XMLNamespaceVCloud,
-			Xsi:   types.XMLNamespaceXSI,
+			Xmlns:      types.XMLNamespaceVCloud,
+			Xsi:        types.XMLNamespaceXSI,
 			TypedValue: &typedValue,
 		})
 	}
 
 	newMetadata := &types.Metadata{
-		Xmlns: types.XMLNamespaceVCloud,
-		Xsi:   types.XMLNamespaceXSI,
+		Xmlns:         types.XMLNamespaceVCloud,
+		Xsi:           types.XMLNamespaceXSI,
 		MetadataEntry: metadataList,
 	}
 
@@ -1108,7 +1108,6 @@ func (media *Media) DeleteMetadata(key string) error {
 func (media *Media) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(media.client, key, media.Media.HREF)
 }
-
 
 // GetMetadata returns MediaItem metadata.
 // Deprecated: Use MediaRecord.GetMetadata.

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -17,7 +17,7 @@ import (
 type MetadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error
-	MergeMetadataEntryByHref(metadata map[string]types.TypedValue) error
+	MergeMetadata(metadata map[string]types.TypedValue) error
 	DeleteMetadataEntry(key string) error
 }
 

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -17,8 +17,12 @@ import (
 type MetadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error
+	MergeMetadataEntryByHref(metadata map[string]types.TypedValue) error
 	DeleteMetadataEntry(key string) error
 }
+
+// ----------------
+// REST API metadata CRUD functions
 
 // GetMetadataByHref returns metadata from the given resource reference.
 func (vcdClient *VCDClient) GetMetadataByHref(href string) (*types.Metadata, error) {
@@ -39,6 +43,22 @@ func (vcdClient *VCDClient) AddMetadataEntryByHref(href, typedValue, key, value 
 // and returns the task.
 func (vcdClient *VCDClient) AddMetadataEntryByHrefAsync(href, typedValue, key, value string) (Task, error) {
 	return addMetadata(&vcdClient.Client, typedValue, key, value, href)
+}
+
+// MergeMetadataByHrefAsync merges metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// and returns the task.
+func (vcdClient *VCDClient) MergeMetadataByHrefAsync(href string, metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(&vcdClient.Client, metadata, href)
+}
+
+// MergeMetadataByHref merges metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vcdClient *VCDClient) MergeMetadataByHref(href string, metadata map[string]types.TypedValue) error {
+	task, err := vcdClient.MergeMetadataByHrefAsync(href, metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
 }
 
 // DeleteMetadataEntryByHref deletes metadata from the given resource reference, depending on key provided as input
@@ -63,73 +83,153 @@ func (vm *VM) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(vm.client, vm.VM.HREF)
 }
 
-// Deprecated: use VM.DeleteMetadataEntry.
-func (vm *VM) DeleteMetadata(key string) (Task, error) {
+// AddMetadataEntry adds VM metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (vm *VM) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := vm.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds VM metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (vm *VM) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(vm.client, typedValue, key, value, vm.VM.HREF)
+}
+
+// MergeMetadataAsync merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then returns the task.
+func (vm *VM) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(vm.client, metadata, vm.VM.HREF)
+}
+
+// MergeMetadata merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vm *VM) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := vm.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes VM metadata by key provided as input and waits for the task to finish.
+func (vm *VM) DeleteMetadataEntry(key string) error {
+	task, err := vm.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes VM metadata depending on key provided as input
+// and returns the task.
+func (vm *VM) DeleteMetadataEntryAsync(key string) (Task, error) {
 	return deleteMetadata(vm.client, key, vm.VM.HREF)
 }
 
-// Deprecated: use VM.AddMetadataEntry.
-func (vm *VM) AddMetadata(key string, value string) (Task, error) {
-	return addMetadata(vm.client, types.MetadataStringValue, key, value, vm.VM.HREF)
-}
-
 // GetMetadata returns Vdc metadata.
+// Note: Requires system administrator privileges.
 func (vdc *Vdc) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vdc.client, getAdminVdcURL(vdc.Vdc.HREF))
+	return getMetadata(vdc.client, getAdminURL(vdc.Vdc.HREF))
 }
 
-// Deprecated: use Vdc.DeleteMetadataEntry.
-func (vdc *Vdc) DeleteMetadata(key string) (Vdc, error) {
-	task, err := deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
+// AddMetadataEntry adds Vdc metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := vdc.AddMetadataEntryAsync(typedValue, key, value)
 	if err != nil {
-		return Vdc{}, err
+		return err
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return Vdc{}, err
+		return err
 	}
 
 	err = vdc.Refresh()
 	if err != nil {
-		return Vdc{}, err
+		return err
 	}
 
-	return *vdc, nil
+	return nil
 }
 
-// Deprecated: use Vdc.AddMetadataEntry.
-func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
-	task, err := addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
+// AddMetadataEntryAsync adds Vdc metadata typedValue and key/value pair provided as input and returns the task.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(vdc.client, typedValue, key, value, getAdminURL(vdc.Vdc.HREF))
+}
+
+// MergeMetadataAsync merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(vdc.client, metadata, getAdminURL(vdc.Vdc.HREF))
+}
+
+// MergeMetadata merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := vdc.MergeMetadataAsync(metadata)
 	if err != nil {
-		return Vdc{}, err
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes Vdc metadata by key provided as input and waits for
+// the task to finish.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) DeleteMetadataEntry(key string) error {
+	task, err := vdc.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return Vdc{}, err
+		return err
 	}
 
 	err = vdc.Refresh()
 	if err != nil {
-		return Vdc{}, err
+		return err
 	}
 
-	return *vdc, nil
+	return nil
 }
 
-// Deprecated: use Vdc.AddMetadataEntryAsync.
-func (vdc *Vdc) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
-}
-
-// Deprecated: use Vdc.DeleteMetadataEntryAsync.
-func (vdc *Vdc) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
-}
-
-func getAdminVdcURL(vdcURL string) string {
-	return strings.Split(vdcURL, "/api/vdc/")[0] + "/api/admin/vdc/" + strings.Split(vdcURL, "/api/vdc/")[1]
+// DeleteMetadataEntryAsync deletes Vdc metadata depending on key provided as input and returns the task.
+// Note: Requires system administrator privileges.
+func (vdc *Vdc) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(vdc.client, key, getAdminURL(vdc.Vdc.HREF))
 }
 
 // GetMetadata returns VApp metadata.
@@ -137,6 +237,652 @@ func (vapp *VApp) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(vapp.client, vapp.VApp.HREF)
 }
 
+// AddMetadataEntry adds VApp metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (vapp *VApp) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := vapp.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vapp.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds VApp metadata typedValue and key/value pair provided as input and returns the task.
+func (vapp *VApp) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(vapp.client, typedValue, key, value, vapp.VApp.HREF)
+}
+
+// MergeMetadataAsync merges VApp metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vapp *VApp) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(vapp.client, metadata, vapp.VApp.HREF)
+}
+
+// MergeMetadata merges VApp metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vapp *VApp) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := vapp.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes VApp metadata by key provided as input and waits for
+// the task to finish.
+func (vapp *VApp) DeleteMetadataEntry(key string) error {
+	task, err := vapp.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vapp.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes VApp metadata depending on key provided as input and returns the task.
+func (vapp *VApp) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(vapp.client, key, vapp.VApp.HREF)
+}
+
+// GetMetadata returns VAppTemplate metadata.
+func (vAppTemplate *VAppTemplate) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
+}
+
+// AddMetadataEntry adds VAppTemplate metadata typedValue and key/value pair provided as input and
+// waits for the task to finish.
+func (vAppTemplate *VAppTemplate) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := vAppTemplate.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vAppTemplate.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds VAppTemplate metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (vAppTemplate *VAppTemplate) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(vAppTemplate.client, typedValue, key, value, vAppTemplate.VAppTemplate.HREF)
+}
+
+// MergeMetadataAsync merges VAppTemplate metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vAppTemplate *VAppTemplate) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(vAppTemplate.client, metadata, vAppTemplate.VAppTemplate.HREF)
+}
+
+// MergeMetadata merges VAppTemplate metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (vAppTemplate *VAppTemplate) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := vAppTemplate.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes VAppTemplate metadata depending on key provided as input
+// and waits for the task to finish.
+func (vAppTemplate *VAppTemplate) DeleteMetadataEntry(key string) error {
+	task, err := vAppTemplate.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = vAppTemplate.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes VAppTemplate metadata depending on key provided as input
+// and returns the task.
+func (vAppTemplate *VAppTemplate) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
+}
+
+// GetMetadata returns MediaRecord metadata.
+func (mediaRecord *MediaRecord) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(mediaRecord.client, mediaRecord.MediaRecord.HREF)
+}
+
+// AddMetadataEntry adds MediaRecord metadata typedValue and key/value pair provided as input and
+// waits for the task to finish.
+func (mediaRecord *MediaRecord) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := mediaRecord.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = mediaRecord.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds MediaRecord metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (mediaRecord *MediaRecord) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(mediaRecord.client, typedValue, key, value, mediaRecord.MediaRecord.HREF)
+}
+
+// MergeMetadataAsync merges MediaRecord metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (mediaRecord *MediaRecord) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(mediaRecord.client, metadata, mediaRecord.MediaRecord.HREF)
+}
+
+// MergeMetadata merges MediaRecord metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (mediaRecord *MediaRecord) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := mediaRecord.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes MediaRecord metadata depending on key provided as input
+// and waits for the task to finish.
+func (mediaRecord *MediaRecord) DeleteMetadataEntry(key string) error {
+	task, err := mediaRecord.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = mediaRecord.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes MediaRecord metadata depending on key provided as input
+// and returns the task.
+func (mediaRecord *MediaRecord) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(mediaRecord.client, key, mediaRecord.MediaRecord.HREF)
+}
+
+// GetMetadata returns Media metadata.
+func (media *Media) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(media.client, media.Media.HREF)
+}
+
+// AddMetadataEntry adds Media metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (media *Media) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := media.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = media.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds Media metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (media *Media) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(media.client, typedValue, key, value, media.Media.HREF)
+}
+
+// MergeMetadataAsync merges Media metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (media *Media) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(media.client, metadata, media.Media.HREF)
+}
+
+// MergeMetadata merges Media metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (media *Media) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := media.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes Media metadata depending on key provided as input
+// and waits for the task to finish.
+func (media *Media) DeleteMetadataEntry(key string) error {
+	task, err := media.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = media.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes Media metadata depending on key provided as input
+// and returns the task.
+func (media *Media) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(media.client, key, media.Media.HREF)
+}
+
+// GetMetadata returns Catalog metadata.
+func (catalog *Catalog) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(catalog.client, catalog.Catalog.HREF)
+}
+
+// GetMetadata returns AdminCatalog metadata.
+func (adminCatalog *AdminCatalog) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(adminCatalog.client, adminCatalog.AdminCatalog.HREF)
+}
+
+// AddMetadataEntry adds AdminCatalog metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (adminCatalog *AdminCatalog) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := adminCatalog.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = adminCatalog.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetadataEntryAsync adds AdminCatalog metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (adminCatalog *AdminCatalog) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(adminCatalog.client, typedValue, key, value, adminCatalog.AdminCatalog.HREF)
+}
+
+// MergeMetadataAsync merges AdminCatalog metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (adminCatalog *AdminCatalog) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(adminCatalog.client, metadata, adminCatalog.AdminCatalog.HREF)
+}
+
+// MergeMetadata merges AdminCatalog metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (adminCatalog *AdminCatalog) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := adminCatalog.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes AdminCatalog metadata depending on key provided as input
+// and waits for the task to finish.
+func (adminCatalog *AdminCatalog) DeleteMetadataEntry(key string) error {
+	task, err := adminCatalog.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	err = adminCatalog.Refresh()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes AdminCatalog metadata depending on key provided as input
+// and returns a task.
+func (adminCatalog *AdminCatalog) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(adminCatalog.client, key, adminCatalog.AdminCatalog.HREF)
+}
+
+// GetMetadata returns the Org metadata of the corresponding organization seen as administrator
+func (org *Org) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(org.client, org.Org.HREF)
+}
+
+// GetMetadata returns the AdminOrg metadata of the corresponding organization seen as administrator
+func (adminOrg *AdminOrg) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(adminOrg.client, adminOrg.AdminOrg.HREF)
+}
+
+// AddMetadataEntry adds AdminOrg metadata key/value pair provided as input to the corresponding organization seen as administrator
+// and waits for completion.
+func (adminOrg *AdminOrg) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := adminOrg.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryAsync adds AdminOrg metadata key/value pair provided as input to the corresponding organization seen as administrator
+// and returns a task.
+func (adminOrg *AdminOrg) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(adminOrg.client, typedValue, key, value, adminOrg.AdminOrg.HREF)
+}
+
+// MergeMetadataAsync merges AdminOrg metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (adminOrg *AdminOrg) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(adminOrg.client, metadata, adminOrg.AdminOrg.HREF)
+}
+
+// MergeMetadata merges AdminOrg metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (adminOrg *AdminOrg) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := adminOrg.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes metadata of the corresponding organization with the given key, and waits for completion
+func (adminOrg *AdminOrg) DeleteMetadataEntry(key string) error {
+	task, err := adminOrg.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error completing delete metadata for organization task: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes metadata of the corresponding organization with the given key, and returns
+// a task.
+func (adminOrg *AdminOrg) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(adminOrg.client, key, adminOrg.AdminOrg.HREF)
+}
+
+// GetMetadata returns the metadata of the corresponding independent disk
+func (disk *Disk) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(disk.client, disk.Disk.HREF)
+}
+
+// AddMetadataEntry adds metadata key/value pair provided as input to the corresponding independent disk and waits for completion.
+func (disk *Disk) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := disk.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryAsync adds metadata key/value pair provided as input to the corresponding independent disk and returns a task.
+func (disk *Disk) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(disk.client, typedValue, key, value, disk.Disk.HREF)
+}
+
+// MergeMetadataAsync merges Disk metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (disk *Disk) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(disk.client, metadata, disk.Disk.HREF)
+}
+
+// MergeMetadata merges Disk metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (disk *Disk) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := disk.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes metadata of the corresponding independent disk with the given key, and waits for completion
+func (disk *Disk) DeleteMetadataEntry(key string) error {
+	task, err := disk.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error completing delete metadata for independent disk task: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteMetadataEntryAsync deletes metadata of the corresponding independent disk with the given key, and returns
+// a task.
+func (disk *Disk) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(disk.client, key, disk.Disk.HREF)
+}
+
+// GetMetadata returns OrgVDCNetwork metadata.
+func (orgVdcNetwork *OrgVDCNetwork) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(orgVdcNetwork.client, orgVdcNetwork.OrgVDCNetwork.HREF)
+}
+
+// AddMetadataEntry adds OrgVDCNetwork metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := orgVdcNetwork.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryAsync adds OrgVDCNetwork metadata typedValue and key/value pair provided as input
+// and returns the task.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(orgVdcNetwork.client, typedValue, key, value, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
+}
+
+// MergeMetadataAsync merges OrgVDCNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(orgVdcNetwork.client, metadata, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
+}
+
+// MergeMetadata merges OrgVDCNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := orgVdcNetwork.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes OrgVDCNetwork metadata depending on key provided as input
+// and waits for the task to finish.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) DeleteMetadataEntry(key string) error {
+	task, err := orgVdcNetwork.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntryAsync deletes OrgVDCNetwork metadata depending on key provided as input
+// and returns a task.
+// Note: Requires system administrator privileges.
+func (orgVdcNetwork *OrgVDCNetwork) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(orgVdcNetwork.client, key, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
+}
+
+// GetMetadata returns CatalogItem metadata.
+func (catalogItem *CatalogItem) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(catalogItem.client, catalogItem.CatalogItem.HREF)
+}
+
+// AddMetadataEntry adds CatalogItem metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+func (catalogItem *CatalogItem) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := catalogItem.AddMetadataEntryAsync(typedValue, key, value)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// AddMetadataEntryAsync adds CatalogItem metadata typedValue and key/value pair provided as input
+// and returns the task.
+func (catalogItem *CatalogItem) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
+	return addMetadata(catalogItem.client, typedValue, key, value, catalogItem.CatalogItem.HREF)
+}
+
+// MergeMetadataAsync merges CatalogItem metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (catalogItem *CatalogItem) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(catalogItem.client, metadata, catalogItem.CatalogItem.HREF)
+}
+
+// MergeMetadata merges CatalogItem metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// then waits for the task to complete.
+func (catalogItem *CatalogItem) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := catalogItem.MergeMetadataAsync(metadata)
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes CatalogItem metadata depending on key provided as input
+// and waits for the task to finish.
+func (catalogItem *CatalogItem) DeleteMetadataEntry(key string) error {
+	task, err := catalogItem.DeleteMetadataEntryAsync(key)
+	if err != nil {
+		return err
+	}
+
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntryAsync deletes CatalogItem metadata depending on key provided as input
+// and returns a task.
+func (catalogItem *CatalogItem) DeleteMetadataEntryAsync(key string) (Task, error) {
+	return deleteMetadata(catalogItem.client, key, catalogItem.CatalogItem.HREF)
+}
+
+// ----------------
+// OpenAPI metadata functions
+
+// GetMetadata returns OpenApiOrgVdcNetwork metadata.
+// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) GetMetadata() (*types.Metadata, error) {
+	return getMetadata(openApiOrgVdcNetwork.client, fmt.Sprintf("%s/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
+}
+
+// AddMetadataEntry adds OpenApiOrgVdcNetwork metadata typedValue and key/value pair provided as input
+// and waits for the task to finish.
+// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) AddMetadataEntry(typedValue, key, value string) error {
+	task, err := addMetadata(openApiOrgVdcNetwork.client, typedValue, key, value, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// MergeMetadata merges OpenApiOrgVdcNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// and waits for the task to finish.
+// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) MergeMetadata(metadata map[string]types.TypedValue) error {
+	task, err := mergeAllMetadata(openApiOrgVdcNetwork.client, metadata, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}
+
+// DeleteMetadataEntry deletes OpenApiOrgVdcNetwork metadata depending on key provided as input
+// and waits for the task to finish.
+// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. // TODO: This function is currently using XML underneath as metadata is supported in v37.0 and at the moment is in alpha state. See https://github.com/vmware/go-vcloud-director/pull/455
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) DeleteMetadataEntry(key string) error {
+	task, err := deleteMetadata(openApiOrgVdcNetwork.client, key, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
+	if err != nil {
+		return err
+	}
+
+	return task.WaitTaskCompletion()
+}
+
+// ----------------
+// Generic private functions
+
+// Generic function to retrieve metadata from VCD
 func getMetadata(client *Client, requestUri string) (*types.Metadata, error) {
 	metadata := &types.Metadata{}
 
@@ -146,24 +892,27 @@ func getMetadata(client *Client, requestUri string) (*types.Metadata, error) {
 	return metadata, err
 }
 
-// Deprecated: use VApp.DeleteMetadataEntry.
-func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
-	return deleteMetadata(vapp.client, key, vapp.VApp.HREF)
-}
+// addMetadata adds metadata to an entity.
+// The function supports passing a typedValue. Use one of the constants defined.
+// Constants are types.MetadataStringValue, types.MetadataNumberValue, types.MetadataDateTimeValue and types.MetadataBooleanValue.
+// Only tested with types.MetadataStringValue and types.MetadataNumberValue.
+// TODO: We might also need to add support to MetadataDateTimeValue and MetadataBooleanValue
+func addMetadata(client *Client, typedValue, key, value, requestUri string) (Task, error) {
+	newMetadata := &types.MetadataValue{
+		Xmlns: types.XMLNamespaceVCloud,
+		Xsi:   types.XMLNamespaceXSI,
+		TypedValue: &types.TypedValue{
+			XsiType: typedValue,
+			Value:   value,
+		},
+	}
 
-// deleteMetadata Deletes metadata from an entity.
-func deleteMetadata(client *Client, key string, requestUri string) (Task, error) {
 	apiEndpoint := urlParseRequestURI(requestUri)
 	apiEndpoint.Path += "/metadata/" + key
 
 	// Return the task
-	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodDelete,
-		"", "error deleting metadata: %s", nil)
-}
-
-// Deprecated: use VApp.AddMetadataEntry
-func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
-	return addMetadata(vapp.client, types.MetadataStringValue, key, value, vapp.VApp.HREF)
+	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
+		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
 }
 
 // mergeAllMetadata merges the metadata key-values provided as parameter with existing entity metadata
@@ -191,32 +940,87 @@ func mergeAllMetadata(client *Client, metadata map[string]types.TypedValue, requ
 		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
 }
 
-// Adds metadata to an entity
-// The function supports passing a typedValue. Use one of the constants defined.
-// Constants are types.MetadataStringValue, types.MetadataNumberValue, types.MetadataDateTimeValue and types.MetadataBooleanValue.
-// Only tested with types.MetadataStringValue and types.MetadataNumberValue.
-// TODO: We might also need to add support to MetadataDateTimeValue and MetadataBooleanValue
-func addMetadata(client *Client, typedValue, key, value, requestUri string) (Task, error) {
-	newMetadata := &types.MetadataValue{
-		Xmlns: types.XMLNamespaceVCloud,
-		Xsi:   types.XMLNamespaceXSI,
-		TypedValue: &types.TypedValue{
-			XsiType: typedValue,
-			Value:   value,
-		},
-	}
-
+// deleteMetadata Deletes metadata from an entity.
+func deleteMetadata(client *Client, key string, requestUri string) (Task, error) {
 	apiEndpoint := urlParseRequestURI(requestUri)
 	apiEndpoint.Path += "/metadata/" + key
 
 	// Return the task
-	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPut,
-		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
+	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodDelete,
+		"", "error deleting metadata: %s", nil)
 }
 
-// GetMetadata returns VAppTemplate metadata.
-func (vAppTemplate *VAppTemplate) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(vAppTemplate.client, vAppTemplate.VAppTemplate.HREF)
+// ----------------
+// Deprecations
+
+// Deprecated: use VM.DeleteMetadataEntry.
+func (vm *VM) DeleteMetadata(key string) (Task, error) {
+	return deleteMetadata(vm.client, key, vm.VM.HREF)
+}
+
+// Deprecated: use VM.AddMetadataEntry.
+func (vm *VM) AddMetadata(key string, value string) (Task, error) {
+	return addMetadata(vm.client, types.MetadataStringValue, key, value, vm.VM.HREF)
+}
+
+// Deprecated: use Vdc.DeleteMetadataEntry.
+func (vdc *Vdc) DeleteMetadata(key string) (Vdc, error) {
+	task, err := deleteMetadata(vdc.client, key, getAdminURL(vdc.Vdc.HREF))
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	err = vdc.Refresh()
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	return *vdc, nil
+}
+
+// Deprecated: use Vdc.AddMetadataEntry.
+func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
+	task, err := addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminURL(vdc.Vdc.HREF))
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	err = vdc.Refresh()
+	if err != nil {
+		return Vdc{}, err
+	}
+
+	return *vdc, nil
+}
+
+// Deprecated: use Vdc.AddMetadataEntryAsync.
+func (vdc *Vdc) AddMetadataAsync(key string, value string) (Task, error) {
+	return addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
+}
+
+// Deprecated: use Vdc.DeleteMetadataEntryAsync.
+func (vdc *Vdc) DeleteMetadataAsync(key string) (Task, error) {
+	return deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
+}
+
+// Deprecated: use VApp.DeleteMetadataEntry.
+func (vapp *VApp) DeleteMetadata(key string) (Task, error) {
+	return deleteMetadata(vapp.client, key, vapp.VApp.HREF)
+}
+
+// Deprecated: use VApp.AddMetadataEntry
+func (vapp *VApp) AddMetadata(key string, value string) (Task, error) {
+	return addMetadata(vapp.client, types.MetadataStringValue, key, value, vapp.VApp.HREF)
 }
 
 // Deprecated: use VAppTemplate.AddMetadataEntry.
@@ -261,6 +1065,50 @@ func (vAppTemplate *VAppTemplate) DeleteMetadata(key string) error {
 func (vAppTemplate *VAppTemplate) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
 }
+
+// Deprecated: use Media.AddMetadataEntry.
+func (media *Media) AddMetadata(key string, value string) (*Media, error) {
+	task, err := media.AddMetadataAsync(key, value)
+	if err != nil {
+		return nil, err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
+	}
+
+	err = media.Refresh()
+	if err != nil {
+		return nil, fmt.Errorf("error refreshing media item: %s", err)
+	}
+
+	return media, nil
+}
+
+// Deprecated: use Media.AddMetadataEntryAsync.
+func (media *Media) AddMetadataAsync(key string, value string) (Task, error) {
+	return addMetadata(media.client, types.MetadataStringValue, key, value, media.Media.HREF)
+}
+
+// Deprecated: use Media.DeleteMetadataEntry.
+func (media *Media) DeleteMetadata(key string) error {
+	task, err := media.DeleteMetadataAsync(key)
+	if err != nil {
+		return err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
+	}
+
+	return nil
+}
+
+// Deprecated: use Media.DeleteMetadataEntryAsync.
+func (media *Media) DeleteMetadataAsync(key string) (Task, error) {
+	return deleteMetadata(media.client, key, media.Media.HREF)
+}
+
 
 // GetMetadata returns MediaItem metadata.
 // Deprecated: Use MediaRecord.GetMetadata.
@@ -314,11 +1162,6 @@ func (mediaItem *MediaItem) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(mediaItem.vdc.client, key, mediaItem.MediaItem.HREF)
 }
 
-// GetMetadata returns MediaRecord metadata.
-func (mediaRecord *MediaRecord) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(mediaRecord.client, mediaRecord.MediaRecord.HREF)
-}
-
 // Deprecated: use MediaRecord.AddMetadataEntry.
 func (mediaRecord *MediaRecord) AddMetadata(key string, value string) (*MediaRecord, error) {
 	task, err := mediaRecord.AddMetadataAsync(key, value)
@@ -360,622 +1203,4 @@ func (mediaRecord *MediaRecord) DeleteMetadata(key string) error {
 // Deprecated: use MediaRecord.DeleteMetadataEntryAsync.
 func (mediaRecord *MediaRecord) DeleteMetadataAsync(key string) (Task, error) {
 	return deleteMetadata(mediaRecord.client, key, mediaRecord.MediaRecord.HREF)
-}
-
-// GetMetadata returns Media metadata.
-func (media *Media) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(media.client, media.Media.HREF)
-}
-
-// Deprecated: use Media.AddMetadataEntry.
-func (media *Media) AddMetadata(key string, value string) (*Media, error) {
-	task, err := media.AddMetadataAsync(key, value)
-	if err != nil {
-		return nil, err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return nil, fmt.Errorf("error completing add metadata for media item task: %s", err)
-	}
-
-	err = media.Refresh()
-	if err != nil {
-		return nil, fmt.Errorf("error refreshing media item: %s", err)
-	}
-
-	return media, nil
-}
-
-// Deprecated: use Media.AddMetadataEntryAsync.
-func (media *Media) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(media.client, types.MetadataStringValue, key, value, media.Media.HREF)
-}
-
-// Deprecated: use Media.DeleteMetadataEntry.
-func (media *Media) DeleteMetadata(key string) error {
-	task, err := media.DeleteMetadataAsync(key)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return fmt.Errorf("error completing delete metadata for media item task: %s", err)
-	}
-
-	return nil
-}
-
-// Deprecated: use Media.DeleteMetadataEntryAsync.
-func (media *Media) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(media.client, key, media.Media.HREF)
-}
-
-// DeleteMetadataEntry deletes VM metadata by key provided as input and waits for the task to finish.
-func (vm *VM) DeleteMetadataEntry(key string) error {
-	task, err := vm.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vm.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes VM metadata depending on key provided as input
-// and returns the task.
-func (vm *VM) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(vm.client, key, vm.VM.HREF)
-}
-
-// AddMetadataEntry adds VM metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (vm *VM) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := vm.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vm.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds VM metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (vm *VM) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(vm.client, typedValue, key, value, vm.VM.HREF)
-}
-
-// DeleteMetadataEntry deletes Vdc metadata by key provided as input and waits for
-// the task to finish.
-func (vdc *Vdc) DeleteMetadataEntry(key string) error {
-	task, err := vdc.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vdc.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes Vdc metadata depending on key provided as input and returns the task.
-func (vdc *Vdc) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
-}
-
-// AddMetadataEntry adds Vdc metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (vdc *Vdc) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := vdc.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vdc.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds Vdc metadata typedValue and key/value pair provided as input and returns the task.
-func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(vdc.client, typedValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
-}
-
-// DeleteMetadataEntry deletes VApp metadata by key provided as input and waits for
-// the task to finish.
-func (vapp *VApp) DeleteMetadataEntry(key string) error {
-	task, err := vapp.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vapp.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes VApp metadata depending on key provided as input and returns the task.
-func (vapp *VApp) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(vapp.client, key, vapp.VApp.HREF)
-}
-
-// AddMetadataEntry adds VApp metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (vapp *VApp) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := vapp.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vapp.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds VApp metadata typedValue and key/value pair provided as input and returns the task.
-func (vapp *VApp) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(vapp.client, typedValue, key, value, vapp.VApp.HREF)
-}
-
-// AddMetadataEntry adds VAppTemplate metadata typedValue and key/value pair provided as input and
-// waits for the task to finish.
-func (vAppTemplate *VAppTemplate) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := vAppTemplate.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vAppTemplate.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds VAppTemplate metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (vAppTemplate *VAppTemplate) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(vAppTemplate.client, typedValue, key, value, vAppTemplate.VAppTemplate.HREF)
-}
-
-// DeleteMetadataEntry deletes VAppTemplate metadata depending on key provided as input
-// and waits for the task to finish.
-func (vAppTemplate *VAppTemplate) DeleteMetadataEntry(key string) error {
-	task, err := vAppTemplate.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = vAppTemplate.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes VAppTemplate metadata depending on key provided as input
-// and returns the task.
-func (vAppTemplate *VAppTemplate) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(vAppTemplate.client, key, vAppTemplate.VAppTemplate.HREF)
-}
-
-// AddMetadataEntry adds MediaRecord metadata typedValue and key/value pair provided as input and
-// waits for the task to finish.
-func (mediaRecord *MediaRecord) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := mediaRecord.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = mediaRecord.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds MediaRecord metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (mediaRecord *MediaRecord) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(mediaRecord.client, typedValue, key, value, mediaRecord.MediaRecord.HREF)
-}
-
-// DeleteMetadataEntry deletes MediaRecord metadata depending on key provided as input
-// and waits for the task to finish.
-func (mediaRecord *MediaRecord) DeleteMetadataEntry(key string) error {
-	task, err := mediaRecord.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = mediaRecord.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes MediaRecord metadata depending on key provided as input
-// and returns the task.
-func (mediaRecord *MediaRecord) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(mediaRecord.client, key, mediaRecord.MediaRecord.HREF)
-}
-
-// AddMetadataEntry adds Media metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (media *Media) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := media.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = media.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds Media metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (media *Media) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(media.client, typedValue, key, value, media.Media.HREF)
-}
-
-// DeleteMetadataEntry deletes Media metadata depending on key provided as input
-// and waits for the task to finish.
-func (media *Media) DeleteMetadataEntry(key string) error {
-	task, err := media.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = media.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes Media metadata depending on key provided as input
-// and returns the task.
-func (media *Media) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(media.client, key, media.Media.HREF)
-}
-
-// GetMetadata returns AdminCatalog metadata.
-func (adminCatalog *AdminCatalog) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(adminCatalog.client, adminCatalog.AdminCatalog.HREF)
-}
-
-// AddMetadataEntry adds AdminCatalog metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (adminCatalog *AdminCatalog) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := adminCatalog.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = adminCatalog.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AddMetadataEntryAsync adds AdminCatalog metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (adminCatalog *AdminCatalog) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(adminCatalog.client, typedValue, key, value, adminCatalog.AdminCatalog.HREF)
-}
-
-// DeleteMetadataEntry deletes AdminCatalog metadata depending on key provided as input
-// and waits for the task to finish.
-func (adminCatalog *AdminCatalog) DeleteMetadataEntry(key string) error {
-	task, err := adminCatalog.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return err
-	}
-
-	err = adminCatalog.Refresh()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes AdminCatalog metadata depending on key provided as input
-// and returns a task.
-func (adminCatalog *AdminCatalog) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(adminCatalog.client, key, adminCatalog.AdminCatalog.HREF)
-}
-
-// GetMetadata returns Catalog metadata.
-func (catalog *Catalog) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(catalog.client, catalog.Catalog.HREF)
-}
-
-// GetMetadata returns the metadata of the corresponding organization seen as administrator
-func (adminOrg *AdminOrg) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(adminOrg.client, adminOrg.AdminOrg.HREF)
-}
-
-// GetMetadata returns the metadata of the corresponding organization seen as administrator
-func (org *Org) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(org.client, org.Org.HREF)
-}
-
-// AddMetadataEntry adds metadata key/value pair provided as input to the corresponding organization seen as administrator
-// and waits for completion.
-func (adminOrg *AdminOrg) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := adminOrg.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	return task.WaitTaskCompletion()
-}
-
-// AddMetadataEntryAsync adds metadata key/value pair provided as input to the corresponding organization seen as administrator
-// and returns a task.
-func (adminOrg *AdminOrg) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(adminOrg.client, typedValue, key, value, adminOrg.AdminOrg.HREF)
-}
-
-// DeleteMetadataEntry deletes metadata of the corresponding organization with the given key, and waits for completion
-func (adminOrg *AdminOrg) DeleteMetadataEntry(key string) error {
-	task, err := adminOrg.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return fmt.Errorf("error completing delete metadata for organization task: %s", err)
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes metadata of the corresponding organization with the given key, and returns
-// a task.
-func (adminOrg *AdminOrg) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(adminOrg.client, key, adminOrg.AdminOrg.HREF)
-}
-
-// GetMetadata returns the metadata of the corresponding independent disk
-func (disk *Disk) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(disk.client, disk.Disk.HREF)
-}
-
-// AddMetadataEntry adds metadata key/value pair provided as input to the corresponding independent disk and waits for completion.
-func (disk *Disk) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := disk.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	return task.WaitTaskCompletion()
-}
-
-// AddMetadataEntryAsync adds metadata key/value pair provided as input to the corresponding independent disk and returns a task.
-func (disk *Disk) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(disk.client, typedValue, key, value, disk.Disk.HREF)
-}
-
-// DeleteMetadataEntry deletes metadata of the corresponding independent disk with the given key, and waits for completion
-func (disk *Disk) DeleteMetadataEntry(key string) error {
-	task, err := disk.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return fmt.Errorf("error completing delete metadata for independent disk task: %s", err)
-	}
-
-	return nil
-}
-
-// DeleteMetadataEntryAsync deletes metadata of the corresponding independent disk with the given key, and returns
-// a task.
-func (disk *Disk) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(disk.client, key, disk.Disk.HREF)
-}
-
-// GetMetadata returns OrgVDCNetwork metadata.
-func (orgVdcNetwork *OrgVDCNetwork) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(orgVdcNetwork.client, orgVdcNetwork.OrgVDCNetwork.HREF)
-}
-
-// AddMetadataEntry adds OrgVDCNetwork metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := orgVdcNetwork.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	return task.WaitTaskCompletion()
-}
-
-// AddMetadataEntryAsync adds OrgVDCNetwork metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(orgVdcNetwork.client, typedValue, key, value, strings.ReplaceAll(orgVdcNetwork.OrgVDCNetwork.HREF, "/api/", "/api/admin/"))
-}
-
-// DeleteMetadataEntry deletes OrgVDCNetwork metadata depending on key provided as input
-// and waits for the task to finish.
-func (orgVdcNetwork *OrgVDCNetwork) DeleteMetadataEntry(key string) error {
-	task, err := orgVdcNetwork.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	return task.WaitTaskCompletion()
-}
-
-// DeleteMetadataEntryAsync deletes OrgVDCNetwork metadata depending on key provided as input
-// and returns a task.
-func (orgVdcNetwork *OrgVDCNetwork) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(orgVdcNetwork.client, key, strings.ReplaceAll(orgVdcNetwork.OrgVDCNetwork.HREF, "/api/", "/api/admin/"))
-}
-
-// GetMetadata returns CatalogItem metadata.
-func (catalogItem *CatalogItem) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(catalogItem.client, catalogItem.CatalogItem.HREF)
-}
-
-// AddMetadataEntry adds CatalogItem metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-func (catalogItem *CatalogItem) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := catalogItem.AddMetadataEntryAsync(typedValue, key, value)
-	if err != nil {
-		return err
-	}
-	return task.WaitTaskCompletion()
-}
-
-// AddMetadataEntryAsync adds CatalogItem metadata typedValue and key/value pair provided as input
-// and returns the task.
-func (catalogItem *CatalogItem) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
-	return addMetadata(catalogItem.client, typedValue, key, value, catalogItem.CatalogItem.HREF)
-}
-
-// DeleteMetadataEntry deletes CatalogItem metadata depending on key provided as input
-// and waits for the task to finish.
-func (catalogItem *CatalogItem) DeleteMetadataEntry(key string) error {
-	task, err := catalogItem.DeleteMetadataEntryAsync(key)
-	if err != nil {
-		return err
-	}
-
-	return task.WaitTaskCompletion()
-}
-
-// DeleteMetadataEntryAsync deletes CatalogItem metadata depending on key provided as input
-// and returns a task.
-func (catalogItem *CatalogItem) DeleteMetadataEntryAsync(key string) (Task, error) {
-	return deleteMetadata(catalogItem.client, key, catalogItem.CatalogItem.HREF)
-}
-
-// OpenAPI metadata functions
-
-// GetMetadata returns OpenApiOrgVdcNetwork metadata.
-// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
-func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) GetMetadata() (*types.Metadata, error) {
-	return getMetadata(openApiOrgVdcNetwork.client, fmt.Sprintf("%s/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
-}
-
-// AddMetadataEntry adds OpenApiOrgVdcNetwork metadata typedValue and key/value pair provided as input
-// and waits for the task to finish.
-// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
-func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) AddMetadataEntry(typedValue, key, value string) error {
-	task, err := addMetadata(openApiOrgVdcNetwork.client, typedValue, key, value, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
-	if err != nil {
-		return err
-	}
-	return task.WaitTaskCompletion()
-}
-
-// DeleteMetadataEntry deletes OpenApiOrgVdcNetwork metadata depending on key provided as input
-// and waits for the task to finish.
-// TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. // TODO: This function is currently using XML underneath as metadata is supported in v37.0 and at the moment is in alpha state. See https://github.com/vmware/go-vcloud-director/pull/455
-func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) DeleteMetadataEntry(key string) error {
-	task, err := deleteMetadata(openApiOrgVdcNetwork.client, key, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
-	if err != nil {
-		return err
-	}
-
-	return task.WaitTaskCompletion()
 }

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -17,7 +17,7 @@ import (
 type MetadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error
-	MergeMetadata(metadata map[string]types.TypedValue) error
+	MergeMetadata(typedValue, metadata map[string]string) error
 	DeleteMetadataEntry(key string) error
 }
 
@@ -45,16 +45,16 @@ func (vcdClient *VCDClient) AddMetadataEntryByHrefAsync(href, typedValue, key, v
 	return addMetadata(&vcdClient.Client, typedValue, key, value, href)
 }
 
-// MergeMetadataByHrefAsync merges metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataByHrefAsync merges metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // and returns the task.
-func (vcdClient *VCDClient) MergeMetadataByHrefAsync(href string, metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(&vcdClient.Client, metadata, href)
+func (vcdClient *VCDClient) MergeMetadataByHrefAsync(href, typedValue string, metadata map[string]types.TypedValue) (Task, error) {
+	return mergeAllMetadata(&vcdClient.Client, typedValue, typedValue, metadata, href)
 }
 
-// MergeMetadataByHref merges metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataByHref merges metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vcdClient *VCDClient) MergeMetadataByHref(href string, metadata map[string]types.TypedValue) error {
-	task, err := vcdClient.MergeMetadataByHrefAsync(href, metadata)
+func (vcdClient *VCDClient) MergeMetadataByHref(href, typedValue string, metadata map[string]types.TypedValue) error {
+	task, err := vcdClient.MergeMetadataByHrefAsync(href, typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -110,16 +110,16 @@ func (vm *VM) AddMetadataEntryAsync(typedValue, key, value string) (Task, error)
 	return addMetadata(vm.client, typedValue, key, value, vm.VM.HREF)
 }
 
-// MergeMetadataAsync merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then returns the task.
-func (vm *VM) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(vm.client, metadata, vm.VM.HREF)
+func (vm *VM) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(vm.client, typedValue, metadata, vm.VM.HREF)
 }
 
-// MergeMetadata merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vm *VM) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := vm.MergeMetadataAsync(metadata)
+func (vm *VM) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := vm.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -186,18 +186,18 @@ func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, erro
 	return addMetadata(vdc.client, typedValue, key, value, getAdminURL(vdc.Vdc.HREF))
 }
 
-// MergeMetadataAsync merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (vdc *Vdc) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(vdc.client, metadata, getAdminURL(vdc.Vdc.HREF))
+func (vdc *Vdc) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(vdc.client, typedValue, metadata, getAdminURL(vdc.Vdc.HREF))
 }
 
-// MergeMetadata merges VM metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (vdc *Vdc) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := vdc.MergeMetadataAsync(metadata)
+func (vdc *Vdc) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := vdc.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -263,16 +263,16 @@ func (vapp *VApp) AddMetadataEntryAsync(typedValue, key, value string) (Task, er
 	return addMetadata(vapp.client, typedValue, key, value, vapp.VApp.HREF)
 }
 
-// MergeMetadataAsync merges VApp metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges VApp metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vapp *VApp) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(vapp.client, metadata, vapp.VApp.HREF)
+func (vapp *VApp) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(vapp.client, typedValue, metadata, vapp.VApp.HREF)
 }
 
-// MergeMetadata merges VApp metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges VApp metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vapp *VApp) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := vapp.MergeMetadataAsync(metadata)
+func (vapp *VApp) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := vapp.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -336,16 +336,16 @@ func (vAppTemplate *VAppTemplate) AddMetadataEntryAsync(typedValue, key, value s
 	return addMetadata(vAppTemplate.client, typedValue, key, value, vAppTemplate.VAppTemplate.HREF)
 }
 
-// MergeMetadataAsync merges VAppTemplate metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges VAppTemplate metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vAppTemplate *VAppTemplate) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(vAppTemplate.client, metadata, vAppTemplate.VAppTemplate.HREF)
+func (vAppTemplate *VAppTemplate) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(vAppTemplate.client, typedValue, metadata, vAppTemplate.VAppTemplate.HREF)
 }
 
-// MergeMetadata merges VAppTemplate metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges VAppTemplate metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (vAppTemplate *VAppTemplate) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := vAppTemplate.MergeMetadataAsync(metadata)
+func (vAppTemplate *VAppTemplate) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := vAppTemplate.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -410,16 +410,16 @@ func (mediaRecord *MediaRecord) AddMetadataEntryAsync(typedValue, key, value str
 	return addMetadata(mediaRecord.client, typedValue, key, value, mediaRecord.MediaRecord.HREF)
 }
 
-// MergeMetadataAsync merges MediaRecord metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges MediaRecord metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (mediaRecord *MediaRecord) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(mediaRecord.client, metadata, mediaRecord.MediaRecord.HREF)
+func (mediaRecord *MediaRecord) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(mediaRecord.client, typedValue, metadata, mediaRecord.MediaRecord.HREF)
 }
 
-// MergeMetadata merges MediaRecord metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges MediaRecord metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (mediaRecord *MediaRecord) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := mediaRecord.MergeMetadataAsync(metadata)
+func (mediaRecord *MediaRecord) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := mediaRecord.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -483,16 +483,16 @@ func (media *Media) AddMetadataEntryAsync(typedValue, key, value string) (Task, 
 	return addMetadata(media.client, typedValue, key, value, media.Media.HREF)
 }
 
-// MergeMetadataAsync merges Media metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges Media metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (media *Media) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(media.client, metadata, media.Media.HREF)
+func (media *Media) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(media.client, typedValue, metadata, media.Media.HREF)
 }
 
-// MergeMetadata merges Media metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges Media metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (media *Media) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := media.MergeMetadataAsync(metadata)
+func (media *Media) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := media.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -562,16 +562,16 @@ func (adminCatalog *AdminCatalog) AddMetadataEntryAsync(typedValue, key, value s
 	return addMetadata(adminCatalog.client, typedValue, key, value, adminCatalog.AdminCatalog.HREF)
 }
 
-// MergeMetadataAsync merges AdminCatalog metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges AdminCatalog metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminCatalog *AdminCatalog) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(adminCatalog.client, metadata, adminCatalog.AdminCatalog.HREF)
+func (adminCatalog *AdminCatalog) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(adminCatalog.client, typedValue, metadata, adminCatalog.AdminCatalog.HREF)
 }
 
-// MergeMetadata merges AdminCatalog metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges AdminCatalog metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminCatalog *AdminCatalog) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := adminCatalog.MergeMetadataAsync(metadata)
+func (adminCatalog *AdminCatalog) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := adminCatalog.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -631,16 +631,16 @@ func (adminOrg *AdminOrg) AddMetadataEntryAsync(typedValue, key, value string) (
 	return addMetadata(adminOrg.client, typedValue, key, value, adminOrg.AdminOrg.HREF)
 }
 
-// MergeMetadataAsync merges AdminOrg metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges AdminOrg metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminOrg *AdminOrg) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(adminOrg.client, metadata, adminOrg.AdminOrg.HREF)
+func (adminOrg *AdminOrg) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(adminOrg.client, typedValue, metadata, adminOrg.AdminOrg.HREF)
 }
 
-// MergeMetadata merges AdminOrg metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges AdminOrg metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (adminOrg *AdminOrg) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := adminOrg.MergeMetadataAsync(metadata)
+func (adminOrg *AdminOrg) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := adminOrg.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -686,16 +686,16 @@ func (disk *Disk) AddMetadataEntryAsync(typedValue, key, value string) (Task, er
 	return addMetadata(disk.client, typedValue, key, value, disk.Disk.HREF)
 }
 
-// MergeMetadataAsync merges Disk metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges Disk metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (disk *Disk) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(disk.client, metadata, disk.Disk.HREF)
+func (disk *Disk) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(disk.client, typedValue, metadata, disk.Disk.HREF)
 }
 
-// MergeMetadata merges Disk metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges Disk metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (disk *Disk) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := disk.MergeMetadataAsync(metadata)
+func (disk *Disk) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := disk.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -745,18 +745,18 @@ func (orgVdcNetwork *OrgVDCNetwork) AddMetadataEntryAsync(typedValue, key, value
 	return addMetadata(orgVdcNetwork.client, typedValue, key, value, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
 }
 
-// MergeMetadataAsync merges OrgVDCNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges OrgVDCNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (orgVdcNetwork *OrgVDCNetwork) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(orgVdcNetwork.client, metadata, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(orgVdcNetwork.client, typedValue, metadata, getAdminURL(orgVdcNetwork.OrgVDCNetwork.HREF))
 }
 
-// MergeMetadata merges OrgVDCNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges OrgVDCNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
-func (orgVdcNetwork *OrgVDCNetwork) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := orgVdcNetwork.MergeMetadataAsync(metadata)
+func (orgVdcNetwork *OrgVDCNetwork) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := orgVdcNetwork.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -803,16 +803,16 @@ func (catalogItem *CatalogItem) AddMetadataEntryAsync(typedValue, key, value str
 	return addMetadata(catalogItem.client, typedValue, key, value, catalogItem.CatalogItem.HREF)
 }
 
-// MergeMetadataAsync merges CatalogItem metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadataAsync merges CatalogItem metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (catalogItem *CatalogItem) MergeMetadataAsync(metadata map[string]types.TypedValue) (Task, error) {
-	return mergeAllMetadata(catalogItem.client, metadata, catalogItem.CatalogItem.HREF)
+func (catalogItem *CatalogItem) MergeMetadataAsync(typedValue string, metadata map[string]string) (Task, error) {
+	return mergeAllMetadata(catalogItem.client, typedValue, metadata, catalogItem.CatalogItem.HREF)
 }
 
-// MergeMetadata merges CatalogItem metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges CatalogItem metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
-func (catalogItem *CatalogItem) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := catalogItem.MergeMetadataAsync(metadata)
+func (catalogItem *CatalogItem) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := catalogItem.MergeMetadataAsync(typedValue, metadata)
 	if err != nil {
 		return err
 	}
@@ -856,11 +856,11 @@ func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) AddMetadataEntry(typedValue, k
 	return task.WaitTaskCompletion()
 }
 
-// MergeMetadata merges OpenApiOrgVdcNetwork metadata provided as a map of key->types.TypedValue with the already present in VCD,
+// MergeMetadata merges OpenApiOrgVdcNetwork metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // and waits for the task to finish.
 // TODO: This function is currently using XML API underneath as OpenAPI metadata is supported from v37.0 and is currently in alpha at the moment. See https://github.com/vmware/go-vcloud-director/pull/455
-func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) MergeMetadata(metadata map[string]types.TypedValue) error {
-	task, err := mergeAllMetadata(openApiOrgVdcNetwork.client, metadata, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
+func (openApiOrgVdcNetwork *OpenApiOrgVdcNetwork) MergeMetadata(typedValue string, metadata map[string]string) error {
+	task, err := mergeAllMetadata(openApiOrgVdcNetwork.client, typedValue, metadata, fmt.Sprintf("%s/admin/network/%s", openApiOrgVdcNetwork.client.VCDHREF.String(), strings.ReplaceAll(openApiOrgVdcNetwork.OpenApiOrgVdcNetwork.ID, "urn:vcloud:network:", "")))
 	if err != nil {
 		return err
 	}
@@ -916,20 +916,23 @@ func addMetadata(client *Client, typedValue, key, value, requestUri string) (Tas
 }
 
 // mergeAllMetadata merges the metadata key-values provided as parameter with existing entity metadata
-func mergeAllMetadata(client *Client, metadata map[string]types.TypedValue, requestUri string) (Task, error) {
-	var metadataList []*types.MetadataEntry
-	for _, typedValue := range metadata {
-		metadataList = append(metadataList, &types.MetadataEntry{
+func mergeAllMetadata(client *Client, typedValue string, metadata map[string]string, requestUri string) (Task, error) {
+	var metadataToMerge []*types.MetadataEntry
+	for _, value := range metadata {
+		metadataToMerge = append(metadataToMerge, &types.MetadataEntry{
 			Xmlns:      types.XMLNamespaceVCloud,
 			Xsi:        types.XMLNamespaceXSI,
-			TypedValue: &typedValue,
+			TypedValue: &types.TypedValue{
+				XsiType: typedValue,
+				Value:   value,
+			},
 		})
 	}
 
 	newMetadata := &types.Metadata{
 		Xmlns:         types.XMLNamespaceVCloud,
 		Xsi:           types.XMLNamespaceXSI,
-		MetadataEntry: metadataList,
+		MetadataEntry: metadataToMerge,
 	}
 
 	apiEndpoint := urlParseRequestURI(requestUri)

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-type Metadata interface {
+type MetadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error
 	DeleteMetadataEntry(key string) error

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -918,10 +918,11 @@ func addMetadata(client *Client, typedValue, key, value, requestUri string) (Tas
 // mergeAllMetadata merges the metadata key-values provided as parameter with existing entity metadata
 func mergeAllMetadata(client *Client, typedValue string, metadata map[string]interface{}, requestUri string) (Task, error) {
 	var metadataToMerge []*types.MetadataEntry
-	for _, value := range metadata {
+	for key, value := range metadata {
 		metadataToMerge = append(metadataToMerge, &types.MetadataEntry{
 			Xmlns: types.XMLNamespaceVCloud,
 			Xsi:   types.XMLNamespaceXSI,
+			Key: key,
 			TypedValue: &types.TypedValue{
 				XsiType: typedValue,
 				Value:   value.(string),
@@ -940,7 +941,7 @@ func mergeAllMetadata(client *Client, typedValue string, metadata map[string]int
 
 	// Return the task
 	return client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
-		types.MimeMetaDataValue, "error adding metadata: %s", newMetadata)
+		types.MimeMetaData, "error adding metadata: %s", newMetadata)
 }
 
 // deleteMetadata Deletes metadata from an entity.

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -12,6 +12,12 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+type Metadata interface {
+	GetMetadata() (*types.Metadata, error)
+	AddMetadataEntry(typedValue, key, value string) error
+	DeleteMetadataEntry(key string) error
+}
+
 // GetMetadataByHref returns metadata from the given resource reference.
 func (vcdClient *VCDClient) GetMetadataByHref(href string) (*types.Metadata, error) {
 	return getMetadata(&vcdClient.Client, href)

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -12,15 +12,6 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-// MetadataCompatible allows consumers of this library to consider all structs that implement
-// this interface to be the same type
-type MetadataCompatible interface {
-	GetMetadata() (*types.Metadata, error)
-	AddMetadataEntry(typedValue, key, value string) error
-	MergeMetadata(typedValue string, metadata map[string]interface{}) error
-	DeleteMetadataEntry(key string) error
-}
-
 // ----------------
 // REST API metadata CRUD functions
 

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -143,13 +143,13 @@ func (vm *VM) DeleteMetadataEntryAsync(key string) (Task, error) {
 	return deleteMetadata(vm.client, key, vm.VM.HREF)
 }
 
-// GetMetadata returns Vdc metadata.
+// GetMetadata returns VDC metadata.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) GetMetadata() (*types.Metadata, error) {
 	return getMetadata(vdc.client, getAdminURL(vdc.Vdc.HREF))
 }
 
-// AddMetadataEntry adds Vdc metadata typedValue and key/value pair provided as input
+// AddMetadataEntry adds VDC metadata typedValue and key/value pair provided as input
 // and waits for the task to finish.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) AddMetadataEntry(typedValue, key, value string) error {
@@ -171,20 +171,20 @@ func (vdc *Vdc) AddMetadataEntry(typedValue, key, value string) error {
 	return nil
 }
 
-// AddMetadataEntryAsync adds Vdc metadata typedValue and key/value pair provided as input and returns the task.
+// AddMetadataEntryAsync adds VDC metadata typedValue and key/value pair provided as input and returns the task.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) AddMetadataEntryAsync(typedValue, key, value string) (Task, error) {
 	return addMetadata(vdc.client, typedValue, key, value, getAdminURL(vdc.Vdc.HREF))
 }
 
-// MergeMetadataAsync merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
+// MergeMetadataAsync merges VDC metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) MergeMetadataAsync(typedValue string, metadata map[string]interface{}) (Task, error) {
 	return mergeAllMetadata(vdc.client, typedValue, metadata, getAdminURL(vdc.Vdc.HREF))
 }
 
-// MergeMetadata merges VM metadata provided as a key-value map of type `typedValue` with the already present in VCD,
+// MergeMetadata merges VDC metadata provided as a key-value map of type `typedValue` with the already present in VCD,
 // then waits for the task to complete.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) MergeMetadata(typedValue string, metadata map[string]interface{}) error {
@@ -195,7 +195,7 @@ func (vdc *Vdc) MergeMetadata(typedValue string, metadata map[string]interface{}
 	return task.WaitTaskCompletion()
 }
 
-// DeleteMetadataEntry deletes Vdc metadata by key provided as input and waits for
+// DeleteMetadataEntry deletes VDC metadata by key provided as input and waits for
 // the task to finish.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) DeleteMetadataEntry(key string) error {
@@ -217,7 +217,7 @@ func (vdc *Vdc) DeleteMetadataEntry(key string) error {
 	return nil
 }
 
-// DeleteMetadataEntryAsync deletes Vdc metadata depending on key provided as input and returns the task.
+// DeleteMetadataEntryAsync deletes VDC metadata depending on key provided as input and returns the task.
 // Note: Requires system administrator privileges.
 func (vdc *Vdc) DeleteMetadataEntryAsync(key string) (Task, error) {
 	return deleteMetadata(vdc.client, key, getAdminURL(vdc.Vdc.HREF))

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -21,7 +21,7 @@ type MetadataCompatible interface {
 	DeleteMetadataEntry(key string) error
 }
 
-// ----------------
+// -----------------
 // REST API metadata CRUD functions
 
 // GetMetadataByHref returns metadata from the given resource reference.

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -1005,12 +1005,12 @@ func (vdc *Vdc) AddMetadata(key string, value string) (Vdc, error) {
 
 // Deprecated: use Vdc.AddMetadataEntryAsync.
 func (vdc *Vdc) AddMetadataAsync(key string, value string) (Task, error) {
-	return addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminVdcURL(vdc.Vdc.HREF))
+	return addMetadata(vdc.client, types.MetadataStringValue, key, value, getAdminURL(vdc.Vdc.HREF))
 }
 
 // Deprecated: use Vdc.DeleteMetadataEntryAsync.
 func (vdc *Vdc) DeleteMetadataAsync(key string) (Task, error) {
-	return deleteMetadata(vdc.client, key, getAdminVdcURL(vdc.Vdc.HREF))
+	return deleteMetadata(vdc.client, key, getAdminURL(vdc.Vdc.HREF))
 }
 
 // Deprecated: use VApp.DeleteMetadataEntry.

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -922,7 +922,7 @@ func mergeAllMetadata(client *Client, typedValue string, metadata map[string]int
 		metadataToMerge = append(metadataToMerge, &types.MetadataEntry{
 			Xmlns: types.XMLNamespaceVCloud,
 			Xsi:   types.XMLNamespaceXSI,
-			Key: key,
+			Key:   key,
 			TypedValue: &types.TypedValue{
 				XsiType: typedValue,
 				Value:   value.(string),

--- a/govcd/metadata.go
+++ b/govcd/metadata.go
@@ -21,7 +21,7 @@ type MetadataCompatible interface {
 	DeleteMetadataEntry(key string) error
 }
 
-// -----------------
+// ----------------
 // REST API metadata CRUD functions
 
 // GetMetadataByHref returns metadata from the given resource reference.

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -20,6 +20,15 @@ func init() {
 	testingTags["metadata"] = "metadata_test.go"
 }
 
+// MetadataCompatible allows consumers of this library to consider all structs that implement
+// this interface to be the same type
+type metadataCompatible interface {
+	GetMetadata() (*types.Metadata, error)
+	AddMetadataEntry(typedValue, key, value string) error
+	MergeMetadata(typedValue string, metadata map[string]interface{}) error
+	DeleteMetadataEntry(key string) error
+}
+
 func (vcd *TestVCD) Test_AddAndDeleteMetadataForVdc(check *C) {
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")
@@ -554,7 +563,7 @@ func (vcd *TestVCD) Test_MetadataByHrefCRUD(check *C) {
 	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
-func testMetadataCRUDActions(resource MetadataCompatible, check *C, extraCheck func()) {
+func testMetadataCRUDActions(resource metadataCompatible, check *C, extraCheck func()) {
 	// Check how much metadata exists
 	metadata, err := resource.GetMetadata()
 	check.Assert(err, IsNil)

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -42,10 +42,6 @@ func (vcd *TestVCD) Test_AddMetadataForVdc(check *C) {
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")
 }
 
-func (vcd *TestVCD) Testfoo(check *C) {
-	getAdminVdcURL("")
-}
-
 func (vcd *TestVCD) Test_DeleteMetadataForVdc(check *C) {
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -589,7 +589,6 @@ func (vcd *TestVCD) Test_MetadataOnCatalogItemCRUD(check *C) {
 	testMetadataCRUDActions(catalogItem, check, nil)
 }
 
-
 func (vcd *TestVCD) Test_MetadataOnOpenApiOrgVdcNetworkCRUD(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	net, err := vcd.vdc.GetOpenApiOrgVdcNetworkByName(vcd.config.VCD.Network.Net1)
@@ -744,4 +743,3 @@ func testMetadataCRUDActions(resource MetadataCompatible, check *C, extraCheck f
 	check.Assert(metadata, NotNil)
 	check.Assert(len(metadata.MetadataEntry), Equals, existingMetaDataCount)
 }
-

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -20,8 +20,6 @@ func init() {
 	testingTags["metadata"] = "metadata_test.go"
 }
 
-// MetadataCompatible allows consumers of this library to consider all structs that implement
-// this interface to be the same type
 type metadataCompatible interface {
 	GetMetadata() (*types.Metadata, error)
 	AddMetadataEntry(typedValue, key, value string) error

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -42,6 +42,10 @@ func (vcd *TestVCD) Test_AddMetadataForVdc(check *C) {
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")
 }
 
+func (vcd *TestVCD) Testfoo(check *C) {
+	getAdminVdcURL("")
+}
+
 func (vcd *TestVCD) Test_DeleteMetadataForVdc(check *C) {
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -20,7 +20,7 @@ func init() {
 	testingTags["metadata"] = "metadata_test.go"
 }
 
-func (vcd *TestVCD) Test_AddMetadataForVdc(check *C) {
+func (vcd *TestVCD) Test_AddAndDeleteMetadataForVdc(check *C) {
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")
 	}
@@ -51,7 +51,7 @@ func (vcd *TestVCD) Test_AddMetadataForVdc(check *C) {
 	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
-func (vcd *TestVCD) Test_AddMetadataOnVapp(check *C) {
+func (vcd *TestVCD) Test_AddAndDeleteMetadataOnVapp(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	if vcd.skipVappTests {
@@ -70,37 +70,20 @@ func (vcd *TestVCD) Test_AddMetadataOnVapp(check *C) {
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")
-}
-
-func (vcd *TestVCD) Test_DeleteMetadataOnVapp(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-
-	if vcd.skipVappTests {
-		check.Skip("Skipping test because vApp was not successfully created at setup")
-	}
-	// Add metadata
-	task, err := vcd.vapp.AddMetadata("key2", "value2")
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-	check.Assert(task.Task.Status, Equals, "success")
 
 	// Remove metadata
-	task, err = vcd.vapp.DeleteMetadata("key2")
+	task, err = vcd.vapp.DeleteMetadata("key")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-	metadata, err := vcd.vapp.GetMetadata()
+
+	metadata, err = vcd.vapp.GetMetadata()
 	check.Assert(err, IsNil)
-	for _, k := range metadata.MetadataEntry {
-		if k.Key == "key2" {
-			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
-		}
-	}
+	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
-func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
+func (vcd *TestVCD) Test_AddAndDeleteMetadataOnVm(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	if vcd.skipVappTests {
@@ -134,92 +117,19 @@ func (vcd *TestVCD) Test_AddMetadataOnVm(check *C) {
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")
-}
 
-func (vcd *TestVCD) Test_DeleteMetadataOnVm(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-
-	if vcd.skipVappTests {
-		check.Skip("Skipping test because vapp was not successfully created at setup")
-	}
-
-	// Find VApp
-	if vcd.vapp.VApp == nil {
-		check.Skip("skipping test because no vApp is found")
-	}
-
-	vapp := vcd.findFirstVapp()
-	vmType, vmName := vcd.findFirstVm(vapp)
-	if vmName == "" {
-		check.Skip("skipping test because no VM is found")
-	}
-
-	vm := NewVM(&vcd.client.Client)
-	vm.VM = &vmType
-
-	// Add metadata
-	task, err := vm.AddMetadata("key2", "value2")
+	// Remove metadata
+	task, err = vm.DeleteMetadata("key")
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
-
-	// Remove metadata
-	task, err = vm.DeleteMetadata("key2")
+	metadata, err = vm.GetMetadata()
 	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-	check.Assert(task.Task.Status, Equals, "success")
-	metadata, err := vm.GetMetadata()
-	check.Assert(err, IsNil)
-	for _, k := range metadata.MetadataEntry {
-		if k.Key == "key2" {
-			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
-		}
-	}
+	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
-func (vcd *TestVCD) Test_DeleteMetadataOnVAppTemplate(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
-	if err != nil {
-		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog not found. Test can't proceed")
-		return
-	}
-
-	if vcd.config.VCD.Catalog.CatalogItem == "" {
-		check.Skip("Test_DeleteMetadataOnCatalogItem: Catalog Item not given. Test can't proceed")
-	}
-
-	catItem, err := cat.GetCatalogItemByName(vcd.config.VCD.Catalog.CatalogItem, false)
-	check.Assert(err, IsNil)
-	check.Assert(catItem, NotNil)
-	check.Assert(catItem.CatalogItem.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
-
-	vAppTemplate, err := catItem.GetVAppTemplate()
-	check.Assert(err, IsNil)
-	check.Assert(vAppTemplate, NotNil)
-	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.CatalogItem)
-
-	// Add metadata
-	_, err = vAppTemplate.AddMetadata("key2", "value2")
-	check.Assert(err, IsNil)
-
-	// Remove metadata
-	err = vAppTemplate.DeleteMetadata("key2")
-	check.Assert(err, IsNil)
-
-	metadata, err := vAppTemplate.GetMetadata()
-	check.Assert(err, IsNil)
-	check.Assert(metadata, NotNil)
-	for _, k := range metadata.MetadataEntry {
-		if k.Key == "key2" {
-			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
-		}
-	}
-}
-
-func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
+func (vcd *TestVCD) Test_AddAndDeleteMetadataOnVAppTemplate(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 	cat, err := vcd.org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
 	if err != nil {
@@ -266,60 +176,15 @@ func (vcd *TestVCD) Test_AddMetadataOnVAppTemplate(check *C) {
 	check.Assert(foundEntry.Key, Equals, "key")
 	check.Assert(foundEntry.TypedValue.Value, Equals, "value")
 
+	// Remove metadata
 	err = vAppTemplate.DeleteMetadata("key")
 	check.Assert(err, IsNil)
+	metadata, err = vAppTemplate.GetMetadata()
+	check.Assert(err, IsNil)
+	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
-func (vcd *TestVCD) Test_DeleteMetadataOnMediaRecord(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-
-	//prepare mediaRecord item
-	skipWhenMediaPathMissing(vcd, check)
-	itemName := "TestDeleteMediaMetaData"
-
-	org, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
-	check.Assert(err, IsNil)
-	check.Assert(org, NotNil)
-
-	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.Name, false)
-	check.Assert(err, IsNil)
-	check.Assert(catalog, NotNil)
-
-	uploadTask, err := catalog.UploadMediaImage(itemName, "upload from test", vcd.config.Media.MediaPath, 1024)
-	check.Assert(err, IsNil)
-	check.Assert(uploadTask, NotNil)
-	err = uploadTask.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-
-	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_DeleteMetadataOnMediaRecord")
-
-	err = vcd.org.Refresh()
-	check.Assert(err, IsNil)
-
-	mediaRecord, err := catalog.QueryMedia(itemName)
-	check.Assert(err, IsNil)
-	check.Assert(mediaRecord, NotNil)
-	check.Assert(mediaRecord.MediaRecord.Name, Equals, itemName)
-
-	// Add metadata
-	_, err = mediaRecord.AddMetadata("key2", "value2")
-	check.Assert(err, IsNil)
-
-	// Remove metadata
-	err = mediaRecord.DeleteMetadata("key2")
-	check.Assert(err, IsNil)
-
-	metadata, err := mediaRecord.GetMetadata()
-	check.Assert(err, IsNil)
-	check.Assert(metadata, NotNil)
-	for _, k := range metadata.MetadataEntry {
-		if k.Key == "key2" {
-			check.Errorf("metadata.MetadataEntry should not contain key: 'key2'")
-		}
-	}
-}
-
-func (vcd *TestVCD) Test_AddMetadataOnMediaRecord(check *C) {
+func (vcd *TestVCD) Test_AddAndDeleteMetadataOnMediaRecord(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
 	//prepare media item
@@ -362,6 +227,13 @@ func (vcd *TestVCD) Test_AddMetadataOnMediaRecord(check *C) {
 	check.Assert(len(metadata.MetadataEntry), Equals, 1)
 	check.Assert(metadata.MetadataEntry[0].Key, Equals, "key")
 	check.Assert(metadata.MetadataEntry[0].TypedValue.Value, Equals, "value")
+
+	// Remove metadata
+	err = mediaRecord.DeleteMetadata("key")
+	check.Assert(err, IsNil)
+	metadata, err = mediaRecord.GetMetadata()
+	check.Assert(err, IsNil)
+	check.Assert(len(metadata.MetadataEntry), Equals, 0)
 }
 
 func (vcd *TestVCD) Test_MetadataOnAdminCatalogCRUD(check *C) {


### PR DESCRIPTION
## Enhancements

* Adds the POST operation for metadata, called `MergeMetadata` and `MergeMetadataAsync` as it is what it does: Updates existing keys, and adds the non-existing ones. The operation was added to all existing supported VCD entities. The input parameter is the Metadata `typedValue` and a map with `string` keys and `interface{}` values, in order to support the different typed values that metadata can handle in VCD.

## Refactoring

* Moved deprecated functions to the bottom, now they can be easily deleted when a new major comes, as before they were mixed up with new ones.
* Ordered the functions that were a bit chaotic-ordered. Now they respect the same order always.
* Moved the `getAdminUrl()` to a more general place, modified its implementation to avoid coupling with Vdc and also avoid a bug when the method is called with sysadmin user.
* Deleted a lot of duplicated code in metadata tests.
* Deleted test `Test_DeleteMetadataForXxxx`. Now both Add/Delete are in the same test: `Test_AddAndDeleteMetadataForXxx` to avoid dangling metadata. Anyway, these test will be removed in next major as they test deprecated methods.
* Fixes `findFirstVapp()` testing function that didn't return always the defined in configuration vApp. Now it does if present.

## Testing

Executed `go test -v -tags "metadata"` on VCD 10.3.2