### PR TITLE
remove deprected build tags

### DIFF
--- a/govcd/access_control_catalog_test.go
+++ b/govcd/access_control_catalog_test.go
@@ -1,5 +1,4 @@
 //go:build functional || catalog || ALL
-// +build functional catalog ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/access_control_test.go
+++ b/govcd/access_control_test.go
@@ -1,5 +1,4 @@
 //go:build functional || vapp || catalog || ALL
-// +build functional vapp catalog ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/access_control_vapp_test.go
+++ b/govcd/access_control_vapp_test.go
@@ -1,5 +1,4 @@
 //go:build functional || vapp || ALL
-// +build functional vapp ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminorg_administration_test.go
+++ b/govcd/adminorg_administration_test.go
@@ -1,5 +1,4 @@
 //go:build org || functional || ALL
-// +build org functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -1,5 +1,4 @@
 //go:build user || functional || ALL
-// +build user functional ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminorg_test.go
+++ b/govcd/adminorg_test.go
@@ -1,5 +1,4 @@
 //go:build org || functional || ALL
-// +build org functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminorg_unit_test.go
+++ b/govcd/adminorg_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminvdc_nsxt_test.go
+++ b/govcd/adminvdc_nsxt_test.go
@@ -1,5 +1,4 @@
 //go:build org || functional || nsxt || ALL
-// +build org functional nsxt ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/adminvdc_test.go
+++ b/govcd/adminvdc_test.go
@@ -1,5 +1,4 @@
 //go:build org || functional || ALL
-// +build org functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/anytypeedgegateway_test.go
+++ b/govcd/anytypeedgegateway_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/api_token_test.go
+++ b/govcd/api_token_test.go
@@ -1,5 +1,4 @@
 //go:build api || functional || ALL
-// +build api functional ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,5 +1,4 @@
 //go:build api || openapi || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || search || nsxv || nsxt || auth || affinity || role || alb || certificate || vdcGroup || metadata || providervdc || rde || ALL
-// +build api openapi functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user search nsxv nsxt auth affinity role alb certificate vdcGroup metadata providervdc rde ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/api_vcd_versions_test.go
+++ b/govcd/api_vcd_versions_test.go
@@ -1,5 +1,4 @@
 //go:build api || functional || ALL
-// +build api functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/catalog_subscription_test.go
+++ b/govcd/catalog_subscription_test.go
@@ -1,5 +1,4 @@
 //go:build catalog || functional || ALL
-// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1,5 +1,4 @@
 //go:build catalog || functional || ALL
-// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/catalogitem_test.go
+++ b/govcd/catalogitem_test.go
@@ -1,5 +1,4 @@
 //go:build catalog || functional || ALL
-// +build catalog functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/certificate_management_test.go
+++ b/govcd/certificate_management_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || certificate || ALL
-// +build functional openapi certificate ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/certificates_embedded_test.go
+++ b/govcd/certificates_embedded_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || certificate || alb || nsxt || ALL
-// +build functional openapi certificate alb nsxt ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -1,5 +1,4 @@
 //go:build api || auth || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || role || nsxv || nsxt || openapi || affinity || search || alb || certificate || vdcGroup || metadata || providervdc || rde || ALL
