### PR TITLE
Create catalog by subscription

### DIFF
--- a/.changes/v2.17.0/508-features.md
+++ b/.changes/v2.17.0/508-features.md
@@ -1,0 +1,10 @@
+* Added methods `AdminCatalog.GetParent`, `AdminCatalog.GetAdminParent`, `Catalog.GetParent`, and `Catalog.GetAdminParent` to retrieve parent Organization [GH-508]
+* Added AdminOrg methods `CreateCatalogFromSubscriptionAsync`, `CreateCatalogFromSubscription`, `ImportFromCatalogAsync`, `ImportFromCatalog` to to create a catalog by subscribing to a published one [GH-508]
+* Added method `AdminCatalog.FullSubscriptionUrl` to return a well formatted subscription URL [GH-508]
+* Added method `AdminCatalog.GetSubscribedCatalogItem` to retrieve a (possibly incomplete) catalog item [GH-508]
+* Added functions `ResourceInProgress` and `ResourceComplete` to check for running tasks [GH-508]
+* Add function `IsValidUrl` to check for URL completiion [GH-508]
+* Added methods `client.GetCatalogByHref` and `client.GetAdminCatalogByHref` to retrieve a Catalog or AdminCatalog regardless of the working Org [GH-508]
+* Added methods `catalog.Sync` and `adminCatalog.Sync` to synchronise a subscribed catalog [GH-508]
+* Added methods `adminCatalog.QueryMediaList` and `adminCatalog.QueryVappTemplateList` to retrieve media and vApp template lists[GH-508]
+

