### PR TITLE
Add support for Dynamic Security Groups

### DIFF
--- a/.changes/v2.16.0/487-features.md
+++ b/.changes/v2.16.0/487-features.md
@@ -1,0 +1,4 @@
+* Add support for Dynamic Security Groups in VCD 10.3 by expanding `types.NsxtFirewallGroup` to
+  accommodate fields required for dynamic security groups, implemented automatic API elevation to
+  v36.0. Added New functions `VdcGroup.CreateNsxtFirewallGroup`,
+  `NsxtFirewallGroup.IsDynamicSecurityGroup` [GH-487]

--- a/.changes/v2.16.0/487-features.md
+++ b/.changes/v2.16.0/487-features.md
@@ -1,4 +1,4 @@
 * Add support for Dynamic Security Groups in VCD 10.3 by expanding `types.NsxtFirewallGroup` to
-  accommodate fields required for dynamic security groups, implemented automatic API elevation to
+  accommodate fields required for Dynamic Security Groups, implemented automatic API elevation to
   v36.0. Added New functions `VdcGroup.CreateNsxtFirewallGroup`,
   `NsxtFirewallGroup.IsDynamicSecurityGroup` [GH-487]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -165,13 +165,15 @@ type TestConfig struct {
 		ExternalNetworkPortGroupType string `yaml:"externalNetworkPortGroupType,omitempty"`
 		VimServer                    string `yaml:"vimServer,omitempty"`
 		Nsxt                         struct {
-			Manager           string `yaml:"manager"`
-			Tier0router       string `yaml:"tier0router"`
-			Tier0routerVrf    string `yaml:"tier0routerVrf"`
-			Vdc               string `yaml:"vdc"`
-			ExternalNetwork   string `yaml:"externalNetwork"`
-			EdgeGateway       string `yaml:"edgeGateway"`
-			NsxtImportSegment string `yaml:"nsxtImportSegment"`
+			Manager             string `yaml:"manager"`
+			Tier0router         string `yaml:"tier0router"`
+			Tier0routerVrf      string `yaml:"tier0routerVrf"`
+			Vdc                 string `yaml:"vdc"`
+			ExternalNetwork     string `yaml:"externalNetwork"`
+			EdgeGateway         string `yaml:"edgeGateway"`
+			NsxtImportSegment   string `yaml:"nsxtImportSegment"`
+			VdcGroup            string `yaml:"vdcGroup"`
+			VdcGroupEdgeGateway string `yaml:"vdcGroupEdgeGateway"`
 
 			NsxtAlbControllerUrl      string `yaml:"nsxtAlbControllerUrl"`
 			NsxtAlbControllerUser     string `yaml:"nsxtAlbControllerUser"`

--- a/govcd/nsxt_firewall_group.go
+++ b/govcd/nsxt_firewall_group.go
@@ -36,6 +36,7 @@ func (egw *NsxtEdgeGateway) CreateNsxtFirewallGroup(firewallGroupConfig *types.N
 	return createNsxtFirewallGroup(egw.client, firewallGroupConfig)
 }
 
+// CreateNsxtFirewallGroup allows users to create NSX-T Firewall Group
 func (vdcGroup *VdcGroup) CreateNsxtFirewallGroup(firewallGroupConfig *types.NsxtFirewallGroup) (*NsxtFirewallGroup, error) {
 	return createNsxtFirewallGroup(vdcGroup.client, firewallGroupConfig)
 }
@@ -418,16 +419,15 @@ func createNsxtFirewallGroup(client *Client, firewallGroupConfig *types.NsxtFire
 }
 
 // getFirewallGroupTypeFilterFieldName is a helper that returns the field name to use for filtering
+// TODO - remove this function when VCD 10.2 is no longer supported
 // by type.
 // For VCD < 10.3.0, the type field is called "type" and for VCD >= 10.3.0, the type field is called
 // "typeValue".
 func getFirewallGroupTypeFilterFieldName(client *Client) string {
 	// Starting with API 36.0 new field 'typeValue' was introduced instead of deprecated `type` field.
 	filteringTypeFieldName := "typeValue"
-	// TODO - remove when API < 36.0 are deprecated
 	if client.APIVCDMaxVersionIs(" < 36.0") {
 		filteringTypeFieldName = "type"
 	}
-	// End OfTODO - remove when API 36.0 is deprecated
 	return filteringTypeFieldName
 }

--- a/govcd/nsxt_firewall_group_dynamic_security_group_test.go
+++ b/govcd/nsxt_firewall_group_dynamic_security_group_test.go
@@ -26,8 +26,6 @@ func (vcd *TestVCD) Test_NsxtDynamicSecurityGroup(check *C) {
 	vdcGroup, err := adminOrg.GetVdcGroupByName(vcd.config.VCD.Nsxt.VdcGroup)
 	check.Assert(err, IsNil)
 
-	// vdcGroupEdgeGateway.
-
 	dynamicSecGroupDefinition := &types.NsxtFirewallGroup{
 		Name:        check.TestName(),
 		Description: check.TestName() + "-Description",
@@ -97,7 +95,7 @@ func (vcd *TestVCD) Test_NsxtDynamicSecurityGroup(check *C) {
 
 	check.Assert(updatedDynamicGroup, DeepEquals, createdDynamicGroup)
 
-	// Remove
+	// Remove Dynamic Security Group
 	err = updatedDynamicGroup.Delete()
 	check.Assert(err, IsNil)
 }

--- a/govcd/nsxt_firewall_group_dynamic_security_group_test.go
+++ b/govcd/nsxt_firewall_group_dynamic_security_group_test.go
@@ -1,0 +1,103 @@
+//go:build network || nsxt || functional || openapi || ALL
+// +build network nsxt functional openapi ALL
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+// Test_NsxtDynamicSecurityGroup tests out CRUD of Dynamic NSX-T Security Group
+//
+// Note. Dynamic Security Group is one type of Firewall Group. Other types are IP-Set and Static
+// Security Group.
+func (vcd *TestVCD) Test_NsxtDynamicSecurityGroup(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+
+	if vcd.client.Client.APIVCDMaxVersionIs("< 36.0") {
+		check.Skip("Dynamic security groups require VCD 10.3+")
+	}
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	vdcGroup, err := adminOrg.GetVdcGroupByName(vcd.config.VCD.Nsxt.VdcGroup)
+	check.Assert(err, IsNil)
+
+	// vdcGroupEdgeGateway.
+
+	dynamicSecGroupDefinition := &types.NsxtFirewallGroup{
+		Name:        check.TestName(),
+		Description: check.TestName() + "-Description",
+		TypeValue:   types.FirewallGroupTypeVmCriteria,
+		OwnerRef:    &types.OpenApiReference{ID: vdcGroup.VdcGroup.Id},
+		VmCriteria: []types.NsxtFirewallGroupVmCriteria{
+			{
+				[]types.NsxtFirewallGroupVmCriteriaRule{
+					{
+						AttributeType:  "VM_TAG",
+						Operator:       "EQUALS",
+						AttributeValue: "string",
+					}, // Boolean AND
+					{
+						AttributeType:  "VM_TAG",
+						Operator:       "CONTAINS",
+						AttributeValue: "substring",
+					}, // Boolean AND
+					{
+						AttributeType:  "VM_TAG",
+						Operator:       "STARTS_WITH",
+						AttributeValue: "substring",
+					}, // Boolean AND
+					{
+						AttributeType:  "VM_TAG",
+						Operator:       "ENDS_WITH",
+						AttributeValue: "substring",
+					}, // Boolean AND
+				},
+			}, // Boolean OR
+			{
+				[]types.NsxtFirewallGroupVmCriteriaRule{
+					{
+						AttributeType:  "VM_NAME",
+						Operator:       "CONTAINS",
+						AttributeValue: "substring",
+					}, // Boolean AND
+					{
+						AttributeType:  "VM_NAME",
+						Operator:       "STARTS_WITH",
+						AttributeValue: "substring",
+					}, // Boolean AND
+				},
+			},
+		},
+	}
+
+	createdDynamicGroup, err := vdcGroup.CreateNsxtFirewallGroup(dynamicSecGroupDefinition)
+	check.Assert(err, IsNil)
+	check.Assert(createdDynamicGroup, NotNil)
+
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups + createdDynamicGroup.NsxtFirewallGroup.ID
+	AddToCleanupListOpenApi(createdDynamicGroup.NsxtFirewallGroup.Name, check.TestName(), openApiEndpoint)
+
+	check.Assert(createdDynamicGroup.NsxtFirewallGroup.ID, Not(Equals), "")
+	check.Assert(createdDynamicGroup.NsxtFirewallGroup.OwnerRef.Name, Equals, vcd.config.VCD.Nsxt.VdcGroup)
+	check.Assert(createdDynamicGroup.NsxtFirewallGroup.TypeValue, Equals, types.FirewallGroupTypeVmCriteria)
+
+	// Update
+	createdDynamicGroup.NsxtFirewallGroup.Description = "updated-description"
+	createdDynamicGroup.NsxtFirewallGroup.Name = check.TestName() + "-updated"
+
+	updatedDynamicGroup, err := createdDynamicGroup.Update(createdDynamicGroup.NsxtFirewallGroup)
+	check.Assert(err, IsNil)
+	check.Assert(updatedDynamicGroup, NotNil)
+	check.Assert(updatedDynamicGroup.NsxtFirewallGroup, DeepEquals, createdDynamicGroup.NsxtFirewallGroup)
+
+	check.Assert(updatedDynamicGroup, DeepEquals, createdDynamicGroup)
+
+	// Remove
+	err = updatedDynamicGroup.Delete()
+	check.Assert(err, IsNil)
+}

--- a/govcd/nsxt_firewall_group_static_security_group_test.go
+++ b/govcd/nsxt_firewall_group_static_security_group_test.go
@@ -8,10 +8,10 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-// Test_NsxtSecurityGroup tests out CRUD of NSX-T Security Group
+// Test_NsxtSecurityGroup tests out CRUD of Static NSX-T Security Group
 //
 // Note. Security Group is one type of Firewall Group
-func (vcd *TestVCD) Test_NsxtSecurityGroup(check *C) {
+func (vcd *TestVCD) Test_NsxtStaticSecurityGroup(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
 

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -28,12 +28,14 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointImportableTier0Routers:              "32.0",
 	// OpenApiEndpointExternalNetworks endpoint support was introduced with version 32.0 however it was still not stable
 	// enough to be used. (i.e. it did not support update "PUT")
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks:                   "33.0",
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies:                 "32.0",
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcAssignedComputePolicies:         "33.0",
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent:                     "34.0",
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:                       "34.0", // VCD 10.1+
-	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:                       "34.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks:           "33.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcComputePolicies:         "32.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcAssignedComputePolicies: "33.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSessionCurrent:             "34.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
+
+	// Static security groups and IP sets in VCD 10.2, Dynamic security groups in VCD 10.3+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups:                     "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules:                       "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtFirewallRules:                  "34.0",
@@ -93,6 +95,10 @@ var endpointElevatedApiVersions = map[string][]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworksDhcp: {
 		//"32.0", // Basic minimum required version
 		"36.1", // Adds support for dnsServers
+	},
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointFirewallGroups: {
+		//"34.0", // Basic minimum required version
+		"36.0", // Adds support for Dynamic Security Groups by deprecating `Type` field in favor of `TypeValue`
 	},
 }
 

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -434,12 +434,16 @@ const (
 )
 
 const (
-	// FirewallGroupTypeSecurityGroup can be used in types.NsxtFirewallGroup for 'type' field to
-	// create Security Group
+	// FirewallGroupTypeSecurityGroup can be used in types.NsxtFirewallGroup for 'TypeValue' field
+	// to create Security Group
 	FirewallGroupTypeSecurityGroup = "SECURITY_GROUP"
-	// FirewallGroupTypeIpSet can be used in types.NsxtFirewallGroup for 'type' field to create IP
-	// Set
+	// FirewallGroupTypeIpSet can be used in types.NsxtFirewallGroup for 'TypeValue' field to create
+	// IP Set
 	FirewallGroupTypeIpSet = "IP_SET"
+
+	// FirewallGroupTypeVmCriteria can be used in types.NsxtFirewallGroup for 'TypeValue' field to
+	// create Dynamic Security Group (VCD 10.3+)
+	FirewallGroupTypeVmCriteria = "VM_CRITERIA"
 )
 
 // These constants can be used to pick type of NSX-T NAT Rule

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -279,8 +279,8 @@ type NsxtFirewallGroup struct {
 	// VmCriteria (VCD 10.3+) defines list of dynamic criteria that determines whether a VM belongs
 	// to a dynamic firewall group. A VM needs to meet at least one criteria to belong to the
 	// firewall group. In other words, the logical AND is used for rules within a single criteria
-	// and the logical OR is used in between each criteria. This is only applicable for VM_CRITERIA
-	// Firewall Groups.
+	// and the logical OR is used in between each criteria. This is only applicable for Dynamic
+	// Security Groups (VM_CRITERIA Firewall Groups).
 	VmCriteria []NsxtFirewallGroupVmCriteria `json:"vmCriteria,omitempty"`
 
 	// OwnerRef replaces EdgeGatewayRef in API V35.0+ and can accept both - NSX-T Edge Gateway or a
@@ -296,18 +296,20 @@ type NsxtFirewallGroup struct {
 	// value is only populated in this field (not OwnerRef)
 	EdgeGatewayRef *OpenApiReference `json:"edgeGatewayRef,omitempty"`
 
-	// Type is deprecated starting with API 35.2 (VCD 10.2.2+)
+	// Type is deprecated starting with API 36.0 (VCD 10.3+)
 	Type string `json:"type,omitempty"`
 
-	// TypeValue replaces Type starting with API 35.2 (VCD 10.2.2+) and can be one of:
-	// SECURITY_GROUP, IP_SET, VM_CRITERIA(VCD 10.3+)
+	// TypeValue replaces Type starting with API 36.0 (VCD 10.3+) and can be one of:
+	// SECURITY_GROUP, IP_SET, VM_CRITERIA(VCD 10.3+ only)
+	// Constants `types.FirewallGroupTypeSecurityGroup`, `types.FirewallGroupTypeIpSet`,
+	// `types.FirewallGroupTypeVmCriteria` can be used to set the value.
 	TypeValue string `json:"typeValue,omitempty"`
 }
 
 // NsxtFirewallGroupVmCriteria defines list of rules where criteria represents boolean OR for
 // matching There can be up to 3 criteria
 type NsxtFirewallGroupVmCriteria struct {
-	// VmCriteria is a list of rules where each rule represents boolean and for matching VMs
+	// VmCriteria is a list of rules where each rule represents boolean AND for matching VMs
 	VmCriteriaRule []NsxtFirewallGroupVmCriteriaRule `json:"rules,omitempty"`
 }
 

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -255,7 +255,7 @@ type OpenApiOrgVdcNetworkDhcpPools struct {
 type NsxtFirewallGroup struct {
 	// ID contains Firewall Group ID (URN format)
 	// e.g. urn:vcloud:firewallGroup:d7f4e0b4-b83f-4a07-9f22-d242c9c0987a
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 	// Name of Firewall Group. Name are unique per 'Type'. There cannot be two SECURITY_GROUP or two
 	// IP_SET objects with the same name, but there can be one object of Type SECURITY_GROUP and one
 	// of Type IP_SET named the same.
@@ -276,6 +276,13 @@ type NsxtFirewallGroup struct {
 	// groups )
 	Members []OpenApiReference `json:"members,omitempty"`
 
+	// VmCriteria (VCD 10.3+) defines list of dynamic criteria that determines whether a VM belongs
+	// to a dynamic firewall group. A VM needs to meet at least one criteria to belong to the
+	// firewall group. In other words, the logical AND is used for rules within a single criteria
+	// and the logical OR is used in between each criteria. This is only applicable for VM_CRITERIA
+	// Firewall Groups.
+	VmCriteria []NsxtFirewallGroupVmCriteria `json:"vmCriteria,omitempty"`
+
 	// OwnerRef replaces EdgeGatewayRef in API V35.0+ and can accept both - NSX-T Edge Gateway or a
 	// VDC group ID
 	// Sample VDC Group URN - urn:vcloud:vdcGroup:89a53000-ef41-474d-80dc-82431ff8a020
@@ -289,8 +296,27 @@ type NsxtFirewallGroup struct {
 	// value is only populated in this field (not OwnerRef)
 	EdgeGatewayRef *OpenApiReference `json:"edgeGatewayRef,omitempty"`
 
-	// Type is either SECURITY_GROUP or IP_SET
-	Type string `json:"type"`
+	// Type is deprecated starting with API 35.2 (VCD 10.2.2+)
+	Type string `json:"type,omitempty"`
+
+	// TypeValue replaces Type starting with API 35.2 (VCD 10.2.2+) and can be one of:
+	// SECURITY_GROUP, IP_SET, VM_CRITERIA(VCD 10.3+)
+	TypeValue string `json:"typeValue,omitempty"`
+}
+
+// NsxtFirewallGroupVmCriteria defines list of rules where criteria represents boolean OR for
+// matching There can be up to 3 criteria
+type NsxtFirewallGroupVmCriteria struct {
+	// VmCriteria is a list of rules where each rule represents boolean and for matching VMs
+	VmCriteriaRule []NsxtFirewallGroupVmCriteriaRule `json:"rules,omitempty"`
+}
+
+// NsxtFirewallGroupVmCriteriaRule defines a single rule for matching VM
+// There can be up to 4 rules in a single criteria
+type NsxtFirewallGroupVmCriteriaRule struct {
+	AttributeType  string `json:"attributeType,omitempty"`
+	AttributeValue string `json:"attributeValue,omitempty"`
+	Operator       string `json:"operator,omitempty"`
 }
 
 // NsxtFirewallGroupMemberVms is a structure to read NsxtFirewallGroup associated VMs when its type


### PR DESCRIPTION
This PR adds support for Dynamic Security Groups (or as they are called in API - Firewall Groups).
It reuses the same functions we already have (because IP sets, Static Security Groups and Dynamic Security Groups use the same API), but expands a few places to accommodate Dynamic Security Group handling in VCD 10.3+:
* Expand `types.NsxtFirewallGroup` with new fields introduced with API V36.0 (VCD 10.3)
* New constant `types.FirewallGroupTypeVmCriteria` to match Dynamic Security Group type of Firewall group.
* API elevation to 36.0 when available so that Dynamic security groups can be handled.
* Additional test `Test_NsxtDynamicSecurityGroup` to checkout Dynamic security group creation.
* `NsxtFirewallGroup.IsDynamicSecurityGroup()` function to validate that given Firewall Group is Dynamic Security Group
* Additional Firewall Group functions with `*VdcGroup` pointer receiver
* Internal function `getFirewallGroupTypeFilterFieldName` for embedding into Security Group management functions as new field `TypeValue` must be used instead of now deprecated one `Type` which doesn't support Dynamic Firewall Groups.


More about Dynamic Security Groups in VCD official docs and VMware Blog post:
* https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-CF7FCFE1-7B1C-45CE-B8A0-774E9CD31DB5.html
* https://blogs.vmware.com/cloudprovider/2021/08/vmware-cloud-director-10-3-new-networking-security-features.html