### PR TITLE
Add support for NSX-T Edge Gateway BGP Neighbor configuration

### DIFF
--- a/.changes/v2.16.0/489-features.md
+++ b/.changes/v2.16.0/489-features.md
@@ -1,0 +1,3 @@
+* Add support for managing NSX-T Edge Gateway BGP Neighbor. It is done by adding types `EdgeBgpNeighbor` and
+  `types.EdgeBgpNeighbor` with functions `CreateBgpNeighbor`, `GetAllBgpNeighbors`,
+  `GetBgpNeighborByIp`, `GetBgpNeighborById`, `Update` and `Delete`  [GH-489]

--- a/govcd/nsxt_edgegateway_bgp_neighbor.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+// EdgeBgpNeighbor represents NSX-T Edge Gateway BGP Neighbor
 type EdgeBgpNeighbor struct {
 	EdgeBgpNeighbor *types.EdgeBgpNeighbor
 	client          *Client
@@ -18,6 +19,7 @@ type EdgeBgpNeighbor struct {
 	edgeGatewayId string
 }
 
+// CreateBgpNeighbor creates BGP Neighbor with the given configuration
 func (egw *NsxtEdgeGateway) CreateBgpNeighbor(bgpNeighborConfig *types.EdgeBgpNeighbor) (*EdgeBgpNeighbor, error) {
 	client := egw.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
@@ -70,16 +72,17 @@ func (egw *NsxtEdgeGateway) CreateBgpNeighbor(bgpNeighborConfig *types.EdgeBgpNe
 	} else {
 		// ID after object creation was not returned therefore retrieving the entity by Name to lookup ID
 		// This has a risk of duplicate items, but is the only way to find the object when ID is not returned
-		bgpIpPrefixList, err := egw.GetBgpNeighborByIp(bgpNeighborConfig.NeighborAddress)
+		bgpNeighbor, err := egw.GetBgpNeighborByIp(bgpNeighborConfig.NeighborAddress)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP Neighbor after creation: %s", err)
 		}
-		returnObject = bgpIpPrefixList
+		returnObject = bgpNeighbor
 	}
 
 	return returnObject, nil
 }
 
