### PR TITLE
Adjust VM Placement Policy code

### DIFF
--- a/.changes/v2.17.0/513-improvements.md
+++ b/.changes/v2.17.0/513-improvements.md
@@ -1,0 +1,2 @@
+* Created `VM.UpdateComputePolicyV2` and `VM.UpdateComputePolicyV2Async` that allows updating also VM Placement Policies
+  for a given VM [GH-513]

--- a/.changes/v2.17.0/513-improvements.md
+++ b/.changes/v2.17.0/513-improvements.md
@@ -1,2 +1,2 @@
-* Created `VM.UpdateComputePolicyV2` and `VM.UpdateComputePolicyV2Async` that allows updating also VM Placement Policies
-  for a given VM [GH-513]
+* Created `VM.UpdateComputePolicyV2` and `VM.UpdateComputePolicyV2Async` that uses v2.0.0 of VDC Compute Policy endpoint
+  of OpenAPI and allows updating VM Sizing Policies and also VM Placement Policies for a given VM [GH-513]

--- a/govcd/vdccomputepolicy_v2.go
+++ b/govcd/vdccomputepolicy_v2.go
@@ -46,7 +46,7 @@ func getVdcComputePolicyV2ById(client *VCDClient, id string) (*VdcComputePolicyV
 
 	vdcComputePolicy := &VdcComputePolicyV2{
 		VdcComputePolicyV2: &types.VdcComputePolicyV2{},
-		Href:								urlRef.String(),
+		Href:               urlRef.String(),
 		client:             &client.Client,
 	}
 

--- a/govcd/vdccomputepolicy_v2.go
+++ b/govcd/vdccomputepolicy_v2.go
@@ -17,6 +17,7 @@ import (
 // VdcComputePolicyV2 defines a VDC Compute Policy, which can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy.
 type VdcComputePolicyV2 struct {
 	VdcComputePolicyV2 *types.VdcComputePolicyV2
+	Href               string
 	client             *Client
 }
 
@@ -45,6 +46,7 @@ func getVdcComputePolicyV2ById(client *VCDClient, id string) (*VdcComputePolicyV
 
 	vdcComputePolicy := &VdcComputePolicyV2{
 		VdcComputePolicyV2: &types.VdcComputePolicyV2{},
+		Href:								urlRef.String(),
 		client:             &client.Client,
 	}
 

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1546,7 +1546,7 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId strin
 
 	computePolicy := &types.ComputePolicy{}
 
-	if sizingPolicyId != "" {
+	if strings.TrimSpace(sizingPolicyId) != "" {
 		vdcSizingPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, sizingPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for sizing policy")
@@ -1554,7 +1554,7 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId strin
 		computePolicy.VmSizingPolicy = &types.Reference{HREF: vdcSizingPolicyHref.String()}
 	}
 
-	if placementPolicyId != "" {
+	if strings.TrimSpace(placementPolicyId) != "" {
 		vdcPlacementPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, placementPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for placement policy")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1536,7 +1536,7 @@ func (vm *VM) UpdateComputePolicy(computePolicy *types.VdcComputePolicy) (*VM, e
 // UpdateComputePolicyV2Async updates VM Compute policy with the given compute policies using v2.0.0 OpenAPI endpoint,
 // and returns a Task and an error. Updating with an empty compute policy ID will remove it from the VM. Both
 // policies can't be empty as the VM requires at least one policy.
-// Note: At the moment, vGPU Policies are not supported.
+// WARNING: At the moment, vGPU Policies are not supported. Using one will return an error.
 func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId, vGpuPolicyId string) (Task, error) {
 	if vm.VM.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update VM compute policy, VM HREF is unset")
@@ -1547,7 +1547,7 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId, vGpu
 	vGpuPolicyIsEmpty := strings.TrimSpace(vGpuPolicyId) == ""
 
 	if !vGpuPolicyIsEmpty {
-		util.Logger.Printf("[WARN] vGPU policies are not supported, hence %s will be ignored", vGpuPolicyId)
+		return Task{}, fmt.Errorf("vGPU policies are not supported, hence %s should be empty", vGpuPolicyId)
 	}
 
 	if sizingIsEmpty && placementIsEmpty {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1537,6 +1537,13 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId strin
 		return Task{}, fmt.Errorf("cannot update VM compute policy, VM HREF is unset")
 	}
 
+	sizingIsEmpty := strings.TrimSpace(sizingPolicyId) == ""
+	placementIsEmpty := strings.TrimSpace(placementPolicyId) == ""
+
+	if sizingIsEmpty && placementIsEmpty {
+		return Task{}, fmt.Errorf("either sizing policy ID or placement policy ID is needed")
+	}
+
 	// `reconfigureVm` updates VM name, Description, and any or all of the following sections.
 	//    VirtualHardwareSection
 	//    OperatingSystemSection
@@ -1546,7 +1553,7 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId strin
 
 	computePolicy := &types.ComputePolicy{}
 
-	if strings.TrimSpace(sizingPolicyId) != "" {
+	if !sizingIsEmpty {
 		vdcSizingPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, sizingPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for sizing policy")
@@ -1554,7 +1561,7 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId strin
 		computePolicy.VmSizingPolicy = &types.Reference{HREF: vdcSizingPolicyHref.String()}
 	}
 
-	if strings.TrimSpace(placementPolicyId) != "" {
+	if !placementIsEmpty {
 		vdcPlacementPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, placementPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for placement policy")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1488,8 +1488,8 @@ func (vm *VM) UpdateVmSpecSectionAsync(vmSettingsToUpdate *types.VmSpecSection, 
 }
 
 // UpdateComputePolicyV2 updates VM compute policy and returns refreshed VM or error.
-func (vm *VM) UpdateComputePolicyV2(sizingPolicy, placementPolicy *types.VdcComputePolicyV2) (*VM, error) {
-	task, err := vm.UpdateComputePolicyV2Async(sizingPolicy, placementPolicy)
+func (vm *VM) UpdateComputePolicyV2(sizingPolicyId, placementPolicyId string) (*VM, error) {
+	task, err := vm.UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId)
 	if err != nil {
 		return nil, err
 	}
@@ -1531,8 +1531,8 @@ func (vm *VM) UpdateComputePolicy(computePolicy *types.VdcComputePolicy) (*VM, e
 }
 
 // UpdateComputePolicyV2Async updates VM Compute policy with the given compute policies using v2.0.0 OpenAPI endpoint,
-// and returns a Task and an error.
-func (vm *VM) UpdateComputePolicyV2Async(sizingPolicy, placementPolicy *types.VdcComputePolicyV2) (Task, error) {
+// and returns a Task and an error. Updating with an empty compute policy ID will remove it from the VM.
+func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId string) (Task, error) {
 	if vm.VM.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update VM compute policy, VM HREF is unset")
 	}
@@ -1546,16 +1546,16 @@ func (vm *VM) UpdateComputePolicyV2Async(sizingPolicy, placementPolicy *types.Vd
 
 	computePolicy := &types.ComputePolicy{}
 
-	if sizingPolicy != nil {
-		vdcSizingPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, sizingPolicy.ID)
+	if sizingPolicyId != "" {
+		vdcSizingPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, sizingPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for sizing policy")
 		}
 		computePolicy.VmSizingPolicy = &types.Reference{HREF: vdcSizingPolicyHref.String()}
 	}
 
-	if placementPolicy != nil {
-		vdcPlacementPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, placementPolicy.ID)
+	if placementPolicyId != "" {
+		vdcPlacementPolicyHref, err := vm.client.OpenApiBuildEndpoint(types.OpenApiPathVersion2_0_0, types.OpenApiEndpointVdcComputePolicies, placementPolicyId)
 		if err != nil {
 			return Task{}, fmt.Errorf("error constructing HREF for placement policy")
 		}

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1531,7 +1531,8 @@ func (vm *VM) UpdateComputePolicy(computePolicy *types.VdcComputePolicy) (*VM, e
 }
 
 // UpdateComputePolicyV2Async updates VM Compute policy with the given compute policies using v2.0.0 OpenAPI endpoint,
-// and returns a Task and an error. Updating with an empty compute policy ID will remove it from the VM.
+// and returns a Task and an error. Updating with an empty compute policy ID will remove it from the VM. Both
+// policies can't be empty as the VM requires at least one policy.
 func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId string) (Task, error) {
 	if vm.VM.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update VM compute policy, VM HREF is unset")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1491,8 +1491,8 @@ func (vm *VM) UpdateVmSpecSectionAsync(vmSettingsToUpdate *types.VmSpecSection, 
 // and returns an error if something went wrong, or the refreshed VM if all went OK.
 // Updating with an empty compute policy ID will remove it from the VM. Both policies can't be empty as the VM requires
 // at least one policy.
-func (vm *VM) UpdateComputePolicyV2(sizingPolicyId, placementPolicyId string) (*VM, error) {
-	task, err := vm.UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId)
+func (vm *VM) UpdateComputePolicyV2(sizingPolicyId, placementPolicyId, vGpuPolicyId string) (*VM, error) {
+	task, err := vm.UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId, vGpuPolicyId)
 	if err != nil {
 		return nil, err
 	}
@@ -1536,13 +1536,19 @@ func (vm *VM) UpdateComputePolicy(computePolicy *types.VdcComputePolicy) (*VM, e
 // UpdateComputePolicyV2Async updates VM Compute policy with the given compute policies using v2.0.0 OpenAPI endpoint,
 // and returns a Task and an error. Updating with an empty compute policy ID will remove it from the VM. Both
 // policies can't be empty as the VM requires at least one policy.
-func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId string) (Task, error) {
+// Note: At the moment, vGPU Policies are not supported.
+func (vm *VM) UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId, vGpuPolicyId string) (Task, error) {
 	if vm.VM.HREF == "" {
 		return Task{}, fmt.Errorf("cannot update VM compute policy, VM HREF is unset")
 	}
 
 	sizingIsEmpty := strings.TrimSpace(sizingPolicyId) == ""
 	placementIsEmpty := strings.TrimSpace(placementPolicyId) == ""
+	vGpuPolicyIsEmpty := strings.TrimSpace(vGpuPolicyId) == ""
+
+	if !vGpuPolicyIsEmpty {
+		util.Logger.Printf("[WARN] vGPU policies are not supported, hence %s will be ignored", vGpuPolicyId)
+	}
 
 	if sizingIsEmpty && placementIsEmpty {
 		return Task{}, fmt.Errorf("either sizing policy ID or placement policy ID is needed")

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1487,7 +1487,10 @@ func (vm *VM) UpdateVmSpecSectionAsync(vmSettingsToUpdate *types.VmSpecSection, 
 		})
 }
 
-// UpdateComputePolicyV2 updates VM compute policy and returns refreshed VM or error.
+// UpdateComputePolicyV2 updates VM Compute policy with the given compute policies using v2.0.0 OpenAPI endpoint,
+// and returns an error if something went wrong, or the refreshed VM if all went OK.
+// Updating with an empty compute policy ID will remove it from the VM. Both policies can't be empty as the VM requires
+// at least one policy.
 func (vm *VM) UpdateComputePolicyV2(sizingPolicyId, placementPolicyId string) (*VM, error) {
 	task, err := vm.UpdateComputePolicyV2Async(sizingPolicyId, placementPolicyId)
 	if err != nil {

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1844,7 +1844,7 @@ func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
 	// Remove Sizing Policy
 	vm, err = vm.UpdateComputePolicyV2("", placementPolicies[1].VdcComputePolicyV2.ID)
 	check.Assert(err, IsNil)
-	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy.ID, IsNil)
+	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
 	// Clean VM

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1818,37 +1818,37 @@ func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
 	vapp, vm := createNsxtVAppAndVm(vcd, check)
 	// Update all Compute Policies: Sizing and Placement
 	check.Assert(err, IsNil)
-	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[0].VdcComputePolicyV2.ID, placementPolicies[0].VdcComputePolicyV2.ID)
+	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[0].VdcComputePolicyV2.ID, placementPolicies[0].VdcComputePolicyV2.ID, "")
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy.ID, Equals, sizingPolicies[0].VdcComputePolicyV2.ID)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[0].VdcComputePolicyV2.ID)
 
 	// Update Sizing policy only
-	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[0].VdcComputePolicyV2.ID, placementPolicies[1].VdcComputePolicyV2.ID)
+	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[0].VdcComputePolicyV2.ID, placementPolicies[1].VdcComputePolicyV2.ID, "")
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy.ID, Equals, sizingPolicies[0].VdcComputePolicyV2.ID)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
 	// Update Placement policy only
-	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[1].VdcComputePolicyV2.ID, placementPolicies[1].VdcComputePolicyV2.ID)
+	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[1].VdcComputePolicyV2.ID, placementPolicies[1].VdcComputePolicyV2.ID, "")
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy.ID, Equals, sizingPolicies[1].VdcComputePolicyV2.ID)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
 	// Remove Placement Policy
-	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[1].VdcComputePolicyV2.ID, "")
+	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[1].VdcComputePolicyV2.ID, "", "")
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy.ID, Equals, sizingPolicies[1].VdcComputePolicyV2.ID)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy, IsNil)
 
 	// Remove Sizing Policy
