### PR TITLE
Catalog subscription

### DIFF
--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -355,7 +355,7 @@ func (cat *AdminCatalog) LaunchSynchronisationMediaItems(nameList []string) ([]*
 		for k := range found {
 			foundList = append(foundList, k)
 		}
-		return nil, fmt.Errorf("%d names provided [%v] but %d actions scheduled [%v]\n", len(nameList), nameList, len(actionList), foundList)
+		return nil, fmt.Errorf("%d names provided [%v] but %d actions scheduled [%v]", len(nameList), nameList, len(actionList), foundList)
 	}
 	for _, element := range actionList {
 		util.Logger.Printf("synchronising Media catalog item HREF %s\n", element)

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -7,8 +7,12 @@ package govcd
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
 // AdminCatalog is a admin view of a VMware Cloud Director Catalog
@@ -128,4 +132,277 @@ func (cat *AdminCatalog) PublishToExternalOrganizations(publishExternalCatalog t
 	}
 
 	return err
+}
+
+// CreateCatalogFromSubscriptionAsync creates a new catalog by subscribing to a published catalog
+// Parameter subscription needs to be filled manually
+func (org *AdminOrg) CreateCatalogFromSubscriptionAsync(subscription types.ExternalCatalogSubscription,
+	storageProfiles *types.CatalogStorageProfiles,
+	catalogName, password string, localCopy bool) (*AdminCatalog, error) {
+
+	// If the receiving Org doesn't have any VDCs, it means that there is no storage that can be used
+	// by a catalog
+	if len(org.AdminOrg.Vdcs.Vdcs) == 0 {
+		return nil, fmt.Errorf("org %s does not have any storage to support a catalog", org.AdminOrg.Name)
+	}
+	href := ""
+
+	// The subscribed catalog creation is like a regular catalog creation, with the
+	// difference that the subscription details are filled in
+	for _, link := range org.AdminOrg.Link {
+		if link.Rel == "add" && link.Type == types.MimeAdminCatalog {
+			href = link.HREF
+			break
+		}
+	}
+	if href == "" {
+		return nil, fmt.Errorf("catalog creation link not found for org %s", org.AdminOrg.Name)
+	}
+	reqCatalog := &types.Catalog{
+		Name: catalogName,
+	}
+	adminCatalog := types.AdminCatalog{
+		Xmlns:                  types.XMLNamespaceVCloud,
+		Catalog:                *reqCatalog,
+		CatalogStorageProfiles: storageProfiles,
+		ExternalCatalogSubscription: &types.ExternalCatalogSubscription{
+			LocalCopy:                localCopy,
+			Password:                 password,
+			Location:                 subscription.Location,
+			SubscribeToExternalFeeds: true,
+		},
+	}
+	// The subscription URL returned by the API is in abbreviated form
+	// such as "/vcsp/lib/65637586-c703-48ae-a7e2-82605d18db57/"
+	// If the passed URL is so abbreviated, we need to add the host
+	if !IsValidUrl(subscription.Location) {
+		// Get the catalog base URL
+		cutPosition := strings.Index(org.AdminOrg.HREF, "/api")
+		catalogHost := org.AdminOrg.HREF[:cutPosition]
+		subscriptionUrl, err := url.JoinPath(catalogHost, subscription.Location)
+		if err != nil {
+			return nil, fmt.Errorf("error composing subscription URL: %s", err)
+		}
+		adminCatalog.ExternalCatalogSubscription.Location = subscriptionUrl
+	}
+
+	adminCatalog.ExternalCatalogSubscription.Password = password
+	adminCatalog.ExternalCatalogSubscription.LocalCopy = localCopy
+	_, err := org.client.ExecuteRequest(href, http.MethodPost, types.MimeAdminCatalog,
+		"error subscribing to catalog: %s", adminCatalog, nil)
+	if err != nil {
+		return nil, err
+	}
+	return org.GetAdminCatalogByName(catalogName, true)
+}
+
+// FullSubscriptionUrl returns the subscription URL from a publisher catalog
+// adding the HOST if needed
+func (cat *AdminCatalog) FullSubscriptionUrl() string {
+	if cat.AdminCatalog.PublishExternalCatalogParams == nil {
+		return ""
+	}
+	subscriptionUrl := cat.AdminCatalog.PublishExternalCatalogParams.CatalogPublishedUrl
+	var err error
+	if !IsValidUrl(subscriptionUrl) {
+		// Get the catalog base URL
+		cutPosition := strings.Index(cat.AdminCatalog.HREF, "/api")
+		catalogHost := cat.AdminCatalog.HREF[:cutPosition]
+		subscriptionUrl, err = url.JoinPath(catalogHost, subscriptionUrl)
+		if err != nil {
+			return ""
+		}
+	}
+	return subscriptionUrl
+}
+
+// IsValidUrl returns true if the given URL is complete and usable
+func IsValidUrl(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+// CreateCatalogFromSubscription is a wrapper around CreateCatalogFromSubscriptionAsync
+// After catalog creation, it waits for the import tasks to complete within a given timeout
+func (org *AdminOrg) CreateCatalogFromSubscription(subscription types.ExternalCatalogSubscription,
+	storageProfiles *types.CatalogStorageProfiles,
+	catalogName, password string, localCopy bool, timeout time.Duration) (*AdminCatalog, error) {
+	noTimeout := timeout == 0
+	adminCatalog, err := org.CreateCatalogFromSubscriptionAsync(subscription, storageProfiles, catalogName, password, localCopy)
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	for noTimeout || time.Since(start) < timeout {
+		if noTimeout {
+			util.Logger.Printf("[TRACE] [CreateCatalogFromSubscription] no timeout given - Elapsed %s", time.Since(start))
+		}
+		err = adminCatalog.Refresh()
+		if err != nil {
+			return nil, err
+		}
+		if ResourceComplete(adminCatalog.AdminCatalog.Tasks) {
+			return adminCatalog, nil
+		}
+	}
+	return nil, fmt.Errorf("adminCatalog %s still not complete after %s", adminCatalog.AdminCatalog.Name, timeout)
+}
+
+// Sync synchronises a subscribed AdminCatalog
+func (cat *AdminCatalog) Sync() error {
+	// if the catalog was not subscribed, return
+	if cat.AdminCatalog.ExternalCatalogSubscription == nil || cat.AdminCatalog.ExternalCatalogSubscription.Location == "" {
+		return nil
+	}
+	// The sync operation is only available for Catalog, not AdminCatalog.
+	// We use the embedded Catalog object for this purpose
+	catalogHref, err := cat.GetCatalogHref()
+	if err != nil || catalogHref == "" {
+		return fmt.Errorf("empty catalog HREF for admin catalog %s", cat.AdminCatalog.Name)
+	}
+	return elementSync(cat.client, catalogHref, "admin catalog")
+}
+
+// LaunchSync starts synchronisation of a subscribed AdminCatalog
+func (cat *AdminCatalog) LaunchSync() (*Task, error) {
+	// if the catalog was not subscribed, return
+	if cat.AdminCatalog.ExternalCatalogSubscription == nil || cat.AdminCatalog.ExternalCatalogSubscription.Location == "" {
+		return nil, nil
+	}
+	// The sync operation is only available for Catalog, not AdminCatalog.
+	// We use the embedded Catalog object for this purpose
+	catalogHref, err := cat.GetCatalogHref()
+	if err != nil || catalogHref == "" {
+		return nil, fmt.Errorf("empty catalog HREF for admin catalog %s", cat.AdminCatalog.Name)
+	}
+	return elementLaunchSync(cat.client, catalogHref, "admin catalog")
+}
+
+// GetCatalogHref retrieves the regular catalog HREF from an admin catalog
+func (cat *AdminCatalog) GetCatalogHref() (string, error) {
+	href := ""
+	for _, link := range cat.AdminCatalog.Link {
+		if link.Rel == "alternate" && link.Type == types.MimeCatalog {
+			href = link.HREF
+			break
+		}
+	}
+	if href == "" {
+		return "", fmt.Errorf("no regular Catalog HREF found for admin Catalog %s", cat.AdminCatalog.Name)
+	}
+	return href, nil
+}
+
+// QueryVappTemplateList returns a list of vApp templates for the given catalog
+func (catalog *AdminCatalog) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
+	return queryVappTemplateList(catalog.client, "catalogName", catalog.AdminCatalog.Name)
+}
+
+// QueryMediaList retrieves a list of media items for the Admin Catalog
+func (catalog *AdminCatalog) QueryMediaList() ([]*types.MediaRecordType, error) {
+	return queryMediaList(catalog.client, catalog.AdminCatalog.HREF)
+}
+
+// LaunchSynchronisationVappTemplates starts synchronisation of a list of vApp templates
+func (cat *AdminCatalog) LaunchSynchronisationVappTemplates(nameList []string) ([]*Task, error) {
+	var taskList []*Task
+	for _, element := range nameList {
+		catalogItem, err := cat.QueryCatalogItem(element)
+		if err != nil {
+			return nil, err
+		}
+		task, err := queryResultCatalogItemToCatalogItem(cat.client, catalogItem).LaunchSync()
+		if err != nil {
+			return nil, err
+		}
+		taskList = append(taskList, task)
+	}
+	return taskList, nil
+}
+
+// LaunchSynchronisationAllVappTemplates starts synchronisation of all vApp templates for a given catalog
+func (cat *AdminCatalog) LaunchSynchronisationAllVappTemplates() ([]*Task, error) {
+	vappTemplatesList, err := cat.QueryVappTemplateList()
+	if err != nil {
+		return nil, err
+	}
+	var nameList []string
+	for _, element := range vappTemplatesList {
+		nameList = append(nameList, element.Name)
+	}
+	return cat.LaunchSynchronisationVappTemplates(nameList)
+}
+
+// LaunchSynchronisationMediaItems starts synchronisation of a list of media items
+func (cat *AdminCatalog) LaunchSynchronisationMediaItems(nameList []string) ([]*Task, error) {
+	var taskList []*Task
+	mediaList, err := cat.QueryMediaList()
+	if err != nil {
+		return nil, err
+	}
+	var actionList []string
+
+	var found = make(map[string]string)
+	for _, element := range mediaList {
+		if contains(element.Name, nameList) {
+			util.Logger.Printf("scheduling for synchronisation Media item %s with catalog item HREF %s\n", element.Name, element.CatalogItem)
+			actionList = append(actionList, element.CatalogItem)
+			found[element.Name] = element.CatalogItem
+		}
+	}
+	if len(actionList) < len(nameList) {
+		var foundList []string
+		for k := range found {
+			foundList = append(foundList, k)
+		}
+		return nil, fmt.Errorf("%d names provided [%v] but %d actions scheduled [%v]\n", len(nameList), nameList, len(actionList), foundList)
+	}
+	for _, element := range actionList {
+		util.Logger.Printf("synchronising Media catalog item HREF %s\n", element)
+		catalogItem, err := cat.GetCatalogItemByHref(element)
+		if err != nil {
+			return nil, err
+		}
+		task, err := catalogItem.LaunchSync()
+		if err != nil {
+			return nil, err
+		}
+		taskList = append(taskList, task)
+	}
+	return taskList, nil
+}
+
+// LaunchSynchronisationAllMediaItems starts synchronisation of all media items for a given catalog
+func (cat *AdminCatalog) LaunchSynchronisationAllMediaItems() ([]*Task, error) {
+	var taskList []*Task
+	mediaList, err := cat.QueryMediaList()
+	if err != nil {
+		return nil, err
+	}
+	for _, element := range mediaList {
+		catalogItem, err := cat.GetCatalogItemByHref(element.CatalogItem)
+		if err != nil {
+			return nil, err
+		}
+		task, err := catalogItem.LaunchSync()
+		if err != nil {
+			return nil, err
+		}
+		taskList = append(taskList, task)
+	}
+	return taskList, nil
+}
+
+// GetCatalogItemByHref finds a CatalogItem by HREF
+// On success, returns a pointer to the CatalogItem structure and a nil error
+// On failure, returns a nil pointer and an error
+func (cat *AdminCatalog) GetCatalogItemByHref(catalogItemHref string) (*CatalogItem, error) {
+	catItem := NewCatalogItem(cat.client)
+
+	_, err := cat.client.ExecuteRequest(catalogItemHref, http.MethodGet,
+		"", "error retrieving catalog item: %s", nil, catItem.CatalogItem)
+	if err != nil {
+		return nil, err
+	}
+	return catItem, nil
 }

