### PR TITLE
Go 1.19 release cleanups

### DIFF
--- a/.changes/v2.17.0/497-notes.md
+++ b/.changes/v2.17.0/497-notes.md
@@ -1,8 +1,8 @@
-* `make fmt` using Go 1.19 release (`fmt` automatically changes doc comment structure). This will
-  prevent `make static` errors when running tests using Go 1.19 [GH-497]
-* Update branding `vCloud Director` -> `VMware Cloud Director` [GH-497]
+* Ran `make fmt` using Go 1.19 release (`fmt` automatically changes doc comment structure). This
+  will prevent `make static` errors when running tests in pipeline using Go 1.19 [GH-497]
+* Updated branding `vCloud Director` -> `VMware Cloud Director` [GH-497]
 * Go officially supports 2 last releases. With Go 1.19 being released it means that Go 1.18 is the
-  minimum officially supported Go version and this sets our hands free to use generic in this SDK
+  minimum officially supported Go version and this set our hands free to use generics in this SDK
   (if there is a need for it). `go.mod` is updated to reflect Go minimum version 1.18 [GH-497]
 * package `io/ioutil` is deprecated as of Go 1.16. `staticcheck` started complaining about usage of
   deprecated packages. As a result this PR switches packages to either `io` or `os` (still the same

--- a/.changes/v2.17.0/497-notes.md
+++ b/.changes/v2.17.0/497-notes.md
@@ -1,0 +1,11 @@
+* `make fmt` using Go 1.19 release (`fmt` automatically changes doc comment structure). This will
+  prevent `make static` errors when running tests using Go 1.19 [GH-497]
+* Update branding `vCloud Director` -> `VMware Cloud Director` [GH-497]
+* Go officially supports 2 last releases. With Go 1.19 being released it means that Go 1.18 is the
+  minimum officially supported Go version and this sets our hands free to use generic in this SDK
+  (if there is a need for it). `go.mod` is updated to reflect Go minimum version 1.18 [GH-497]
+* package `io/ioutil` is deprecated as of Go 1.16. `staticcheck` started complaining about usage of
+  deprecated packages. As a result this PR switches packages to either `io` or `os` (still the same
+  functions are used) [GH-497]
+* `staticcheck` switched version naming from `2021.1.2` to `v0.3.3` in download section. This PR
+  also updates code to fetch correct one [GH-497]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.17
+        go-version: '1.19'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: vet
       run: make vet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ request. For any questions about the CLA process, please refer to our
 
 ## Community
 
-vCloud Director Golang and Terraform contributors can be found here: 
-https://vmwarecode.slack.com, vcd-terraform-dev#
+VMware Cloud Director Go(lang) and Terraform contributors can be found here: 
+https://vmwarecode.slack.com, #vcd-terraform-dev
 
 ## Logging Bugs
 
@@ -83,10 +83,7 @@ of the repo for pull requests back to go-vcloud-director.
 ### Clone and Set Upstream Remote
 
 Make a local clone of the forked repo and add the base go-vcloud-director
-repo as the upstream remote repository.
-
-The project uses Go modules so the path is up to you, but do not forget
-to set `GO111MODULE=on` if you are in `GOPATH`
+repo as the upstream remote repository. The project uses Go modules so the path is up to you.
 
 ``` shell
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-vcloud-director [![GoDoc](https://godoc.org/github.com/vmware/go-vcloud-director?status.svg)](http://godoc.org/github.com/vmware/go-vcloud-director) [![Chat](https://img.shields.io/badge/chat-on%20slack-brightgreen.svg)](https://vmwarecode.slack.com/messages/CBBBXVB16)
 
 This repo contains the `go-vcloud-director` package which implements
-an SDK for vCloud Director. The project serves the needs of Golang
-developers who need to integrate with vCloud Director. It is also the
+an SDK for VMware Cloud Director. The project serves the needs of Golang
+developers who need to integrate with VMware Cloud Director. It is also the
 basis of the [vCD Terraform
 Provider](https://github.com/vmware/terraform-provider-vcd).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/go-vcloud-director/v2
 
-go 1.16
+go 1.18
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
@@ -8,9 +8,13 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/kr/pretty v0.2.1
 	github.com/peterhellberg/link v1.1.0
-	github.com/stretchr/testify v1.5.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.2.2
+)
+
+require (
+	github.com/kr/text v0.1.0 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
 )
 
 replace (

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-// AdminCatalog is a admin view of a vCloud Director Catalog
+// AdminCatalog is a admin view of a VMware Cloud Director Catalog
 // To be able to get an AdminCatalog representation, users must have
 // admin credentials to the System org. AdminCatalog is used
 // for creating, updating, and deleting a Catalog.

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -123,8 +123,8 @@ func (adminOrg *AdminOrg) GetStorageProfileReferenceById(id string, refresh bool
 		ErrorEntityNotFound, id, adminOrg.AdminOrg.Name)
 }
 
-//   Deletes the org, returning an error if the vCD call fails.
-//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
+// Deletes the org, returning an error if the vCD call fails.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/DELETE-Organization.html
 func (adminOrg *AdminOrg) Delete(force bool, recursive bool) error {
 	if force && recursive {
 		//undeploys vapps
@@ -191,10 +191,10 @@ func (adminOrg *AdminOrg) Disable() error {
 	return adminOrg.client.ExecuteRequestWithoutResponse(orgHREF.String(), http.MethodPost, "", "error disabling organization: %s", nil)
 }
 
-//   Updates the Org definition from current org struct contents.
-//   Any differences that may be legally applied will be updated.
-//   Returns an error if the call to vCD fails.
-//   API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
+// Updates the Org definition from current org struct contents.
+// Any differences that may be legally applied will be updated.
+// Returns an error if the call to vCD fails.
+// API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/PUT-Organization.html
 func (adminOrg *AdminOrg) Update() (Task, error) {
 	vcomp := &types.AdminOrg{
 		Xmlns:       types.XMLNamespaceVCloud,

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -2,7 +2,7 @@
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
-// Package govcd provides a simple binding for vCloud Director REST APIs.
+// Package govcd provides a simple binding for VMware Cloud Director REST APIs.
 package govcd
 
 import (
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-// Client provides a client to vCloud Director, values can be populated automatically using the Authenticate method.
+// Client provides a client to VMware Cloud Director, values can be populated automatically using the Authenticate method.
 type Client struct {
 	APIVersion       string      // The API version required
 	VCDToken         string      // Access Token (authorization header)
@@ -34,7 +34,7 @@ type Client struct {
 	UsingAccessToken bool        // flag if client is using an API token
 
 	// MaxRetryTimeout specifies a time limit (in seconds) for retrying requests made by the SDK
-	// where vCloud director may take time to respond and retry mechanism is needed.
+	// where VMware Cloud Director may take time to respond and retry mechanism is needed.
 	// This must be >0 to avoid instant timeout errors.
 	MaxRetryTimeout int
 

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -11,7 +11,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -68,9 +67,10 @@ const ApiTokenHeader = "API-token"
 // General purpose error to be used whenever an entity is not found from a "GET" request
 // Allows a simpler checking of the call result
 // such as
-// if err == ErrorEntityNotFound {
-//    // do what is needed in case of not found
-// }
+//
+//	if err == ErrorEntityNotFound {
+//	   // do what is needed in case of not found
+//	}
 var errorEntityNotFoundMessage = "[ENF] entity not found"
 var ErrorEntityNotFound = fmt.Errorf(errorEntityNotFoundMessage)
 
@@ -79,12 +79,14 @@ var debugShowRequestEnabled = os.Getenv("GOVCD_SHOW_REQ") != ""
 var debugShowResponseEnabled = os.Getenv("GOVCD_SHOW_RESP") != ""
 
 // Enables the debugging hook to show requests as they are processed.
+//
 //lint:ignore U1000 this function is used on request for debugging purposes
 func enableDebugShowRequest() {
 	debugShowRequestEnabled = true
 }
 
 // Disables the debugging hook to show requests as they are processed.
+//
 //lint:ignore U1000 this function is used on request for debugging purposes
 func disableDebugShowRequest() {
 	debugShowRequestEnabled = false
@@ -95,12 +97,14 @@ func disableDebugShowRequest() {
 }
 
 // Enables the debugging hook to show responses as they are processed.
+//
 //lint:ignore U1000 this function is used on request for debugging purposes
 func enableDebugShowResponse() {
 	debugShowResponseEnabled = true
 }
 
 // Disables the debugging hook to show responses as they are processed.
+//
 //lint:ignore U1000 this function is used on request for debugging purposes
 func disableDebugShowResponse() {
 	debugShowResponseEnabled = false
@@ -149,9 +153,10 @@ func debugShowResponse(resp *http.Response, body []byte) {
 
 // IsNotFound is a convenience function, similar to os.IsNotExist that checks whether a given error
 // is a "Not found" error, such as
-// if isNotFound(err) {
-//    // do what is needed in case of not found
-// }
+//
+//	if isNotFound(err) {
+//	   // do what is needed in case of not found
+//	}
 func IsNotFound(err error) bool {
 	return err != nil && err == ErrorEntityNotFound
 }
@@ -203,7 +208,7 @@ func (client *Client) newRequest(params map[string]string, notEncodedParams map[
 	var readBody []byte
 	var err error
 	if body != nil {
-		readBody, err = ioutil.ReadAll(body)
+		readBody, err = io.ReadAll(body)
 		if err != nil {
 			util.Logger.Printf("[DEBUG - newRequest] error reading body: %s", err)
 		}
@@ -294,7 +299,7 @@ func ParseErr(bodyType types.BodyType, resp *http.Response, errType error) error
 
 // decodeBody is used to decode a response body of types.BodyType
 func decodeBody(bodyType types.BodyType, resp *http.Response, out interface{}) error {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	// In case of JSON, body does not have indents in response therefore it must be indented
 	if bodyType == types.BodyTypeJSON {
@@ -599,12 +604,12 @@ func (client *Client) ExecuteParamRequestWithCustomError(pathURL string, params 
 	// read from resp.Body io.Reader for debug output if it has body
 	var bodyBytes []byte
 	if resp.Body != nil {
-		bodyBytes, err = ioutil.ReadAll(resp.Body)
+		bodyBytes, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return &http.Response{}, fmt.Errorf("could not read response body: %s", err)
 		}
 		// Restore the io.ReadCloser to its original state with no-op closer
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 
 	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(bodyBytes))

--- a/govcd/api_token.go
+++ b/govcd/api_token.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -67,7 +67,7 @@ func (vcdClient *VCDClient) GetBearerTokenFromApiToken(org, token string) (*type
 	var body []byte
 	var tokenDef types.ApiTokenRefresh
 	if resp.Body != nil {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 	}
 
 	// The default response data to show in the logs is a string of asterisks

--- a/govcd/api_token_test.go
+++ b/govcd/api_token_test.go
@@ -17,10 +17,10 @@ import (
 
 // TestVCDClient_GetBearerTokenFromApiToken tests the token refresh operation
 // To make it work, we need the following, or the test is skipped:
-// * VCD version 10.3.1 or greater
-// * environment variable TEST_VCD_API_TOKEN filled with a valid API token for that VCD
-// * If the API token was not set for the Organization defined in vcd.config.VCD.Org, the variable
-//   TEST_VCD_ORG should be filled with the name of the Org for which the API token was set.
+//   - VCD version 10.3.1 or greater
+//   - environment variable TEST_VCD_API_TOKEN filled with a valid API token for that VCD
+//   - If the API token was not set for the Organization defined in vcd.config.VCD.Org, the variable
+//     TEST_VCD_ORG should be filled with the name of the Org for which the API token was set.
 func (vcd *TestVCD) TestVCDClient_GetBearerTokenFromApiToken(check *C) {
 
 	apiToken := os.Getenv("TEST_VCD_API_TOKEN")

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -102,7 +102,7 @@ func (vcdClient *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.
 	return resp, nil
 }
 
-// NewVCDClient initializes VMware vCloud Director client with reasonable defaults.
+// NewVCDClient initializes VMware VMware Cloud Director client with reasonable defaults.
 // It accepts functions of type VCDClientOption for adjusting defaults.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	minVcdApiVersion := "35.0" // supported by 10.2+
@@ -151,7 +151,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption
 	return vcdClient
 }
 
-// Authenticate is a helper function that performs a login in vCloud Director.
+// Authenticate is a helper function that performs a login in VMware Cloud Director.
 func (vcdClient *VCDClient) Authenticate(username, password, org string) error {
 	_, err := vcdClient.GetAuthResponse(username, password, org)
 	return err
@@ -240,7 +240,7 @@ func (vcdClient *VCDClient) SetToken(org, authHeader, token string) error {
 	return nil
 }
 
-// Disconnect performs a disconnection from the vCloud Director API endpoint.
+// Disconnect performs a disconnection from the VMware Cloud Director API endpoint.
 func (vcdClient *VCDClient) Disconnect() error {
 	if vcdClient.Client.VCDToken == "" && vcdClient.Client.VCDAuthHeader == "" {
 		return fmt.Errorf("cannot disconnect, client is not authenticated")
@@ -251,7 +251,7 @@ func (vcdClient *VCDClient) Disconnect() error {
 	// Set Authorization Header
 	req.Header.Add(vcdClient.Client.VCDAuthHeader, vcdClient.Client.VCDToken)
 	if _, err := checkResp(vcdClient.Client.Http.Do(req)); err != nil {
-		return fmt.Errorf("error processing session delete for vCloud Director: %s", err)
+		return fmt.Errorf("error processing session delete for VMware Cloud Director: %s", err)
 	}
 	return nil
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -305,7 +304,7 @@ func readCleanupList() ([]CleanupEntity, error) {
 	if os.IsNotExist(err) {
 		return nil, err
 	}
-	listText, err := ioutil.ReadFile(persistentCleanupListFile)
+	listText, err := os.ReadFile(persistentCleanupListFile)
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +433,7 @@ func GetConfigStruct() (TestConfig, error) {
 	if os.IsNotExist(err) {
 		return TestConfig{}, fmt.Errorf("Configuration file %s not found: %s", config, err)
 	}
-	yamlFile, err := ioutil.ReadFile(config)
+	yamlFile, err := os.ReadFile(config)
 	if err != nil {
 		return TestConfig{}, fmt.Errorf("could not read config file %s: %s", config, err)
 	}

--- a/govcd/api_vcd_test_unit.go
+++ b/govcd/api_vcd_test_unit.go
@@ -8,7 +8,7 @@
 package govcd
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -35,7 +35,7 @@ func goldenString(t *testing.T, goldenFile string, actual string, update bool) s
 		return actual
 	}
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("error opening file %s: %s", goldenPath, err)
 	}

--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -323,12 +323,15 @@ func intListToVersion(digits []int, atMost int) string {
 // VersionEqualOrGreater return true if the current version is the same or greater than the one being compared.
 // If howManyDigits is > 3, the comparison includes the build.
 // Examples:
-//  client version is 1.2.3.1234
-//  compare version is 1.2.3.2000
+//
+//	client version is 1.2.3.1234
+//	compare version is 1.2.3.2000
+//
 // function return true if howManyDigits is <= 3, but false if howManyDigits is > 3
 //
-//  client version is 1.2.3.1234
-//  compare version is 1.1.1.0
+//	client version is 1.2.3.1234
+//	compare version is 1.1.1.0
+//
 // function returns true regardless of value of howManyDigits
 func (client *Client) VersionEqualOrGreater(compareTo string, howManyDigits int) (bool, error) {
 

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -499,7 +498,7 @@ func uploadOvfDescription(client *Client, ovfFile string, ovfUploadUrl *url.URL)
 }
 
 func parseOvfFileDesc(file *os.File, ovfFileDesc *Envelope) error {
-	ovfXml, err := ioutil.ReadAll(file)
+	ovfXml, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}
@@ -611,12 +610,13 @@ func createItemWithLink(client *Client, createHREF *url.URL, catalogItemName, it
 }
 
 // Helper method to get path to multi-part files.
-//For example a file called test.vmdk with total_file_size = 100 bytes and part_size = 40 bytes, implies the file is made of *3* part files.
-//		- test.vmdk.000000000 = 40 bytes
-//		- test.vmdk.000000001 = 40 bytes
-//		- test.vmdk.000000002 = 20 bytes
-//Say base_dir = /dummy_path/, and base_file_name = test.vmdk then
-//the output of this function will be [/dummy_path/test.vmdk.000000000,
+// For example a file called test.vmdk with total_file_size = 100 bytes and part_size = 40 bytes, implies the file is made of *3* part files.
+//   - test.vmdk.000000000 = 40 bytes
+//   - test.vmdk.000000001 = 40 bytes
+//   - test.vmdk.000000002 = 20 bytes
+//
+// Say base_dir = /dummy_path/, and base_file_name = test.vmdk then
+// the output of this function will be [/dummy_path/test.vmdk.000000000,
 // /dummy_path/test.vmdk.000000001, /dummy_path/test.vmdk.000000002]
 func getChunkedFilePaths(baseDir, baseFileName string, totalFileSize, partSize int) []string {
 	var filePaths []string

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -9,7 +9,7 @@ package govcd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -232,7 +232,7 @@ func (vcd *TestVCD) Test_UploadOvf_ShowUploadProgress_works(check *C) {
 	check.Assert(err, IsNil)
 	w.Close()
 	//read stdin
-	result, _ := ioutil.ReadAll(r)
+	result, _ := io.ReadAll(r)
 	os.Stdout = oldStdout
 
 	err = uploadTask.WaitTaskCompletion()
@@ -323,7 +323,7 @@ func (vcd *TestVCD) Test_UploadOvf_withoutVMDKSize(check *C) {
 }
 
 func countFolders() int {
-	files, err := ioutil.ReadDir(os.TempDir())
+	files, err := os.ReadDir(os.TempDir())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func (vcd *TestVCD) Test_CatalogUploadMediaImage_ShowUploadProgress_works(check 
 	check.Assert(err, IsNil)
 	w.Close()
 	//read stdin
-	result, _ := ioutil.ReadAll(r)
+	result, _ := io.ReadAll(r)
 	os.Stdout = oldStdout
 
 	err = uploadTask.WaitTaskCompletion()

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -10,7 +10,7 @@ package govcd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -197,7 +197,7 @@ func testGetEdgeEndpointXML(endpoint string, edge EdgeGateway, check *C) string 
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	check.Assert(err, IsNil)
 
 	return string(body)

--- a/govcd/entity.go
+++ b/govcd/entity.go
@@ -11,19 +11,19 @@ type genericGetter func(string, bool) (interface{}, error)
 // On failure, returns a nil pointer and an error
 // Example usage:
 //
-// func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
-// 	getByName := func(name string, refresh bool) (interface{}, error) {
-// 		return org.GetCatalogByName(name, refresh)
-// 	}
-// 	getById := func(id string, refresh bool) (interface{}, error) {
-// 	  return org.GetCatalogById(id, refresh)
-// 	}
-// 	entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
-//  if entity != nil {
-//    return nil, err
-//  }
-// 	return entity.(*Catalog), err
-// }
+//	func (org *Org) GetCatalogByNameOrId(identifier string, refresh bool) (*Catalog, error) {
+//		getByName := func(name string, refresh bool) (interface{}, error) {
+//			return org.GetCatalogByName(name, refresh)
+//		}
+//		getById := func(id string, refresh bool) (interface{}, error) {
+//		  return org.GetCatalogById(id, refresh)
+//		}
+//		entity, err := getEntityByNameOrId(getByName, getById, identifier, refresh)
+//	 if entity != nil {
+//	   return nil, err
+//	 }
+//		return entity.(*Catalog), err
+//	}
 func getEntityByNameOrId(getByName, getById genericGetter, identifier string, refresh bool) (interface{}, error) {
 
 	var byNameErr, byIdErr error

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -91,31 +91,31 @@ func (vmar *VmAffinityRule) id() string   { return vmar.VmAffinityRule.ID }
 // and within the caller it must define the getter functions
 // Example usage:
 //
-// func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
-//	if vcd.config.VCD.Org == "" {
-//		check.Skip("Test_OrgGetVdc: Org name not given.")
-//		return
-//	}
-//	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
-//	check.Assert(err, IsNil)
-//	check.Assert(org, NotNil)
+//	func (vcd *TestVCD) Test_OrgGetVdc(check *C) {
+//		if vcd.config.VCD.Org == "" {
+//			check.Skip("Test_OrgGetVdc: Org name not given.")
+//			return
+//		}
+//		org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+//		check.Assert(err, IsNil)
+//		check.Assert(org, NotNil)
 //
-//	getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(name, refresh) }
-//	getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(id, refresh) }
-//	getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
+//		getByName := func(name string, refresh bool) (genericEntity, error) { return org.GetVDCByName(name, refresh) }
+//		getById := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCById(id, refresh) }
+//		getByNameOrId := func(id string, refresh bool) (genericEntity, error) { return org.GetVDCByNameOrId(id, refresh) }
 //
-//	var def = getterTestDefinition{
-//		parentType:       "Org",
-//		parentName:       vcd.config.VCD.Org,
-//		entityType:       "Vdc",
-//		getterPrefix:     "VDC",
-//		entityName:       vcd.config.VCD.Vdc,
-//		getByName:        getByName,
-//		getById:          getById,
-//		getByNameOrId:    getByNameOrId,
+//		var def = getterTestDefinition{
+//			parentType:       "Org",
+//			parentName:       vcd.config.VCD.Org,
+//			entityType:       "Vdc",
+//			getterPrefix:     "VDC",
+//			entityName:       vcd.config.VCD.Vdc,
+//			getByName:        getByName,
+//			getById:          getById,
+//			getByNameOrId:    getByNameOrId,
+//		}
+//		vcd.testFinderGetGenericEntity(def, check)
 //	}
-//	vcd.testFinderGetGenericEntity(def, check)
-// }
 func (vcd *TestVCD) testFinderGetGenericEntity(def getterTestDefinition, check *C) {
 	entityName := def.entityName
 	if entityName == "" {

--- a/govcd/filter_condition.go
+++ b/govcd/filter_condition.go
@@ -51,12 +51,13 @@ type parentIdCondition struct {
 
 // matchParent matches the wanted parent name (passed in 'stored') to the parent of the queryItem
 // Input:
-//   * stored: the data of the condition (a parentCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (a parentCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchParent(stored, item interface{}) (bool, string, error) {
 	condition, ok := stored.(parentCondition)
 	if !ok {
@@ -74,12 +75,13 @@ func matchParent(stored, item interface{}) (bool, string, error) {
 // matchParentId matches the wanted parent ID (passed in 'stored') to the parent ID of the queryItem
 // The IDs being compared are filtered through extractUuid, to make them homogeneous
 // Input:
-//   * stored: the data of the condition (a parentCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (a parentCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchParentId(stored, item interface{}) (bool, string, error) {
 	condition, ok := stored.(parentIdCondition)
 	if !ok {
@@ -98,12 +100,13 @@ func matchParentId(stored, item interface{}) (bool, string, error) {
 
 // matchName matches a name (passed in 'stored') to the name of the queryItem
 // Input:
-//   * stored: the data of the condition (a nameCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (a nameCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchName(stored, item interface{}) (bool, string, error) {
 	re, ok := stored.(nameCondition)
 	if !ok {
@@ -118,12 +121,13 @@ func matchName(stored, item interface{}) (bool, string, error) {
 
 // matchIp matches an IP (passed in 'stored') to the IP of the queryItem
 // Input:
-//   * stored: the data of the condition (an ipCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (an ipCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchIp(stored, item interface{}) (bool, string, error) {
 	re, ok := stored.(ipCondition)
 	if !ok {
@@ -142,12 +146,13 @@ func matchIp(stored, item interface{}) (bool, string, error) {
 
 // matchDate matches a date (passed in 'stored') to the date of the queryItem
 // Input:
-//   * stored: the data of the condition (a dateCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (a dateCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchDate(stored, item interface{}) (bool, string, error) {
 	expr, ok := stored.(dateCondition)
 	if !ok {
@@ -167,12 +172,13 @@ func matchDate(stored, item interface{}) (bool, string, error) {
 
 // matchMetadata matches a value (passed in 'stored') to the metadata value retrieved from queryItem
 // Input:
-//   * stored: the data of the condition (a metadataRegexpCondition)
-//   * item:   a QueryItem
+//   - stored: the data of the condition (a metadataRegexpCondition)
+//   - item:   a QueryItem
+//
 // Returns:
-//   * bool:   the result of the comparison
-//   * string: a description of the operation
-//   * error:  an error when the input is not as expected
+//   - bool:   the result of the comparison
+//   - string: a description of the operation
+//   - error:  an error when the input is not as expected
 func matchMetadata(stored, item interface{}) (bool, string, error) {
 	re, ok := stored.(metadataRegexpCondition)
 	if !ok {

--- a/govcd/filter_util.go
+++ b/govcd/filter_util.go
@@ -117,7 +117,8 @@ func (fd *FilterDef) AddMetadataFilter(key, value, valueType string, isSystem, u
 
 // stringToBool converts a string to a bool
 // The following values are recognized as TRUE:
-//  t, true, y, yes, ok
+//
+//	t, true, y, yes, ok
 func stringToBool(s string) bool {
 	switch strings.ToLower(s) {
 	case "t", "true", "y", "yes", "ok":

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -10,7 +10,7 @@ package govcd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -203,7 +203,7 @@ func checkLb(queryUrl string, expectedResponses []string, maxRetryTimeout int) e
 
 			if err == nil {
 				fmt.Printf(".") // progress bar when waiting for responses from all nodes
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				resp.Body.Close()
 				// check if the element is in the list
 				for index, value := range expectedResponses {

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -163,7 +163,7 @@ func prettyTask(task *types.Task) string {
 }
 
 // Returns an Edge Gateway service configuration structure as JSON
-//func prettyEdgeGatewayServiceConfiguration(conf types.EdgeGatewayServiceConfiguration) string {
+// func prettyEdgeGatewayServiceConfiguration(conf types.EdgeGatewayServiceConfiguration) string {
 func prettyEdgeGateway(egw types.EdgeGateway) string {
 	result := ""
 	byteBuf, err := json.MarshalIndent(egw, " ", " ")

--- a/govcd/nsxt_ipsec_vpn_tunnel.go
+++ b/govcd/nsxt_ipsec_vpn_tunnel.go
@@ -59,7 +59,7 @@ func (egw *NsxtEdgeGateway) GetAllIpSecVpnTunnels(queryParameters url.Values) ([
 	return wrappedResponses, nil
 }
 
-//GetIpSecVpnTunnelById retrieves single IPsec VPN Tunnel by ID
+// GetIpSecVpnTunnelById retrieves single IPsec VPN Tunnel by ID
 func (egw *NsxtEdgeGateway) GetIpSecVpnTunnelById(id string) (*NsxtIpSecVpnTunnel, error) {
 	if id == "" {
 		return nil, fmt.Errorf("canot find NSX-T IPsec VPN Tunnel configuration without ID")

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -636,7 +635,7 @@ func (client *Client) newOpenApiRequest(apiVersion string, params url.Values, me
 	var readBody []byte
 	var err error
 	if body != nil {
-		readBody, err = ioutil.ReadAll(body)
+		readBody, err = io.ReadAll(body)
 		if err != nil {
 			util.Logger.Printf("[DEBUG - newOpenApiRequest] error reading body: %s", err)
 		}

--- a/govcd/saml_auth_test.go
+++ b/govcd/saml_auth_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 // Test_SamlAdfsAuth checks if SAML ADFS login works using WS-TRUST endpoint
-//  "/adfs/services/trust/13/usernamemixed".
+//
+//	"/adfs/services/trust/13/usernamemixed".
+//
 // Credential variables must be specified in test configuration for it to work
 // The steps of this test are:
 // * Query object using test framework vCD connection

--- a/govcd/saml_auth_unit_test.go
+++ b/govcd/saml_auth_unit_test.go
@@ -8,7 +8,7 @@
 package govcd
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -174,7 +174,7 @@ func (mockServer *samlMockServer) adfsSamlAuthHandler(w http.ResponseWriter, r *
 	}
 
 	// Replace known dynamic strings to 'REPLACED' string
-	gotBody, _ := ioutil.ReadAll(r.Body)
+	gotBody, _ := io.ReadAll(r.Body)
 	gotBodyString := string(gotBody)
 	re := regexp.MustCompile(`(<a:To s:mustUnderstand="1">).*(</a:To>)`)
 	gotBodyString = re.ReplaceAllString(gotBodyString, `${1}REPLACED${2}`)

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -33,7 +33,7 @@ provider:
     # The organization you are authenticating with
     sysOrg: System
     # (Optional) MaxRetryTimeout specifies a time limit (in seconds) for retrying requests made by the SDK
-    # where vCloud director may take time to respond and retry mechanism is needed.
+    # where VMware Cloud Director may take time to respond and retry mechanism is needed.
     # This must be >0 to avoid instant timeout errors. If omitted - default value is set.
     # maxRetryTimeout: 60
     #

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -31,8 +31,9 @@ func NewTask(cli *Client) *Task {
 // If the error is not nil, composes an error message
 // made of the error itself + the information from the task's Error component.
 // See:
-//    https://code.vmware.com/apis/220/vcloud#/doc/doc/types/TaskType.html
-//    https://code.vmware.com/apis/220/vcloud#/doc/doc/types/ErrorType.html
+//
+//	https://code.vmware.com/apis/220/vcloud#/doc/doc/types/TaskType.html
+//	https://code.vmware.com/apis/220/vcloud#/doc/doc/types/ErrorType.html
 func (task *Task) getErrorMessage(err error) string {
 	errorMessage := ""
 	if err != nil {

--- a/govcd/user.go
+++ b/govcd/user.go
@@ -337,8 +337,9 @@ func (user *OrgUser) GetRoleName() string {
 // Expected behaviour:
 // with takeOwnership = true, all entities owned by the user being deleted will be transferred to the caller.
 // with takeOwnership = false, if the user own catalogs, networks, or running VMs/vApps, the call will fail.
-//                             If the user owns only powered-off VMs/vApps, the call will succeeds and the
-//                             VMs/vApps will be removed.
+//
+//	If the user owns only powered-off VMs/vApps, the call will succeeds and the
+//	VMs/vApps will be removed.
 func (user *OrgUser) Delete(takeOwnership bool) error {
 	util.Logger.Printf("[TRACE] Deleting user: %#v (take ownership: %v)", user.User.Name, takeOwnership)
 

--- a/govcd/vm_affinity_rule.go
+++ b/govcd/vm_affinity_rule.go
@@ -157,12 +157,12 @@ func (vdc *Vdc) GetVmAffinityRuleByNameOrId(identifier string) (*VmAffinityRule,
 // validateAffinityRule checks that a VM affinity rule has all the needed properties
 // If checkVMs is true, then the function checks that all VMs in the internal list exist.
 // The usual workflow is:
-// 1. validation without VM checking
-// 2. creation or update
-// 3. if no error -> end
-// 4. if error, validation with VM checks
-//    4a. if validation error, it was a VM issue: return combined original error + validation error
-//    4b. if no validation error, the failure was due to something else: return only original error
+//  1. validation without VM checking
+//  2. creation or update
+//  3. if no error -> end
+//  4. if error, validation with VM checks
+//     4a. if validation error, it was a VM issue: return combined original error + validation error
+//     4b. if no validation error, the failure was due to something else: return only original error
 func validateAffinityRule(client *Client, affinityRuleDef *types.VmAffinityRule, checkVMs bool) (*types.VmAffinityRule, error) {
 	if affinityRuleDef == nil {
 		return nil, fmt.Errorf("empty definition given for a VM affinity rule")

--- a/samples/discover/discover.go
+++ b/samples/discover/discover.go
@@ -46,8 +46,6 @@ import (
 	"net/url"
 	"os"
 
-	"io/ioutil"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -96,7 +94,7 @@ func check_configuration(conf Config) {
 // Retrieves the configuration from a Json or Yaml file
 func getConfig(config_file string) Config {
 	var configuration Config
-	buffer, err := ioutil.ReadFile(config_file)
+	buffer, err := os.ReadFile(config_file)
 	if err != nil {
 		fmt.Printf("Configuration file %s not found\n%s\n", config_file, err)
 		os.Exit(1)

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,4 +1,3 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=2022.1
+export STATICCHECK_VERSION=v0.3.3
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
-

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -175,7 +175,7 @@ type OrgVdcNetworkSubnetIPRanges = ExternalNetworkV2IPRanges
 // OrgVdcNetworkSubnetIPRangeValues is a type alias to reuse the same definitions with appropriate names
 type OrgVdcNetworkSubnetIPRangeValues = ExternalNetworkV2IPRange
 
-//OrgVdcNetworkSubnets
+// OrgVdcNetworkSubnets
 type OrgVdcNetworkSubnets struct {
 	Values []OrgVdcNetworkSubnetValues `json:"values"`
 }

--- a/types/v56/nsxv_types.go
+++ b/types/v56/nsxv_types.go
@@ -7,7 +7,7 @@ package types
 import "encoding/xml"
 
 // FirewallConfigWithXml allows to enable/disable firewall on a specific edge gateway
-// Reference: vCloud Director API for NSX Programming Guide
+// Reference: VMware Cloud Director API for NSX Programming Guide
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 //
 // Warning. It nests all firewall rules because Edge Gateway API is done so that if this data is not
@@ -34,7 +34,7 @@ type FirewallDefaultPolicy struct {
 }
 
 // LbGeneralParamsWithXml allows to enable/disable load balancing capabilities on specific edge gateway
-// Reference: vCloud Director API for NSX Programming Guide
+// Reference: VMware Cloud Director API for NSX Programming Guide
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 //
 // Warning. It nests all components (LbMonitor, LbPool, LbAppProfile, LbAppRule, LbVirtualServer)
@@ -74,7 +74,7 @@ type InnerXML struct {
 }
 
 // LbMonitor defines health check parameters for a particular type of network traffic
-// Reference: vCloud Director API for NSX Programming Guide
+// Reference: VMware Cloud Director API for NSX Programming Guide
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type LbMonitor struct {
 	XMLName    xml.Name `xml:"monitor"`
@@ -94,7 +94,7 @@ type LbMonitor struct {
 
 type LbMonitors []LbMonitor
 
-// LbPool represents a load balancer server pool as per "vCloud Director API for NSX Programming Guide"
+// LbPool represents a load balancer server pool as per "VMware Cloud Director API for NSX Programming Guide"
 // Type: LBPoolHealthCheckType
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type LbPool struct {
@@ -126,7 +126,7 @@ type LbPoolMember struct {
 
 type LbPoolMembers []LbPoolMember
 
-// LbAppProfile represents a load balancer application profile as per "vCloud Director API for NSX
+// LbAppProfile represents a load balancer application profile as per "VMware Cloud Director API for NSX
 // Programming Guide"
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type LbAppProfile struct {
@@ -158,7 +158,7 @@ type LbAppProfileHttpRedirect struct {
 	To      string   `xml:"to,omitempty"`
 }
 
-// LbAppRule represents a load balancer application rule as per "vCloud Director API for NSX
+// LbAppRule represents a load balancer application rule as per "VMware Cloud Director API for NSX
 // Programming Guide"
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type LbAppRule struct {
@@ -170,7 +170,7 @@ type LbAppRule struct {
 
 type LbAppRules []LbAppRule
 
-// LbVirtualServer represents a load balancer virtual server as per "vCloud Director API for NSX
+// LbVirtualServer represents a load balancer virtual server as per "VMware Cloud Director API for NSX
 // Programming Guide"
 // https://code.vmware.com/docs/6900/vcloud-director-api-for-nsx-programming-guide
 type LbVirtualServer struct {

--- a/types/v56/nsxv_types.go
+++ b/types/v56/nsxv_types.go
@@ -12,7 +12,7 @@ import "encoding/xml"
 //
 // Warning. It nests all firewall rules because Edge Gateway API is done so that if this data is not
 // sent while enabling it would wipe all firewall rules. InnerXML type field is used with struct tag
-//`innerxml` to prevent any manipulation of configuration and sending it verbatim
+// `innerxml` to prevent any manipulation of configuration and sending it verbatim
 type FirewallConfigWithXml struct {
 	XMLName       xml.Name              `xml:"firewall"`
 	Enabled       bool                  `xml:"enabled"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -556,10 +556,10 @@ type VdcConfiguration struct {
 	IncludeMemoryOverhead    *bool                             `xml:"IncludeMemoryOverhead,omitempty"` // Supported from 32.0 for the Flex model
 }
 
-// Task represents an asynchronous operation in vCloud Director.
+// Task represents an asynchronous operation in VMware Cloud Director.
 // Type: TaskType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents an asynchronous operation in vCloud Director.
+// Description: Represents an asynchronous operation in VMware Cloud Director.
 // Since: 0.9
 // Comments added from https://code.vmware.com/apis/912/vmware-cloud-director/doc/doc/types/TaskType.html
 type Task struct {
@@ -685,17 +685,17 @@ type Link struct {
 // OrgList represents a lists of Organizations
 // Type: OrgType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents a list of vCloud Director organizations.
+// Description: Represents a list of VMware Cloud Director organizations.
 // Since: 0.9
 type OrgList struct {
 	Link LinkList `xml:"Link,omitempty"`
 	Org  []*Org   `xml:"Org,omitempty"`
 }
 
-// Org represents the user view of a vCloud Director organization.
+// Org represents the user view of a VMware Cloud Director organization.
 // Type: OrgType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the user view of a vCloud Director organization.
+// Description: Represents the user view of a VMware Cloud Director organization.
 // Since: 0.9
 type Org struct {
 	HREF         string           `xml:"href,attr,omitempty"`
@@ -730,10 +730,10 @@ type RightsType struct {
 	RightReference []*Reference `xml:"RightReference,omitempty"`
 }
 
-// AdminOrg represents the admin view of a vCloud Director organization.
+// AdminOrg represents the admin view of a VMware Cloud Director organization.
 // Type: AdminOrgType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the admin view of a vCloud Director organization.
+// Description: Represents the admin view of a VMware Cloud Director organization.
 // Since: 0.9
 type AdminOrg struct {
 	XMLName         xml.Name         `xml:"AdminOrg"`
@@ -758,10 +758,10 @@ type AdminOrg struct {
 	RoleReferences  *OrgRoleType     `xml:"RoleReferences,omitempty"`
 }
 
-// OrgSettingsType represents the settings for a vCloud Director organization.
+// OrgSettingsType represents the settings for a VMware Cloud Director organization.
 // Type: OrgSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the settings of a vCloud Director organization.
+// Description: Represents the settings of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgSettings struct {
 	//attributes
@@ -776,10 +776,10 @@ type OrgSettings struct {
 
 }
 
-// OrgGeneralSettingsType represents the general settings for a vCloud Director organization.
+// OrgGeneralSettingsType represents the general settings for a VMware Cloud Director organization.
 // Type: OrgGeneralSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the user view of a vCloud Director organization.
+// Description: Represents the user view of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgGeneralSettings struct {
 	HREF string   `xml:"href,attr,omitempty"` // The URI of the entity.
@@ -795,10 +795,10 @@ type OrgGeneralSettings struct {
 	DelayAfterPowerOnSeconds int  `xml:"DelayAfterPowerOnSeconds,omitempty"`
 }
 
-// VAppTemplateLeaseSettings represents the vapp template lease settings for a vCloud Director organization.
+// VAppTemplateLeaseSettings represents the vapp template lease settings for a VMware Cloud Director organization.
 // Type: VAppTemplateLeaseSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the vapp template lease settings of a vCloud Director organization.
+// Description: Represents the vapp template lease settings of a VMware Cloud Director organization.
 // Since: 0.9
 type VAppTemplateLeaseSettings struct {
 	HREF string   `xml:"href,attr,omitempty"` // The URI of the entity.
@@ -828,10 +828,10 @@ type OrgFederationSettings struct {
 	Enabled bool `xml:"Enabled,omitempty"`
 }
 
-// OrgLdapSettingsType represents the ldap settings for a vCloud Director organization.
+// OrgLdapSettingsType represents the ldap settings for a VMware Cloud Director organization.
 // Type: OrgLdapSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the ldap settings of a vCloud Director organization.
+// Description: Represents the ldap settings of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgLdapSettingsType struct {
 	XMLName xml.Name `xml:"OrgLdapSettings"`
@@ -845,10 +845,10 @@ type OrgLdapSettingsType struct {
 	CustomOrgLdapSettings *CustomOrgLdapSettings `xml:"CustomOrgLdapSettings,omitempty"` // Needs to be set if user chooses custom mode
 }
 
-// CustomOrgLdapSettings represents the custom ldap settings for a vCloud Director organization.
+// CustomOrgLdapSettings represents the custom ldap settings for a VMware Cloud Director organization.
 // Type: CustomOrgLdapSettingsType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the custom ldap settings of a vCloud Director organization.
+// Description: Represents the custom ldap settings of a VMware Cloud Director organization.
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed
 type CustomOrgLdapSettings struct {
@@ -874,10 +874,10 @@ type CustomOrgLdapSettings struct {
 	Realm string `xml:"Realm,omitempty"`
 }
 
-// OrgLdapGroupAttributes	 represents the ldap group attribute settings for a vCloud Director organization.
+// OrgLdapGroupAttributes	 represents the ldap group attribute settings for a VMware Cloud Director organization.
 // Type: OrgLdapGroupAttributesType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the ldap group attribute settings of a vCloud Director organization.
+// Description: Represents the ldap group attribute settings of a VMware Cloud Director organization.
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed
 type OrgLdapGroupAttributes struct {
@@ -889,10 +889,10 @@ type OrgLdapGroupAttributes struct {
 	MembershipIdentifier string `xml:"MembershipIdentifier"`
 }
 
-// OrgLdapUserAttributesType represents the ldap user attribute settings for a vCloud Director organization.
+// OrgLdapUserAttributesType represents the ldap user attribute settings for a VMware Cloud Director organization.
 // Type: OrgLdapUserAttributesType
 // Namespace: http://www.vmware.com/vcloud/v1.5
-// Description: Represents the ldap user attribute settings of a vCloud Director organization.
+// Description: Represents the ldap user attribute settings of a VMware Cloud Director organization.
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed.
 type OrgLdapUserAttributes struct {

--- a/util/logging.go
+++ b/util/logging.go
@@ -9,7 +9,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -137,7 +137,7 @@ func SetLog() {
 		return
 	}
 	if !EnableLogging {
-		Logger = log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
+		Logger = log.New(io.Discard, "", log.Ldate|log.Ltime)
 		return
 	}
 

--- a/util/logging.go
+++ b/util/logging.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	// All go-vcloud director logging goes through this logger
+	// All go-vcloud-director logging goes through this logger
 	Logger *log.Logger
 
 	// It's true if we're using an user provided logger

--- a/util/tar.go
+++ b/util/tar.go
@@ -8,7 +8,6 @@ import (
 	"archive/tar"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func Unpack(tarFile string) ([]string, string, error) {
 
 	tarReader := tar.NewReader(reader)
 
-	dst, err = ioutil.TempDir("", TmpDirPrefix)
+	dst, err = os.MkdirTemp("", TmpDirPrefix)
 	if err != nil {
 		return filePaths, dst, err
 	}


### PR DESCRIPTION
Go 1.19 is released and this PR does a few cleanup adjustments. The main goal is to merge this PR ASAP to avoid messing up other PRs due to broken `make fmt` issues.

* `make fmt` using Go 1.19 release (`fmt` automatically changes doc comment structure). This will prevent `make static` errors when running tests using Go 1.19
* Update branding `vCloud Director` -> `VMware Cloud Director`
* Go officially supports 2 last releases. With Go 1.19 being released it means that Go 1.18 is the minimum officially supported Go version and this sets our hands free to use generic in this SDK (if there is a need for it). `go.mod` is updated to reflect Go minimum version 1.18
* package `io/ioutil` is deprecated as of Go 1.16. `staticcheck` started complaining about usage of deprecated packages. As a result this PR switches packages to either `io` or `os` (still the same functions are used)
* `staticcheck` switched version naming from `2021.1.2` to `v0.3.3` in download section. This PR also updates code to fetch correct one.