### PR TITLE
Add support for NSX-T Edge Gateway BGP IP Prefix lists

### DIFF
--- a/.changes/v2.16.0/488-features.md
+++ b/.changes/v2.16.0/488-features.md
@@ -1,0 +1,3 @@
+* Add support for managing NSX-T Edge Gateway BGP IP Prefix Lists. It is done by adding types `EdgeBgpIpPrefixList` and
+`types.EdgeBgpIpPrefixList` with functions `CreateBgpIpPrefixList`, `GetAllBgpIpPrefixLists`,
+`GetBgpIpPrefixListByName`, `GetBgpIpPrefixListById`, `Update` and `Delete`  [GH-488]

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
-	github.com/davecgh/go-spew v1.1.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.1
 	github.com/peterhellberg/link v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
+	github.com/davecgh/go-spew v1.1.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.1
 	github.com/peterhellberg/link v1.1.0

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
@@ -11,14 +11,83 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-type EdgeBgpConfigPrefixList struct {
-	EdgeBgpConfigPrefixList *types.EdgeBgpConfigPrefixList
-	client                  *Client
-	// edgeGatewayId is stored for usage in EdgeBgpConfigPrefixList receiver functions
+// EdgeBgpIpPrefixList helps to configure BGP IP Prefix Lists in NSX-T Edge Gateways
+type EdgeBgpIpPrefixList struct {
+	EdgeBgpIpPrefixList *types.EdgeBgpIpPrefixList
+	client              *Client
+	// edgeGatewayId is stored for usage in EdgeBgpIpPrefixList receiver functions
 	edgeGatewayId string
 }
 
-func (egw *NsxtEdgeGateway) GetAllBgpIpPrefixLists(queryParameters url.Values) ([]*EdgeBgpConfigPrefixList, error) {
+// CreateBgpIpPrefixList creates a BGP IP Prefix List with supplied information
+//
+// Note. VCD 10.2 versions do not automatically return ID for created BGP IP Prefix List. To work around it this code
+// automatically retrieves the entity by Name after the task is finished. This function may fail on VCD 10.2 if
+// duplicate BGP IP Prefix Lists exist.
+func (egw *NsxtEdgeGateway) CreateBgpIpPrefixList(bgpIpPrefixList *types.EdgeBgpIpPrefixList) (*EdgeBgpIpPrefixList, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpIpPrefixList{
+		client:              egw.client,
+		edgeGatewayId:       egw.EdgeGateway.ID,
+		EdgeBgpIpPrefixList: &types.EdgeBgpIpPrefixList{},
+	}
+
+	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, bgpIpPrefixList)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	// API has problems therefore explicit manual handling is required to lookup newly created object
+	// VCD 10.2 -> no ID for newly created object is returned at all
+	// VCD 10.3.3 `Details` field in task contains ID of newly created object
+	// To cover all cases this code will at first look for ID in `Details` field and fall back to
+	// lookup by name if `Details` field is empty.
+	//
+	// The drawback of this is that it is possible to create duplicate records with the same name,
+	// but there is no better way for VCD versions that don't return API code
+
+	bgpIpPrefixListId := task.Task.Details
+	if bgpIpPrefixListId != "" {
+		getUrlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), bgpIpPrefixListId)
+		if err != nil {
+			return nil, err
+		}
+		err = client.OpenApiGetItem(apiVersion, getUrlRef, nil, returnObject.EdgeBgpIpPrefixList, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List after creation: %s", err)
+		}
+	} else {
+		// ID after object creation was not provided therefore retrieving by name
+		// This has a risk of duplicate items, but is the only way to find the object
+		bgpIpPrefixList, err := egw.GetBgpIpPrefixListByName(bgpIpPrefixList.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List after creation: %s", err)
+		}
+		returnObject = bgpIpPrefixList
+	}
+
+	return returnObject, nil
+}
+
+// GetAllBgpIpPrefixLists retrieves all BGP IP Prefix Lists in a given NSX-T Edge Gateway with optional queryParameters
+func (egw *NsxtEdgeGateway) GetAllBgpIpPrefixLists(queryParameters url.Values) ([]*EdgeBgpIpPrefixList, error) {
 	queryParams := copyOrNewUrlValues(queryParameters)
 
 	client := egw.client
@@ -34,19 +103,19 @@ func (egw *NsxtEdgeGateway) GetAllBgpIpPrefixLists(queryParameters url.Values) (
 		return nil, err
 	}
 
-	typeResponses := []*types.EdgeBgpConfigPrefixList{{}}
+	typeResponses := []*types.EdgeBgpIpPrefixList{{}}
 	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParams, &typeResponses, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Wrap all typeResponses into NsxtNatRule types with client
-	wrappedResponses := make([]*EdgeBgpConfigPrefixList, len(typeResponses))
+	wrappedResponses := make([]*EdgeBgpIpPrefixList, len(typeResponses))
 	for sliceIndex := range typeResponses {
-		wrappedResponses[sliceIndex] = &EdgeBgpConfigPrefixList{
-			EdgeBgpConfigPrefixList: typeResponses[sliceIndex],
-			client:                  client,
-			edgeGatewayId:           egw.EdgeGateway.ID,
+		wrappedResponses[sliceIndex] = &EdgeBgpIpPrefixList{
+			EdgeBgpIpPrefixList: typeResponses[sliceIndex],
+			client:              client,
+			edgeGatewayId:       egw.EdgeGateway.ID,
 		}
 	}
 
@@ -54,10 +123,13 @@ func (egw *NsxtEdgeGateway) GetAllBgpIpPrefixLists(queryParameters url.Values) (
 }
 
 // GetBgpIpPrefixListByName retrieves BGP IP Prefix List By Name
+// It is meant to retrieve exactly one entry:
+// * Will fail if more than one entry with the same name found
+// * Will return an error containing `ErrorEntityNotFound` if no entries are found
 //
 // Note. API does not support filtering by 'name' field therefore filtering is performed on client
 // side
-func (egw *NsxtEdgeGateway) GetBgpIpPrefixListByName(name string) (*EdgeBgpConfigPrefixList, error) {
+func (egw *NsxtEdgeGateway) GetBgpIpPrefixListByName(name string) (*EdgeBgpIpPrefixList, error) {
 	if name == "" {
 		return nil, fmt.Errorf("name cannot be empty")
 	}
@@ -67,9 +139,9 @@ func (egw *NsxtEdgeGateway) GetBgpIpPrefixListByName(name string) (*EdgeBgpConfi
 		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
 	}
 
-	var filteredBgpIpPrefixLists []*EdgeBgpConfigPrefixList
+	var filteredBgpIpPrefixLists []*EdgeBgpIpPrefixList
 	for _, bgpIpPrefixList := range allBgpIpPrefixLists {
-		if bgpIpPrefixList.EdgeBgpConfigPrefixList.Name == name {
+		if bgpIpPrefixList.EdgeBgpIpPrefixList.Name == name {
 			filteredBgpIpPrefixLists = append(filteredBgpIpPrefixLists, bgpIpPrefixList)
 		}
 	}
@@ -79,13 +151,14 @@ func (egw *NsxtEdgeGateway) GetBgpIpPrefixListByName(name string) (*EdgeBgpConfi
 	}
 
 	if len(filteredBgpIpPrefixLists) == 0 {
-		return nil, fmt.Errorf("no NSX-T Edge Gateway BGP IP Prefix List found with name '%s'", name)
+		return nil, fmt.Errorf("%s: no NSX-T Edge Gateway BGP IP Prefix List found with name '%s'", ErrorEntityNotFound, name)
 	}
 
 	return filteredBgpIpPrefixLists[0], nil
 }
 
-func (egw *NsxtEdgeGateway) GetBgpIpPrefixListById(id string) (*EdgeBgpConfigPrefixList, error) {
+// GetBgpIpPrefixListById retrieves BGP IP Prefix List By ID
+func (egw *NsxtEdgeGateway) GetBgpIpPrefixListById(id string) (*EdgeBgpIpPrefixList, error) {
 	if id == "" {
 		return nil, fmt.Errorf("id is required")
 	}
@@ -103,13 +176,13 @@ func (egw *NsxtEdgeGateway) GetBgpIpPrefixListById(id string) (*EdgeBgpConfigPre
 		return nil, err
 	}
 
-	returnObject := &EdgeBgpConfigPrefixList{
-		client:                  egw.client,
-		edgeGatewayId:           egw.EdgeGateway.ID,
-		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
+	returnObject := &EdgeBgpIpPrefixList{
+		client:              egw.client,
+		edgeGatewayId:       egw.EdgeGateway.ID,
+		EdgeBgpIpPrefixList: &types.EdgeBgpIpPrefixList{},
 	}
 
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.EdgeBgpConfigPrefixList, nil)
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.EdgeBgpIpPrefixList, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
 	}
@@ -117,60 +190,8 @@ func (egw *NsxtEdgeGateway) GetBgpIpPrefixListById(id string) (*EdgeBgpConfigPre
 	return returnObject, nil
 }
 
-func (egw *NsxtEdgeGateway) CreateBgpIpPrefixList(bgpConfig *types.EdgeBgpConfigPrefixList) (*EdgeBgpConfigPrefixList, error) {
-	client := egw.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// Insert Edge Gateway ID into endpoint path
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &EdgeBgpConfigPrefixList{
-		client:                  egw.client,
-		edgeGatewayId:           egw.EdgeGateway.ID,
-		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
-	}
-
-	// API returns newly created object ID in Details field therefore regular "automatic"
-	// OpenApiPostItem function cannot handle it and a more verbose way is used by tracking task
-	// and looking up inside Details field for object ID lookup
-	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, bgpConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
-	}
-
-	err = task.WaitTaskCompletion()
-	if err != nil {
-		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
-	}
-
-	bgpIpPrefixListId := task.Task.Details
-	if bgpIpPrefixListId == "" {
-		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: empty ID returned")
-	}
-
-	getUrlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), bgpIpPrefixListId)
-	if err != nil {
-		return nil, err
-	}
-	err = client.OpenApiGetItem(apiVersion, getUrlRef, nil, returnObject.EdgeBgpConfigPrefixList, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List after creation: %s", err)
-	}
-
-	return returnObject, nil
-}
-
-//
-// Note. Update of BGP configuration requires version to be specified in 'Version' field. This
-// function automatically handles it.
-func (egwBgpConfig *EdgeBgpConfigPrefixList) UpdateBgpIpPrefixList(bgpConfig *types.EdgeBgpConfigPrefixList) (*EdgeBgpConfigPrefixList, error) {
+// Update updates existing BGP IP Prefix List with new configuration and returns it
+func (egwBgpConfig *EdgeBgpIpPrefixList) Update(bgpIpPrefixList *types.EdgeBgpIpPrefixList) (*EdgeBgpIpPrefixList, error) {
 	client := egwBgpConfig.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
@@ -179,18 +200,18 @@ func (egwBgpConfig *EdgeBgpConfigPrefixList) UpdateBgpIpPrefixList(bgpConfig *ty
 	}
 
 	// Insert Edge Gateway ID into endpoint path
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), bgpConfig.ID)
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), bgpIpPrefixList.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	returnObject := &EdgeBgpConfigPrefixList{
-		client:                  egwBgpConfig.client,
-		edgeGatewayId:           egwBgpConfig.edgeGatewayId,
-		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
+	returnObject := &EdgeBgpIpPrefixList{
+		client:              egwBgpConfig.client,
+		edgeGatewayId:       egwBgpConfig.edgeGatewayId,
+		EdgeBgpIpPrefixList: &types.EdgeBgpIpPrefixList{},
 	}
 
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, bgpConfig, returnObject.EdgeBgpConfigPrefixList, nil)
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, bgpIpPrefixList, returnObject.EdgeBgpIpPrefixList, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error setting NSX-T Edge Gateway BGP IP Prefix List: %s", err)
 	}