--- a/govcd/catalog_subscription_test.go
+++ b/govcd/catalog_subscription_test.go
@@ -1,0 +1,337 @@
+//go:build catalog || functional || ALL
+// +build catalog functional ALL
+
+/*
+ * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+type subscriptionTestData struct {
+	fromOrg                   *AdminOrg
+	toOrg                     *AdminOrg
+	ovaPath                   string
+	mediaPath                 string
+	localCopy                 bool
+	storageProfile            types.CatalogStorageProfiles
+	uploadWhen                string
+	preservePublishingCatalog bool
+	asynchronousSubscription  bool
+}
+
+func (vcd *TestVCD) Test_SubscribedCatalog(check *C) {
+
+	fromOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	toOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org + "-1")
+	check.Assert(err, IsNil)
+
+	if toOrg.AdminOrg.Vdcs == nil || len(toOrg.AdminOrg.Vdcs.Vdcs) == 0 {
+		check.Skip(fmt.Sprintf("receiving org %s does not have any storage", toOrg.AdminOrg.Name))
+	}
+	// TODO: remove this workaround when support for 10.3.3 is dropped
+	// See Test_PublishToExternalOrganizations for details
+	fromOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs = true
+	fromOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally = true
+	_, err = fromOrg.Update()
+
+	check.Assert(err, IsNil)
+	vdc, err := fromOrg.GetVDCByName(vcd.config.VCD.Nsxt.Vdc, false)
+	check.Assert(err, IsNil)
+
+	storageProfile, err := vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
+	check.Assert(err, IsNil)
+	createStorageProfiles := types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{&storageProfile}}
+
+	testSubscribedCatalog(subscriptionTestData{
+		fromOrg:                  fromOrg,
+		toOrg:                    toOrg,
+		ovaPath:                  vcd.config.OVA.OvaPath,
+		mediaPath:                vcd.config.Media.MediaPath,
+		localCopy:                false,
+		storageProfile:           createStorageProfiles,
+		uploadWhen:               "after_subscription",
+		asynchronousSubscription: true,
+	}, check)
+
+	testSubscribedCatalog(subscriptionTestData{
+		fromOrg:                   fromOrg,
+		toOrg:                     toOrg,
+		ovaPath:                   vcd.config.OVA.OvaPath,
+		mediaPath:                 vcd.config.Media.MediaPath,
+		localCopy:                 true,
+		storageProfile:            createStorageProfiles,
+		uploadWhen:                "after_subscription",
+		preservePublishingCatalog: true,
+		asynchronousSubscription:  true,
+	}, check)
+
+	// For the tests where the items are uploaded before subscription, we can keep the publishing catalog
+	// from the previous test
+	testSubscribedCatalog(subscriptionTestData{
+		fromOrg:                   fromOrg,
+		toOrg:                     toOrg,
+		ovaPath:                   vcd.config.OVA.OvaPath,
+		mediaPath:                 vcd.config.Media.MediaPath,
+		localCopy:                 false,
+		storageProfile:            createStorageProfiles,
+		uploadWhen:                "before_subscription",
+		preservePublishingCatalog: true,
+	}, check)
+	testSubscribedCatalog(subscriptionTestData{
+		fromOrg:                   fromOrg,
+		toOrg:                     toOrg,
+		ovaPath:                   vcd.config.OVA.OvaPath,
+		mediaPath:                 vcd.config.Media.MediaPath,
+		localCopy:                 true,
+		storageProfile:            createStorageProfiles,
+		uploadWhen:                "before_subscription",
+		preservePublishingCatalog: false, // at the last subtest, we remove the publishing catalog
+	}, check)
+
+}
+
+func uploadTestItems(org *AdminOrg, catalogName, templatePath, mediaPath string, numTemplates, numMedia int) error {
+	var taskList []*Task
+
+	catalog, err := org.GetCatalogByName(catalogName, true)
+	if err != nil {
+		return fmt.Errorf("catalog %s not found: %s", catalogName, err)
+	}
+
+	for i := 1; i <= numTemplates; i++ {
+		templateName := fmt.Sprintf("test-vt-%d", i)
+		uploadTask, err := catalog.UploadOvf(templatePath, templateName, "upload from test", 1024)
+		if err != nil {
+			return err
+		}
+		taskList = append(taskList, uploadTask.Task)
+	}
+	for i := 1; i <= numMedia; i++ {
+		mediaName := fmt.Sprintf("test_media-%d", i)
+		uploadTask, err := catalog.UploadMediaImage(mediaName, "upload from test", mediaPath, 1024)
+		if err != nil {
+			return err
+		}
+		taskList = append(taskList, uploadTask.Task)
+	}
+	_, err = WaitTaskListCompletionMonitor(taskList, testMonitor)
+	fmt.Println()
+	return err
+}
+
+func testSubscribedCatalog(testData subscriptionTestData, check *C) {
+
+	startSubtest := time.Now()
+	drawHeader := func(char, msg string) {
+		fmt.Println(strings.Repeat(char, 80))
+		fmt.Printf("%s %s\n", char, msg)
+	}
+	drawHeader("*", fmt.Sprintf("START: upload %s - local copy: %v", testData.uploadWhen, testData.localCopy))
+
+	fromOrg := testData.fromOrg
+	toOrg := testData.toOrg
+
+	publishingCatalogName := "Publisher"
+	subscribingCatalogName := "Subscriber"
+
+	var fromCatalog *AdminCatalog
+	var err error
+	fromCatalog, err = fromOrg.GetAdminCatalogByName(publishingCatalogName, true)
+	if err == nil {
+		drawHeader("-", "publishing catalog retrieved from previous test")
+	} else {
+		drawHeader("-", "creating publishing catalog")
+		fromCatalog, err = fromOrg.CreateCatalogWithStorageProfile(publishingCatalogName, "publisher catalog", &testData.storageProfile)
+		check.Assert(err, IsNil)
+		AddToCleanupList(publishingCatalogName, "catalog", fromOrg.AdminOrg.Name, check.TestName())
+	}
+
+	subscriptionPassword := "superUnknown"
+	err = fromCatalog.PublishToExternalOrganizations(types.PublishExternalCatalogParams{
+		IsPublishedExternally:    takeBoolPointer(true),
+		Password:                 subscriptionPassword,
+		IsCachedEnabled:          takeBoolPointer(true),
+		PreserveIdentityInfoFlag: takeBoolPointer(true),
+	})
+	check.Assert(err, IsNil)
+	//start := time.Now()
+
+	uploadItemsIf := func(wanted string) {
+		if wanted != testData.uploadWhen {
+			return
+		}
+		howManyTemplates := 3
+		howManyMediaItems := 3
+		publishedCatalogItems, err := fromCatalog.QueryCatalogItemList()
+		if err == nil && len(publishedCatalogItems) == (howManyMediaItems+howManyTemplates) {
+			return
+		}
+		drawHeader("-", fmt.Sprintf("uploading catalog items - %s", wanted))
+		err = uploadTestItems(fromOrg, fromCatalog.AdminCatalog.Name, testData.ovaPath, testData.mediaPath, howManyTemplates, howManyMediaItems)
+		check.Assert(err, IsNil)
+	}
+	err = fromCatalog.Refresh()
+	check.Assert(err, IsNil)
+
+	check.Assert(fromCatalog.AdminCatalog.PublishExternalCatalogParams, NotNil)
+	check.Assert(fromCatalog.AdminCatalog.PublishExternalCatalogParams.CatalogPublishedUrl, Not(Equals), "")
+
+	uploadItemsIf("before_subscription")
+	err = fromCatalog.Refresh()
+	check.Assert(err, IsNil)
+
+	subscriptionParams := types.ExternalCatalogSubscription{
+		SubscribeToExternalFeeds: true,
+		Location:                 fromCatalog.AdminCatalog.PublishExternalCatalogParams.CatalogPublishedUrl,
+		Password:                 subscriptionPassword,
+		LocalCopy:                testData.localCopy,
+	}
+
+	var toCatalog *AdminCatalog
+	if testData.asynchronousSubscription {
+		drawHeader("-", "creating subscribed catalog asynchronously")
+		// With asynchronous subscription the catalog starts the subscription but does not report its state, which is
+		// monitored by its internal Task
+		toCatalog, err = toOrg.CreateCatalogFromSubscriptionAsync(
+			subscriptionParams,     // params
+			nil,                    // storage profile
+			subscribingCatalogName, // catalog name
+			subscriptionPassword,   // password
+			testData.localCopy)     // local copy
+	} else {
+		drawHeader("-", "creating subscribed catalog and waiting for completion")
+		toCatalog, err = toOrg.CreateCatalogFromSubscription(
+			subscriptionParams,     // params
+			nil,                    // storage profile
+			subscribingCatalogName, // catalog name
+			subscriptionPassword,   // password
+			testData.localCopy,     // local copy
+			10*time.Minute)         // timeout
+	}
+	check.Assert(err, IsNil)
+	AddToCleanupList(subscribingCatalogName, "catalog", toOrg.AdminOrg.Name, check.TestName())
+
+	if testData.asynchronousSubscription {
+		err = toCatalog.Refresh()
+		check.Assert(err, IsNil)
+		if ResourceInProgress(toCatalog.AdminCatalog.Tasks) {
+			fmt.Println("catalog subscription tasks still in progress")
+			for _, task := range toCatalog.AdminCatalog.Tasks.Task {
+				testMonitor(task)
+			}
+		} else {
+			fmt.Println("catalog subscription tasks complete")
+		}
+	}
+
+	uploadItemsIf("after_subscription")
+
+	// If the catalog items were uploaded before the catalog subscription, we don't need to
+	// synchronise, as the subscription would have got at least the list of items
+	if testData.uploadWhen != "before_subscription" {
+		drawHeader("-", "synchronising catalog")
+		err = toCatalog.Sync()
+		check.Assert(err, IsNil)
+	}
+
+	publishedCatalogItems, err := fromCatalog.QueryCatalogItemList()
+	check.Assert(err, IsNil)
+	subscribedCatalogItems, err := toCatalog.QueryCatalogItemList()
+	check.Assert(err, IsNil)
+	fmt.Printf("Catalog items after catalog sync: %d\n", len(subscribedCatalogItems))
+	publishedVappTemplates, err := fromCatalog.QueryVappTemplateList()
+	check.Assert(err, IsNil)
+	subscribedVappTemplates, err := toCatalog.QueryVappTemplateList()
+	check.Assert(err, IsNil)
+	publishedMediaItems, err := fromCatalog.QueryMediaList()
+	subscribedMediaItems, err := toCatalog.QueryMediaList()
+	check.Assert(err, IsNil)
+
+	fmt.Printf("vApp template after catalog sync %d\n", len(subscribedVappTemplates))
+	fmt.Printf("media item after catalog sync %d\n", len(subscribedMediaItems))
+
+	check.Assert(len(subscribedCatalogItems), Equals, len(publishedCatalogItems))
+	check.Assert(len(subscribedVappTemplates), Equals, len(publishedVappTemplates))
+	check.Assert(len(subscribedMediaItems), Equals, len(publishedMediaItems))
+
+	if testData.localCopy && testData.uploadWhen == "before_subscription" {
+		// we should have all the contents here if the data was available early
+		// and the subscribed catalog uses automatic download
+		retrieveCatalogItems(toCatalog, subscribedCatalogItems, check)
+	}
+
+	// Synchronising all vApp templates and media items. If the subscription includes local copy,
+	// the synchronisation has alredy happened, and this extra call is very quick (~5 seconds)
+	drawHeader("-", "synchronising vApp templates and media items")
+	tasksVappTemplates, err := toCatalog.LaunchSynchronisationAllVappTemplates()
+	check.Assert(err, IsNil)
+	tasksMediaItems, err := toCatalog.LaunchSynchronisationAllMediaItems()
+	check.Assert(err, IsNil)
+
+	// Wait for all synchronisation tasks to end
+	var allTasks []*Task
+	allTasks = append(allTasks, tasksVappTemplates...)
+	allTasks = append(allTasks, tasksMediaItems...)
+	_, err = WaitTaskListCompletionMonitor(allTasks, testMonitor)
+	if !testVerbose {
+		fmt.Println()
+	}
+	check.Assert(err, IsNil)
+
+	// after a full synchronisation, all data should be available	under every condition
+	retrieveCatalogItems(toCatalog, subscribedCatalogItems, check)
+
+	startDelete := time.Now()
+	err = toCatalog.Delete(true, true)
+	check.Assert(err, IsNil)
+	fmt.Printf("subscribed catalog deletion done in %s\n", time.Since(startDelete))
+	startDelete = time.Now()
+	if !testData.preservePublishingCatalog {
+		err = fromCatalog.Delete(true, true)
+		check.Assert(err, IsNil)
+		fmt.Printf("published catalog deletion done in %s\n", time.Since(startDelete))
+	}
+	drawHeader("=", fmt.Sprintf("END: upload %s - local copy: %v - Time taken: %s", testData.uploadWhen, testData.localCopy, time.Since(startSubtest)))
+}
+
+func retrieveCatalogItems(toCatalog *AdminCatalog, subscribed []*types.QueryResultCatalogItemType, check *C) {
+	for _, item := range subscribed {
+		catalogItem, err := toCatalog.GetCatalogItemByHref(item.HREF)
+		check.Assert(err, IsNil)
+		switch catalogItem.CatalogItem.Entity.Type {
+		case types.MimeVAppTemplate:
+			vAppTemplate, err := catalogItem.GetVAppTemplate()
+			check.Assert(err, IsNil)
+			check.Assert(vAppTemplate.VAppTemplate.HREF, Equals, catalogItem.CatalogItem.Entity.HREF)
+		case types.MimeMediaItem:
+			mediaItem, err := toCatalog.GetMediaByHref(catalogItem.CatalogItem.Entity.HREF)
+			check.Assert(err, IsNil)
+			check.Assert(extractUuid(mediaItem.Media.ID), Equals, extractUuid(catalogItem.CatalogItem.Entity.HREF))
+		}
+	}
+}
+
+func testMonitor(task *types.Task) {
+	if testVerbose {
+		fmt.Printf("task %s - owner %s - operation %s -  status %s - progress %d\n", task.ID, task.Owner.Name, task.Operation, task.Status, task.Progress)
+	} else {
+		marker := "."
+		if task.Status == "success" {
+			marker = "+"
+		}
+		if task.Status == "error" {
+			marker = "-"
+		}
+		fmt.Printf(marker)
+	}
+}

--- a/govcd/catalog_subscription_test.go
+++ b/govcd/catalog_subscription_test.go
@@ -254,6 +254,7 @@ func testSubscribedCatalog(testData subscriptionTestData, check *C) {
 	subscribedVappTemplates, err := toCatalog.QueryVappTemplateList()
 	check.Assert(err, IsNil)
 	publishedMediaItems, err := fromCatalog.QueryMediaList()
+	check.Assert(err, IsNil)
 	subscribedMediaItems, err := toCatalog.QueryMediaList()
 	check.Assert(err, IsNil)
 
@@ -332,6 +333,6 @@ func testMonitor(task *types.Task) {
 		if task.Status == "error" {
 			marker = "-"
 		}
-		fmt.Printf(marker)
+		fmt.Print(marker)
 	}
 }

--- a/govcd/catalogitem.go
+++ b/govcd/catalogitem.go
@@ -126,3 +126,85 @@ func (vdc *AdminVdc) QueryVappTemplateList() ([]*types.QueryResultVappTemplateTy
 func (catalog *Catalog) QueryVappTemplateList() ([]*types.QueryResultVappTemplateType, error) {
 	return queryVappTemplateList(catalog.client, "catalogName", catalog.Catalog.Name)
 }
+
+// queryCatalogItemFilteredList returns a list of Catalog Items with an optional filter
+func queryCatalogItemFilteredList(client *Client, filter map[string]string) ([]*types.QueryResultCatalogItemType, error) {
+	catalogItemType := types.QtCatalogItem
+	if client.IsSysAdmin {
+		catalogItemType = types.QtAdminCatalogItem
+	}
+
+	filterText := ""
+	for k, v := range filter {
+		if filterText != "" {
+			filterText += ";"
+		}
+		filterText += fmt.Sprintf("%s==%s", k, url.QueryEscape(v))
+	}
+
+	notEncodedParams := map[string]string{
+		"type": catalogItemType,
+	}
+	if filterText != "" {
+		notEncodedParams["filter"] = filterText
+	}
+	results, err := client.cumulativeQuery(catalogItemType, nil, notEncodedParams)
+	if err != nil {
+		return nil, fmt.Errorf("error querying catalog items %s", err)
+	}
+
+	if client.IsSysAdmin {
+		return results.Results.AdminCatalogItemRecord, nil
+	} else {
+		return results.Results.CatalogItemRecord, nil
+	}
+}
+
+// QueryCatalogItemList returns a list of Catalog Item for the given admin catalog
+func (catalog *AdminCatalog) QueryCatalogItemList() ([]*types.QueryResultCatalogItemType, error) {
+	return queryCatalogItemList(catalog.client, "catalog", catalog.AdminCatalog.ID)
+}
+
+// QueryCatalogItem returns a named Catalog Item for the given catalog
+func (catalog *AdminCatalog) QueryCatalogItem(name string) (*types.QueryResultCatalogItemType, error) {
+	return queryCatalogItem(catalog.client, "catalog", catalog.AdminCatalog.ID, name)
+}
+
+// queryCatalogItem returns a named Catalog Item for the given parent
+func queryCatalogItem(client *Client, parentField, parentValue, name string) (*types.QueryResultCatalogItemType, error) {
+
+	result, err := queryCatalogItemFilteredList(client, map[string]string{parentField: parentValue, "name": name})
+	if err != nil {
+		return nil, err
+	}
+	if len(result) == 0 {
+		return nil, ErrorEntityNotFound
+	}
+	if len(result) > 1 {
+		return nil, fmt.Errorf("more than one item (%d) found with name %s", len(result), name)
+	}
+	return result[0], nil
+}
+
+// queryResultCatalogItemToCatalogItem converts a catalog item as retrieved from a query into a regular one
+func queryResultCatalogItemToCatalogItem(client *Client, qr *types.QueryResultCatalogItemType) *CatalogItem {
+	var catalogItem = NewCatalogItem(client)
+	catalogItem.CatalogItem = &types.CatalogItem{
+		HREF:        qr.HREF,
+		Type:        qr.Type,
+		ID:          extractUuid(qr.HREF),
+		Name:        qr.Name,
+		DateCreated: qr.CreationDate,
+		Entity: &types.Entity{
+			HREF: qr.Entity,
+			Type: qr.EntityType,
+			Name: qr.EntityName,
+		},
+	}
+	return catalogItem
+}
+
+// LaunchSync starts synchronisation of a subscribed Catalog item
+func (item *CatalogItem) LaunchSync() (*Task, error) {
+	return elementLaunchSync(item.client, item.CatalogItem.HREF, "catalog item")
+}

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -308,6 +308,20 @@ func SimpleShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, f
 	simpleOutTask("screen", task, howManyTimes, elapsed, first, last)
 }
 
+func MinimalShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
+	marker := "."
+	if task.Status == "success" {
+		marker = "+"
+	}
+	if task.Status == "error" {
+		marker = "-"
+	}
+	fmt.Printf(marker)
+	if last {
+		fmt.Println()
+	}
+}
+
 func SimpleLogTask(task *types.Task, howManyTimes int, elapsed time.Duration, first, last bool) {
 	simpleOutTask("log", task, howManyTimes, elapsed, first, last)
 }

--- a/govcd/monitor.go
+++ b/govcd/monitor.go
@@ -316,7 +316,7 @@ func MinimalShowTask(task *types.Task, howManyTimes int, elapsed time.Duration, 
 	if task.Status == "error" {
 		marker = "-"
 	}
-	fmt.Printf(marker)
+	fmt.Print(marker)
 	if last {
 		fmt.Println()
 	}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -137,6 +137,8 @@ const (
 	MimeLeaseSettingSection = "application/vnd.vmware.vcloud.leaseSettingsSection+xml"
 	// Mime to publish external catalog
 	PublishExternalCatalog = "application/vnd.vmware.admin.publishExternalCatalogParams+xml"
+	// Mime to identify a media item
+	MimeMediaItem = "application/vnd.vmware.vcloud.media+xml"
 )
 
 const (

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1139,11 +1139,13 @@ type PublishExternalCatalogParams struct {
 // Description: Represents the configuration parameters for a catalog that has an external subscription.
 // Since: 5.5
 type ExternalCatalogSubscription struct {
-	ExpectedSslThumbprint    bool   `xml:"ExpectedSslThumbprint,omitempty"`
-	LocalCopy                bool   `xml:"LocalCopy,omitempty"`
-	Password                 string `xml:"Password,omitempty"`
-	SubscribeToExternalFeeds bool   `xml:"SubscribeToExternalFeeds,omitempty"`
-	Location                 string `xml:"Location,omitempty"`
+	XMLName                  xml.Name `xml:"ExternalCatalogSubscriptionParams"`
+	Xmlns                    string   `xml:"xmlns,attr,omitempty"`
+	ExpectedSslThumbprint    string   `xml:"ExpectedSslThumbprint,omitempty"`
+	SubscribeToExternalFeeds bool     `xml:"SubscribeToExternalFeeds,omitempty"`
+	Location                 string   `xml:"Location,omitempty"`
+	Password                 string   `xml:"Password,omitempty"`
+	LocalCopy                bool     `xml:"LocalCopy,omitempty"`
 }
 
 // CatalogStorageProfiles represents a container for storage profiles used by this catalog


### PR DESCRIPTION
Addresses Issue [#776](https://github.com/vmware/terraform-provider-vcd/issues/776).

Add methods to create a catalog by subscribing to a published one. 
Add methods to synchronise a subscribed catalog and its items .
Add methods to handle lists of tasks, which are useful when starting synchronisation operations in multiple objects, and monitoring the whole effects later.
 
(Replaces PR #508)