-// +build api auth functional catalog vapp gateway network org query extnetwork task vm vdc system disk lb lbAppRule lbAppProfile lbServerPool lbServiceMonitor lbVirtualServer user role nsxv nsxt openapi affinity search alb certificate vdcGroup metadata providervdc rde ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/defined_entity_test.go
+++ b/govcd/defined_entity_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || rde || ALL
-// +build functional openapi rde ALL
 
 /*
  * Copyright 2023 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/defined_interface_test.go
+++ b/govcd/defined_interface_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || rde || ALL
-// +build functional openapi rde ALL
 
 /*
  * Copyright 2023 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -1,5 +1,4 @@
 //go:build disk || functional || ALL
-// +build disk functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -1,5 +1,4 @@
 //go:build gateway || functional || ALL
-// +build gateway functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/edgegateway_unit_test.go
+++ b/govcd/edgegateway_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/entity_test.go
+++ b/govcd/entity_test.go
@@ -1,5 +1,4 @@
 //go:build api || functional || catalog || org || extnetwork || vm || vdc || system || user || nsxv || network || vapp || vm || affinity || ALL
-// +build api functional catalog org extnetwork vm vdc system user nsxv network vapp vm affinity ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -1,5 +1,4 @@
 //go:build extnetwork || network || functional || openapi || ALL
-// +build extnetwork network functional openapi ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/externalnetwork_test.go
+++ b/govcd/externalnetwork_test.go
@@ -1,5 +1,4 @@
 //go:build extnetwork || network || functional || ALL
-// +build extnetwork network functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/filter_engine_test.go
+++ b/govcd/filter_engine_test.go
@@ -1,5 +1,4 @@
 //go:build search || functional || ALL
-// +build search functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/filter_engine_unit_test.go
+++ b/govcd/filter_engine_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit
-// +build unit
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/filter_util_unit_test.go
+++ b/govcd/filter_util_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/global_role_test.go
+++ b/govcd/global_role_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || role || ALL
-// +build functional openapi role ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/group_test.go
+++ b/govcd/group_test.go
@@ -1,5 +1,4 @@
 //go:build user || functional || ALL
-// +build user functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lb_test.go
+++ b/govcd/lb_test.go
@@ -1,6 +1,4 @@
 //go:build (lb || functional || integration || ALL) && !skipLong
-// +build lb functional integration ALL
-// +build !skipLong
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lb_unit_test.go
+++ b/govcd/lb_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || lb || lbAppProfile || functional || ALL
-// +build unit lb lbAppProfile functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lbappprofile_test.go
+++ b/govcd/lbappprofile_test.go
@@ -1,5 +1,4 @@
 //go:build lb || lbAppProfile || nsxv || functional || ALL
-// +build lb lbAppProfile nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lbapprule_test.go
+++ b/govcd/lbapprule_test.go
@@ -1,5 +1,4 @@
 //go:build lb || lbAppRule || nsxv || functional || ALL
-// +build lb lbAppRule nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lbserverpool_test.go
+++ b/govcd/lbserverpool_test.go
@@ -1,5 +1,4 @@
 //go:build lb || lbServerPool || nsxv || functional || ALL
-// +build lb lbServerPool nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lbservicemonitor_test.go
+++ b/govcd/lbservicemonitor_test.go
@@ -1,5 +1,4 @@
 //go:build lb || lbServiceMonitor || nsxv || functional || ALL
-// +build lb lbServiceMonitor nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/lbvirtualserver_test.go
+++ b/govcd/lbvirtualserver_test.go
@@ -1,5 +1,4 @@
 //go:build lb || lbVirtualServer || nsxv || functional || ALL
-// +build lb lbVirtualServer nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -1,5 +1,4 @@
 //go:build catalog || functional || ALL
-// +build catalog functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || vdc || metadata || functional || ALL
-// +build vapp vdc metadata functional ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || vdc || metadata || functional || ALL
-// +build vapp vdc metadata functional ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxt_alb_clouds_test.go
+++ b/govcd/nsxt_alb_clouds_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_controllers_test.go
+++ b/govcd/nsxt_alb_controllers_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_importable_clouds_test.go
+++ b/govcd/nsxt_alb_importable_clouds_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_importable_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_importable_service_engine_groups_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_service_engine_group_assignment_test.go
+++ b/govcd/nsxt_alb_service_engine_group_assignment_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_settings_test.go
+++ b/govcd/nsxt_alb_settings_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_alb_virtual_service_test.go
+++ b/govcd/nsxt_alb_virtual_service_test.go
@@ -1,5 +1,4 @@
 //go:build nsxt || alb || functional || ALL
-// +build nsxt alb functional ALL
 
 package govcd
 

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_distributed_firewall_test.go
+++ b/govcd/nsxt_distributed_firewall_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_edge_cluster_test.go
+++ b/govcd/nsxt_edge_cluster_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxt_edgegateway_bgp_configuration_test.go
+++ b/govcd/nsxt_edgegateway_bgp_configuration_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_edgegateway_bgp_neighbor_test.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_firewall_group_dynamic_security_group_test.go
+++ b/govcd/nsxt_firewall_group_dynamic_security_group_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_firewall_group_ip_set_test.go
+++ b/govcd/nsxt_firewall_group_ip_set_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_firewall_group_static_security_group_test.go
+++ b/govcd/nsxt_firewall_group_static_security_group_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_importable_switch_test.go
+++ b/govcd/nsxt_importable_switch_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || ALL
-// +build network nsxt functional ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxt_ipsec_vpn_tunnel_test.go
+++ b/govcd/nsxt_ipsec_vpn_tunnel_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_network_context_profile_test.go
+++ b/govcd/nsxt_network_context_profile_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/nsxt_route_advertisement_test.go
+++ b/govcd/nsxt_route_advertisement_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxt_test.go
+++ b/govcd/nsxt_test.go
@@ -1,5 +1,4 @@
 //go:build ALL || openapi || functional || nsxt
-// +build ALL openapi functional nsxt
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxv_dhcprelay_test.go
+++ b/govcd/nsxv_dhcprelay_test.go
@@ -1,5 +1,4 @@
 //go:build nsxv || functional || ALL
-// +build nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxv_distributed_firewall_test.go
+++ b/govcd/nsxv_distributed_firewall_test.go
@@ -7,10 +7,11 @@ package govcd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/kr/pretty"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
-	"strings"
 )
 
 func (vcd *TestVCD) Test_NsxvDistributedFirewall(check *C) {

--- a/govcd/nsxv_firewall_test.go
+++ b/govcd/nsxv_firewall_test.go
@@ -1,5 +1,4 @@
 //go:build nsxv || edge || firewall || functional || ALL
-// +build nsxv edge firewall functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxv_ipset_test.go
+++ b/govcd/nsxv_ipset_test.go
@@ -1,5 +1,4 @@
 //go:build nsxv || functional || ALL
-// +build nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/nsxv_nat_test.go
+++ b/govcd/nsxv_nat_test.go
@@ -1,5 +1,4 @@
 //go:build edge || nat || nsxv || functional || ALL
-// +build edge nat nsxv functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/openapi_endpoints_unit_test.go
+++ b/govcd/openapi_endpoints_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 package govcd
 

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/openapi_test.go
+++ b/govcd/openapi_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || ALL
-// +build functional openapi ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/openapi_unit_test.go
+++ b/govcd/openapi_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 package govcd
 

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -1,5 +1,4 @@
 //go:build org || functional || ALL
-// +build org functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -1,5 +1,4 @@
 //go:build network || functional || ALL
-// +build network functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/provider_vdc_test.go
+++ b/govcd/provider_vdc_test.go
@@ -1,5 +1,4 @@
 //go:build providervdc || functional || ALL
-// +build providervdc functional ALL
 
 package govcd
 

--- a/govcd/query_test.go
+++ b/govcd/query_test.go
@@ -1,5 +1,4 @@
 //go:build query || functional || ALL
-// +build query functional ALL
 
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/rights_bundle_test.go
+++ b/govcd/rights_bundle_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || role || ALL
-// +build functional openapi role ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/rights_test.go
+++ b/govcd/rights_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || role || ALL
-// +build functional openapi role ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/roles_test.go
+++ b/govcd/roles_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || role || ALL
-// +build functional openapi role ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/saml_auth_test.go
+++ b/govcd/saml_auth_test.go
@@ -1,5 +1,4 @@
 //go:build auth || functional || ALL
-// +build auth functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/saml_auth_unit_test.go
+++ b/govcd/saml_auth_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/security_tags_test.go
+++ b/govcd/security_tags_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/session_info_test.go
+++ b/govcd/session_info_test.go
@@ -1,5 +1,4 @@
 //go:build api || functional || ALL
-// +build api functional ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -1,5 +1,4 @@
 //go:build system || functional || ALL
-// +build system functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/system_unit_test.go
+++ b/govcd/system_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/tenant_context_test.go
+++ b/govcd/tenant_context_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || ALL
-// +build functional openapi ALL
 
 package govcd
 

--- a/govcd/user_test.go
+++ b/govcd/user_test.go
@@ -1,5 +1,4 @@
 //go:build user || functional || ALL
-// +build user functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapp_concurrent_test.go
+++ b/govcd/vapp_concurrent_test.go
@@ -1,5 +1,4 @@
 //go:build concurrent
-// +build concurrent
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || functional || ALL
-// +build vapp functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || functional || ALL
-// +build vapp functional ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapp_vm_test.go
+++ b/govcd/vapp_vm_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || vm || functional || ALL
-// +build vapp vm functional ALL
 
 /*
  * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vapptemplate_test.go
+++ b/govcd/vapptemplate_test.go
@@ -1,5 +1,4 @@
 //go:build vapp || functional || ALL
-// +build vapp functional ALL
 
 /*
  * Copyright 2018 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vdc_group_common_test.go
+++ b/govcd/vdc_group_common_test.go
@@ -1,5 +1,4 @@
 //go:build network || functional || openapi || vdcGroup || nsxt || gateway || ALL
-// +build network functional openapi vdcGroup nsxt gateway ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vdc_group_test.go
+++ b/govcd/vdc_group_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || vdcGroup || nsxt || ALL
-// +build functional openapi vdcGroup nsxt ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vdc_network_profile_test.go
+++ b/govcd/vdc_network_profile_test.go
@@ -1,5 +1,4 @@
 //go:build network || nsxt || functional || openapi || ALL
-// +build network nsxt functional openapi ALL
 
 package govcd
 

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -1,5 +1,4 @@
 //go:build vdc || functional || ALL
-// +build vdc functional ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vdccomputepolicy_test.go
+++ b/govcd/vdccomputepolicy_test.go
@@ -1,5 +1,4 @@
 //go:build vdc || functional || openapi || ALL
-// +build vdc functional openapi ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vdccomputepolicy_v2_test.go
+++ b/govcd/vdccomputepolicy_v2_test.go
@@ -1,5 +1,4 @@
 //go:build vdc || functional || openapi || ALL
-// +build vdc functional openapi ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_affinity_rule_test.go
+++ b/govcd/vm_affinity_rule_test.go
@@ -1,5 +1,4 @@
 //go:build vdc || affinity || functional || ALL
-// +build vdc affinity functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_concurrent_test.go
+++ b/govcd/vm_concurrent_test.go
@@ -1,5 +1,4 @@
 //go:build concurrent
-// +build concurrent
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_dhcp_test.go
+++ b/govcd/vm_dhcp_test.go
@@ -1,5 +1,4 @@
 //go:build nsxv || vm || functional || ALL
-// +build nsxv vm functional ALL
 
 /*
  * Copyright 2020 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_groups_test.go
+++ b/govcd/vm_groups_test.go
@@ -1,5 +1,4 @@
 //go:build functional || openapi || ALL
-// +build functional openapi ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_groups_unit_test.go
+++ b/govcd/vm_groups_unit_test.go
@@ -1,5 +1,4 @@
 //go:build unit || ALL
-// +build unit ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1,5 +1,4 @@
 //go:build vm || functional || ALL
-// +build vm functional ALL
 
 /*
 * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/vm_unit_test.go
+++ b/govcd/vm_unit_test.go
@@ -1,5 +1,4 @@
 //go:build vm || unit || ALL
-// +build vm unit ALL
 
 /*
 * Copyright 2019 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.


### PR DESCRIPTION
## Description

This is a pretty straight forward PR that removes the `// +build` directive from all the test files, as `//go:build` should be used for programs compiled with Go1.17 and newer, as described here https://pkg.go.dev/cmd/go#hdr-Build_constraints
