### PR TITLE
Create Test_RenameCatalog

### DIFF
--- a/.changes/v2.20.0/546-notes.md
+++ b/.changes/v2.20.0/546-notes.md
@@ -1,1 +1,1 @@
-* Created `Test_RenameCatalog` for making sure the contents of the Catalog don't change after rename  [GH-546]
+* Created `Test_RenameCatalog` for making sure the contents of the Catalog don't change after rename [GH-546]

--- a/.changes/v2.20.0/546-notes.md
+++ b/.changes/v2.20.0/546-notes.md
@@ -1,0 +1,1 @@
+* Created `Test_RenameCatalog` for making sure the contents of the Catalog don't change after rename  [GH-546]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -56,6 +56,7 @@ const (
 	TestRefreshOrgFullName        = "TestRefreshOrgFullName"
 	TestUpdateCatalog             = "TestUpdateCatalog"
 	TestDeleteCatalog             = "TestDeleteCatalog"
+	TestRenameCatalog             = "TestRenameCatalog"
 	TestRefreshOrg                = "TestRefreshOrg"
 	TestComposeVapp               = "TestComposeVapp"
 	TestComposeVappDesc           = "vApp created by tests"

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -56,7 +56,6 @@ const (
 	TestRefreshOrgFullName        = "TestRefreshOrgFullName"
 	TestUpdateCatalog             = "TestUpdateCatalog"
 	TestDeleteCatalog             = "TestDeleteCatalog"
-	TestRenameCatalog             = "TestRenameCatalog"
 	TestRefreshOrg                = "TestRefreshOrg"
 	TestComposeVapp               = "TestComposeVapp"
 	TestComposeVappDesc           = "vApp created by tests"

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -224,7 +224,7 @@ func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminCatalog, NotNil)
 	AddToCleanupList(testRenameCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
-	
+
 	catalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, testRenameCatalog)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -269,6 +269,9 @@ func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	// catalog and updatedCatalog
 	check.Assert(vAppTemplate1.VAppTemplate.HREF, Equals, vAppTemplate2.VAppTemplate.HREF)
 	check.Assert(mediaImage1.Media.HREF, Equals, mediaImage2.Media.HREF)
+
+	err = updatedCatalog.Delete(true, true)
+	check.Assert(err, IsNil)
 }
 
 // Tests System function UploadOvf by creating catalog and

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -215,11 +215,26 @@ func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	catalog, err := org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
+	adminCatalog, err := org.CreateCatalog(TestRenameCatalog, TestRenameCatalog)
 	check.Assert(err, IsNil)
-	check.Assert(catalog, NotNil)
+	check.Assert(adminCatalog, NotNil)
 
-	AddToCleanupList(TestCreateCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
+	AddToCleanupList(TestRenameCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
+
+	task, err := adminCatalog.UploadOvf(vcd.config.OVA.OvaPath, TestRenameCatalog, TestRenameCatalog, 1024)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	catalog, err := vcd.client.Client.GetAdminCatalogById(adminCatalog.AdminCatalog.ID)
+	adminCatalog.Update()
+	check.Assert(adminCatalog.AdminCatalog.CatalogItems[0].CatalogItem[0].ID, Equals, catalog.AdminCatalog.CatalogItems[0].CatalogItem[0].ID)
+
+	catalog.AdminCatalog.Name = TestRenameCatalog + "_updated"
+	catalog.Update()
+	adminCatalog.Update()
+	check.Assert(adminCatalog.AdminCatalog.CatalogItems[0].CatalogItem[0].ID, Equals, catalog.AdminCatalog.CatalogItems[0].CatalogItem[0].ID)
+
 }
 
 // Tests System function UploadOvf by creating catalog and

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -207,6 +207,21 @@ func doesCatalogExist(check *C, org *AdminOrg) {
 	check.Assert(err, NotNil)
 }
 
+// Creates a Catalog, adds items to it, renames it, then checks if no data has been lost in the process
+func (vcd *TestVCD) Test_RenameCatalog(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(org, NotNil)
+
+	catalog, err := org.CreateCatalog(TestCreateCatalog, TestCreateCatalogDesc)
+	check.Assert(err, IsNil)
+	check.Assert(catalog, NotNil)
+
+	AddToCleanupList(TestCreateCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
+}
+
 // Tests System function UploadOvf by creating catalog and
 // checking if provided standard ova file uploaded.
 func (vcd *TestVCD) Test_UploadOvf(check *C) {

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -207,7 +207,9 @@ func doesCatalogExist(check *C, org *AdminOrg) {
 	check.Assert(err, NotNil)
 }
 
-// Creates a Catalog, uploads a vApp template to it, renames it, then checks if the vAPp is retrievable
+// Creates a Catalog, uploads a vApp template to it, renames it, retrieves it
+// using the updated name and checks if it has the same vApp template.
+// If it doesn't the assertion fails.
 func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 
@@ -236,8 +238,11 @@ func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	err = adminCatalog.Update()
 	check.Assert(err, IsNil)
 
+	// The catalog is added to the cleanup list only after the name update, as
+	// the old one can't be found.
 	AddToCleanupList(TestRenameCatalog+"_updated", "catalog", vcd.config.VCD.Org, check.TestName())
 
+	// Get a Catalog using the previously updated name
 	updatedCatalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, TestRenameCatalog+"_updated")
 	check.Assert(err, IsNil)
 	check.Assert(updatedCatalog, NotNil)
@@ -246,8 +251,9 @@ func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate2, NotNil)
 
+	// Check the HREFs of the vApp templates that were retrieved from catalog
+	// and updatedCatalog
 	check.Assert(vAppTemplate1.VAppTemplate.HREF, Equals, vAppTemplate2.VAppTemplate.HREF)
-
 }
 
 // Tests System function UploadOvf by creating catalog and

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -212,48 +212,63 @@ func doesCatalogExist(check *C, org *AdminOrg) {
 // If it doesn't the assertion fails.
 func (vcd *TestVCD) Test_RenameCatalog(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	testRenameCatalog := check.TestName()
+	testUploadOvf := check.TestName() + "_ovf"
+	testUploadMedia := check.TestName() + "_media"
 
 	org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	check.Assert(org, NotNil)
 
-	adminCatalog, err := org.CreateCatalog(TestRenameCatalog, TestRenameCatalog)
+	adminCatalog, err := org.CreateCatalog(testRenameCatalog, testRenameCatalog)
 	check.Assert(err, IsNil)
 	check.Assert(adminCatalog, NotNil)
-
-	task, err := adminCatalog.UploadOvf(vcd.config.OVA.OvaPath, TestUploadOvf, TestUploadOvf, 1024)
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-
-	catalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, TestRenameCatalog)
+	AddToCleanupList(testRenameCatalog, "catalog", vcd.config.VCD.Org, check.TestName())
+	
+	catalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, testRenameCatalog)
 	check.Assert(err, IsNil)
 	check.Assert(catalog, NotNil)
 
