### PR TITLE
Adjust ALB Settings configuration to support IPv6 and Transparent mode

### DIFF
--- a/.changes/v2.20.0/549-improvements.md
+++ b/.changes/v2.20.0/549-improvements.md
@@ -1,0 +1,3 @@
+* NSX-T ALB settings for Edge Gateway gain support for IPv6 service network definition (VCD 10.4.0+)
+  and Transparent mode (VCD 10.4.1+) by adding new fields to `types.NsxtAlbConfig` and automatically
+  elevating API up to 37.1 [GH-549]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo. Unless a later match takes
 # precedence all these users will be requested for review when someone opens a pull request.
-* @lvirbalas @Didainius @adambarreiro @dataclouder
+* @lvirbalas @Didainius @adambarreiro @dataclouder @adezxc

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -81,10 +81,6 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile:          "36.0", // VCD 10.3+
 }
 
-// elevateNsxtNatRuleApiVersion helps to elevate API version to consume newer NSX-T NAT Rule features
-// API V35.2+ supports new fields FirewallMatch and Priority
-// API V36.0+ supports new RuleType - REFLEXIVE
-
 // endpointElevatedApiVersions endpoint elevated API versions
 var endpointElevatedApiVersions = map[string][]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules: {
@@ -120,7 +116,8 @@ var endpointElevatedApiVersions = map[string][]string{
 	},
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointAlbEdgeGateway: {
 		//"35.0", // Basic minimum required version
-		"37.0", // Deprecates LicenseType in favor of SupportedFeatureSet
+		"37.0", // Deprecates LicenseType in favor of SupportedFeatureSet. Adds IPv6 service network definition support
+		"37.1", // Adds support for Transparent Mode
 	},
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile: {
 		//"36.0", // Introduced support

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -879,6 +879,20 @@ type NsxtAlbConfig struct {
 	// must be 25. If nothing is set, the default is 192.168.255.1/25. Default CIDR can be configured. This field cannot
 	// be updated.
 	ServiceNetworkDefinition string `json:"serviceNetworkDefinition,omitempty"`
+
+	// The IPv6 network definition in Gateway CIDR format which will be used by Load Balancer
+	// service on Edge. All the load balancer service engines associated with the Service Engine
+	// Group will be attached to this network.
+	// Once set, this field cannot be updated. The default
+	// IPv4 service network will be used if both the serviceNetworkDefinition and
+	// ipv6ServiceNetworkDefinition properties are unset. If both are set, it will still be one
+	// service network with a dual IPv4 and IPv6 stack.
+	// This field is only available for VCD 10.4.0+ (v37.0+)
+	Ipv6ServiceNetworkDefinition string `json:"ipv6ServiceNetworkDefinition,omitempty"`
+
+	// TransparentModeEnabled allows to configure Preserve Client IP on a Virtual Service
+	// This field is only available for VCD 10.4.1+ (v37.1+)
+	TransparentModeEnabled *bool `json:"transparentModeEnabled,omitempty"`
 }
 
 // NsxtAlbServiceEngineGroupAssignment configures Service Engine Group assignments to Edge Gateway. The only mandatory


### PR DESCRIPTION
This PR catches up on ALB latest capability settings on Edge Gateway (up to VCD 10.4.1) and adds two new fields `Ipv6ServiceNetworkDefinition` (VCD 10.4.0+) and `TransparentModeEnabled` (VCD 10.4.1+).

Automatic API elevation configuration updated to match these requirements.