### PR TITLE
Update ALB service engine group and ALB settings to support SupportedFeatureSet in VCD 10.4

### DIFF
--- a/.changes/v2.16.0/485-improvements.md
+++ b/.changes/v2.16.0/485-improvements.md
@@ -1,1 +1,2 @@
-* Add `SupportedFeatureSet` attribute to `NsxtAlbServiceEngineGroup` and `NsxtAlbConfig` to support v37.0 license management for AVI Load Balancer [GH-485]
+* Add `SupportedFeatureSet` attribute to `NsxtAlbServiceEngineGroup` and `NsxtAlbConfig` to support v37.0 license management for AVI Load Balancer
+and replace `LicenseType` from `NsxtAlbController` [GH-485]

--- a/.changes/v2.16.0/485-improvements.md
+++ b/.changes/v2.16.0/485-improvements.md
@@ -1,1 +1,1 @@
-* Add `SupportedFeatureSet` attribute to `NsxtAlbServiceEngineGroup` to support v37.0 AVI Load Balancer license management [GH-485]
+* Add `SupportedFeatureSet` attribute to `NsxtAlbServiceEngineGroup` and `NsxtAlbConfig` to support v37.0 license management for AVI Load Balancer [GH-485]

--- a/.changes/v2.16.0/485-improvements.md
+++ b/.changes/v2.16.0/485-improvements.md
@@ -1,0 +1,1 @@
+* Add `SupportedFeatureSet` attribute to `NsxtAlbServiceEngineGroup` to support v37.0 AVI Load Balancer license management [GH-485]

--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -46,7 +46,8 @@ var apiVersionToVcdVersion = map[string]string{
 	"33.0": "10.0",
 	"34.0": "10.1",
 	"35.0": "10.2",
-	"36.0": "10.3", // Provisional version for non-GA release. It may change later
+	"36.0": "10.3",
+	"37.0": "10.4", // Provisional version for non-GA release. It may change later
 }
 
 // vcdVersionToApiVersion gets the max supported API version from vCD version
@@ -58,7 +59,8 @@ var vcdVersionToApiVersion = map[string]string{
 	"10.0": "33.0",
 	"10.1": "34.0",
 	"10.2": "35.0",
-	"10.3": "36.0", // Provisional version for non-GA release. It may change later
+	"10.3": "36.0",
+	"10.4": "37.0", // Provisional version for non-GA release. It may change later
 }
 
 // to make vcdVersionToApiVersion used

