### PR TITLE
Fix quirks in Test_CreateOrgVdcWithFlex and Test_VMPowerOnPowerOff

### DIFF
--- a/.changes/v2.19.0/538-notes.md
+++ b/.changes/v2.19.0/538-notes.md
@@ -1,0 +1,1 @@
+* Amended a quirky test `Test_CreateOrgVdcWithFlex` that failed randomly due to recovered VDC Storage Profiles being unordered [GH-538]

--- a/.changes/v2.19.0/538-notes.md
+++ b/.changes/v2.19.0/538-notes.md
@@ -1,1 +1,2 @@
 * Amended a quirky test `Test_CreateOrgVdcWithFlex` that failed randomly due to recovered VDC Storage Profiles being unordered [GH-538]
+* Amended a quirky test `Test_VMPowerOnPowerOff` that failed due to the testing VM not being powered off fast enough [GH-538]

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -679,7 +679,7 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	vmStatus, err := vm.GetStatus()
 	check.Assert(err, IsNil)
 	if vmStatus != "POWERED_OFF" && vmStatus != "PARTIALLY_POWERED_OFF" {
-		fmt.Println("VM status: %s, powering off", vmStatus)
+		fmt.Printf("VM status: %s, powering off", vmStatus)
 		task, err := vm.PowerOff()
 		check.Assert(err, IsNil)
 		err = task.WaitTaskCompletion()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -678,7 +678,8 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	// Ensure VM is not powered on
 	vmStatus, err := vm.GetStatus()
 	check.Assert(err, IsNil)
-	if vmStatus != "POWERED_OFF" {
+	if vmStatus != "POWERED_OFF" && vmStatus != "PARTIALLY_POWERED_OFF" {
+		fmt.Println("VM status: %s, powering off", vmStatus)
 		task, err := vm.PowerOff()
 		check.Assert(err, IsNil)
 		err = task.WaitTaskCompletion()


### PR DESCRIPTION
This PR amends two tests:

## Test_CreateOrgVdcWithFlex

It failed randomly with the following error:

```
START: adminvdc_test.go:24: TestVCD.Test_CreateOrgVdcWithFlex
adminvdc_test.go:150:
    check.Assert(*vdcStorageProfileDetails.Enabled, Equals, false)
... obtained bool = true
... expected bool = false

FAIL: adminvdc_test.go:24: TestVCD.Test_CreateOrgVdcWithFlex
```

I could reproduce this issue several times, then it started to pass without any change. Given that the variable `vdcStorageProfileDetails` was being retrieved from a fixed index from an array, my assumption is that it failed due to the array being unordered.

I could not demonstrate this hypothesis but I changed the test implementation to use a loop to avoid the situation if that's the case. It should make the test more robust anyway.

## Test_VMPowerOnPowerOff

Thanks to @Didainius for fixing this one.

This one failed randomly with the following error:

```
START: vm_test.go:666: TestVCD.Test_VMPowerOnPowerOff
vm_test.go:683:
    check.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"error powering off VM: API Error: 400: [ 714a562e-1f6b-4e06-8ba5-621564803be1 ] The requested operation could not be executed since VM \"My-vm\" is not powered on."} ("error powering off VM: API Error: 400: [ 714a562e-1f6b-4e06-8ba5-621564803be1 ] The requested operation could not be executed since VM \"My-vm\" is not powered on.")

FAIL: vm_test.go:666: TestVCD.Test_VMPowerOnPowerOff
```

Due to the underlying VCD not being as fast as expected in powering off the VM, it could be in state "Powering off".

## Tests done

Just a simple

```
  for i in {1..$2}
  do
    echo "####### Iteration $i"
    go test -tags functional -check.vv -check.f $1 -timeout=120m .
  done 
```

Where `$1` is `Test_CreateOrgVdcWithFlex` (add `GOVCD_SKIP_VAPP_CREATION=1`) and `Test_VMPowerOnPowerOff` and `$2` is `25`.

- [x] All 25 passed successfully for Test_CreateOrgVdcWithFlex.
- [x] All 25 passed successfully for Test_VMPowerOnPowerOff.