### PR TITLE
Change position of BackLinkIdentifier in LDAP type

### DIFF
--- a/.changes/v2.18.0/533-bug-fixes.md
+++ b/.changes/v2.18.0/533-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fixed issue that prevented Org update because of wrong field position in LDAP settings [GH-533]

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -985,8 +985,8 @@ type OrgLdapGroupAttributes struct {
 	ObjectIdentifier     string `xml:"ObjectIdentifier"`
 	GroupName            string `xml:"GroupName"`
 	Membership           string `xml:"Membership"`
-	BackLinkIdentifier   string `xml:"BackLinkIdentifier,omitempty"`
 	MembershipIdentifier string `xml:"MembershipIdentifier"`
+	BackLinkIdentifier   string `xml:"BackLinkIdentifier,omitempty"`
 }
 
 // OrgLdapUserAttributesType represents the ldap user attribute settings for a VMware Cloud Director organization.


### PR DESCRIPTION
The position of the field  was wrong, and prevented update when that field was set.

To test: 
```
go test -tags functional -check.f Test_LDAP -check.vv -timeout 0
```