--- a/govcd/access_control_catalog_test.go
+++ b/govcd/access_control_catalog_test.go
@@ -2,7 +2,7 @@
 // +build functional catalog ALL
 
 /*
- * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -17,7 +17,7 @@ import (
 )
 
 // catalogTenantContext defines whether we use tenant context during catalog tests.
-// By default is off, unless variable VCD_CATALOG_TENANT_CONTEXT is set
+// By default, is off, unless variable VCD_CATALOG_TENANT_CONTEXT is set
 var catalogTenantContext = os.Getenv("VCD_CATALOG_TENANT_CONTEXT") != ""
 
 // GetId completes the implementation of interface accessControlType
@@ -94,14 +94,20 @@ func (vcd *TestVCD) Test_CatalogAccessControl(check *C) {
 
 func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessControlType, testName, catalogName string, check *C) {
 
-	var users = []struct {
+	type testUser struct {
 		name string
 		role string
 		user *OrgUser
-	}{
-		{"ac-user1", OrgUserRoleVappAuthor, nil},
-		{"ac-user2", OrgUserRoleOrganizationAdministrator, nil},
-		{"ac-user3", OrgUserRoleCatalogAuthor, nil},
+	}
+	var sameOrgUsers = []testUser{
+		{"ac-vapp-author", OrgUserRoleVappAuthor, nil},
+		{"ac-org-admin", OrgUserRoleOrganizationAdministrator, nil},
+		{"ac-cat-author", OrgUserRoleCatalogAuthor, nil},
+	}
+	var newOrgUsers = []testUser{
+		{"ac-new-vapp-author", OrgUserRoleVappAuthor, nil},
+		{"ac-new-org-admin", OrgUserRoleOrganizationAdministrator, nil},
+		{"ac-new-cat-author", OrgUserRoleCatalogAuthor, nil},
 	}
 
 	orgName := "ac-testorg"
@@ -126,8 +132,31 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			err = newOrg.Delete(true, true)
 			check.Assert(err, IsNil)
 		}()
+		// Create three users in the new org
+		for i := 0; i < len(newOrgUsers); i++ {
+			newOrgUsers[i].user, err = newOrg.CreateUserSimple(OrgUserConfiguration{
+				Name: newOrgUsers[i].name, Password: newOrgUsers[i].name, RoleName: newOrgUsers[i].role, IsEnabled: true,
+			})
+			check.Assert(err, IsNil)
+			check.Assert(newOrgUsers[i].user, NotNil)
+			// No need to add this user to clean-up list. It will be removed when its org is deleted
+		}
 	}
 
+	checkAllUsersAccess := func(label string) {
+		if !testVerbose {
+			return
+		}
+		fmt.Printf("[checkAllUsersAccess] %s\n", label)
+		for _, user := range sameOrgUsers {
+			err := testAccessToSharedCatalog(adminOrg, catalogName, user.name, user.name)
+			check.Assert(err, IsNil)
+		}
+		for _, user := range newOrgUsers {
+			err := testAccessToSharedCatalog(newOrg, catalogName, user.name, user.name)
+			check.Assert(err, IsNil)
+		}
+	}
 	checkEmpty := func() {
 		settings, err := catalog.GetAccessControl(catalogTenantContext)
 		check.Assert(err, IsNil)
@@ -135,32 +164,37 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		check.Assert(settings.AccessSettings, IsNil)             // There should not be any explicit sharing
 	}
 
-	// Create three users
-	for i := 0; i < len(users); i++ {
-		users[i].user, err = adminOrg.CreateUserSimple(OrgUserConfiguration{
-			Name: users[i].name, Password: users[i].name, RoleName: users[i].role, IsEnabled: true,
+	// Create three users in the same org
+	for i := 0; i < len(sameOrgUsers); i++ {
+		sameOrgUsers[i].user, err = adminOrg.CreateUserSimple(OrgUserConfiguration{
+			Name: sameOrgUsers[i].name, Password: sameOrgUsers[i].name, RoleName: sameOrgUsers[i].role, IsEnabled: true,
 		})
 		check.Assert(err, IsNil)
-		check.Assert(users[i].user, NotNil)
-		AddToCleanupList(users[i].name, "user", vcd.config.VCD.Org, testName)
+		check.Assert(sameOrgUsers[i].user, NotNil)
+		AddToCleanupList(sameOrgUsers[i].name, "user", vcd.config.VCD.Org, testName)
 	}
+
 	defer func() {
-		for i := 0; i < len(users); i++ {
+		for i := 0; i < len(sameOrgUsers); i++ {
 			if testVerbose {
-				fmt.Printf("deleting %s\n", users[i].name)
+				fmt.Printf("deleting %s\n", sameOrgUsers[i].name)
 			}
-			err = users[i].user.Delete(false)
+			err = sameOrgUsers[i].user.Delete(false)
 			check.Assert(err, IsNil)
 		}
 	}()
 	checkEmpty()
-	//globalSettings := types.ControlAccessParams{
-	//	IsSharedToEveryone:  true,
-	//	EveryoneAccessLevel: takeStringPointer(types.ControlAccessReadWrite),
-	//	AccessSettings: nil,
-	//}
-	//err = testAccessControl(catalogName+" catalog global", catalog, globalSettings, globalSettings, true, check)
-	//check.Assert(err, IsNil)
+	checkAllUsersAccess("empty")
+	globalSettings := types.ControlAccessParams{
+		IsSharedToEveryone:  true,
+		EveryoneAccessLevel: takeStringPointer(types.ControlAccessReadOnly),
+		AccessSettings:      nil,
+	}
+	err = testAccessControl(catalogName+" catalog global", catalog, globalSettings, globalSettings, true, catalogTenantContext, check)
+	check.Assert(err, IsNil)
+
+	// All users on all orgs should be able to see the catalog
+	checkAllUsersAccess("shared to everyone")
 
 	// Set control access to one user
 	oneUserSettings := types.ControlAccessParams{
@@ -170,9 +204,9 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			[]*types.AccessSetting{
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[0].user.User.Href,
-						Name: users[0].user.User.Name,
-						Type: users[0].user.User.Type,
+						HREF: sameOrgUsers[0].user.User.Href,
+						Name: sameOrgUsers[0].user.User.Name,
+						Type: sameOrgUsers[0].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadWrite,
@@ -183,7 +217,33 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 	err = testAccessControl(catalogName+" catalog one user", catalog, oneUserSettings, oneUserSettings, true, catalogTenantContext, check)
 	check.Assert(err, IsNil)
 
-	// Check that vapp.GetAccessControl and vdc.GetVappAccessControl return the same data
+	checkAllUsersAccess("one user - same org")
+
+	// Set control access to one user on a different org
+	oneUserOtherOrgSettings := types.ControlAccessParams{
+		IsSharedToEveryone:  false,
+		EveryoneAccessLevel: nil,
+		AccessSettings: &types.AccessSettingList{
+			[]*types.AccessSetting{
+				&types.AccessSetting{
+					Subject: &types.LocalSubject{
+						HREF: newOrgUsers[1].user.User.Href,
+						Name: newOrgUsers[1].user.User.Name,
+						Type: newOrgUsers[1].user.User.Type,
+					},
+					ExternalSubject: nil,
+					AccessLevel:     types.ControlAccessReadWrite,
+				},
+			},
+		},
+	}
+	// sharing with a user of a different Org is not allowed: we expect a failure
+	err = testAccessControl(catalogName+" catalog one user - other org", catalog, oneUserOtherOrgSettings, oneUserOtherOrgSettings, true, catalogTenantContext, check)
+	check.Assert(err, NotNil)
+	check.Assert(err.Error(), Matches, `.*Sharing is only supported in an organization.*`)
+	checkAllUsersAccess("one user - other org")
+
+	// Check that catalog.GetAccessControl and vdc.GetCatalogAccessControl return the same data
 	controlAccess, err := catalog.GetAccessControl(catalogTenantContext)
 	check.Assert(err, IsNil)
 	orgControlAccessByName, err := adminOrg.GetCatalogAccessControl(catalogName, catalogTenantContext)
@@ -202,18 +262,18 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			[]*types.AccessSetting{
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[0].user.User.Href,
+						HREF: sameOrgUsers[0].user.User.Href,
 						//Name: users[0].user.User.Name, // Pass info without name for one of the subjects
-						Type: users[0].user.User.Type,
+						Type: sameOrgUsers[0].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[1].user.User.Href,
-						Name: users[1].user.User.Name,
-						Type: users[1].user.User.Type,
+						HREF: sameOrgUsers[1].user.User.Href,
+						Name: sameOrgUsers[1].user.User.Name,
+						Type: sameOrgUsers[1].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessFullControl,
@@ -223,6 +283,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 	}
 	err = testAccessControl(catalogName+" catalog two users", catalog, twoUserSettings, twoUserSettings, true, catalogTenantContext, check)
 	check.Assert(err, IsNil)
+
+	checkAllUsersAccess("two users - same org")
 
 	// Check removal of sharing setting
 	err = catalog.RemoveAccessControl(catalogTenantContext)
@@ -237,27 +299,27 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			[]*types.AccessSetting{
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[0].user.User.Href,
-						Name: users[0].user.User.Name,
-						Type: users[0].user.User.Type,
+						HREF: sameOrgUsers[0].user.User.Href,
+						Name: sameOrgUsers[0].user.User.Name,
+						Type: sameOrgUsers[0].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[1].user.User.Href,
+						HREF: sameOrgUsers[1].user.User.Href,
 						//Name: users[1].user.User.Name,// Pass info without name for one of the subjects
-						Type: users[1].user.User.Type,
+						Type: sameOrgUsers[1].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessFullControl,
 				},
 				&types.AccessSetting{
 					Subject: &types.LocalSubject{
-						HREF: users[2].user.User.Href,
-						Name: users[2].user.User.Name,
-						Type: users[2].user.User.Type,
+						HREF: sameOrgUsers[2].user.User.Href,
+						Name: sameOrgUsers[2].user.User.Name,
+						Type: sameOrgUsers[2].user.User.Type,
 					},
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadWrite,
@@ -267,6 +329,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 	}
 	err = testAccessControl(catalogName+" catalog three users", catalog, threeUserSettings, threeUserSettings, true, catalogTenantContext, check)
 	check.Assert(err, IsNil)
+	checkAllUsersAccess("three users - same org")
 
 	if vcd.client.Client.IsSysAdmin && newOrg != nil {
 
@@ -278,27 +341,27 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 				[]*types.AccessSetting{
 					&types.AccessSetting{
 						Subject: &types.LocalSubject{
-							HREF: users[0].user.User.Href,
-							Name: users[0].user.User.Name,
-							Type: users[0].user.User.Type,
+							HREF: sameOrgUsers[0].user.User.Href,
+							Name: sameOrgUsers[0].user.User.Name,
+							Type: sameOrgUsers[0].user.User.Type,
 						},
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessReadOnly,
 					},
 					&types.AccessSetting{
 						Subject: &types.LocalSubject{
-							HREF: users[1].user.User.Href,
+							HREF: sameOrgUsers[1].user.User.Href,
 							//Name: users[1].user.User.Name,// Pass info without name for one of the subjects
-							Type: users[1].user.User.Type,
+							Type: sameOrgUsers[1].user.User.Type,
 						},
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessFullControl,
 					},
 					&types.AccessSetting{
 						Subject: &types.LocalSubject{
-							HREF: users[2].user.User.Href,
-							Name: users[2].user.User.Name,
-							Type: users[2].user.User.Type,
+							HREF: sameOrgUsers[2].user.User.Href,
+							Name: sameOrgUsers[2].user.User.Name,
+							Type: sameOrgUsers[2].user.User.Type,
 						},
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessReadWrite,
@@ -317,6 +380,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		}
 		err = testAccessControl(catalogName+" catalog three users and org", catalog, threeUserOrgSettings, threeUserOrgSettings, true, catalogTenantContext, check)
 		check.Assert(err, IsNil)
+		checkAllUsersAccess("three users + one org ")
 
 		err = catalog.RemoveAccessControl(catalogTenantContext)
 		check.Assert(err, IsNil)
@@ -351,6 +415,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		}
 		err = testAccessControl(catalogName+" catalog two org", catalog, twoOrgsSettings, twoOrgsSettings, true, catalogTenantContext, check)
 		check.Assert(err, IsNil)
+		checkAllUsersAccess("two orgs ")
 	}
 
 	// Set empty settings explicitly
@@ -362,4 +427,34 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 
 	checkEmpty()
 
+}
+
+// testAccessToSharedCatalog is an informational tool to show whether a given user can access a shared catalog
+// Its output is visible when -vcd-verbose is used on the command line
+func testAccessToSharedCatalog(org *AdminOrg, catalogName, userName, password string) error {
+	vcdClient := NewVCDClient(org.client.VCDHREF, true)
+	err := vcdClient.Authenticate(userName, password, org.AdminOrg.Name)
+	if err != nil {
+		return err
+	}
+	catalogs, err := queryCatalogList(&vcdClient.Client, nil)
+	if err != nil {
+		return fmt.Errorf("error retrieving catalogs as user '%s': %s", userName, err)
+	}
+
+	found := false
+	for _, cat := range catalogs {
+		if catalogName == cat.Name {
+			found = true
+		}
+	}
+
+	if testVerbose {
+		if found {
+			fmt.Printf("++ user %s from org %s can access catalog %s\n", userName, org.AdminOrg.Name, catalogName)
+		} else {
+			fmt.Printf("## user %s from org %s CANNOT access catalog %s\n", userName, org.AdminOrg.Name, catalogName)
+		}
+	}
+	return nil
 }

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -597,6 +597,22 @@ func (adminOrg *AdminOrg) GetAdminCatalogByHref(catalogHref string) (*AdminCatal
 	return adminCatalog, nil
 }
 
+// GetAdminCatalogByHref  finds an AdminCatalog by HREF
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (client *Client) GetAdminCatalogByHref(catalogHref string) (*AdminCatalog, error) {
+	adminCatalog := NewAdminCatalog(client)
+
+	_, err := client.ExecuteRequest(catalogHref, http.MethodGet,
+		"", "error retrieving catalog: %s", nil, adminCatalog.AdminCatalog)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return adminCatalog, nil
+}
+
 // GetCatalogByName finds an AdminCatalog by Name
 // On success, returns a pointer to the AdminCatalog structure and a nil error
 // On failure, returns a nil pointer and an error

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -919,14 +919,14 @@ func queryMediaList(client *Client, catalogHref string) ([]*types.MediaRecordTyp
 
 // Sync synchronise a subscribed catalog
 func (cat *Catalog) Sync() error {
-	return catalogSync(cat.client, cat.Catalog.HREF)
+	return elementSync(cat.client, cat.Catalog.HREF, "catalog")
 }
 
-// catalogSync is a low level function that synchronises a Catalog or AdminCatalog
-func catalogSync(client *Client, catalogHref string) error {
-	href := catalogHref + "/sync"
+// elementSync is a low level function that synchronises a Catalog, AdminCatalog, CatalogItem, or Media item
+func elementSync(client *Client, elementHref, label string) error {
+	href := elementHref + "/action/sync"
 	syncTask, err := client.ExecuteTaskRequest(href, http.MethodPost,
-		"", "error synchronizing catalog: %s", nil)
+		"", "error synchronizing "+label+": %s", nil)
 
 	if err != nil {
 		return err

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -126,3 +126,8 @@ func (vdc *AdminVdc) QueryVappTemplateList() ([]*types.QueryResultVappTemplateTy
 func (catalog *Catalog) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
 	return queryVappTemplateList(catalog.client, "catalogName", catalog.Catalog.Name)
 }
+
+// Sync synchronises a subscribed Catalog item
+func (item *CatalogItem) Sync() error {
+	return elementSync(item.client, item.CatalogItem.HREF, "catalog item")
+}

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -706,3 +706,12 @@ func (vdc *Vdc) QueryAllMedia(mediaName string) ([]*MediaRecord, error) {
 	util.Logger.Printf("[TRACE] Found media records by name: %#v \n", mediaResults)
 	return newMediaRecords, nil
 }
+
+// Sync synchronises a subscribed media item
+func (item *MediaRecord) Sync() error {
+	if item.MediaRecord.CatalogItem == "" {
+		return fmt.Errorf("could not find catalog item HREF for media %s", item.MediaRecord.Name)
+	}
+	// only catalog items can be synchronised
+	return elementSync(item.client, item.MediaRecord.CatalogItem, "catalog media")
+}

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -308,6 +308,20 @@ func SimpleShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, f
 	simpleOutTask("screen", task, howManyTimes, elapsed, first, last)
 }
 
+func MinimalShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	marker := "."
+	if task.Status == "success" {
+		marker = "+"
+	}
+	if task.Status == "error" {
+		marker = "-"
+	}
+	fmt.Printf(marker)
+	if last {
+		fmt.Println()
+	}
+}
+
 func SimpleLogTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
 	simpleOutTask("log", task, howManyTimes, elapsed, first, last)
 }

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -216,6 +216,20 @@ func (org *Org) GetCatalogByHref(catalogHref string) (*Catalog, error) {
 	return cat, nil
 }
 
+// GetCatalogByHref  finds a Catalog by HREF
+// On success, returns a pointer to the Catalog structure and a nil error
+// On failure, returns a nil pointer and an error
+func (client *Client) GetCatalogByHref(catalogHref string) (*Catalog, error) {
+	cat := NewCatalog(client)
+
+	_, err := client.ExecuteRequest(catalogHref, http.MethodGet,
+		"", "error retrieving catalog: %s", nil, cat.Catalog)
+	if err != nil {
+		return nil, err
+	}
+	return cat, nil
+}
+
 // GetCatalogByName  finds a Catalog by Name
 // On success, returns a pointer to the Catalog structure and a nil error
 // On failure, returns a nil pointer and an error

--- a/govcd/task.go
+++ b/govcd/task.go
@@ -197,3 +197,22 @@ func (task *Task) CancelTask() error {
 	}
 	return nil
 }
+
+// ResourceInProgress returns true if any of the provided tasks is still running
+func ResourceInProgress(task *types.TasksInProgress) bool {
+	if task == nil {
+		return false
+	}
+	tasks := task.Task
+	for _, task := range tasks {
+		if task.Status == "running" || task.Status == "preRunning" || task.Status == "queued" || task.Progress < 100 {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourceComplete return true is none of its tasks are running
+func ResourceComplete(task *types.TasksInProgress) bool {
+	return !ResourceInProgress(task)
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -139,6 +139,8 @@ const (
 	PublishExternalCatalog = "application/vnd.vmware.admin.publishExternalCatalogParams+xml"
 	// Mime to subscribe to external catalog
 	SubscribeToExternalCatalog = "application/vnd.vmware.admin.externalCatalogSubscriptionParams+xml"
+	// Mime to identify a media item
+	MimeMediaItem = "application/vnd.vmware.vcloud.media+xml"
 )
 
 const (

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -137,6 +137,8 @@ const (
 	MimeLeaseSettingSection = "application/vnd.vmware.vcloud.leaseSettingsSection+xml"
 	// Mime to publish external catalog
 	PublishExternalCatalog = "application/vnd.vmware.admin.publishExternalCatalogParams+xml"
+	// Mime to subscribe to external catalog
+	SubscribeToExternalCatalog = "application/vnd.vmware.admin.externalCatalogSubscriptionParams+xml"
 )
 
 const (

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1139,11 +1139,13 @@ type PublishExternalCatalogParams struct {
 // Description: Represents the configuration parameters for a catalog that has an external subscription.
 // Since: 5.5
 type ExternalCatalogSubscription struct {
-	ExpectedSslThumbprint    bool   `xml:"ExpectedSslThumbprint,omitempty"`
-	LocalCopy                bool   `xml:"LocalCopy,omitempty"`
-	Password                 string `xml:"Password,omitempty"`
-	SubscribeToExternalFeeds bool   `xml:"SubscribeToExternalFeeds,omitempty"`
-	Location                 string `xml:"Location,omitempty"`
+	XMLName                  xml.Name `xml:"ExternalCatalogSubscriptionParams"`
+	Xmlns                    string   `xml:"xmlns,attr,omitempty"`
+	ExpectedSslThumbprint    string   `xml:"ExpectedSslThumbprint,omitempty"`
+	SubscribeToExternalFeeds bool     `xml:"SubscribeToExternalFeeds,omitempty"`
+	Location                 string   `xml:"Location,omitempty"`
+	Password                 string   `xml:"Password,omitempty"`
+	LocalCopy                bool     `xml:"LocalCopy,omitempty"`
 }
 
 // CatalogStorageProfiles represents a container for storage profiles used by this catalog


### PR DESCRIPTION
Add methods `adminOrg.CreateCatalogFromSubscription` and `adminOrg.SubscribeToCatalog` to address Issue [#776](https://github.com/vmware/terraform-provider-vcd/issues/776)

Also, improve `catalog.PublishToExternalOrganizations` and `adminCatalog.PublishToExternalOrganizations` by checking whether the publishing catalog parent organization allows the operation.