@@ -198,7 +219,8 @@ func (egwBgpConfig *EdgeBgpConfigPrefixList) UpdateBgpIpPrefixList(bgpConfig *ty
 	return returnObject, nil
 }
 
-func (egwBgpConfig *EdgeBgpConfigPrefixList) Delete() error {
+// Delete deletes existing IP Prefix List
+func (egwBgpConfig *EdgeBgpIpPrefixList) Delete() error {
 	client := egwBgpConfig.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
@@ -207,7 +229,7 @@ func (egwBgpConfig *EdgeBgpConfigPrefixList) Delete() error {
 	}
 
 	// Insert Edge Gateway ID into endpoint path
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), egwBgpConfig.EdgeBgpConfigPrefixList.ID)
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), egwBgpConfig.EdgeBgpIpPrefixList.ID)
 	if err != nil {
 		return err
 	}

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
@@ -54,7 +54,9 @@ func (egw *NsxtEdgeGateway) CreateBgpIpPrefixList(bgpIpPrefixList *types.EdgeBgp
 		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
 	}
 
-	// API is not consistent across different versions therefore explicit manual handling is required to lookup newly created object
+	// API is not consistent across different versions therefore explicit manual handling is
+	// required to lookup newly created object
+	//
 	// VCD 10.2 -> no ID for newly created object is returned at all
 	// VCD 10.3 -> `Details` field in task contains ID of newly created object
 	// To cover all cases this code will at first look for ID in `Details` field and fall back to

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type EdgeBgpConfigPrefixList struct {
+	EdgeBgpConfigPrefixList *types.EdgeBgpConfigPrefixList
+	client                  *Client
+	// edgeGatewayId is stored for usage in EdgeBgpConfigPrefixList receiver functions
+	edgeGatewayId string
+}
+
+func (egw *NsxtEdgeGateway) GetAllBgpIpPrefixLists(queryParameters url.Values) ([]*EdgeBgpConfigPrefixList, error) {
+	queryParams := copyOrNewUrlValues(queryParameters)
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	typeResponses := []*types.EdgeBgpConfigPrefixList{{}}
+	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParams, &typeResponses, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap all typeResponses into NsxtNatRule types with client
+	wrappedResponses := make([]*EdgeBgpConfigPrefixList, len(typeResponses))
+	for sliceIndex := range typeResponses {
+		wrappedResponses[sliceIndex] = &EdgeBgpConfigPrefixList{
+			EdgeBgpConfigPrefixList: typeResponses[sliceIndex],
+			client:                  client,
+			edgeGatewayId:           egw.EdgeGateway.ID,
+		}
+	}
+
+	return wrappedResponses, nil
+}
+
+// GetBgpIpPrefixListByName retrieves BGP IP Prefix List By Name
+//
+// Note. API does not support filtering by 'name' field therefore filtering is performed on client
+// side
+func (egw *NsxtEdgeGateway) GetBgpIpPrefixListByName(name string) (*EdgeBgpConfigPrefixList, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name cannot be empty")
+	}
+
+	allBgpIpPrefixLists, err := egw.GetAllBgpIpPrefixLists(nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	var filteredBgpIpPrefixLists []*EdgeBgpConfigPrefixList
+	for _, bgpIpPrefixList := range allBgpIpPrefixLists {
+		if bgpIpPrefixList.EdgeBgpConfigPrefixList.Name == name {
+			filteredBgpIpPrefixLists = append(filteredBgpIpPrefixLists, bgpIpPrefixList)
+		}
+	}
+
+	if len(filteredBgpIpPrefixLists) > 1 {
+		return nil, fmt.Errorf("more than one NSX-T Edge Gateway BGP IP Prefix List found with Name '%s'", name)
+	}
+
+	if len(filteredBgpIpPrefixLists) == 0 {
+		return nil, fmt.Errorf("no NSX-T Edge Gateway BGP IP Prefix List found with name '%s'", name)
+	}
+
+	return filteredBgpIpPrefixLists[0], nil
+}
+
+func (egw *NsxtEdgeGateway) GetBgpIpPrefixListById(id string) (*EdgeBgpConfigPrefixList, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id is required")
+	}
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), id)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpConfigPrefixList{
+		client:                  egw.client,
+		edgeGatewayId:           egw.EdgeGateway.ID,
+		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
+	}
+
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.EdgeBgpConfigPrefixList, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+func (egw *NsxtEdgeGateway) CreateBgpIpPrefixList(bgpConfig *types.EdgeBgpConfigPrefixList) (*EdgeBgpConfigPrefixList, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpConfigPrefixList{
+		client:                  egw.client,
+		edgeGatewayId:           egw.EdgeGateway.ID,
+		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
+	}
+
+	// API returns newly created object ID in Details field therefore regular "automatic"
+	// OpenApiPostItem function cannot handle it and a more verbose way is used by tracking task
+	// and looking up inside Details field for object ID lookup
+	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, bgpConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	bgpIpPrefixListId := task.Task.Details
+	if bgpIpPrefixListId == "" {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP IP Prefix List: empty ID returned")
+	}
+
+	getUrlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), bgpIpPrefixListId)
+	if err != nil {
+		return nil, err
+	}
+	err = client.OpenApiGetItem(apiVersion, getUrlRef, nil, returnObject.EdgeBgpConfigPrefixList, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP IP Prefix List after creation: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+//
+// Note. Update of BGP configuration requires version to be specified in 'Version' field. This
+// function automatically handles it.
+func (egwBgpConfig *EdgeBgpConfigPrefixList) UpdateBgpIpPrefixList(bgpConfig *types.EdgeBgpConfigPrefixList) (*EdgeBgpConfigPrefixList, error) {
+	client := egwBgpConfig.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), bgpConfig.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpConfigPrefixList{
+		client:                  egwBgpConfig.client,
+		edgeGatewayId:           egwBgpConfig.edgeGatewayId,
+		EdgeBgpConfigPrefixList: &types.EdgeBgpConfigPrefixList{},
+	}
+
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, bgpConfig, returnObject.EdgeBgpConfigPrefixList, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error setting NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+func (egwBgpConfig *EdgeBgpConfigPrefixList) Delete() error {
+	client := egwBgpConfig.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egwBgpConfig.edgeGatewayId), egwBgpConfig.EdgeBgpConfigPrefixList.ID)
+	if err != nil {
+		return err
+	}
+
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	return nil
+}

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
@@ -8,6 +8,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+// Test_NsxEdgeBgpIpPrefixList tests CRUD operations for NSX-T Edge Gateway BGP IP Prefix Lists
 func (vcd *TestVCD) Test_NsxEdgeBgpIpPrefixList(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpConfigPrefixLists)

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
@@ -89,10 +89,3 @@ func (vcd *TestVCD) Test_NsxEdgeBgpIpPrefixList(check *C) {
 	check.Assert(notFoundById, IsNil)
 
 }
