### PR TITLE
Add ResourcePoolRefs read support for AdminVdc type

### DIFF
--- a/.changes/v2.17.0/494-improvements.md
+++ b/.changes/v2.17.0/494-improvements.md
@@ -1,0 +1,1 @@
+Fix type `types.AdminVdc.ResourcePoolRefs` to make unmarshaling work (read-only) [GH-494]

--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -251,6 +251,10 @@ func (adminVdc *AdminVdc) Update() (AdminVdc, error) {
 
 	util.Logger.Printf("[DEBUG] Update call function for version %s", vdcFunctions.SupportedVersion)
 
+	// Explicitly remove ResourcePoolRefs because it cannot be set and breaks Go marshaling bug
+	// https://github.com/golang/go/issues/9519
+	adminVdc.AdminVdc.ResourcePoolRefs = nil
+
 	updatedAdminVdc, err := vdcFunctions.UpdateVdc(adminVdc)
 	if err != nil {
 		return AdminVdc{}, err

--- a/govcd/adminvdc_nsxt_test.go
+++ b/govcd/adminvdc_nsxt_test.go
@@ -12,7 +12,6 @@ package govcd
 import (
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
@@ -122,8 +121,7 @@ func (vcd *TestVCD) Test_CreateNsxtOrgVdc(check *C) {
 		check.Assert(vdc.Vdc.Name, Equals, vdcConfiguration.Name)
 		check.Assert(vdc.Vdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 		check.Assert(vdc.Vdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
-		spew.Dump(adminVdc.AdminVdc)
-		// check.Assert(len(adminVdc.AdminVdc.ResourcePoolRefs) > 0, Equals, true)
+		check.Assert(len(adminVdc.AdminVdc.ResourcePoolRefs.VimObjectRef) > 0, Equals, true)
 
 		// Test  update
 		adminVdc.AdminVdc.Description = "updated-description" + check.TestName()

--- a/govcd/adminvdc_nsxt_test.go
+++ b/govcd/adminvdc_nsxt_test.go
@@ -12,6 +12,7 @@ package govcd
 import (
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
 )
@@ -121,6 +122,8 @@ func (vcd *TestVCD) Test_CreateNsxtOrgVdc(check *C) {
 		check.Assert(vdc.Vdc.Name, Equals, vdcConfiguration.Name)
 		check.Assert(vdc.Vdc.IsEnabled, Equals, vdcConfiguration.IsEnabled)
 		check.Assert(vdc.Vdc.AllocationModel, Equals, vdcConfiguration.AllocationModel)
+		spew.Dump(adminVdc.AdminVdc)
+		// check.Assert(len(adminVdc.AdminVdc.ResourcePoolRefs) > 0, Equals, true)
 
 		// Test  update
 		adminVdc.AdminVdc.Description = "updated-description" + check.TestName()

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -447,14 +447,17 @@ type AdminVdc struct {
 	Xmlns string `xml:"xmlns,attr"`
 	Vdc
 
-	VCpuInMhz2                    *int64         `xml:"VCpuInMhz2,omitempty"`
-	ResourceGuaranteedMemory      *float64       `xml:"ResourceGuaranteedMemory,omitempty"`
-	ResourceGuaranteedCpu         *float64       `xml:"ResourceGuaranteedCpu,omitempty"`
-	VCpuInMhz                     *int64         `xml:"VCpuInMhz,omitempty"`
-	IsThinProvision               *bool          `xml:"IsThinProvision,omitempty"`
-	NetworkPoolReference          *Reference     `xml:"NetworkPoolReference,omitempty"`
-	ProviderVdcReference          *Reference     `xml:"ProviderVdcReference"`
-	ResourcePoolRefs              *VimObjectRefs `xml:"vmext:ResourcePoolRefs,omitempty"`
+	VCpuInMhz2               *int64     `xml:"VCpuInMhz2,omitempty"`
+	ResourceGuaranteedMemory *float64   `xml:"ResourceGuaranteedMemory,omitempty"`
+	ResourceGuaranteedCpu    *float64   `xml:"ResourceGuaranteedCpu,omitempty"`
+	VCpuInMhz                *int64     `xml:"VCpuInMhz,omitempty"`
+	IsThinProvision          *bool      `xml:"IsThinProvision,omitempty"`
+	NetworkPoolReference     *Reference `xml:"NetworkPoolReference,omitempty"`
+	ProviderVdcReference     *Reference `xml:"ProviderVdcReference"`
+
+	// ResourcePoolRefs is a read-only field and should be avoided in XML structure for write
+	// operations because it breaks on Go marshalling bug https://github.com/golang/go/issues/9519
+	ResourcePoolRefs              *VimObjectRefs `xml:"ResourcePoolRefs,omitempty"`
 	UsesFastProvisioning          *bool          `xml:"UsesFastProvisioning,omitempty"`
 	OverCommitAllowed             bool           `xml:"OverCommitAllowed,omitempty"`
 	VmDiscoveryEnabled            bool           `xml:"VmDiscoveryEnabled,omitempty"`


### PR DESCRIPTION
This PR builds on top of #483 to fix the problem with `AdminVdc.ResourcePoolRefs` read capabilities (this is a read-only field).

There is a Go marshaling problem https://github.com/golang/go/issues/9519 which makes marshaling/unmarshaling non symmetric, but as this field is read-only - we care about  reading it.
So the goal is to:
* Be able to read resources pools backing VDCs
* Avoid breaking code on `create/update` operations

Test `go test -tags "org vdc" -check.vv  -timeout=255m .` passed

Closes #483 