--- a/govcd/nsxt_alb_controllers.go
+++ b/govcd/nsxt_alb_controllers.go
@@ -29,7 +29,7 @@ func (vcdClient *VCDClient) GetAllAlbControllers(queryParameters url.Values) ([]
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController
-	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (vcdClient *VCDClient) GetAlbControllerById(id string) (*NsxtAlbController,
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController
-	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbController(albControllerConfig *types.N
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbController(albControllerConfig *types.N
 		vcdClient:         vcdClient,
 	}
 
-	err = client.OpenApiPostItem(minimumApiVersion, urlRef, nil, albControllerConfig, returnObject.NsxtAlbController, nil)
+	err = client.OpenApiPostItem(apiVersion, urlRef, nil, albControllerConfig, returnObject.NsxtAlbController, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NSX-T ALB Controller: %s", err)
 	}
@@ -178,7 +178,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbController(albControllerConfig *types.N
 func (nsxtAlbController *NsxtAlbController) Update(albControllerConfig *types.NsxtAlbController) (*NsxtAlbController, error) {
 	client := nsxtAlbController.vcdClient.Client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (nsxtAlbController *NsxtAlbController) Update(albControllerConfig *types.Ns
 		vcdClient:         nsxtAlbController.vcdClient,
 	}
 
-	err = client.OpenApiPutItem(minimumApiVersion, urlRef, nil, albControllerConfig, responseAlbController.NsxtAlbController, nil)
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, albControllerConfig, responseAlbController.NsxtAlbController, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error updating NSX-T ALB Controller: %s", err)
 	}
@@ -209,7 +209,7 @@ func (nsxtAlbController *NsxtAlbController) Update(albControllerConfig *types.Ns
 func (nsxtAlbController *NsxtAlbController) Delete() error {
 	client := nsxtAlbController.vcdClient.Client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (nsxtAlbController *NsxtAlbController) Delete() error {
 		return err
 	}
 
-	err = client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil, nil)
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting NSX-T ALB Controller: %s", err)
 	}

--- a/govcd/nsxt_alb_controllers_test.go
+++ b/govcd/nsxt_alb_controllers_test.go
@@ -63,7 +63,7 @@ func (vcd *TestVCD) Test_NsxtAlbController(check *C) {
 		Url:         vcd.config.VCD.Nsxt.NsxtAlbControllerUrl,
 		Username:    vcd.config.VCD.Nsxt.NsxtAlbControllerUser,
 		Password:    vcd.config.VCD.Nsxt.NsxtAlbControllerPassword,
-		LicenseType: "BASIC",
+		LicenseType: "BASIC", // Not used since v37.0
 	}
 	updatedController, err := controllerByUrl.Update(updateControllerDef)
 	check.Assert(err, IsNil)
@@ -71,7 +71,6 @@ func (vcd *TestVCD) Test_NsxtAlbController(check *C) {
 	check.Assert(updatedController.NsxtAlbController.Description, Equals, updateControllerDef.Description)
 	check.Assert(updatedController.NsxtAlbController.Url, Equals, updateControllerDef.Url)
 	check.Assert(updatedController.NsxtAlbController.Username, Equals, updateControllerDef.Username)
-	// LicenseType has been removed since v37.0
 	if vcd.client.Client.APIVCDMaxVersionIs("< 37.0") {
 		check.Assert(updatedController.NsxtAlbController.LicenseType, Equals, updateControllerDef.LicenseType)
 	}
@@ -98,7 +97,7 @@ func spawnAlbController(vcd *TestVCD, check *C) *NsxtAlbController {
 		Url:         vcd.config.VCD.Nsxt.NsxtAlbControllerUrl,
 		Username:    vcd.config.VCD.Nsxt.NsxtAlbControllerUser,
 		Password:    vcd.config.VCD.Nsxt.NsxtAlbControllerPassword,
-		LicenseType: "ENTERPRISE",
+		LicenseType: "ENTERPRISE", // Not used since v37.0
 	}
 
 	newController, err := vcd.client.CreateNsxtAlbController(newControllerDef)

--- a/govcd/nsxt_alb_controllers_test.go
+++ b/govcd/nsxt_alb_controllers_test.go
@@ -71,7 +71,10 @@ func (vcd *TestVCD) Test_NsxtAlbController(check *C) {
 	check.Assert(updatedController.NsxtAlbController.Description, Equals, updateControllerDef.Description)
 	check.Assert(updatedController.NsxtAlbController.Url, Equals, updateControllerDef.Url)
 	check.Assert(updatedController.NsxtAlbController.Username, Equals, updateControllerDef.Username)
-	check.Assert(updatedController.NsxtAlbController.LicenseType, Equals, updateControllerDef.LicenseType)
+	// LicenseType has been removed since v37.0
+	if vcd.client.Client.APIVCDMaxVersionIs("< 37.0") {
+		check.Assert(updatedController.NsxtAlbController.LicenseType, Equals, updateControllerDef.LicenseType)
+	}
 
 	// Revert settings to original ones
 	_, err = controllerByUrl.Update(controllerByUrl.NsxtAlbController)

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -249,8 +249,13 @@ func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *Nsx
 	// Enable ALB on Edge Gateway with default ServiceNetworkDefinition
 	albSettingsConfig := &types.NsxtAlbConfig{
 		Enabled:             true,
-		SupportedFeatureSet: "PREMIUM",
 	}
+
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		albSettingsConfig.SupportedFeatureSet = takeStringPointer("PREMIUM")
+	}
+
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
 	check.Assert(err, IsNil)
 	check.Assert(enabledSettings.Enabled, Equals, true)

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -67,17 +67,17 @@ func testAdvancedPoolConfig(check *C, edge *NsxtEdgeGateway, vcd *TestVCD, clien
 		PassiveMonitoringEnabled: takeBoolPointer(true),
 		HealthMonitors:           nil,
 		Members: []types.NsxtAlbPoolMember{
-			types.NsxtAlbPoolMember{
+			{
 				Enabled:   true,
 				IpAddress: "1.1.1.1",
 				Port:      8400,
 				Ratio:     takeIntAddress(2),
 			},
-			types.NsxtAlbPoolMember{
+			{
 				Enabled:   false,
 				IpAddress: "1.1.1.2",
 			},
-			types.NsxtAlbPoolMember{
+			{
 				Enabled:   true,
 				IpAddress: "1.1.1.3",
 			},
@@ -98,13 +98,13 @@ func testAdvancedPoolConfig(check *C, edge *NsxtEdgeGateway, vcd *TestVCD, clien
 		PassiveMonitoringEnabled: takeBoolPointer(false),
 		HealthMonitors:           nil,
 		Members: []types.NsxtAlbPoolMember{
-			types.NsxtAlbPoolMember{
+			{
 				Enabled:   true,
 				IpAddress: "1.1.1.1",
 				Port:      8300,
 				Ratio:     takeIntAddress(3),
 			},
-			types.NsxtAlbPoolMember{
+			{
 				Enabled:   true,
 				IpAddress: "1.1.1.2",
 			},
@@ -248,7 +248,8 @@ func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *Nsx
 
 	// Enable ALB on Edge Gateway with default ServiceNetworkDefinition
 	albSettingsConfig := &types.NsxtAlbConfig{
-		Enabled: true,
+		Enabled:             true,
+		SupportedFeatureSet: "PREMIUM",
 	}
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -253,7 +253,7 @@ func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *Nsx
 
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		albSettingsConfig.SupportedFeatureSet = takeStringPointer("PREMIUM")
+		albSettingsConfig.SupportedFeatureSet = "PREMIUM"
 	}
 
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -248,7 +248,7 @@ func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *Nsx
 
 	// Enable ALB on Edge Gateway with default ServiceNetworkDefinition
 	albSettingsConfig := &types.NsxtAlbConfig{
-		Enabled:             true,
+		Enabled: true,
 	}
 
 	// Field is only available when using API version v37.0 onwards

--- a/govcd/nsxt_alb_service_engine_groups.go
+++ b/govcd/nsxt_alb_service_engine_groups.go
@@ -39,7 +39,7 @@ func (vcdClient *VCDClient) GetAllAlbServiceEngineGroups(context string, queryPa
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (vcdClient *VCDClient) GetAlbServiceEngineGroupById(id string) (*NsxtAlbSer
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	apiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbServiceEngineGroup(albServiceEngineGrou
 	}
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbServiceEngineGroup(albServiceEngineGrou
 		vcdClient:                 vcdClient,
 	}
 
-	err = client.OpenApiPostItem(minimumApiVersion, urlRef, nil, albServiceEngineGroup, returnObject.NsxtAlbServiceEngineGroup, nil)
+	err = client.OpenApiPostItem(apiVersion, urlRef, nil, albServiceEngineGroup, returnObject.NsxtAlbServiceEngineGroup, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating NSX-T ALB Service Engine Group: %s", err)
 	}
@@ -169,7 +169,7 @@ func (vcdClient *VCDClient) CreateNsxtAlbServiceEngineGroup(albServiceEngineGrou
 func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Update(albSEGroupConfig *types.NsxtAlbServiceEngineGroup) (*NsxtAlbServiceEngineGroup, error) {
 	client := nsxtAlbServiceEngineGroup.vcdClient.Client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Update(albSEGroupCon
 		vcdClient:                 nsxtAlbServiceEngineGroup.vcdClient,
 	}
 
-	err = client.OpenApiPutItem(minimumApiVersion, urlRef, nil, albSEGroupConfig, responseAlbController.NsxtAlbServiceEngineGroup, nil)
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, albSEGroupConfig, responseAlbController.NsxtAlbServiceEngineGroup, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error updating NSX-T ALB Service Engine Group: %s", err)
 	}
@@ -200,7 +200,7 @@ func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Update(albSEGroupCon
 func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Delete() error {
 	client := nsxtAlbServiceEngineGroup.vcdClient.Client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Delete() error {
 		return err
 	}
 
-	err = client.OpenApiDeleteItem(minimumApiVersion, urlRef, nil, nil)
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting NSX-T ALB Service Engine Group: %s", err)
 	}
@@ -228,7 +228,7 @@ func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Delete() error {
 func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Sync() error {
 	client := nsxtAlbServiceEngineGroup.vcdClient.Client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups
-	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (nsxtAlbServiceEngineGroup *NsxtAlbServiceEngineGroup) Sync() error {
 		return err
 	}
 
-	task, err := client.OpenApiPostItemAsync(minimumApiVersion, urlRef, nil, nil)
+	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error syncing NSX-T ALB Service Engine Group: %s", err)
 	}

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -31,7 +31,11 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 				ID: createdAlbCloud.NsxtAlbCloud.ID,
 			},
 		},
-		SupportedFeatureSet: "PREMIUM",
+	}
+
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		albSeGroup.SupportedFeatureSet = takeStringPointer("PREMIUM")
 	}
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)
@@ -42,7 +46,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.Description, Equals, albSeGroup.Description)
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.ReservationType, Equals, albSeGroup.ReservationType)
 	// Field is only populated in responses when using API version v37.0 onwards
-	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") && vcd.client.Client.APIClientVersionIs(">= 37.0") {
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
 		check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, albSeGroup.SupportedFeatureSet)
 	}
 
@@ -68,7 +72,10 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 
 	// Test update
 	createdSeGroup.NsxtAlbServiceEngineGroup.Name = createdSeGroup.NsxtAlbServiceEngineGroup.Name + "updated"
-	createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet = "STANDARD"
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		albSeGroup.SupportedFeatureSet = takeStringPointer("STANDARD")
+	}
 	updatedSeGroup, err := createdSeGroup.Update(createdSeGroup.NsxtAlbServiceEngineGroup)
 	check.Assert(err, IsNil)
 
@@ -109,7 +116,11 @@ func spawnAlbControllerCloudServiceEngineGroup(vcd *TestVCD, check *C, seGroupRe
 				ID: createdAlbCloud.NsxtAlbCloud.ID,
 			},
 		},
-		SupportedFeatureSet: "PREMIUM",
+	}
+
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		albSeGroup.SupportedFeatureSet = takeStringPointer("PREMIUM")
 	}
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -47,7 +47,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.ReservationType, Equals, albSeGroup.ReservationType)
 	// Field is only populated in responses when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, albSeGroup.SupportedFeatureSet)
+		check.Assert(*createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, *albSeGroup.SupportedFeatureSet)
 	}
 
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups + createdSeGroup.NsxtAlbServiceEngineGroup.ID
@@ -80,7 +80,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(err, IsNil)
 
 	// SupportedFeatureSet is a field only available since v37.0, in that case we ignore it in the following DeepEquals
-	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+	if vcd.client.Client.APIVCDMaxVersionIs("< 37.0") {
 		updatedSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet = createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet
 	}
 	check.Assert(updatedSeGroup.NsxtAlbServiceEngineGroup, DeepEquals, createdSeGroup.NsxtAlbServiceEngineGroup)

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -31,7 +31,10 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 				ID: createdAlbCloud.NsxtAlbCloud.ID,
 			},
 		},
+		SupportedFeatureSet: "PREMIUM",
 	}