-	vm, err = vm.UpdateComputePolicyV2("", placementPolicies[1].VdcComputePolicyV2.ID)
+	vm, err = vm.UpdateComputePolicyV2("", placementPolicies[1].VdcComputePolicyV2.ID, "")
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
 	// Try to remove both, it should fail
-	_, err = vm.UpdateComputePolicyV2("", "")
+	_, err = vm.UpdateComputePolicyV2("", "", "")
 	check.Assert(err, NotNil)
 	check.Assert(true, Equals, strings.Contains(err.Error(), "either sizing policy ID or placement policy ID is needed"))
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1848,7 +1848,7 @@ func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
 	// Try to remove both, it should fail
-	vm, err = vm.UpdateComputePolicyV2("", "")
+	_, err = vm.UpdateComputePolicyV2("", "")
 	check.Assert(err, NotNil)
 	check.Assert(true, Equals, strings.Contains(err.Error(), "either sizing policy ID or placement policy ID is needed"))
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1847,6 +1847,11 @@ func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
 	check.Assert(vm.VM.ComputePolicy.VmSizingPolicy, IsNil)
 	check.Assert(vm.VM.ComputePolicy.VmPlacementPolicy.ID, Equals, placementPolicies[1].VdcComputePolicyV2.ID)
 
+	// Try to remove both, it should fail
+	vm, err = vm.UpdateComputePolicyV2("", "")
+	check.Assert(err, NotNil)
+	check.Assert(true, Equals, strings.Contains(err.Error(), "either sizing policy ID or placement policy ID is needed"))
+
 	// Clean VM
 	task, err := vapp.Undeploy()
 	check.Assert(err, IsNil)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1816,6 +1816,9 @@ func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
 	check.Assert(len(alreadyAssignedPolicies)+numberOfPolicies*2, Equals, len(assignedVdcComputePolicies.VdcComputePolicyReference))
 
 	vapp, vm := createNsxtVAppAndVm(vcd, check)
+	check.Assert(vapp, NotNil)
+	check.Assert(vm, NotNil)
+
 	// Update all Compute Policies: Sizing and Placement
 	check.Assert(err, IsNil)
 	vm, err = vm.UpdateComputePolicyV2(sizingPolicies[0].VdcComputePolicyV2.ID, placementPolicies[0].VdcComputePolicyV2.ID, "")
@@ -2175,6 +2178,8 @@ func (vcd *TestVCD) Test_VMChangeMemory(check *C) {
 
 func (vcd *TestVCD) Test_AddRawVm(check *C) {
 	vapp, vm := createNsxtVAppAndVm(vcd, check)
+	check.Assert(vapp, NotNil)
+	check.Assert(vm, NotNil)
 
 	// Check that vApp did not lose its state
 	vappStatus, err := vapp.GetStatus()


### PR DESCRIPTION
### Overview

This PR adds a new method to update Compute Policies in **VMs** with the v2.0.0 version of the API, that also adds support for VM Placement Policies.

It sets the foundations for https://github.com/vmware/terraform-provider-vcd/pull/922, as in this PR we onboard VM Placement Policies for VMs.