-	vAppTemplate1, err := catalog.GetVAppTemplateByName(TestUploadOvf)
+	uploadTask, err := adminCatalog.UploadOvf(vcd.config.OVA.OvaPath, testUploadOvf, testUploadOvf, 1024)
+	check.Assert(err, IsNil)
+	err = uploadTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	uploadTask, err = catalog.UploadMediaImage(testUploadMedia, testUploadMedia, vcd.config.Media.MediaPath, 1024)
+	check.Assert(err, IsNil)
+	err = uploadTask.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	vAppTemplate1, err := catalog.GetVAppTemplateByName(testUploadOvf)
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate1, NotNil)
 
-	adminCatalog.AdminCatalog.Name = TestRenameCatalog + "_updated"
+	mediaImage1, err := catalog.GetMediaByName(testUploadMedia, true)
+	check.Assert(err, IsNil)
+	check.Assert(mediaImage1, NotNil)
+
+	adminCatalog.AdminCatalog.Name = testRenameCatalog + "_updated"
 	err = adminCatalog.Update()
 	check.Assert(err, IsNil)
-
-	// The catalog is added to the cleanup list only after the name update, as
-	// the old one can't be found.
-	AddToCleanupList(TestRenameCatalog+"_updated", "catalog", vcd.config.VCD.Org, check.TestName())
+	AddToCleanupList(testRenameCatalog+"_updated", "catalog", vcd.config.VCD.Org, check.TestName())
 
 	// Get a Catalog using the previously updated name
-	updatedCatalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, TestRenameCatalog+"_updated")
+	updatedCatalog, err := vcd.client.Client.GetCatalogByName(vcd.config.VCD.Org, testRenameCatalog+"_updated")
 	check.Assert(err, IsNil)
 	check.Assert(updatedCatalog, NotNil)
 
-	vAppTemplate2, err := updatedCatalog.GetVAppTemplateByName(TestUploadOvf)
+	vAppTemplate2, err := updatedCatalog.GetVAppTemplateByName(testUploadOvf)
 	check.Assert(err, IsNil)
 	check.Assert(vAppTemplate2, NotNil)
 
-	// Check the HREFs of the vApp templates that were retrieved from catalog
-	// and updatedCatalog
+	mediaImage2, err := updatedCatalog.GetMediaByName(testUploadMedia, false)
+	check.Assert(err, IsNil)
+	check.Assert(mediaImage2, NotNil)
+
+	// Check the HREFs of the vApp templates and media images that were retrieved from
+	// catalog and updatedCatalog
 	check.Assert(vAppTemplate1.VAppTemplate.HREF, Equals, vAppTemplate2.VAppTemplate.HREF)
+	check.Assert(mediaImage1.Media.HREF, Equals, mediaImage2.Media.HREF)
 }
 
 // Tests System function UploadOvf by creating catalog and


### PR DESCRIPTION
## About
This PR introduces a new test: `Test_RenameCatalog` to check that the contents of the catalog have not changed after renaming it by following these steps:

1. Creates a catalog with the name `TestRenameCatalog`
2. Uploads a vApp template with the name `TestUploadOvf` to the catalog.
3. Retrieves `vAppTemplate1` with the name `TestUploadOvf` from the new catalog object.
4. Updates the catalog name to `TestRenameCatalog_updated`
5. Retrieves a new catalog object using the updated name
6. Retrieves `vAppTemplate2` with the name `TestUploadOvf` from the new catalog object.
7. Compares the vApp templates from `catalog` and `updatedCatalog`