+
+
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)
 	check.Assert(err, IsNil)
@@ -40,6 +43,9 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.Name, Equals, albSeGroup.Name)
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.Description, Equals, albSeGroup.Description)
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.ReservationType, Equals, albSeGroup.ReservationType)
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, albSeGroup.SupportedFeatureSet)
+	}
 
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups + createdSeGroup.NsxtAlbServiceEngineGroup.ID
 	AddToCleanupListOpenApi(createdSeGroup.NsxtAlbServiceEngineGroup.Name, check.TestName(), openApiEndpoint)
@@ -66,6 +72,10 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	updatedSeGroup, err := createdSeGroup.Update(createdSeGroup.NsxtAlbServiceEngineGroup)
 	check.Assert(err, IsNil)
 
+	// SupportedFeatureSet is a field only available since v37.0, so in prior versions we ignore it
+	if vcd.client.Client.APIVCDMaxVersionIs("< 37.0") {
+		updatedSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet = createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet
+	}
 	check.Assert(updatedSeGroup.NsxtAlbServiceEngineGroup, DeepEquals, createdSeGroup.NsxtAlbServiceEngineGroup)
 
 	// Cleanup
@@ -99,6 +109,7 @@ func spawnAlbControllerCloudServiceEngineGroup(vcd *TestVCD, check *C, seGroupRe
 				ID: createdAlbCloud.NsxtAlbCloud.ID,
 			},
 		},
