### PR TITLE
Fix Test_NsxtSecurityGroupGetAssociatedVms

### DIFF
--- a/.changes/v2.17.0/498-improvements.md
+++ b/.changes/v2.17.0/498-improvements.md
@@ -1,0 +1,1 @@
+* Fix Test_NsxtSecurityGroupGetAssociatedVms which had name clash [GH-498]

--- a/govcd/nsxt_firewall_group_static_security_group_test.go
+++ b/govcd/nsxt_firewall_group_static_security_group_test.go
@@ -126,7 +126,7 @@ func (vcd *TestVCD) Test_NsxtSecurityGroupGetAssociatedVms(check *C) {
 
 	// VMs are prependend to cleanup list to make sure they are removed before routed network
 	standaloneVm := createStandaloneVm(check, vcd, nsxtVdc, routedNet)
-	PrependToCleanupList(standaloneVm.VM.ID, "standaloneVm", "", check.TestName())
+	PrependToCleanupList(standaloneVm.VM.ID, "standaloneVm", "", standaloneVm.VM.Name)
 
 	secGroupDefinition := &types.NsxtFirewallGroup{
 		Name:           check.TestName(),
@@ -208,10 +208,10 @@ func createNsxtRoutedNetwork(check *C, vcd *TestVCD, vdc *Vdc, edgeGatewayId str
 
 func createStandaloneVm(check *C, vcd *TestVCD, vdc *Vdc, net *OpenApiOrgVdcNetwork) *VM {
 	params := types.CreateVmParams{
-		Name:    check.TestName(),
+		Name:    check.TestName() + "-standalone",
 		PowerOn: false,
 		CreateVm: &types.Vm{
-			Name:                   check.TestName(),
+			Name:                   check.TestName() + "-standalone",
 			VirtualHardwareSection: nil,
 			NetworkConnectionSection: &types.NetworkConnectionSection{
 				Info:                          "Network Configuration for VM",


### PR DESCRIPTION
This PR fixes Test_NsxtSecurityGroupGetAssociatedVms. The reason for its failure is that the test creates a standalone VM and a VM within a vApp using the same name in VCD 10.4. 


Sample error before this fix:
```
START: nsxt_firewall_group_static_security_group_test.go:106: TestVCD.Test_NsxtSecurityGroupGetAssociatedVms
nsxt_firewall_group_static_security_group_test.go:128:
// VMs are prependend to cleanup list to make sure they are removed before routed network
standaloneVm := createStandaloneVm(check, vcd, nsxtVdc, routedNet)
nsxt_firewall_group_static_security_group_test.go:270:
check.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"error creating standalone VM: API Error: 400: [ a355e5d1-be85-4bbe-89bd-28298b405da7 ] The VMware Cloud Director entity TestVCD.Test_NsxtSecurityGroupGetAssociatedVms already exists."} ("error creating standalone VM: API Error: 400: [ a355e5d1-be85-4bbe-89bd-28298b405da7 ] The VMware Cloud Director entity TestVCD.Test_NsxtSecurityGroupGetAssociatedVms already exists.")

FAIL: nsxt_firewall_group_static_security_group_test.go:106: TestVCD.Test_NsxtSecurityGroupGetAssociatedVms
```