### PR TITLE
Amend changelog to add missing change entry

### DIFF
--- a/.changes/v2.17.0/500-improvements.md
+++ b/.changes/v2.17.0/500-improvements.md
@@ -1,0 +1,1 @@
+* Bumped Default API Version to V36.0 (VCD 10.3+) [GH-500]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Changes in progress for v2.20.0 are available at [.changes/v2.20.0](https://gith
 * Added `VCDClient.QuerySynchronizedVAppTemplateById` to get a synchronized vApp Template query record from a vApp Template ID ([#520](https://github.com/vmware/go-vcloud-director/pull/520))
 
 ### IMPROVEMENTS
+* Bumped Default API Version to V36.0 (VCD 10.3+) [#500](https://github.com/vmware/go-vcloud-director/pull/500)
 * Added method `VM.Shutdown` to shut down guest OS ([#413](https://github.com/vmware/go-vcloud-director/pull/413), [#496](https://github.com/vmware/go-vcloud-director/pull/496))
 * Add support for MoRef ID on VM record type. Using the MoRef ID, we can then correlate that back to vCenter Server and find the VM with matching MoRef ID  ([#491](https://github.com/vmware/go-vcloud-director/pull/491))
 * Added support for querying VdcStorageProfile:  


### PR DESCRIPTION
Adds the missing changelog entry to state that default API version was bumped to v36.0 (VCD 10.3+)