+		SupportedFeatureSet: "PREMIUM",
 	}
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -34,8 +34,6 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 		SupportedFeatureSet: "PREMIUM",
 	}
 
-
-
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)
 	check.Assert(err, IsNil)
 
@@ -43,7 +41,8 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.Name, Equals, albSeGroup.Name)
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.Description, Equals, albSeGroup.Description)
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.ReservationType, Equals, albSeGroup.ReservationType)
-	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+	// Field is only populated in responses when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") && vcd.client.Client.APIClientVersionIs(">= 37.0") {
 		check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, albSeGroup.SupportedFeatureSet)
 	}
 
@@ -69,11 +68,12 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 
 	// Test update
 	createdSeGroup.NsxtAlbServiceEngineGroup.Name = createdSeGroup.NsxtAlbServiceEngineGroup.Name + "updated"
+	createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet = "STANDARD"
 	updatedSeGroup, err := createdSeGroup.Update(createdSeGroup.NsxtAlbServiceEngineGroup)
 	check.Assert(err, IsNil)
 
-	// SupportedFeatureSet is a field only available since v37.0, so in prior versions we ignore it
-	if vcd.client.Client.APIVCDMaxVersionIs("< 37.0") {
+	// SupportedFeatureSet is a field only available since v37.0, in that case we ignore it in the following DeepEquals
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
 		updatedSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet = createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet
 	}
 	check.Assert(updatedSeGroup.NsxtAlbServiceEngineGroup, DeepEquals, createdSeGroup.NsxtAlbServiceEngineGroup)

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -35,7 +35,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		albSeGroup.SupportedFeatureSet = takeStringPointer("PREMIUM")
+		albSeGroup.SupportedFeatureSet = "PREMIUM"
 	}
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)
@@ -47,7 +47,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.ReservationType, Equals, albSeGroup.ReservationType)
 	// Field is only populated in responses when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		check.Assert(*createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, *albSeGroup.SupportedFeatureSet)
