### PR TITLE
Fix API token URL generation

### DIFF
--- a/govcd/api_token.go
+++ b/govcd/api_token.go
@@ -43,7 +43,10 @@ func (vcdClient *VCDClient) GetBearerTokenFromApiToken(org, token string) (*type
 		return nil, fmt.Errorf("minimum API version for API token is 36.1 - Version detected: %s", vcdClient.Client.APIVersion)
 	}
 	var userDef string
-	urlStr := strings.Replace(vcdClient.Client.VCDHREF.String(), "/api", "", 1)
+	newUrl := new(url.URL)
+	newUrl.Scheme = vcdClient.Client.VCDHREF.Scheme
+	newUrl.Host = vcdClient.Client.VCDHREF.Host
+	urlStr := newUrl.String()
 	if strings.EqualFold(org, "system") {
 		userDef = "provider"
 	} else {

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,3 +1,3 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=v0.3.3
+export STATICCHECK_VERSION=2023.1
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz


### PR DESCRIPTION
The API token URL was created by removing "/api" from the client URL. This method fails when the URL host name starts with "api". ([Issue #994](https://github.com/vmware/terraform-provider-vcd/issues/994))

The new method uses a more robust approach, by combining the existing elements of the client URL.

To test that the API token works, set an API token in your VCD, and then:

```
export TEST_VCD_ORG=System 
export TEST_VCD_API_TOKEN=$YOUR_API_TOKEN 
go test -tags api -check.f TestVCDClient_GetBearerTokenFromApiToken -check.vv -timeout 0

unset TEST_VCD_ORG
unset TEST_VCD_API_TOKEN
```