### PR TITLE
Fix issue terraform-provider-vcd-944

### DIFF
--- a/.changes/v2.18.0/531-features.md
+++ b/.changes/v2.18.0/531-features.md
@@ -1,0 +1,1 @@
+* Added `client` methods `QueryCatalogRecords` and `GetCatalogByHref` [GH-531]

--- a/govcd/access_control_catalog_test.go
+++ b/govcd/access_control_catalog_test.go
@@ -351,6 +351,12 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		}
 		err = testAccessControl(catalogName+" catalog two org", catalog, twoOrgsSettings, twoOrgsSettings, true, catalogTenantContext, check)
 		check.Assert(err, IsNil)
+		catalogs, err := vcd.client.Client.QueryCatalogRecords(catalogName, TenantContext{newOrg.AdminOrg.ID, newOrg.AdminOrg.Name})
+		check.Assert(err, IsNil)
+		check.Assert(len(catalogs), Equals, 1)
+		foundCatalog, err := vcd.client.Client.GetCatalogByHref(catalogs[0].HREF)
+		check.Assert(err, IsNil)
+		check.Assert(foundCatalog.AdminCatalog.ID, Equals, catalog.GetId())
 	}
 
 	// Set empty settings explicitly

--- a/govcd/admincatalog.go
+++ b/govcd/admincatalog.go
@@ -647,7 +647,7 @@ func (client *Client) GetCatalogByHref(catalogHref string) (*AdminCatalog, error
 // QueryCatalogRecords given a catalog name, retrieves the catalogRecords that match its name
 // Returns a list of catalog records for such name, empty list if none was found
 func (client *Client) QueryCatalogRecords(name string) ([]*types.CatalogRecord, error) {
-	util.Logger.Printf("[DEBUG] QueryCatalogList")
+	util.Logger.Printf("[DEBUG] QueryCatalogRecords")
 
 	var filter string
 	if name != "" {
@@ -669,10 +669,10 @@ func (client *Client) QueryCatalogRecords(name string) ([]*types.CatalogRecord, 
 	}
 
 	catalogs := results.Results.CatalogRecord
-	if catalogs == nil {
-		return nil, ErrorEntityNotFound
+	if client.IsSysAdmin {
+		catalogs = results.Results.AdminCatalogRecord
 	}
 
-	util.Logger.Printf("[DEBUG] QueryCatalogList returned with : %#v and error: %s", catalogs, err)
+	util.Logger.Printf("[DEBUG] QueryCatalogRecords returned with : %#v and error: %s", catalogs, err)
 	return catalogs, nil
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -3142,6 +3142,7 @@ type CatalogRecord struct {
 	Description             string    `xml:"description,attr,omitempty"`
 	IsPublished             bool      `xml:"isPublished,attr,omitempty"`
 	IsShared                bool      `xml:"isShared,attr,omitempty"`
+	IsLocal                 bool      `xml:"isLocal,attr,omitempty"`
 	CreationDate            string    `xml:"creationDate,attr,omitempty"`
 	OrgName                 string    `xml:"orgName,attr,omitempty"`
 	OwnerName               string    `xml:"ownerName,attr,omitempty"`


### PR DESCRIPTION
This PR adds two methods that are needed to fix [Issue 944](https://github.com/vmware/terraform-provider-vcd/issues/944).
These methods allow to query a catalog and to retrieve a full catalog without its parent.