### PR TITLE
Fix test Test_CatalogAccessAsOrgUsers

### DIFF
--- a/.changes/v2.19.0/537-bug-fixes.md
+++ b/.changes/v2.19.0/537-bug-fixes.md
@@ -1,1 +1,1 @@
-* Remove URL checks from `CreateCatalogFromSubscriptionAsync` to allow catalog creation from non-VCD entities, such as vSphere shared library [GH-537]
+* Removed URL checks from `CreateCatalogFromSubscriptionAsync` to allow catalog creation from non-VCD entities, such as vSphere shared library [GH-537]

--- a/.changes/v2.19.0/540-bug-fixes.md
+++ b/.changes/v2.19.0/540-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fixed flaky test `Test_CatalogAccessAsOrgUsers` that failed randomly for timing issues [GH-540]

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1226,6 +1226,15 @@ func (vcd *TestVCD) Test_CatalogAccessAsOrgUsers(check *C) {
 	check.Assert(adminCatalog1FromOrg.AdminCatalog.HREF, Equals, adminCatalog1AsSystem.AdminCatalog.HREF)
 	check.Assert(adminCatalog2FromOrg.AdminCatalog.HREF, Equals, adminCatalog1AsSystem.AdminCatalog.HREF)
 	check.Assert(catalog2FromOrg.Catalog.HREF, Equals, catalog1AsSystem.Catalog.HREF)
-	err = adminCatalog1AsSystem.Delete(true, true)
+	timeout = 30 * time.Second
+	startTime = time.Now()
+	for time.Since(startTime) < timeout {
+		err = adminCatalog1AsSystem.Delete(true, true)
+		if err == nil {
+			fmt.Printf("shared catalog deleted in %s\n", time.Since(startTime))
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 	check.Assert(err, IsNil)
 }


### PR DESCRIPTION

The test was failing randomly, due to environmental issues. Depending on the VCD version, the deletion may be slower than expected. Adding a delay+timeout solves the issue.

