### PR TITLE
Add VM.GetEnvironment() to retrieve OVF Environment

### DIFF
--- a/.changes/v2.20.0/528-features.md
+++ b/.changes/v2.20.0/528-features.md
@@ -1,0 +1,1 @@
+* Added method `VM.GetEnvironment` to retrieve OVF Environment [GH-528]

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -836,11 +836,11 @@ func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 func (vm *VM) GetEnvironment() (*types.OVF_Environment, error) {
 	vmStatus, err := vm.GetStatus()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get ovf environment: %s", err)
+		return nil, fmt.Errorf("unable to get OVF environment: %s", err)
 	}
 
 	if vmStatus != "POWERED_ON" {
-		return nil, fmt.Errorf("ovf environment is only available when VM is poweredOn")
+		return nil, fmt.Errorf("OVF environment is only available when VM is powered on")
 	}
 
 	return vm.VM.Environment, nil

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -832,6 +832,21 @@ func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 	return getProductSectionList(vm.client, vm.VM.HREF)
 }
 
+// GetEnvironment returns the OVF Environment. It's only available for poweredOn VM
+func (vm *VM) GetEnvironment() (*types.OVF_Environment, error) {
+	v := &types.Vm{}
+
+	if vm.VM.HREF == "" {
+		return nil, fmt.Errorf("cannot refresh, invalid reference url")
+	}
+
+	_, err := vm.client.ExecuteRequest(vm.VM.HREF, http.MethodGet,
+		types.MimeVM, "error retrieving ovf environment: %s", nil, v)
+
+	// The request was successful
+	return v.Environment, err
+}
+
 // GetGuestCustomizationSection retrieves guest customization section for a VM. It allows to read VM guest customization properties.
 func (vm *VM) GetGuestCustomizationSection() (*types.GuestCustomizationSection, error) {
 	if vm == nil || vm.VM.HREF == "" {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -834,17 +834,16 @@ func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 
 // GetEnvironment returns the OVF Environment. It's only available for poweredOn VM
 func (vm *VM) GetEnvironment() (*types.OVF_Environment, error) {
-	v := &types.Vm{}
-
-	if vm.VM.HREF == "" {
-		return nil, fmt.Errorf("cannot refresh, invalid reference url")
+	vmStatus, err := vm.GetStatus()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get ovf environment: %s", err)
 	}
 
-	_, err := vm.client.ExecuteRequest(vm.VM.HREF, http.MethodGet,
-		types.MimeVM, "error retrieving ovf environment: %s", nil, v)
+	if vmStatus != "POWERED_ON" {
+		return nil, fmt.Errorf("ovf environment is only available when VM is poweredOn")
+	}
 
-	// The request was successful
-	return v.Environment, err
+	return vm.VM.Environment, nil
 }
 
 // GetGuestCustomizationSection retrieves guest customization section for a VM. It allows to read VM guest customization properties.

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -833,7 +833,7 @@ func (vm *VM) GetProductSectionList() (*types.ProductSectionList, error) {
 }
 
 // GetEnvironment returns the OVF Environment. It's only available for poweredOn VM
-func (vm *VM) GetEnvironment() (*types.OVF_Environment, error) {
+func (vm *VM) GetEnvironment() (*types.OvfEnvironment, error) {
 	vmStatus, err := vm.GetStatus()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get OVF environment: %s", err)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2318,13 +2318,13 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 
 	// Check guest operating system level configuration for hostname
 	check.Assert(ovfenv.PropertySection, NotNil)
-	for _, p := range ovfenv.PropertySection.PropertyList {
+	for _, p := range ovfenv.PropertySection.Properties {
 		if p.Key == "vCloud_computerName" {
 			check.Assert(p.Value, Not(Equals), "")
 		}
 	}
 	check.Assert(ovfenv.EthernetAdapterSection, NotNil)
-	for _, p := range ovfenv.EthernetAdapterSection.AdapterList {
+	for _, p := range ovfenv.EthernetAdapterSection.Adapters {
 		check.Assert(p.Mac, Not(Equals), "")
 	}
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2307,10 +2307,15 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 	// Read ovfenv when VM is started
 	ovfenv, err := vm.GetEnvironment()
 	check.Assert(err, IsNil)
+
+	// Provides information from the virtualization platform like VM moref
 	check.Assert(strings.Contains(ovfenv.VCenterId, "vm-"), Equals, true)
-	check.Assert(ovfenv, NotNil)
+
+	// Check virtualization platform Vendor
 	check.Assert(ovfenv.PlatformSection, NotNil)
-	check.Assert(ovfenv.PlatformSection.Kind, Equals, "VMware ESXi")
+	check.Assert(ovfenv.PlatformSection.Vendor, Equals, "VMware, Inc.")
+
+	// Check guest operating system level configuration for hostname
 	check.Assert(ovfenv.PropertySection, NotNil)
 	for _, p := range ovfenv.PropertySection.PropertyList {
 		if p.Key == "vCloud_computerName" {
@@ -2330,6 +2335,15 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 
 	ovfenv, err = vm.GetEnvironment()
-	check.Assert(err, IsNil)
+	check.Assert(strings.Contains(err.Error(), "ovf environment is only available when VM is poweredOn"), Equals, true)
 	check.Assert(ovfenv, IsNil)
+
+	// Leave things as they were
+	if vmStatus != "POWERED_OFF" {
+		task, err := vm.PowerOn()
+		check.Assert(err, IsNil)
+		err = task.WaitTaskCompletion()
+		check.Assert(err, IsNil)
+		check.Assert(task.Task.Status, Equals, "success")
+	}
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2307,6 +2307,7 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 	// Read ovfenv when VM is started
 	ovfenv, err := vm.GetEnvironment()
 	check.Assert(err, IsNil)
+	check.Assert(ovfenv, NotNil)
 
 	// Provides information from the virtualization platform like VM moref
 	check.Assert(strings.Contains(ovfenv.VCenterId, "vm-"), Equals, true)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2336,7 +2336,7 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 
 	ovfenv, err = vm.GetEnvironment()
-	check.Assert(strings.Contains(err.Error(), "ovf environment is only available when VM is poweredOn"), Equals, true)
+	check.Assert(strings.Contains(err.Error(), "OVF environment is only available when VM is powered on"), Equals, true)
 	check.Assert(ovfenv, IsNil)
 
 	// Leave things as they were

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -188,11 +188,9 @@ type PlatformSection struct {
 // Application-level configuration such as DNS name of active directory server, databases and
 // other external services.
 type PropertySection struct {
-	XMLName      xml.Name     `xml:"PropertySection"`
-	PropertyList PropertyList `xml:"Property,omitempty"`
+	XMLName    xml.Name        `xml:"PropertySection"`
+	Properties []*OVF_Property `xml:"Property,omitempty"`
 }
-
-type PropertyList []*OVF_Property
 
 type OVF_Property struct {
 	Key   string `xml:"key,attr"`
@@ -201,11 +199,9 @@ type OVF_Property struct {
 
 // Contains adapters info and virtual networks attached
 type EthernetAdapterSection struct {
-	XMLName     xml.Name    `xml:"EthernetAdapterSection"`
-	AdapterList AdapterList `xml:"Adapter,omitempty"`
+	XMLName  xml.Name   `xml:"EthernetAdapterSection"`
+	Adapters []*Adapter `xml:"Adapter,omitempty"`
 }
-
-type AdapterList []*Adapter
 
 type Adapter struct {
 	Mac        string `xml:"mac,attr"`

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -166,7 +166,7 @@ type SourcedVmTemplateParams struct {
 // the user-specified values for the properties defined in the OVF descriptor.
 type OVF_Environment struct {
 	XMLName                xml.Name                `xml:"Environment"`
-	Ve                     string                  `xml:"ve,attr,omitempty"`				// Xml namespace
+	Ve                     string                  `xml:"ve,attr,omitempty"`                // Xml namespace
 	Id                     string                  `xml:"id,attr,omitempty"`                // Identification of VM from OVF Descriptor. Describes this virtual system.
 	VCenterId              string                  `xml:"vCenterId,attr,omitempty"`         // VM moref in the vCenter
 	PlatformSection        *PlatformSection        `xml:"PlatformSection,omitempty"`        // Describes the virtualization platform

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -188,7 +188,7 @@ type PlatformSection struct {
 // Application-level configuration such as DNS name of active directory server, databases and
 // other external services.
 type PropertySection struct {
-	XMLName    xml.Name        `xml:"PropertySection"`
+	XMLName    xml.Name       `xml:"PropertySection"`
 	Properties []*OvfProperty `xml:"Property,omitempty"`
 }
 

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -51,8 +51,7 @@ type Vm struct {
 
 	Snapshots *SnapshotSection `xml:"SnapshotSection,omitempty"`
 
-	// TODO: OVF Sections to be implemented
-	// Environment OVF_Environment `xml:"Environment,omitempty"
+	Environment *OVF_Environment `xml:"Environment,omitempty"`
 
 	VmSpecSection *VmSpecSection `xml:"VmSpecSection,omitempty"`
 
@@ -160,4 +159,47 @@ type SourcedVmTemplateParams struct {
 	VmGeneralParams               *VMGeneralParams     `xml:"VmGeneralParams,omitempty"`               // Specify name, description, and other properties of a VM during instantiation.
 	VmTemplateInstantiationParams *InstantiationParams `xml:"VmTemplateInstantiationParams,omitempty"` // Same as InstantiationParams used for VMs within a vApp
 	StorageProfile                *Reference           `xml:"StorageProfile,omitempty"`                // A reference to a storage profile to be used for the VM. The specified storage profile must exist in the organization vDC that contains the composed vApp. If not specified, the default storage profile for the vDC is used.
+}
+
+type OVF_Environment struct {
+	XMLName                xml.Name                `xml:"Environment"`
+	Ve                     string                  `xml:"ve,attr,omitempty"`
+	Id                     string                  `xml:"id,attr,omitempty"`
+	VCenterId              string                  `xml:"vCenterId,attr,omitempty"`
+	PlatformSection        *PlatformSection        `xml:"PlatformSection,omitempty"`
+	PropertySection        *PropertySection        `xml:"PropertySection,omitempty"`
+	EthernetAdapterSection *EthernetAdapterSection `xml:"EthernetAdapterSection,omitempty"`
+}
+
+type PlatformSection struct {
+	XMLName xml.Name `xml:"PlatformSection"`
+	Kind    string   `xml:"Kind,omitempty"`
+	Version string   `xml:"Version,omitempty"`
+	Vendor  string   `xml:"Vendor,omitempty"`
+	Locale  string   `xml:"Locale,omitempty"`
+}
+
+type PropertySection struct {
+	XMLName      xml.Name     `xml:"PropertySection"`
+	PropertyList PropertyList `xml:"Property,omitempty"`
+}
+
+type PropertyList []*OVF_Property
+
+type OVF_Property struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type EthernetAdapterSection struct {
+	XMLName     xml.Name    `xml:"EthernetAdapterSection"`
+	AdapterList AdapterList `xml:"Adapter,omitempty"`
+}
+
+type AdapterList []*Adapter
+
+type Adapter struct {
+	Mac        string `xml:"mac,attr"`
+	Network    string `xml:"network,attr"`
+	UnitNumber string `xml:"unitNumber,attr"`
 }

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -51,6 +51,7 @@ type Vm struct {
 
 	Snapshots *SnapshotSection `xml:"SnapshotSection,omitempty"`
 
+	// The OVF environment defines how the guest software and the virtualization platform interact.
 	Environment *OVF_Environment `xml:"Environment,omitempty"`
 
 	VmSpecSection *VmSpecSection `xml:"VmSpecSection,omitempty"`
@@ -161,24 +162,31 @@ type SourcedVmTemplateParams struct {
 	StorageProfile                *Reference           `xml:"StorageProfile,omitempty"`                // A reference to a storage profile to be used for the VM. The specified storage profile must exist in the organization vDC that contains the composed vApp. If not specified, the default storage profile for the vDC is used.
 }
 
+// The OVF environment enables the guest software to access information about the virtualization platform, such as
+// the user-specified values for the properties defined in the OVF descriptor.
 type OVF_Environment struct {
 	XMLName                xml.Name                `xml:"Environment"`
-	Ve                     string                  `xml:"ve,attr,omitempty"`
-	Id                     string                  `xml:"id,attr,omitempty"`
-	VCenterId              string                  `xml:"vCenterId,attr,omitempty"`
-	PlatformSection        *PlatformSection        `xml:"PlatformSection,omitempty"`
-	PropertySection        *PropertySection        `xml:"PropertySection,omitempty"`
-	EthernetAdapterSection *EthernetAdapterSection `xml:"EthernetAdapterSection,omitempty"`
+	Ve                     string                  `xml:"ve,attr,omitempty"`				// Xml namespace
+	Id                     string                  `xml:"id,attr,omitempty"`                // Identification of VM from OVF Descriptor. Describes this virtual system.
+	VCenterId              string                  `xml:"vCenterId,attr,omitempty"`         // VM moref in the vCenter
+	PlatformSection        *PlatformSection        `xml:"PlatformSection,omitempty"`        // Describes the virtualization platform
+	PropertySection        *PropertySection        `xml:"PropertySection,omitempty"`        // Property elements with key/value pairs
+	EthernetAdapterSection *EthernetAdapterSection `xml:"EthernetAdapterSection,omitempty"` // Contains adapters info and virtual networks attached
 }
 
+// Provides information from the virtualization platform
 type PlatformSection struct {
 	XMLName xml.Name `xml:"PlatformSection"`
-	Kind    string   `xml:"Kind,omitempty"`
-	Version string   `xml:"Version,omitempty"`
-	Vendor  string   `xml:"Vendor,omitempty"`
-	Locale  string   `xml:"Locale,omitempty"`
+	Kind    string   `xml:"Kind,omitempty"`    // Hypervisor kind is typically VMware ESXi
+	Version string   `xml:"Version,omitempty"` // Hypervisor version
+	Vendor  string   `xml:"Vendor,omitempty"`  // VMware, Inc.
+	Locale  string   `xml:"Locale,omitempty"`  // Hypervisor locale
 }
 
+// Contains a list of key/value pairs corresponding to properties defined in the OVF descriptor
+// Operating system level configuration, such as host names, IP address, subnets, gateways, etc.
+// Application-level configuration such as DNS name of active directory server, databases and
+// other external services.
 type PropertySection struct {
 	XMLName      xml.Name     `xml:"PropertySection"`
 	PropertyList PropertyList `xml:"Property,omitempty"`
@@ -191,6 +199,7 @@ type OVF_Property struct {
 	Value string `xml:"value,attr"`
 }
 
+// Contains adapters info and virtual networks attached
 type EthernetAdapterSection struct {
 	XMLName     xml.Name    `xml:"EthernetAdapterSection"`
 	AdapterList AdapterList `xml:"Adapter,omitempty"`

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -52,7 +52,7 @@ type Vm struct {
 	Snapshots *SnapshotSection `xml:"SnapshotSection,omitempty"`
 
 	// The OVF environment defines how the guest software and the virtualization platform interact.
-	Environment *OVF_Environment `xml:"Environment,omitempty"`
+	Environment *OvfEnvironment `xml:"Environment,omitempty"`
 
 	VmSpecSection *VmSpecSection `xml:"VmSpecSection,omitempty"`
 
@@ -164,7 +164,7 @@ type SourcedVmTemplateParams struct {
 
 // The OVF environment enables the guest software to access information about the virtualization platform, such as
 // the user-specified values for the properties defined in the OVF descriptor.
-type OVF_Environment struct {
+type OvfEnvironment struct {
 	XMLName                xml.Name                `xml:"Environment"`
 	Ve                     string                  `xml:"ve,attr,omitempty"`                // Xml namespace
 	Id                     string                  `xml:"id,attr,omitempty"`                // Identification of VM from OVF Descriptor. Describes this virtual system.
@@ -189,10 +189,10 @@ type PlatformSection struct {
 // other external services.
 type PropertySection struct {
 	XMLName    xml.Name        `xml:"PropertySection"`
-	Properties []*OVF_Property `xml:"Property,omitempty"`
+	Properties []*OvfProperty `xml:"Property,omitempty"`
 }
 
-type OVF_Property struct {
+type OvfProperty struct {
 	Key   string `xml:"key,attr"`
 	Value string `xml:"value,attr"`
 }


### PR DESCRIPTION
Signed-off-by: Olivier DRAGHI <odraghi@gmail.com>

## Description
I need a way for a service running inside a VM to query cloud director as an OrgAdmin and find itself.
I think about checking the VM moref that is available with vmtools :
  vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "ve:vCenterId" | cut -d'"' -f2

Unfortunately getting ovfenv ( Environment ) was not implemeted in govdc.

Related issue: (#526)
