### PR TITLE
fix(vapp): pointer Features not initialized

### DIFF
--- a/govcd/vapp.go
+++ b/govcd/vapp.go
@@ -1042,6 +1042,9 @@ func (vapp *VApp) UpdateNetworkAsync(networkSettingsToUpdate *VappNetworkSetting
 	if networkToUpdate.Configuration == nil {
 		networkToUpdate.Configuration = &types.NetworkConfiguration{}
 	}
+	if networkToUpdate.Configuration.Features == nil {
+		networkToUpdate.Configuration.Features = &types.NetworkFeatures{}
+	}
 	networkToUpdate.Configuration.RetainNetInfoAcrossDeployments = networkSettingsToUpdate.RetainIpMacEnabled
 	// new network to connect
 	if networkToUpdate.Configuration.ParentNetwork == nil && orgNetwork != nil {


### PR DESCRIPTION
Fix nil point dereference in UpdateNetworkAsync function on networkToUpdate.Configuration.Features

## IMPORTANT

To help us process your pull request efficiently, please follow the 
guidelines shown below. 

## A Pull Request should be associated with an Issue

We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
and potentially we'll be able to point development in a particular direction.

We accept PRs without associated issues provided the change is sufficiently evident 
from the commit message. If you have typos or simple bug fixes go for it.

## Description

Related issue: #554

- (Required) Short description of changes in the PR subject

- (Required) Detailed description of changes include tests and
  documentation. If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name
