### PR TITLE
Simplify Test_LDAP

### DIFF
--- a/.changes/v2.17.0/505-improvements.md
+++ b/.changes/v2.17.0/505-improvements.md
@@ -1,0 +1,2 @@
+* Simplify `Test_LDAP` by using a pre-configured LDAP server [GH-505]
+

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -40,7 +40,7 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 	publishExternalCatalogs := adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally
 	subscribeToExternalCatalogs := adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe
 
-	fmt.Println("Setting up LDAP")
+	fmt.Printf("Setting up LDAP (IP: %s)\n", ldapHostIp)
 	err = configureLdapForOrg(vcd, adminOrg, ldapHostIp, check.TestName())
 	check.Assert(err, IsNil)
 	defer func() {

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -163,6 +163,7 @@ type TestConfig struct {
 		ExternalNetworkPortGroup     string `yaml:"externalNetworkPortGroup,omitempty"`
 		ExternalNetworkPortGroupType string `yaml:"externalNetworkPortGroupType,omitempty"`
 		VimServer                    string `yaml:"vimServer,omitempty"`
+		LdapServer                   string `yaml:"ldap_server,omitempty"`
 		Nsxt                         struct {
 			Manager             string `yaml:"manager"`
 			Tier0router         string `yaml:"tier0router"`

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -204,9 +204,6 @@ type TestConfig struct {
 		PhotonOsOvaPath  string `yaml:"photonOsOvaPath,omitempty"`
 		MediaUdfTypePath string `yaml:"mediaUdfTypePath,omitempty"`
 	} `yaml:"media"`
-	Misc struct {
-		LdapContainer string `yaml:"ldapContainer,omitempty"`
-	} `yaml:"misc"`
 }
 
 // Test struct for vcloud-director.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -163,7 +163,7 @@ type TestConfig struct {
 		ExternalNetworkPortGroup     string `yaml:"externalNetworkPortGroup,omitempty"`
 		ExternalNetworkPortGroupType string `yaml:"externalNetworkPortGroupType,omitempty"`
 		VimServer                    string `yaml:"vimServer,omitempty"`
-		LdapServer                   string `yaml:"ldap_server,omitempty"`
+		LdapServer                   string `yaml:"ldapServer,omitempty"`
 		Nsxt                         struct {
 			Manager             string `yaml:"manager"`
 			Tier0router         string `yaml:"tier0router"`

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -191,8 +191,3 @@ media:
   mediaPath: ../test-resources/test.iso
   # Existing media in test system
   mediaName: uploadedMediaName
-misc:
-  # By default tests in this repository pick LDAP container 'rroemhild/test-openldap'. As docker throttles downloads
-  # it can help to host the image on local registry and pull it from there. This variable overrides default container
-  # location when set.
-  #ldapContainer: custom-registry.yyy/directory/test-openldap:latest

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -132,6 +132,9 @@ vcd:
     # A vSphere server name for creating an external network
     vimServer: vc9
     #
+    # IP of a pre-configured LDAP server
+    # using Docker image https://github.com/rroemhild/docker-test-openldap
+    ldap_server: 10.10.10.99
 logging:
     # All items in this section are optional
     # Logging is disabled by default.


### PR DESCRIPTION
* Remove VM and network creation from LDAP test
* Replace ephemeral VM with permanent LDAP server in the testing VCD
* Remove functions that were only used to create the VM for this test

This is similar to the change of `TestAccVcdOrgGroup` in [PR-909](https://github.com/vmware/terraform-provider-vcd/pull/909)

The reason for this change is that what we are testing within TestLDAP is quite fast, but the *preparation* takes a long time, so much that we added a tag `skipLong` to avoid such test in given circumstances. Moreover, creating a LDAP server (which requires routing to the VM) would fail for environmental reasons that add nothing to our testing experience.
The change requires a pre-set LDAP server, which is created only once per each VCD in a separate –automated– task, thus allowing us to test the intended feature without waiting for the server to be up.