+		check.Assert(createdSeGroup.NsxtAlbServiceEngineGroup.SupportedFeatureSet, Equals, albSeGroup.SupportedFeatureSet)
 	}
 
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups + createdSeGroup.NsxtAlbServiceEngineGroup.ID
@@ -74,7 +74,7 @@ func (vcd *TestVCD) Test_GetAllAlbServiceEngineGroups(check *C) {
 	createdSeGroup.NsxtAlbServiceEngineGroup.Name = createdSeGroup.NsxtAlbServiceEngineGroup.Name + "updated"
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		albSeGroup.SupportedFeatureSet = takeStringPointer("STANDARD")
+		albSeGroup.SupportedFeatureSet = "STANDARD"
 	}
 	updatedSeGroup, err := createdSeGroup.Update(createdSeGroup.NsxtAlbServiceEngineGroup)
 	check.Assert(err, IsNil)
@@ -120,7 +120,7 @@ func spawnAlbControllerCloudServiceEngineGroup(vcd *TestVCD, check *C, seGroupRe
 
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		albSeGroup.SupportedFeatureSet = takeStringPointer("PREMIUM")
+		albSeGroup.SupportedFeatureSet = "PREMIUM"
 	}
 
 	createdSeGroup, err := vcd.client.CreateNsxtAlbServiceEngineGroup(albSeGroup)

--- a/govcd/nsxt_alb_settings_test.go
+++ b/govcd/nsxt_alb_settings_test.go
@@ -39,10 +39,20 @@ func (vcd *TestVCD) Test_UpdateAlbSettings(check *C) {
 	albSettingsConfig := &types.NsxtAlbConfig{
 		Enabled: true,
 	}
+
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		albSettingsConfig.SupportedFeatureSet = takeStringPointer("STANDARD")
+	}
+
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
 	check.Assert(err, IsNil)
 	check.Assert(enabledSettings.Enabled, Equals, true)
 	check.Assert(enabledSettings.ServiceNetworkDefinition, Equals, "192.168.255.1/25")
+	// Field is only available when using API version v37.0 onwards
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
+		check.Assert(*enabledSettings.SupportedFeatureSet, Equals, "STANDARD")
+	}
 	PrependToCleanupList("", "OpenApiEntityAlbSettingsDisable", edge.EdgeGateway.Name, check.TestName())
 
 	// Disable ALB on Edge Gateway

