### PR TITLE
Add org users to govcd test configuration

### DIFF
--- a/.changes/v2.17.0/515-improvements.md
+++ b/.changes/v2.17.0/515-improvements.md
@@ -1,0 +1,1 @@
+* Add `[]tenant` structure to simplify org user testing [GH-515]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -41,7 +41,8 @@ func init() {
 	setBoolFlag(&ignoreCleanupFile, "vcd-ignore-cleanup-file", "GOVCD_IGNORE_CLEANUP_FILE", "Does not process previous cleanup file")
 	setBoolFlag(&debugShowRequestEnabled, "vcd-show-request", "GOVCD_SHOW_REQ", "Shows API request")
 	setBoolFlag(&debugShowResponseEnabled, "vcd-show-response", "GOVCD_SHOW_RESP", "Shows API response")
-
+	setBoolFlag(&connectAsOrgUser, "vcd-test-org-user", "VCD_TEST_ORG_USER", "Connect as Org user")
+	flag.IntVar(&connectTenantNum, "vcd-connect-tenant", connectTenantNum, "change index of tenant to use (0=first)")
 }
 
 const (
@@ -95,6 +96,14 @@ const (
 	TestRequiresSysAdminPrivileges = "Test %s requires system administrator privileges"
 )
 
+type Tenant struct {
+	User     string `yaml:"user,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	Token    string `yaml:"token,omitempty"`
+	ApiToken string `yaml:"api_token,omitempty"`
+	SysOrg   string `yaml:"sysOrg,omitempty"`
+}
+
 // Struct to get info from a config yaml file that the user
 // specifies
 type TestConfig struct {
@@ -125,7 +134,8 @@ type TestConfig struct {
 		MaxRetryTimeout int    `yaml:"maxRetryTimeout,omitempty"`
 		HttpTimeout     int64  `yaml:"httpTimeout,omitempty"`
 	}
-	VCD struct {
+	Tenants []Tenant `yaml:"tenants,omitempty"`
+	VCD     struct {
 		Org         string `yaml:"org"`
 		Vdc         string `yaml:"vdc"`
 		ProviderVdc struct {
@@ -265,6 +275,10 @@ var enableDebug bool
 
 // ignoreCleanupFile prevents processing a previous cleanup file
 var ignoreCleanupFile bool
+
+// connectAsOrgUser connects as Org user instead of System administrator
+var connectAsOrgUser bool
+var connectTenantNum int
 
 // Makes the name for the cleanup entities persistent file
 // Using a name for each vCD allows us to run tests with different servers
@@ -442,6 +456,20 @@ func GetConfigStruct() (TestConfig, error) {
 	if err != nil {
 		return TestConfig{}, fmt.Errorf("could not unmarshal yaml file: %s", err)
 	}
+	if connectAsOrgUser {
+		if len(configStruct.Tenants) == 0 {
+			return TestConfig{}, fmt.Errorf("org user connection required, but 'tenants[%d]' is empty", connectTenantNum)
+		}
+		if connectTenantNum > len(configStruct.Tenants)-1 {
+			return TestConfig{}, fmt.Errorf("org user connection required, but tenant number %d is higher than the number of tenants ", connectTenantNum)
+		}
+		// Change configStruct.Provider, to reuse the global fields, such as URL
+		configStruct.Provider.User = configStruct.Tenants[connectTenantNum].User
+		configStruct.Provider.Password = configStruct.Tenants[connectTenantNum].Password
+		configStruct.Provider.SysOrg = configStruct.Tenants[connectTenantNum].SysOrg
+		configStruct.Provider.Token = configStruct.Tenants[connectTenantNum].Token
+		configStruct.Provider.ApiToken = configStruct.Tenants[connectTenantNum].ApiToken
+	}
 	return configStruct, nil
 }
 
@@ -485,15 +513,17 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 		fmt.Println()
 		// Prints only the flags defined in this package
 		flag.CommandLine.VisitAll(func(f *flag.Flag) {
-			if strings.Contains(f.Name, "vcd-") {
+			if strings.HasPrefix(f.Name, "vcd-") {
 				fmt.Printf("  -%-40s %s (%v)\n", f.Name, f.Usage, f.Value)
 			}
 		})
 		fmt.Println()
-		os.Exit(0)
+		// This will skip the whole suite.
+		// Instead, running os.Exit(0) will panic
+		check.Skip("--- showing help ---")
 	}
 	config, err := GetConfigStruct()
-	if config == (TestConfig{}) || err != nil {
+	if config.Provider.Url == "" || err != nil {
 		panic(err)
 	}
 	vcd.config = config

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -40,6 +40,22 @@ provider:
     # (Optional) httpTimeout specifies a time limit (in seconds) for waiting http response.
     # If omitted - default value is set.
     # httpTimeout: 600
+# 'tenants' is an array of org users with their relative organization
+# This structure makes it easier to run go-vcloud-director tests as org-user
+# with the options '-vcd-test-org-user' (bool) and '-vcd-connect-tenant' (int)
+tenants:
+    # the first user is the one that will be picked by default when -vcd-test-org-user is set
+  - user: user-first-org
+    password: password-first-user
+    sysOrg: first-org
+    token: optional-token
+    api_token: optional-api-token
+    # with -vcd-connect-tenant=1 the second user will be picked for connection 
+  - user: user-second-org
+    password: password-second-org
+    sysOrg: second-org
+    token: optional-token
+    api_token: optional-api-token
 vcd:
     # Name of the organization (mandatory)
     org: myorg


### PR DESCRIPTION
A new structure `[]tenant` is added to `TestConfig`, to allow connecting as tenant user.
When the option `-vcd-test-org-user` (same as what is used in terraform-provider-vcd) is se, the first tenant in the list is selected for connection.
To use the second tenant (or an optional third one), we can use the option `-vcd-connect-tenant=1` (or `-vcd-connect-tenant=2` if a third one exists).

