### PR TITLE
Add ipv6 support for vApp network configuration

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -40,6 +40,7 @@ type VappNetworkSettings struct {
 	Description        string
 	Gateway            string
 	NetMask            string
+	PrefixLength       string
 	DNS1               string
 	DNS2               string
 	DNSSuffix          string
@@ -920,14 +921,22 @@ func (vapp *VApp) CreateVappNetworkAsync(newNetworkSettings *VappNetworkSettings
 			FenceMode:        types.FenceModeIsolated,
 			GuestVlanAllowed: newNetworkSettings.GuestVLANAllowed,
 			Features:         networkFeatures,
-			IPScopes: &types.IPScopes{IPScope: []*types.IPScope{&types.IPScope{IsInherited: false, Gateway: newNetworkSettings.Gateway,
-				Netmask: newNetworkSettings.NetMask, DNS1: newNetworkSettings.DNS1,
-				DNS2: newNetworkSettings.DNS2, DNSSuffix: newNetworkSettings.DNSSuffix, IsEnabled: true,
-				IPRanges: &types.IPRanges{IPRange: newNetworkSettings.StaticIPRanges}}}},
+			IPScopes: &types.IPScopes{
+				IPScope: []*types.IPScope{{
+					IsInherited:  false,
+					Gateway:      newNetworkSettings.Gateway,
+					PrefixLength: newNetworkSettings.PrefixLength,
+					Netmask:      newNetworkSettings.NetMask,
+					DNS1:         newNetworkSettings.DNS1,
+					DNS2:         newNetworkSettings.DNS2,
+					DNSSuffix:    newNetworkSettings.DNSSuffix,
+					IsEnabled:    true,
+					IPRanges:     &types.IPRanges{IPRange: newNetworkSettings.StaticIPRanges}}}},
 			RetainNetInfoAcrossDeployments: newNetworkSettings.RetainIpMacEnabled,
 		},
 		IsDeployed: false,
 	}