--- a/govcd/nsxt_alb_settings_test.go
+++ b/govcd/nsxt_alb_settings_test.go
@@ -42,7 +42,7 @@ func (vcd *TestVCD) Test_UpdateAlbSettings(check *C) {
 
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		albSettingsConfig.SupportedFeatureSet = takeStringPointer("STANDARD")
+		albSettingsConfig.SupportedFeatureSet = "STANDARD"
 	}
 
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
@@ -51,7 +51,7 @@ func (vcd *TestVCD) Test_UpdateAlbSettings(check *C) {
 	check.Assert(enabledSettings.ServiceNetworkDefinition, Equals, "192.168.255.1/25")
 	// Field is only available when using API version v37.0 onwards
 	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.0") {
-		check.Assert(*enabledSettings.SupportedFeatureSet, Equals, "STANDARD")
+		check.Assert(enabledSettings.SupportedFeatureSet, Equals, "STANDARD")
 	}
 	PrependToCleanupList("", "OpenApiEntityAlbSettingsDisable", edge.EdgeGateway.Name, check.TestName())
 

--- a/govcd/nsxt_distributed_firewall_test.go
+++ b/govcd/nsxt_distributed_firewall_test.go
@@ -265,6 +265,7 @@ func getRandomListOfNetworkContextProfiles(check *C, vcd *TestVCD, vdcClient *VC
 	check.Assert(err, IsNil)
 	openApiRefs := make([]types.OpenApiReference, 1)
 	for _, networkContextProfile := range networkContextProfiles {
+		// Skipping network context profile which has hardcoded destinations and throws error when used in firewall rules with specified destinations
 		if strings.Contains(networkContextProfile.Description, "ALG") || strings.Contains(networkContextProfile.Description, "includes the URL categories") {
 			continue
 		}

--- a/govcd/nsxt_distributed_firewall_test.go
+++ b/govcd/nsxt_distributed_firewall_test.go
@@ -191,7 +191,7 @@ func createDistributedFirewallDefinitions(check *C, vcd *TestVCD, vdcGroupId str
 			networkContextProfile := make([]types.OpenApiReference, 0)
 			for _, netCtxProf := range netCtxProfile {
 				if netCtxProf.ID != "" {
-					networkContextProfile = append(networkContextProfile, types.OpenApiReference{ID: netCtxProf.ID})
+					networkContextProfile = append(networkContextProfile, types.OpenApiReference{ID: netCtxProf.ID, Name: netCtxProf.Name})
 				}
 			}
 
@@ -265,7 +265,7 @@ func getRandomListOfNetworkContextProfiles(check *C, vcd *TestVCD, vdcClient *VC
 	check.Assert(err, IsNil)
 	openApiRefs := make([]types.OpenApiReference, 1)
 	for _, networkContextProfile := range networkContextProfiles {
-		if strings.Contains(networkContextProfile.Description, "ALG") {
+		if strings.Contains(networkContextProfile.Description, "ALG") || strings.Contains(networkContextProfile.Description, "includes the URL categories") {
 			continue
 		}
 		openApiRef := types.OpenApiReference{

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -94,6 +94,18 @@ var endpointElevatedApiVersions = map[string][]string{
 		//"32.0", // Basic minimum required version
 		"36.1", // Adds support for dnsServers
 	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbController: {
+		//"35.0", // Basic minimum required version
+		"37.0", // Deprecates LicenseType in favor of SupportedFeatureSet
+	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbServiceEngineGroups: {
+		"35.0", // Basic minimum required version
+		"37.0", // Adds SupportedFeatureSet
+	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbEdgeGateway: {
+		"35.0", // Basic minimum required version
+		"37.0", // Deprecates LicenseType in favor of SupportedFeatureSet
+	},
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -802,7 +802,7 @@ type NsxtAlbServiceEngineGroup struct {
 	OverAllocated *bool `json:"overAllocated,omitempty"`
 	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbController.LicenseType.
 	// Possible values are: "STANDARD", "PREMIUM".
-	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
+	SupportedFeatureSet *string `json:"supportedFeatureSet,omitempty"`
 }
 
 type ServiceEngineGroupBacking struct {
@@ -835,7 +835,7 @@ type NsxtAlbConfig struct {
 	LicenseType string `json:"licenseType,omitempty"`
 	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbConfig.LicenseType.
 	// Possible values are: "STANDARD", "PREMIUM".
-	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
+	SupportedFeatureSet *string `json:"supportedFeatureSet,omitempty"`
 	// LoadBalancerCloudRef
 	LoadBalancerCloudRef *OpenApiReference `json:"loadBalancerCloudRef,omitempty"`
 	// ServiceNetworkDefinition in Gateway CIDR format which will be used by Load Balancer service. All the load balancer

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -802,7 +802,7 @@ type NsxtAlbServiceEngineGroup struct {
 	OverAllocated *bool `json:"overAllocated,omitempty"`
 	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbController.LicenseType.
 	// Possible values are: "STANDARD", "PREMIUM".
-	SupportedFeatureSet *string `json:"supportedFeatureSet,omitempty"`
+	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
 }
 
 type ServiceEngineGroupBacking struct {
@@ -835,7 +835,7 @@ type NsxtAlbConfig struct {
 	LicenseType string `json:"licenseType,omitempty"`
 	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbConfig.LicenseType.
 	// Possible values are: "STANDARD", "PREMIUM".
-	SupportedFeatureSet *string `json:"supportedFeatureSet,omitempty"`
+	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
 	// LoadBalancerCloudRef
 	LoadBalancerCloudRef *OpenApiReference `json:"loadBalancerCloudRef,omitempty"`
 	// ServiceNetworkDefinition in Gateway CIDR format which will be used by Load Balancer service. All the load balancer

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -704,6 +704,7 @@ type NsxtAlbController struct {
 	// LicenseType By enabling this feature, the provider acknowledges that they have independently licensed the
 	// enterprise version of the NSX AVI LB.
 	// Possible options: 'BASIC', 'ENTERPRISE'
+	// This field was removed since VCD 10.4.0 (v37.0) in favor of NsxtAlbServiceEngineGroup.SupportedFeatureSet
 	LicenseType string `json:"licenseType,omitempty"`
 	// Version of ALB (e.g. 20.1.3). Read-only
 	Version string `json:"version,omitempty"`
@@ -799,6 +800,9 @@ type NsxtAlbServiceEngineGroup struct {
 	// OverAllocated indicates whether the maximum number of virtual services supported on the Load Balancer Service
 	// Engine Group has been surpassed by the current number of reserved virtual services.
 	OverAllocated *bool `json:"overAllocated,omitempty"`
+	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbController.LicenseType.
+	// Possible values are: "STANDARD", "PREMIUM".
+	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
 }
 
 type ServiceEngineGroupBacking struct {

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -831,10 +831,13 @@ type NsxtAlbConfig struct {
 	// LicenseType of the backing Load Balancer Cloud.
 	// * BASIC - Basic edition of the NSX Advanced Load Balancer.
 	// * ENTERPRISE - Full featured edition of the NSX Advanced Load Balancer.
+	// This field was removed since VCD 10.4.0 (v37.0) in favor of NsxtAlbConfig.SupportedFeatureSet
 	LicenseType string `json:"licenseType,omitempty"`
+	// SupportedFeatureSet was added in VCD 10.4.0 (v37.0) as substitute of NsxtAlbConfig.LicenseType.
+	// Possible values are: "STANDARD", "PREMIUM".
+	SupportedFeatureSet string `json:"supportedFeatureSet,omitempty"`
 	// LoadBalancerCloudRef
 	LoadBalancerCloudRef *OpenApiReference `json:"loadBalancerCloudRef,omitempty"`
-
 	// ServiceNetworkDefinition in Gateway CIDR format which will be used by Load Balancer service. All the load balancer
 	// service engines associated with the Service Engine Group will be attached to this network. The subnet prefix length
 	// must be 25. If nothing is set, the default is 192.168.255.1/25. Default CIDR can be configured. This field cannot


### PR DESCRIPTION
This PR is not associated to any issue.

## Description

When executing the tests using VCD 10.4, I found that some of them were failing due to:

- ALB Controller does not use `LicenseType` attribute in 10.4 (v37.0)
- ALB Service Engine Group has a new `SupportedFeatureSet` in 10.4 (v37.0) that replaces the above `LicenseType`
- ALB Settings has a new `SupportedFeatureSet` in 10.4 (v37.0) that replaces the above `LicenseType`

The goal of this PR is to adapt the mentioned data structures to **make the Go SDK compatible with v37.0** of the API (VCD 10.4).

In consequence, the failing tests have been adapted and some functions now use `getOpenApiHighestElevatedVersion` to support both old and new scenarios.

## Tests

- [x] Tests pass on VCD 10.2
- [x] Tests pass on VCD 10.3
- [x] Tests pass on VCD 10.4