### PR TITLE
Adjust vet and gosec complaints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ testnsxv:
 # any common errors.
 vet:
 	@echo "==> Running Go Vet"
-	@go vet ./... ; if [ $$? -ne 0 ] ; then echo "vet error!" ; exit 1 ; fi
+	@go vet -tags ALL ./... ; if [ $$? -ne 0 ] ; then echo "vet error!" ; exit 1 ; fi
 
 # static runs the source code static analysis tool `staticcheck`
 static: fmtcheck

--- a/govcd/access_control_catalog_test.go
+++ b/govcd/access_control_catalog_test.go
@@ -167,8 +167,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						Name: users[0].user.User.Name,
@@ -199,8 +199,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						//Name: users[0].user.User.Name, // Pass info without name for one of the subjects
@@ -209,7 +209,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[1].user.User.Href,
 						Name: users[1].user.User.Name,
@@ -234,8 +234,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						Name: users[0].user.User.Name,
@@ -244,7 +244,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[1].user.User.Href,
 						//Name: users[1].user.User.Name,// Pass info without name for one of the subjects
@@ -253,7 +253,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessFullControl,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[2].user.User.Href,
 						Name: users[2].user.User.Name,
@@ -275,8 +275,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			IsSharedToEveryone:  false,
 			EveryoneAccessLevel: nil,
 			AccessSettings: &types.AccessSettingList{
-				[]*types.AccessSetting{
-					&types.AccessSetting{
+				AccessSetting: []*types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: users[0].user.User.Href,
 							Name: users[0].user.User.Name,
@@ -285,7 +285,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessReadOnly,
 					},
-					&types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: users[1].user.User.Href,
 							//Name: users[1].user.User.Name,// Pass info without name for one of the subjects
@@ -294,7 +294,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessFullControl,
 					},
-					&types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: users[2].user.User.Href,
 							Name: users[2].user.User.Name,
@@ -303,7 +303,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessReadWrite,
 					},
-					&types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: newOrg.AdminOrg.HREF,
 							Name: newOrg.AdminOrg.Name,