+
 	if orgNetwork != nil {
 		vappConfiguration.Configuration.ParentNetwork = &types.Reference{
 			HREF: orgNetwork.HREF,
@@ -1174,12 +1183,8 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 		return errors.New("network gateway IP is missing")
 	}
 
-	if networkSettings.NetMask == "" {
-		return errors.New("network mask config is missing")
-	}
-
-	if networkSettings.NetMask == "" {
-		return errors.New("network mask config is missing")
+	if networkSettings.NetMask == "" && networkSettings.PrefixLength == "" {
+		return errors.New("network mask and subnet prefix length config is missing")
 	}
 
 	if networkSettings.DhcpSettings != nil && networkSettings.DhcpSettings.IPRange == nil {

--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1187,6 +1187,10 @@ func validateNetworkConfigSettings(networkSettings *VappNetworkSettings) error {
 		return errors.New("network mask and subnet prefix length config is missing")
 	}
 
+	if networkSettings.NetMask != "" && networkSettings.PrefixLength != "" {
+		return errors.New("only one of netmask and prefix length can be supplied")
+	}
+
 	if networkSettings.DhcpSettings != nil && networkSettings.DhcpSettings.IPRange == nil {
 		return errors.New("network DHCP ip range config is missing")
 	}

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -97,24 +97,24 @@ func (vcd *TestVCD) prepareVappWithVappNetwork(check *C, vappName, orgVdcNetwork
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork, NotNil)
 
-	vappNetworkSettings := &VappNetworkSettings{
+	vappNetworkSettings_v4 := &VappNetworkSettings{
 		Name:               vappNetworkName,
-		Gateway:            "192.168.0.1",
-		NetMask:            "255.255.255.0",
-		DNS1:               "8.8.8.8",
-		DNS2:               "1.1.1.1",
+		Gateway:            "fe80::aaaa",
+		PrefixLength:       "100",
+		DNS1:               "d231:d231:d231:d231:d231:d231:d231:d231",
+		DNS2:               "d231:d231:d231:d231:d231:d231:d231:d231",
 		DNSSuffix:          "biz.biz",
-		StaticIPRanges:     []*types.IPRange{{StartAddress: "192.168.0.10", EndAddress: "192.168.0.20"}},
-		DhcpSettings:       &DhcpSettings{IsEnabled: true, MaxLeaseTime: 3500, DefaultLeaseTime: 2400, IPRange: &types.IPRange{StartAddress: "192.168.0.30", EndAddress: "192.168.0.40"}},
+		StaticIPRanges:     []*types.IPRange{{StartAddress: "fe80::aaab", EndAddress: "fe80::aaac"}},
+		DhcpSettings:       &DhcpSettings{IsEnabled: true, MaxLeaseTime: 3500, DefaultLeaseTime: 2400, IPRange: &types.IPRange{StartAddress: "fe80::aaad", EndAddress: "fe80::aaae"}},
 		GuestVLANAllowed:   &guestVlanAllowed,
 		Description:        description,
 		RetainIpMacEnabled: &retainIpMacEnabled,
 	}
 
-	vappNetworkConfig, err := vapp.CreateVappNetwork(vappNetworkSettings, orgVdcNetwork.OrgVDCNetwork)
+	vappNetworkConfigv4, err := vapp.CreateVappNetwork(vappNetworkSettings_v4, orgVdcNetwork.OrgVDCNetwork)
 	check.Assert(err, IsNil)
-	check.Assert(vappNetworkConfig, NotNil)
-	return vapp, vappNetworkName, vappNetworkConfig, err
+	check.Assert(vappNetworkConfigv4, NotNil)
+	return vapp, vappNetworkName, vappNetworkConfigv4, err
 }
 
 func (vcd *TestVCD) Test_GetVappNetworkByNameOrId(check *C) {

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -97,24 +97,24 @@ func (vcd *TestVCD) prepareVappWithVappNetwork(check *C, vappName, orgVdcNetwork
 	check.Assert(err, IsNil)
 	check.Assert(orgVdcNetwork, NotNil)
 
-	vappNetworkSettings_v4 := &VappNetworkSettings{
+	vappNetworkSettings := &VappNetworkSettings{
 		Name:               vappNetworkName,
-		Gateway:            "fe80::aaaa",
-		PrefixLength:       "100",
-		DNS1:               "d231:d231:d231:d231:d231:d231:d231:d231",
-		DNS2:               "d231:d231:d231:d231:d231:d231:d231:d231",
+		Gateway:            "192.168.0.1",
+		NetMask:            "255.255.255.0",
+		DNS1:               "8.8.8.8",
+		DNS2:               "1.1.1.1",
 		DNSSuffix:          "biz.biz",
-		StaticIPRanges:     []*types.IPRange{{StartAddress: "fe80::aaab", EndAddress: "fe80::aaac"}},
-		DhcpSettings:       &DhcpSettings{IsEnabled: true, MaxLeaseTime: 3500, DefaultLeaseTime: 2400, IPRange: &types.IPRange{StartAddress: "fe80::aaad", EndAddress: "fe80::aaae"}},
+		StaticIPRanges:     []*types.IPRange{{StartAddress: "192.168.0.10", EndAddress: "192.168.0.20"}},
+		DhcpSettings:       &DhcpSettings{IsEnabled: true, MaxLeaseTime: 3500, DefaultLeaseTime: 2400, IPRange: &types.IPRange{StartAddress: "192.168.0.30", EndAddress: "192.168.0.40"}},
 		GuestVLANAllowed:   &guestVlanAllowed,
 		Description:        description,
 		RetainIpMacEnabled: &retainIpMacEnabled,
 	}
 
-	vappNetworkConfigv4, err := vapp.CreateVappNetwork(vappNetworkSettings_v4, orgVdcNetwork.OrgVDCNetwork)
+	vappNetworkConfig, err := vapp.CreateVappNetwork(vappNetworkSettings, orgVdcNetwork.OrgVDCNetwork)
 	check.Assert(err, IsNil)
-	check.Assert(vappNetworkConfigv4, NotNil)
-	return vapp, vappNetworkName, vappNetworkConfigv4, err
+	check.Assert(vappNetworkConfig, NotNil)
+	return vapp, vappNetworkName, vappNetworkConfig, err
 }
 
 func (vcd *TestVCD) Test_GetVappNetworkByNameOrId(check *C) {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -853,6 +853,89 @@ func (vcd *TestVCD) Test_AddAndRemoveIsolatedVappNetwork(check *C) {
 	check.Assert(task.Task.Status, Equals, "success")
 }
 
+func (vcd *TestVCD) Test_AddAndRemoveIsolatedVappNetworkIpv6(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	vapp, err := deployVappForTest(vcd, "Test_AddAndRemoveIsolatedVappNetwork")
+	check.Assert(err, IsNil)
+	check.Assert(vapp, NotNil)
+
+	// Add Metadata
+	networkName := check.TestName()
+	description := "Created in test"
+	const gateway = "fe80:0:0:0:0:0:0:aaaa"
+	const prefixlength = "100"
+	const dns1 = "2001:4860:4860:0:0:0:0:8844"
+	const dns2 = "2001:4860:4860:0:0:0:0:8844"
+	const dnsSuffix = "biz.biz"
+	const startAddress = "fe80:0:0:0:0:0:0:aaab"
+	const endAddress = "fe80:0:0:0:0:0:0:bbbb"
+	const dhcpStartAddress = "fe80:0:0:0:0:0:0:cccc"
+	const dhcpEndAddress = "fe80:0:0:0:0:0:0:dddd"
+	const maxLeaseTime = 3500
+	const defaultLeaseTime = 2400
+	var guestVlanAllowed = true
+
+	vappNetworkSettings := &VappNetworkSettings{
+		Name:             networkName,
+		Gateway:          gateway,
+		PrefixLength:     prefixlength,
+		DNS1:             dns1,
+		DNS2:             dns2,
+		DNSSuffix:        dnsSuffix,
+		StaticIPRanges:   []*types.IPRange{{StartAddress: startAddress, EndAddress: endAddress}},
+		DhcpSettings:     &DhcpSettings{IsEnabled: true, MaxLeaseTime: maxLeaseTime, DefaultLeaseTime: defaultLeaseTime, IPRange: &types.IPRange{StartAddress: dhcpStartAddress, EndAddress: dhcpEndAddress}},
+		GuestVLANAllowed: &guestVlanAllowed,
+		Description:      description,
+	}
+
+	vappNetworkConfig, err := vapp.CreateVappNetwork(vappNetworkSettings, nil)
+	check.Assert(err, IsNil)
+	check.Assert(vappNetworkConfig, NotNil)
+
+	networkFound := types.VAppNetworkConfiguration{}
+	for _, networkConfig := range vappNetworkConfig.NetworkConfig {
+		if networkConfig.NetworkName == networkName {
+			networkFound = networkConfig
+		}
+	}
+
+	check.Assert(networkFound.Description, Equals, description)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].Gateway, Equals, gateway)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].PrefixLength, Equals, prefixlength)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].DNS1, Equals, dns1)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].DNS2, Equals, dns2)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].DNSSuffix, Equals, dnsSuffix)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, startAddress)
+	check.Assert(networkFound.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, endAddress)
+
+	check.Assert(networkFound.Configuration.Features.DhcpService.IsEnabled, Equals, true)
+	check.Assert(networkFound.Configuration.Features.DhcpService.MaxLeaseTime, Equals, maxLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.DefaultLeaseTime, Equals, defaultLeaseTime)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.StartAddress, Equals, dhcpStartAddress)
+	check.Assert(networkFound.Configuration.Features.DhcpService.IPRange.EndAddress, Equals, dhcpEndAddress)
+
+	err = vapp.Refresh()
+	check.Assert(err, IsNil)
+	vappNetworkConfig, err = vapp.RemoveNetwork(networkName)
+	check.Assert(err, IsNil)
+	check.Assert(vappNetworkConfig, NotNil)
+
+	isExist := false
+	for _, networkConfig := range vappNetworkConfig.NetworkConfig {
+		if networkConfig.NetworkName == networkName {
+			isExist = true
+		}
+	}
+	check.Assert(isExist, Equals, false)
+
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
+}
+
 func (vcd *TestVCD) Test_AddAndRemoveNatVappNetwork(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
 

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -171,9 +171,10 @@ type IPRanges struct {
 // Description: Specify network settings like gateway, network mask, DNS servers, IP ranges, etc.
 // Since: 0.9
 type IPScope struct {
-	IsInherited          bool            `xml:"IsInherited"`                    // True if the IP scope is inherit from parent network.
-	Gateway              string          `xml:"Gateway,omitempty"`              // Gateway of the network.
-	Netmask              string          `xml:"Netmask,omitempty"`              // Network mask.
+	IsInherited          bool            `xml:"IsInherited"`       // True if the IP scope is inherit from parent network.
+	Gateway              string          `xml:"Gateway,omitempty"` // Gateway of the network.
+	Netmask              string          `xml:"Netmask,omitempty"` // Network mask.
+	PrefixLength         string          `xml:"SubnetPrefixLength,omitempty"`
 	DNS1                 string          `xml:"Dns1,omitempty"`                 // Primary DNS server.
 	DNS2                 string          `xml:"Dns2,omitempty"`                 // Secondary DNS server.
 	DNSSuffix            string          `xml:"DnsSuffix,omitempty"`            // DNS suffix.


### PR DESCRIPTION
Original issue:
[terraform-provider-vcd issue #999](https://github.com/vmware/terraform-provider-vcd/issues/999)

This PR adds support to creating vApp networks using ipv6, as before it would not work because `VAppNetworkConfiguration` didn't have `SubnetPrefixLength` field which is needed for ipv6 handling. https://developer.vmware.com/apis/1507/vmware-cloud-director/doc/doc//types/IpScopeType.html

- Add `PrefixLength` to `IPScope` and `VappNetworkSettings`structs
- Create `Test_AddAndRemoveIsolatedVappNetworkIpv6` which tests creation and removal of ipv6 vApp networks