-
-func switchEdgeGatewayDedication(edge *NsxtEdgeGateway, isDedicated bool) error {
-	edge.EdgeGateway.EdgeGatewayUplinks[0].Dedicated = isDedicated
-	_, err := edge.Update(edge.EdgeGateway)
-
-	return err
-}

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
@@ -1,0 +1,97 @@
+//go:build network || nsxt || functional || openapi || ALL
+// +build network nsxt functional openapi ALL
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_NsxEdgeBgpIpPrefixList(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpConfigPrefixLists)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	// Switch Edge Gateway to use dedicated uplink for the time of this test and then turn it off
+	err = switchEdgeGatewayDedication(edge, true) // Turn on Dedicated Tier 0 gateway
+	check.Assert(err, IsNil)
+	defer switchEdgeGatewayDedication(edge, false) // Turn off Dedicated Tier 0 gateway
+
+	// Create a new BGP IP Prefix List
+	bgpIpPrefixList := &types.EdgeBgpIpPrefixList{
+		Name:        check.TestName(),
+		Description: "test-description",
+		Prefixes: []types.EdgeBgpConfigPrefixListPrefixes{
+			{
+				Network: "1.1.1.0/24",
+				Action:  "PERMIT",
+			},
+			{
+				Network:            "2.1.0.0/16",
+				Action:             "PERMIT",
+				LessThanEqualTo:    29,
+				GreaterThanEqualTo: 24,
+			},
+		},
+	}
+
+	bgpIpPrefix, err := edge.CreateBgpIpPrefixList(bgpIpPrefixList)
+	check.Assert(err, IsNil)
+	check.Assert(bgpIpPrefix, NotNil)
+
+	// Get all BGP IP Prefix Lists
+	bgpIpPrefixLists, err := edge.GetAllBgpIpPrefixLists(nil)
+	check.Assert(err, IsNil)
+	check.Assert(bgpIpPrefixLists, NotNil)
+	check.Assert(len(bgpIpPrefixLists), Equals, 1)
+	check.Assert(bgpIpPrefixLists[0].EdgeBgpIpPrefixList.Name, Equals, bgpIpPrefixList.Name)
+
+	// Get By Name
+	bgpPrefixListByName, err := edge.GetBgpIpPrefixListByName(bgpIpPrefixList.Name)
+	check.Assert(err, IsNil)
+	check.Assert(bgpPrefixListByName, NotNil)
+
+	// Get By Id
+	bgpPrefixListById, err := edge.GetBgpIpPrefixListById(bgpIpPrefix.EdgeBgpIpPrefixList.ID)
+	check.Assert(err, IsNil)
+	check.Assert(bgpPrefixListById, NotNil)
+
+	// Update
+	bgpIpPrefixList.Name = check.TestName() + "-updated"
+	bgpIpPrefixList.Description = "test-description-updated"
+	bgpIpPrefixList.ID = bgpIpPrefixLists[0].EdgeBgpIpPrefixList.ID
+
+	updatedBgpIpPrefixList, err := bgpIpPrefixLists[0].Update(bgpIpPrefixList)
+	check.Assert(err, IsNil)
+	check.Assert(updatedBgpIpPrefixList, NotNil)
+
+	check.Assert(updatedBgpIpPrefixList.EdgeBgpIpPrefixList.ID, Equals, bgpIpPrefixLists[0].EdgeBgpIpPrefixList.ID)
+
+	// Delete
+	err = bgpIpPrefixLists[0].Delete()
+	check.Assert(err, IsNil)
+
+	// Try to get once again and ensure it is not there
+	notFoundByName, err := edge.GetBgpIpPrefixListByName(bgpIpPrefixList.Name)
+	check.Assert(err, NotNil)
+	check.Assert(notFoundByName, IsNil)
+
+	notFoundById, err := edge.GetBgpIpPrefixListById(bgpIpPrefix.EdgeBgpIpPrefixList.ID)
+	check.Assert(err, NotNil)
+	check.Assert(notFoundById, IsNil)
+
+}
+
+func switchEdgeGatewayDedication(edge *NsxtEdgeGateway, isDedicated bool) error {
+	edge.EdgeGateway.EdgeGatewayUplinks[0].Dedicated = isDedicated
+	_, err := edge.Update(edge.EdgeGateway)
+
+	return err
+}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -67,6 +67,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibraryOld:         "35.0", // VCD 10.2+ and deprecated from 10.3
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules:                "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles:           "35.0", // VCD 10.2+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpConfigPrefixLists:         "35.0", // VCD 10.2+
 }
 
 // elevateNsxtNatRuleApiVersion helps to elevate API version to consume newer NSX-T NAT Rule features

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -375,6 +375,8 @@ const (
 	OpenApiEndpointSecurityTags                       = "securityTags"
 	OpenApiEndpointNsxtRouteAdvertisement             = "edgeGateways/%s/routing/advertisement"
 
+	OpenApiEndpointEdgeBgpConfigPrefixLists = "edgeGateways/%s/routing/bgp/prefixLists/" // '%s' is NSX-T Edge gateway ID
+
 	// NSX-T ALB related endpoints
 
 	OpenApiEndpointAlbController = "loadBalancer/controllers/"

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1255,7 +1255,8 @@ type RouteAdvertisement struct {
 	Subnets []string `json:"subnets"`
 }
 
-type EdgeBgpConfigPrefixList struct {
+// EdgeBgpIpPrefixList holds BGP IP Prefix List configuration for NSX-T Edge Gateways
+type EdgeBgpIpPrefixList struct {
 	// ID is the unique identifier of the entity in URN format.
 	ID string `json:"id,omitempty"`
 

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1254,3 +1254,36 @@ type RouteAdvertisement struct {
 	// external network.
 	Subnets []string `json:"subnets"`
 }
+
+type EdgeBgpConfigPrefixList struct {
+	// ID is the unique identifier of the entity in URN format.
+	ID string `json:"id,omitempty"`
+
+	// Name of the entity
+	Name string `json:"name"`
+
+	// Description of the entity
+	Description string `json:"description,omitempty"`
+
+	// Prefixes is the list of prefixes that will be advertised so that the Edge Gateway can route out to the
+	// connected external network.
+	Prefixes []EdgeBgpConfigPrefixListPrefixes `json:"prefixes,omitempty"`
+}
+
+// EdgeBgpConfigPrefixListPrefixes is a list of prefixes that will be advertised so that the Edge Gateway can route out to the
+// connected external network.
+type EdgeBgpConfigPrefixListPrefixes struct {
+	// Network is the network address of the prefix
+	Network string `json:"network,omitempty"`
+
+	// Action is the action to be taken on the prefix. Can be 'PERMIT' or 'DENY'
+	Action string `json:"action,omitempty"`
+
+	// GreateerThan is the the value which the prefix length must be greater than or equal to. Must
+	// be less than or equal to 'LessThanEqualTo'
+	GreaterThanEqualTo int `json:"greaterThanEqualTo,omitempty"`
+
+	// The value which the prefix length must be less than or equal to. Must be greater than or
+	// equal to 'GreaterThanEqualTo'
+	LessThanEqualTo int `json:"lessThanEqualTo,omitempty"`
+}


### PR DESCRIPTION
This PR continues to add support for BGP configuration (as PR #480)  for BGP and adds support for  IP Prefix Lists. These list can be consumed when defining BGP neighbors (a PR yet to be done)

It adds types `EdgeBgpIpPrefixList` and `types.EdgeBgpIpPrefixList` with functions `CreateBgpIpPrefixList`, `GetAllBgpIpPrefixLists`, `GetBgpIpPrefixListByName`, `GetBgpIpPrefixListById`, `Update` and `Delete`

**Note.** VCD 10.2 versions have a problem - they do not return a new entity ID when it is created. Function `CreateBgpIpPrefixList` handles this internally by waiting for task completion and checking if ID was returned (it is returned in 10.3). If the ID is not returned - the function will lookup the entity by Name and return it with the corresponding ID. **There is a risk that** - if more than one entity with such a name exists - it will fail to find a correct object and return an error. 



VCD Docs ->  https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Service-Provider-Admin-Portal-Guide/GUID-F2A3BC91-036A-4E29-A1C9-6EAB8602562E.html