@@ -327,8 +327,8 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 			IsSharedToEveryone:  false,
 			EveryoneAccessLevel: nil,
 			AccessSettings: &types.AccessSettingList{
-				[]*types.AccessSetting{
-					&types.AccessSetting{
+				AccessSetting: []*types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: adminOrg.AdminOrg.HREF,
 							Name: adminOrg.AdminOrg.Name,
@@ -337,7 +337,7 @@ func (vcd *TestVCD) testCatalogAccessControl(adminOrg *AdminOrg, catalog accessC
 						ExternalSubject: nil,
 						AccessLevel:     types.ControlAccessFullControl,
 					},
-					&types.AccessSetting{
+					{
 						Subject: &types.LocalSubject{
 							HREF: newOrg.AdminOrg.HREF,
 							Name: newOrg.AdminOrg.Name,

--- a/govcd/access_control_vapp_test.go
+++ b/govcd/access_control_vapp_test.go
@@ -119,8 +119,8 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						Name: users[0].user.User.Name,
@@ -151,8 +151,8 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						//Name: users[0].user.User.Name, // Pass info without name for one of the subjects
@@ -161,7 +161,7 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[1].user.User.Href,
 						Name: users[1].user.User.Name,
@@ -186,8 +186,8 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: nil,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
-				&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[0].user.User.Href,
 						Name: users[0].user.User.Name,
@@ -196,7 +196,7 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessReadOnly,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[1].user.User.Href,
 						//Name: users[1].user.User.Name,// Pass info without name for one of the subjects
@@ -205,7 +205,7 @@ func (vcd *TestVCD) Test_VappAccessControl(check *C) {
 					ExternalSubject: nil,
 					AccessLevel:     types.ControlAccessFullControl,
 				},
-				&types.AccessSetting{
+				{
 					Subject: &types.LocalSubject{
 						HREF: users[2].user.User.Href,
 						Name: users[2].user.User.Name,

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -7,6 +7,7 @@ package govcd
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -91,7 +92,12 @@ func (vcdClient *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [vcdCloudApiAuthorize]: %s", err)
+		}
+	}(resp.Body)
 
 	// Catch HTTP 401 (Status Unauthorized) to return an error as otherwise this library would return
 	// odd errors while doing lookup of resources and confuse user.

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -620,7 +620,12 @@ func createItemForUpload(client *Client, createHREF *url.URL, catalogItemName st
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [createItemForUpload]: %s", err)
+		}
+	}(response.Body)
 
 	catalogItemParsed := &types.CatalogItem{}
 	if err = decodeBody(types.BodyTypeXML, response, catalogItemParsed); err != nil {
@@ -651,7 +656,12 @@ func createItemWithLink(client *Client, createHREF *url.URL, catalogItemName, it
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [createItemWithLink]: %s", err)
+		}
+	}(response.Body)
 
 	catalogItemParsed := &types.CatalogItem{}
 	if err = decodeBody(types.BodyTypeXML, response, catalogItemParsed); err != nil {

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1134,7 +1134,7 @@ func (vcd *TestVCD) Test_CatalogAccessAsOrgUsers(check *C) {
 	err = adminCatalog1AsSystem.SetAccessControl(&types.ControlAccessParams{
 		IsSharedToEveryone: false,
 		AccessSettings: &types.AccessSettingList{
-			[]*types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{
 				{
 					Subject: &types.LocalSubject{
 						HREF: org2.Org.HREF,

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -10,6 +10,7 @@ package govcd
 import (
 	"errors"
 	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/util"
 	"io"
 	"net/http"
 	"net/url"
@@ -171,7 +172,12 @@ func testGetEdgeEndpointXML(endpoint string, edge EdgeGateway, check *C) string 
 		fmt.Sprintf("unable to get XML from endpoint %s: %%s", endpoint), nil, &types.NSXError{})
 	check.Assert(err, IsNil)
 
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [testGetEdgeEndpointXML]: %s", err)
+		}
+	}(resp.Body)
 
 	body, err := io.ReadAll(resp.Body)
 	check.Assert(err, IsNil)

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -152,14 +152,14 @@ func testExternalNetworkV2(vcd *TestVCD, name, backingType, backingId, NetworkPr
 		ID:          "",
 		Name:        name,
 		Description: "",
-		Subnets: types.ExternalNetworkV2Subnets{[]types.ExternalNetworkV2Subnet{
+		Subnets: types.ExternalNetworkV2Subnets{Values: []types.ExternalNetworkV2Subnet{
 			{
 				Gateway:      "1.1.1.1",
 				PrefixLength: 24,
 				DNSSuffix:    "",
 				DNSServer1:   "",
 				DNSServer2:   "",
-				IPRanges: types.ExternalNetworkV2IPRanges{[]types.ExternalNetworkV2IPRange{
+				IPRanges: types.ExternalNetworkV2IPRanges{Values: []types.ExternalNetworkV2IPRange{
 					{
 						StartAddress: "1.1.1.3",
 						EndAddress:   "1.1.1.50",
@@ -170,7 +170,7 @@ func testExternalNetworkV2(vcd *TestVCD, name, backingType, backingId, NetworkPr
 				TotalIPCount: 0,
 			},
 		}},
-		NetworkBackings: types.ExternalNetworkV2Backings{[]types.ExternalNetworkV2Backing{
+		NetworkBackings: types.ExternalNetworkV2Backings{Values: []types.ExternalNetworkV2Backing{
 			{
 				BackingID: backingId,
 				NetworkProvider: types.NetworkProvider{

--- a/govcd/media.go
+++ b/govcd/media.go
@@ -184,7 +184,12 @@ func createMedia(client *Client, link, mediaName, mediaDescription string, fileS
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [createMedia]: %s", err)
+		}
+	}(response.Body)
 
 	mediaForUpload := &types.Media{}
 	if err = decodeBody(types.BodyTypeXML, response, mediaForUpload); err != nil {

--- a/govcd/nsxt_firewall_group_dynamic_security_group_test.go
+++ b/govcd/nsxt_firewall_group_dynamic_security_group_test.go
@@ -29,7 +29,7 @@ func (vcd *TestVCD) Test_NsxtDynamicSecurityGroup(check *C) {
 		OwnerRef:    &types.OpenApiReference{ID: vdcGroup.VdcGroup.Id},
 		VmCriteria: []types.NsxtFirewallGroupVmCriteria{
 			{
-				[]types.NsxtFirewallGroupVmCriteriaRule{
+				VmCriteriaRule: []types.NsxtFirewallGroupVmCriteriaRule{
 					{
 						AttributeType:  "VM_TAG",
 						Operator:       "EQUALS",
@@ -53,7 +53,7 @@ func (vcd *TestVCD) Test_NsxtDynamicSecurityGroup(check *C) {
 				},
 			}, // Boolean OR
 			{
-				[]types.NsxtFirewallGroupVmCriteriaRule{
+				VmCriteriaRule: []types.NsxtFirewallGroupVmCriteriaRule{
 					{
 						AttributeType:  "VM_NAME",
 						Operator:       "CONTAINS",

--- a/govcd/nsxt_importable_switch.go
+++ b/govcd/nsxt_importable_switch.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -192,7 +193,12 @@ func getFilteredNsxtImportableSwitches(filter map[string]string, client *Client)
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			util.Logger.Printf("error closing response Body [getFilteredNsxtImportableSwitches]: %s", err)
+		}
+	}(response.Body)
 
 	var nsxtImportableSwitches []*types.NsxtImportableSwitch
 	if err = decodeBody(types.BodyTypeJSON, response, &nsxtImportableSwitches); err != nil {

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -35,11 +35,19 @@ function get_gosec {
             echo "'curl' executable not found - Skipping gosec"
             exit 0
         fi
-        $curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh
+        $curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh > gosec_install.sh
+        exit_code=$?
+        if [ "$exit_code" != "0" ]
+        then
+          echo "Error downloading gosec installer"
+          exit $exit_code
+        fi
+        sh -x gosec_install.sh > gosec_install.log 2>&1
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then
           echo "Error installing gosec"
+          cat gosec_install.log
           exit $exit_code
         fi
         gosec=$PWD/bin/gosec


### PR DESCRIPTION
The command `make vet` was running without tags, and therefore it was ignoring most of the test files.
After adding `-tags ALL`, some complains appeared that are addressed here.

* `Makefile`
* `govcd/access_control_catalog_test.go`
* `govcd/access_control_vapp_test.go`
* `govcd/catalog_test.go`
* `govcd/common_test.go`
* `govcd/external_network_v2_test.go`
* `govcd/nsxt_firewall_group_dynamic_security_group_test.go`

The latest version of `gosec` (2.15 released today) raises several security complaints related to unsafe usage of `defer`. Such usages are fixed in this PR.

* `govcd/api_vcd.go`
* `govcd/catalog.go` 
* `govcd/media.go` 
* `govcd/nsxt_importable_switch.go`

Furthermore, the installation of `gosec` in the Github Actions worker sometimes [fails with unclear errors](https://github.com/vmware/go-vcloud-director/actions/runs/4107335176/jobs/7086703205). To help understanding the issue, we have added more debugging information to `scripts/gosec.sh`.