+// GetAllBgpNeighbors retrieves all BGP Neighbors
 func (egw *NsxtEdgeGateway) GetAllBgpNeighbors(queryParameters url.Values) ([]*EdgeBgpNeighbor, error) {
 	queryParams := copyOrNewUrlValues(queryParameters)
 
@@ -115,12 +118,13 @@ func (egw *NsxtEdgeGateway) GetAllBgpNeighbors(queryParameters url.Values) ([]*E
 	return wrappedResponses, nil
 }
 
-// GetBgpNeighborByIp retrieves BGP IP Prefix List By Name
+// GetBgpNeighborByIp retrieves BGP Neighbor by Neighbor IP address
 // It is meant to retrieve exactly one entry:
-// * Will fail if more than one entry with the same name found
+// * Will fail if more than one entry with the same Neighbor IP found (should not happen as uniqueness is
+// enforced by API)
 // * Will return an error containing `ErrorEntityNotFound` if no entries are found
 //
-// Note. API does not support filtering by 'name' field therefore filtering is performed on client
+// Note. API does not support filtering by 'neighborIpAddress' field therefore filtering is performed on client
 // side
 func (egw *NsxtEdgeGateway) GetBgpNeighborByIp(neighborIpAddress string) (*EdgeBgpNeighbor, error) {
 	if neighborIpAddress == "" {
@@ -133,9 +137,9 @@ func (egw *NsxtEdgeGateway) GetBgpNeighborByIp(neighborIpAddress string) (*EdgeB
 	}
 
 	var filteredBgpNeighbors []*EdgeBgpNeighbor
-	for _, bgpIpPrefixList := range allBgpNeighbors {
-		if bgpIpPrefixList.EdgeBgpNeighbor.NeighborAddress == neighborIpAddress {
-			filteredBgpNeighbors = append(filteredBgpNeighbors, bgpIpPrefixList)
+	for _, bgpNeighbor := range allBgpNeighbors {
+		if bgpNeighbor.EdgeBgpNeighbor.NeighborAddress == neighborIpAddress {
+			filteredBgpNeighbors = append(filteredBgpNeighbors, bgpNeighbor)
 		}
 	}
 
@@ -150,7 +154,7 @@ func (egw *NsxtEdgeGateway) GetBgpNeighborByIp(neighborIpAddress string) (*EdgeB
 	return filteredBgpNeighbors[0], nil
 }
 
-// GetBgpNeighborById retrieves BGP IP Prefix List By ID
+// GetBgpNeighborById retrieves BGP Neighbor By ID
 func (egw *NsxtEdgeGateway) GetBgpNeighborById(id string) (*EdgeBgpNeighbor, error) {
 	if id == "" {
 		return nil, fmt.Errorf("id is required")
@@ -183,7 +187,7 @@ func (egw *NsxtEdgeGateway) GetBgpNeighborById(id string) (*EdgeBgpNeighbor, err
 	return returnObject, nil
 }
 
-// Update updates existing BGP IP Prefix List with new configuration and returns it
+// Update updates existing BGP Neighbor with new configuration and returns it
 func (bgpNeighbor *EdgeBgpNeighbor) Update(bgpNeighborConfig *types.EdgeBgpNeighbor) (*EdgeBgpNeighbor, error) {
 	client := bgpNeighbor.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
@@ -212,7 +216,7 @@ func (bgpNeighbor *EdgeBgpNeighbor) Update(bgpNeighborConfig *types.EdgeBgpNeigh
 	return returnObject, nil
 }
 
-// Delete deletes existing BGP IP Prefix List
+// Delete deletes existing BGP Neighbor
 func (bgpNeighbor *EdgeBgpNeighbor) Delete() error {
 	client := bgpNeighbor.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor

--- a/govcd/nsxt_edgegateway_bgp_neighbor.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type EdgeBgpNeighbor struct {
+	EdgeBgpNeighbor *types.EdgeBgpNeighbor
+	client          *Client
+	// edgeGatewayId is stored for usage in EdgeBgpNeighbor receiver functions
+	edgeGatewayId string
+}
+
+func (egw *NsxtEdgeGateway) CreateBgpNeighbor(bgpNeighborConfig *types.EdgeBgpNeighbor) (*EdgeBgpNeighbor, error) {
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpNeighbor{
+		client:          egw.client,
+		edgeGatewayId:   egw.EdgeGateway.ID,
+		EdgeBgpNeighbor: &types.EdgeBgpNeighbor{},
+	}
+
+	task, err := client.OpenApiPostItemAsync(apiVersion, urlRef, nil, bgpNeighborConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, fmt.Errorf("error creating NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	// API has problems therefore explicit manual handling is required to lookup newly created object
+	// VCD 10.2 -> no ID for newly created object is returned at all
+	// VCD 10.3 -> `Details` field in task contains ID of newly created object
+	// To cover all cases this code will at first look for ID in `Details` field and fall back to
+	// lookup by name if `Details` field is empty.
+	//
+	// The drawback of this is that it is possible to create duplicate records with the same name on VCDs that don't
+	// return IDs, but there is no better way for VCD versions that don't return API code
+
+	bgpNeighborId := task.Task.Details
+	if bgpNeighborId != "" {
+		getUrlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), bgpNeighborId)
+		if err != nil {
+			return nil, err
+		}
+		err = client.OpenApiGetItem(apiVersion, getUrlRef, nil, returnObject.EdgeBgpNeighbor, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP Neighbor after creation: %s", err)
+		}
+	} else {
+		// ID after object creation was not returned therefore retrieving the entity by Name to lookup ID
+		// This has a risk of duplicate items, but is the only way to find the object when ID is not returned
+		bgpIpPrefixList, err := egw.GetBgpNeighborByIp(bgpNeighborConfig.NeighborAddress)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP Neighbor after creation: %s", err)
+		}
+		returnObject = bgpIpPrefixList
+	}
+
+	return returnObject, nil
+}
+
+func (egw *NsxtEdgeGateway) GetAllBgpNeighbors(queryParameters url.Values) ([]*EdgeBgpNeighbor, error) {
+	queryParams := copyOrNewUrlValues(queryParameters)
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	typeResponses := []*types.EdgeBgpNeighbor{{}}
+	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParams, &typeResponses, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap all typeResponses into NsxtNatRule types with client
+	wrappedResponses := make([]*EdgeBgpNeighbor, len(typeResponses))
+	for sliceIndex := range typeResponses {
+		wrappedResponses[sliceIndex] = &EdgeBgpNeighbor{
+			EdgeBgpNeighbor: typeResponses[sliceIndex],
+			client:          client,
+			edgeGatewayId:   egw.EdgeGateway.ID,
+		}
+	}
+
+	return wrappedResponses, nil
+}
+
+// GetBgpNeighborByIp retrieves BGP IP Prefix List By Name
+// It is meant to retrieve exactly one entry:
+// * Will fail if more than one entry with the same name found
+// * Will return an error containing `ErrorEntityNotFound` if no entries are found
+//
+// Note. API does not support filtering by 'name' field therefore filtering is performed on client
+// side
+func (egw *NsxtEdgeGateway) GetBgpNeighborByIp(neighborIpAddress string) (*EdgeBgpNeighbor, error) {
+	if neighborIpAddress == "" {
+		return nil, fmt.Errorf("neighborIpAddress cannot be empty")
+	}
+
+	allBgpNeighbors, err := egw.GetAllBgpNeighbors(nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	var filteredBgpNeighbors []*EdgeBgpNeighbor
+	for _, bgpIpPrefixList := range allBgpNeighbors {
+		if bgpIpPrefixList.EdgeBgpNeighbor.NeighborAddress == neighborIpAddress {
+			filteredBgpNeighbors = append(filteredBgpNeighbors, bgpIpPrefixList)
+		}
+	}
+
+	if len(filteredBgpNeighbors) > 1 {
+		return nil, fmt.Errorf("more than one NSX-T Edge Gateway BGP Neighbor found with IP Address '%s'", neighborIpAddress)
+	}
+
+	if len(filteredBgpNeighbors) == 0 {
+		return nil, fmt.Errorf("%s: no NSX-T Edge Gateway BGP Neighbor found with IP Address '%s'", ErrorEntityNotFound, neighborIpAddress)
+	}
+
+	return filteredBgpNeighbors[0], nil
+}
+
+// GetBgpNeighborById retrieves BGP IP Prefix List By ID
+func (egw *NsxtEdgeGateway) GetBgpNeighborById(id string) (*EdgeBgpNeighbor, error) {
+	if id == "" {
+		return nil, fmt.Errorf("id is required")
+	}
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID), id)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpNeighbor{
+		client:          egw.client,
+		edgeGatewayId:   egw.EdgeGateway.ID,
+		EdgeBgpNeighbor: &types.EdgeBgpNeighbor{},
+	}
+
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.EdgeBgpNeighbor, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+// Update updates existing BGP IP Prefix List with new configuration and returns it
+func (bgpNeighbor *EdgeBgpNeighbor) Update(bgpNeighborConfig *types.EdgeBgpNeighbor) (*EdgeBgpNeighbor, error) {
+	client := bgpNeighbor.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, bgpNeighbor.edgeGatewayId), bgpNeighborConfig.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	returnObject := &EdgeBgpNeighbor{
+		client:          bgpNeighbor.client,
+		edgeGatewayId:   bgpNeighbor.edgeGatewayId,
+		EdgeBgpNeighbor: &types.EdgeBgpNeighbor{},
+	}
+
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, bgpNeighborConfig, returnObject.EdgeBgpNeighbor, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error setting NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	return returnObject, nil
+}
+
+// Delete deletes existing BGP IP Prefix List
+func (bgpNeighbor *EdgeBgpNeighbor) Delete() error {
+	client := bgpNeighbor.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return err
+	}
+
+	// Insert Edge Gateway ID into endpoint path
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, bgpNeighbor.edgeGatewayId), bgpNeighbor.EdgeBgpNeighbor.ID)
+	if err != nil {
+		return err
+	}
+
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	return nil
+}

--- a/govcd/nsxt_edgegateway_bgp_neighbor.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor.go
@@ -82,7 +82,7 @@ func (egw *NsxtEdgeGateway) CreateBgpNeighbor(bgpNeighborConfig *types.EdgeBgpNe
 	return returnObject, nil
 }
 
-// GetAllBgpNeighbors retrieves all BGP Neighbors
+// GetAllBgpNeighbors retrieves all BGP Neighbors with an optional filter
 func (egw *NsxtEdgeGateway) GetAllBgpNeighbors(queryParameters url.Values) ([]*EdgeBgpNeighbor, error) {
 	queryParams := copyOrNewUrlValues(queryParameters)
 
@@ -105,7 +105,6 @@ func (egw *NsxtEdgeGateway) GetAllBgpNeighbors(queryParameters url.Values) ([]*E
 		return nil, err
 	}
 
-	// Wrap all typeResponses into NsxtNatRule types with client
 	wrappedResponses := make([]*EdgeBgpNeighbor, len(typeResponses))
 	for sliceIndex := range typeResponses {
 		wrappedResponses[sliceIndex] = &EdgeBgpNeighbor{

--- a/govcd/nsxt_edgegateway_bgp_neighbor_test.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor_test.go
@@ -24,8 +24,8 @@ func (vcd *TestVCD) Test_NsxEdgeBgpNeighbor(check *C) {
 	check.Assert(err, IsNil)
 	defer switchEdgeGatewayDedication(edge, false) // Turn off Dedicated Tier 0 gateway
 
-	// Create a new BGP IP Prefix List
-	BgpNeighbor := &types.EdgeBgpNeighbor{
+	// Create a new BGP IP Neighbor
+	bgpNeighbor := &types.EdgeBgpNeighbor{
 		NeighborAddress:        "11.11.11.11",
 		RemoteASNumber:         "64123",
 		KeepAliveTimer:         80,
@@ -36,47 +36,47 @@ func (vcd *TestVCD) Test_NsxEdgeBgpNeighbor(check *C) {
 		IpAddressTypeFiltering: "DISABLED",
 	}
 
-	bgpIpPrefix, err := edge.CreateBgpNeighbor(BgpNeighbor)
+	createdBgpNeighbor, err := edge.CreateBgpNeighbor(bgpNeighbor)
 	check.Assert(err, IsNil)
-	check.Assert(bgpIpPrefix, NotNil)
+	check.Assert(createdBgpNeighbor, NotNil)
 
-	// Get all BGP IP Prefix Lists
+	// Get all BGP Neighbors
 	BgpNeighbors, err := edge.GetAllBgpNeighbors(nil)
 	check.Assert(err, IsNil)
 	check.Assert(BgpNeighbors, NotNil)
 	check.Assert(len(BgpNeighbors), Equals, 1)
-	check.Assert(BgpNeighbors[0].EdgeBgpNeighbor.NeighborAddress, Equals, BgpNeighbor.NeighborAddress)
+	check.Assert(BgpNeighbors[0].EdgeBgpNeighbor.NeighborAddress, Equals, bgpNeighbor.NeighborAddress)
 
-	// Get By Neighbor IP Address
-	bgpPrefixListByName, err := edge.GetBgpNeighborByIp(BgpNeighbor.NeighborAddress)
+	// Get BGP Neighbor By Neighbor IP Address
+	bgpNeighborByIp, err := edge.GetBgpNeighborByIp(bgpNeighbor.NeighborAddress)
 	check.Assert(err, IsNil)
-	check.Assert(bgpPrefixListByName, NotNil)
+	check.Assert(bgpNeighborByIp, NotNil)
 
-	// Get By Id
-	bgpPrefixListById, err := edge.GetBgpNeighborById(bgpIpPrefix.EdgeBgpNeighbor.ID)
+	// Get BGP Neighbor By Id
+	bgpNeighborById, err := edge.GetBgpNeighborById(createdBgpNeighbor.EdgeBgpNeighbor.ID)
 	check.Assert(err, IsNil)
-	check.Assert(bgpPrefixListById, NotNil)
+	check.Assert(bgpNeighborById, NotNil)
 
-	// Update
-	BgpNeighbor.NeighborAddress = "12.12.12.12"
-	BgpNeighbor.ID = BgpNeighbors[0].EdgeBgpNeighbor.ID
+	// Update BGP Neighbor
+	bgpNeighbor.NeighborAddress = "12.12.12.12"
+	bgpNeighbor.ID = BgpNeighbors[0].EdgeBgpNeighbor.ID
 
-	updatedBgpNeighbor, err := BgpNeighbors[0].Update(BgpNeighbor)
+	updatedBgpNeighbor, err := BgpNeighbors[0].Update(bgpNeighbor)
 	check.Assert(err, IsNil)
 	check.Assert(updatedBgpNeighbor, NotNil)
 
 	check.Assert(updatedBgpNeighbor.EdgeBgpNeighbor.ID, Equals, BgpNeighbors[0].EdgeBgpNeighbor.ID)
 
-	// Delete
+	// Delete BGP Neighbor
 	err = BgpNeighbors[0].Delete()
 	check.Assert(err, IsNil)
 
-	// Try to get once again and ensure it is not there
-	notFoundByName, err := edge.GetBgpNeighborByIp(BgpNeighbor.NeighborAddress)
+	// Try to get deleted BGP Neighbor once again and ensure it is not there
+	notFoundByIp, err := edge.GetBgpNeighborByIp(bgpNeighbor.NeighborAddress)
 	check.Assert(err, NotNil)
-	check.Assert(notFoundByName, IsNil)
+	check.Assert(notFoundByIp, IsNil)
 
-	notFoundById, err := edge.GetBgpNeighborById(bgpIpPrefix.EdgeBgpNeighbor.ID)
+	notFoundById, err := edge.GetBgpNeighborById(createdBgpNeighbor.EdgeBgpNeighbor.ID)
 	check.Assert(err, NotNil)
 	check.Assert(notFoundById, IsNil)
 

--- a/govcd/nsxt_edgegateway_bgp_neighbor_test.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor_test.go
@@ -1,0 +1,90 @@
+//go:build network || nsxt || functional || openapi || ALL
+// +build network nsxt functional openapi ALL
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_NsxEdgeBgpNeighbor(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpNeighbor)
+
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	nsxtVdc, err := org.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+	edge, err := nsxtVdc.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
+	check.Assert(err, IsNil)
+
+	// Switch Edge Gateway to use dedicated uplink for the time of this test and then turn it off
+	err = switchEdgeGatewayDedication(edge, true) // Turn on Dedicated Tier 0 gateway
+	check.Assert(err, IsNil)
+	defer switchEdgeGatewayDedication(edge, false) // Turn off Dedicated Tier 0 gateway
+
+	// Create a new BGP IP Prefix List
+	BgpNeighbor := &types.EdgeBgpNeighbor{
+		NeighborAddress:        "11.11.11.11",
+		RemoteASNumber:         "64123",
+		KeepAliveTimer:         80,
+		HoldDownTimer:          241,
+		NeighborPassword:       "iQuee-ph2phe",
+		AllowASIn:              true,
+		GracefulRestartMode:    "HELPER_ONLY",
+		IpAddressTypeFiltering: "DISABLED",
+	}
+
+	bgpIpPrefix, err := edge.CreateBgpNeighbor(BgpNeighbor)
+	check.Assert(err, IsNil)
+	check.Assert(bgpIpPrefix, NotNil)
+
+	// Get all BGP IP Prefix Lists
+	BgpNeighbors, err := edge.GetAllBgpNeighbors(nil)
+	check.Assert(err, IsNil)
+	check.Assert(BgpNeighbors, NotNil)
+	check.Assert(len(BgpNeighbors), Equals, 1)
+	check.Assert(BgpNeighbors[0].EdgeBgpNeighbor.NeighborAddress, Equals, BgpNeighbor.NeighborAddress)
+
+	// Get By Neighbor IP Address
+	bgpPrefixListByName, err := edge.GetBgpNeighborByIp(BgpNeighbor.NeighborAddress)
+	check.Assert(err, IsNil)
+	check.Assert(bgpPrefixListByName, NotNil)
+
+	// Get By Id
+	bgpPrefixListById, err := edge.GetBgpNeighborById(bgpIpPrefix.EdgeBgpNeighbor.ID)
+	check.Assert(err, IsNil)
+	check.Assert(bgpPrefixListById, NotNil)
+
+	// Update
+	BgpNeighbor.NeighborAddress = "12.12.12.12"
+	BgpNeighbor.ID = BgpNeighbors[0].EdgeBgpNeighbor.ID
+
+	updatedBgpNeighbor, err := BgpNeighbors[0].Update(BgpNeighbor)
+	check.Assert(err, IsNil)
+	check.Assert(updatedBgpNeighbor, NotNil)
+
+	check.Assert(updatedBgpNeighbor.EdgeBgpNeighbor.ID, Equals, BgpNeighbors[0].EdgeBgpNeighbor.ID)
+
+	// Delete
+	err = BgpNeighbors[0].Delete()
+	check.Assert(err, IsNil)
+
+	// Try to get once again and ensure it is not there
+	notFoundByName, err := edge.GetBgpNeighborByIp(BgpNeighbor.NeighborAddress)
+	check.Assert(err, NotNil)
+	check.Assert(notFoundByName, IsNil)
+
+	notFoundById, err := edge.GetBgpNeighborById(bgpIpPrefix.EdgeBgpNeighbor.ID)
+	check.Assert(err, NotNil)
+	check.Assert(notFoundById, IsNil)
+
+}
+
+func switchEdgeGatewayDedication(edge *NsxtEdgeGateway, isDedicated bool) error {
+	edge.EdgeGateway.EdgeGatewayUplinks[0].Dedicated = isDedicated
+	_, err := edge.Update(edge.EdgeGateway)
+
+	return err
+}

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -67,6 +67,8 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibraryOld:         "35.0", // VCD 10.2+ and deprecated from 10.3
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules:                "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles:           "35.0", // VCD 10.2+
+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeBgpNeighbor: "35.0", // VCD 10.2+
 }
 
 // elevateNsxtNatRuleApiVersion helps to elevate API version to consume newer NSX-T NAT Rule features

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -375,6 +375,7 @@ const (
 	OpenApiEndpointSecurityTags                       = "securityTags"
 	OpenApiEndpointNsxtRouteAdvertisement             = "edgeGateways/%s/routing/advertisement"
 
+	OpenApiEndpointEdgeBgpNeighbor = "edgeGateways/%s/routing/bgp/neighbors/" // '%s' is NSX-T Edge gateway ID
 	// NSX-T ALB related endpoints
 
 	OpenApiEndpointAlbController = "loadBalancer/controllers/"

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1255,6 +1255,7 @@ type RouteAdvertisement struct {
 	Subnets []string `json:"subnets"`
 }
 
+// EdgeBgpNeighbor represents a BGP neighbor on the NSX-T Edge Gateway
 type EdgeBgpNeighbor struct {
 	ID string `json:"id,omitempty"`
 
@@ -1262,6 +1263,7 @@ type EdgeBgpNeighbor struct {
 	//
 	// Note. Uniqueness is enforced by NeighborAddress
 	NeighborAddress string `json:"neighborAddress"`
+
 	// RemoteASNumber specified Autonomous System (AS) number of a BGP neighbor in ASPLAIN format.
 	RemoteASNumber string `json:"remoteASNumber"`
 
@@ -1274,20 +1276,20 @@ type EdgeBgpNeighbor struct {
 
 	// NeighborPassword for BGP neighbor authentication. Empty string ("") clears existing password.
 	// Not specifying a value will be treated as "no password".
-	NeighborPassword string `json:"neighborPassword,omitempty"`
+	NeighborPassword string `json:"neighborPassword"`
 
 	// AllowASIn is a flag indicating whether BGP neighbors can receive routes with same AS.
 	AllowASIn bool `json:"allowASIn,omitempty"`
 
 	// GracefulRestartMode Describes Graceful Restart configuration Modes for BGP configuration on
-	// an edge gateway. HELPER_ONLY mode is the ability for a BGP speaker to indicate its ability to
-	// preserve forwarding state during BGP restart. GRACEFUL_RESTART mode is the ability of a BGP
-	// speaker to advertise its restart to its peers.
+	// an Edge Gateway.
 	//
 	// Possible values are: DISABLE , HELPER_ONLY , GRACEFUL_AND_HELPER
 	// * DISABLE - Both graceful restart and helper modes are disabled.
-	// * HELPER_ONLY - Only helper mode is enabled.
-	// * GRACEFUL_AND_HELPER - Both graceful restart and helper modes are enabled.
+	// * HELPER_ONLY - Only helper mode is enabled. (ability for a BGP speaker to indicate its ability to preserve
+	//   forwarding state during BGP restart
+	// * GRACEFUL_AND_HELPER - Both graceful restart and helper modes are enabled.  Ability of a BGP
+	//	 speaker to advertise its restart to its peers.
 	GracefulRestartMode string `json:"gracefulRestartMode,omitempty"`
 
 	// IpAddressTypeFiltering specifies IP address type based filtering in each direction. Setting
@@ -1296,23 +1298,22 @@ type EdgeBgpNeighbor struct {
 	// Possible values are: IPV4 , IPV6 , DISABLED
 	IpAddressTypeFiltering string `json:"ipAddressTypeFiltering,omitempty"`
 
-	// InRoutesFilterRef specifies route filtering configuration for the BGP neighbor in IN
+	// InRoutesFilterRef specifies route filtering configuration for the BGP neighbor in 'IN'
 	// direction. It is the reference to the prefix list, indicating which routes to filter for IN
 	// direction. Not specifying a value will be treated as "no IN route filters".
 	InRoutesFilterRef *OpenApiReference `json:"inRoutesFilterRef,omitempty"`
 
-	// OutRoutesFilterRef specifies route filtering configuration for the BGP neighbor in OUT
+	// OutRoutesFilterRef specifies route filtering configuration for the BGP neighbor in 'OUT'
 	// direction. It is the reference to the prefix list, indicating which routes to filter for OUT
 	// direction. Not specifying a value will be treated as "no OUT route filters".
 	OutRoutesFilterRef *OpenApiReference `json:"outRoutesFilterRef,omitempty"`
 
-	// Specifies the BFD configuration for failure detection. Not specifying a value results in
-	// default behavior.
+	// Specifies the BFD  (Bidirectional Forwarding Detection) configuration for failure detection. Not specifying a value
+	// results in default behavior.
 	Bfd *EdgeBgpNeighborBfd `json:"bfd,omitempty"`
 }
 
-// EdgeBgpNeighborBfd describes BFD (Bidirectional Forwarding Detection) configuration for failure
-// detection.
+// EdgeBgpNeighborBfd describes BFD (Bidirectional Forwarding Detection) configuration for failure detection.
 type EdgeBgpNeighborBfd struct {
 	// A flag indicating whether BFD configuration is enabled or not.
 	Enabled bool `json:"enabled"`

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1254,3 +1254,73 @@ type RouteAdvertisement struct {
 	// external network.
 	Subnets []string `json:"subnets"`
 }
+
+type EdgeBgpNeighbor struct {
+	ID string `json:"id,omitempty"`
+
+	// NeighborAddress holds IP address of the BGP neighbor. Both IPv4 and IPv6 formats are supported.
+	//
+	// Note. Uniqueness is enforced by NeighborAddress
+	NeighborAddress string `json:"neighborAddress"`
+	// RemoteASNumber specified Autonomous System (AS) number of a BGP neighbor in ASPLAIN format.
+	RemoteASNumber string `json:"remoteASNumber"`
+
+	// KeepAliveTimer specifies the time interval (in seconds) between keep alive messages sent to
+	// peer.
+	KeepAliveTimer int `json:"keepAliveTimer,omitempty"`
+
+	// HoldDownTimer specifies the time interval (in seconds) before declaring a peer dead.
+	HoldDownTimer int `json:"holdDownTimer,omitempty"`
+
+	// NeighborPassword for BGP neighbor authentication. Empty string ("") clears existing password.
+	// Not specifying a value will be treated as "no password".
+	NeighborPassword string `json:"neighborPassword,omitempty"`
+
+	// AllowASIn is a flag indicating whether BGP neighbors can receive routes with same AS.
+	AllowASIn bool `json:"allowASIn,omitempty"`
+
+	// GracefulRestartMode Describes Graceful Restart configuration Modes for BGP configuration on
+	// an edge gateway. HELPER_ONLY mode is the ability for a BGP speaker to indicate its ability to
+	// preserve forwarding state during BGP restart. GRACEFUL_RESTART mode is the ability of a BGP
+	// speaker to advertise its restart to its peers.
+	//
+	// Possible values are: DISABLE , HELPER_ONLY , GRACEFUL_AND_HELPER
+	// * DISABLE - Both graceful restart and helper modes are disabled.
+	// * HELPER_ONLY - Only helper mode is enabled.
+	// * GRACEFUL_AND_HELPER - Both graceful restart and helper modes are enabled.
+	GracefulRestartMode string `json:"gracefulRestartMode,omitempty"`
+
+	// IpAddressTypeFiltering specifies IP address type based filtering in each direction. Setting
+	// the value to "DISABLED" will disable address family based filtering.
+	//
+	// Possible values are: IPV4 , IPV6 , DISABLED
+	IpAddressTypeFiltering string `json:"ipAddressTypeFiltering,omitempty"`
+
+	// InRoutesFilterRef specifies route filtering configuration for the BGP neighbor in IN
+	// direction. It is the reference to the prefix list, indicating which routes to filter for IN
+	// direction. Not specifying a value will be treated as "no IN route filters".
+	InRoutesFilterRef *OpenApiReference `json:"inRoutesFilterRef,omitempty"`
+
+	// OutRoutesFilterRef specifies route filtering configuration for the BGP neighbor in OUT
+	// direction. It is the reference to the prefix list, indicating which routes to filter for OUT
+	// direction. Not specifying a value will be treated as "no OUT route filters".
+	OutRoutesFilterRef *OpenApiReference `json:"outRoutesFilterRef,omitempty"`
+
+	// Specifies the BFD configuration for failure detection. Not specifying a value results in
+	// default behavior.
+	Bfd *EdgeBgpNeighborBfd `json:"bfd,omitempty"`
+}
+
+// EdgeBgpNeighborBfd describes BFD (Bidirectional Forwarding Detection) configuration for failure
+// detection.
+type EdgeBgpNeighborBfd struct {
+	// A flag indicating whether BFD configuration is enabled or not.
+	Enabled bool `json:"enabled"`
+
+	// BfdInterval specifies the time interval (in milliseconds) between heartbeat packets.
+	BfdInterval int `json:"bfdInterval,omitempty"`
+
+	// DeclareDeadMultiple specifies number of times heartbeat packet is missed before BFD declares
+	// that the neighbor is down.
+	DeclareDeadMultiple int `json:"declareDeadMultiple,omitempty"`
+}

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1336,7 +1336,7 @@ type EdgeBgpNeighbor struct {
 	// direction. Not specifying a value will be treated as "no OUT route filters".
 	OutRoutesFilterRef *OpenApiReference `json:"outRoutesFilterRef,omitempty"`
 
-	// Specifies the BFD  (Bidirectional Forwarding Detection) configuration for failure detection. Not specifying a value
+	// Specifies the BFD (Bidirectional Forwarding Detection) configuration for failure detection. Not specifying a value
 	// results in default behavior.
 	Bfd *EdgeBgpNeighborBfd `json:"bfd,omitempty"`
 }


### PR DESCRIPTION
This PR continues on the track of PRs #480 and #488 and completes coverage of NSX-T Edge Gateway BGP Configuration by adding Neighbor configuration support.

Add support for managing NSX-T Edge Gateway BGP Neighbor. It is done by adding types `EdgeBgpNeighbor` and
  `types.EdgeBgpNeighbor` with functions `CreateBgpNeighbor`, `GetAllBgpNeighbors`,
  `GetBgpNeighborByIp`, `GetBgpNeighborById`, `Update` and `Delete`

Note. VCD 10.2 versions have a problem - they do not return a new entity ID when it is created. Function `CreateBgpNeighbor` handles this internally by waiting for task completion and checking if ID was returned (it is returned in 10.3). If the ID is not returned - the function will lookup the entity Neighbor IP address. This should be safe (as opposed to lookup by name in `CreateBgpIpPrefixList`) as the uniqueness of this IP is enforced by API