### PR TITLE
NSX-T ALB Virtual Service Transparent mode and Pool Firewall Group membership

### DIFF
--- a/.changes/v2.20.0/XXX-improvements.md
+++ b/.changes/v2.20.0/XXX-improvements.md
@@ -1,0 +1,4 @@
+* Add new field `TransparentModeEnabled` to `types.NsxtAlbVirtualService` which allows to preserve
+  client IP for NSX-T ALB Virtual Service (VCD 10.4.1+) [GH-XXX]
+* Add new field `MemberGroupRef` to `types.NsxtAlbPool` which allows to define NSX-T ALB Pool
+  membership by using Edge Firewall Group (`NsxtFirewallGroup`) instead of plain IPs [GH-XXX]

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -687,6 +687,11 @@ func combinedTaskErrorMessage(task *types.Task, err error) string {
 	return extendedError
 }
 
+// addrOf is a generic function to return the address of a variable
+func addrOf[T any](variable T) *T {
+	return &variable
+}
+
 func takeBoolPointer(value bool) *bool {
 	return &value
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -194,6 +194,7 @@ type TestConfig struct {
 			NsxtAlbControllerUser     string `yaml:"nsxtAlbControllerUser"`
 			NsxtAlbControllerPassword string `yaml:"nsxtAlbControllerPassword"`
 			NsxtAlbImportableCloud    string `yaml:"nsxtAlbImportableCloud"`
+			NsxtAlbServiceEngineGroup string `yaml:"nsxtAlbServiceEngineGroup"`
 		} `yaml:"nsxt"`
 	} `yaml:"vcd"`
 	Logging struct {

--- a/govcd/nsxt_alb_pool_test.go
+++ b/govcd/nsxt_alb_pool_test.go
@@ -256,6 +256,12 @@ func setupAlbPoolPrerequisites(check *C, vcd *TestVCD) (*NsxtAlbController, *Nsx
 		albSettingsConfig.SupportedFeatureSet = "PREMIUM"
 	}
 
+	// Enable Transparent mode on VCD >= 10.4.1
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.1") {
+		printVerbose("# Enabling Transparent mode on Edge Gateway (VCD 10.4.1+)\n")
+		albSettingsConfig.TransparentModeEnabled = addrOf(true)
+	}
+
 	enabledSettings, err := edge.UpdateAlbSettings(albSettingsConfig)
 	if err != nil {
 		fmt.Printf("# error occured while enabling ALB on Edge Gateway. Cleaning up Service Engine Group, ALB Cloud and ALB Controller: %s", err)

--- a/govcd/nsxt_alb_service_engine_groups_test.go
+++ b/govcd/nsxt_alb_service_engine_groups_test.go
@@ -103,15 +103,16 @@ func spawnAlbControllerCloudServiceEngineGroup(vcd *TestVCD, check *C, seGroupRe
 
 	albController, createdAlbCloud := spawnAlbControllerAndCloud(vcd, check)
 
-	importableSeGroups, err := vcd.client.GetAllAlbImportableServiceEngineGroups(createdAlbCloud.NsxtAlbCloud.ID, nil)
+	importableSeGroup, err := vcd.client.GetAlbImportableServiceEngineGroupByName(createdAlbCloud.NsxtAlbCloud.ID, vcd.config.VCD.Nsxt.NsxtAlbServiceEngineGroup)
+
 	check.Assert(err, IsNil)
-	check.Assert(len(importableSeGroups) > 0, Equals, true)
+	// check.Assert(len(importableSeGroups) > 0, Equals, true)
 	albSeGroup := &types.NsxtAlbServiceEngineGroup{
 		Name:            check.TestName() + "SE-group",
 		Description:     "Service Engine Group created by " + check.TestName(),
 		ReservationType: seGroupReservationType,
 		ServiceEngineGroupBacking: types.ServiceEngineGroupBacking{
-			BackingId: importableSeGroups[0].NsxtAlbImportableServiceEngineGroups.ID,
+			BackingId: importableSeGroup.NsxtAlbImportableServiceEngineGroups.ID,
 			LoadBalancerCloudRef: &types.OpenApiReference{
 				ID: createdAlbCloud.NsxtAlbCloud.ID,
 			},

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -94,6 +94,16 @@ vcd:
       nsxtImportSegment: vcd-org-vdc-imported-network-backing
       # Existing NSX-T Edge Cluster name
       nsxtEdgeCluster: existing-nsxt-edge-cluster
+      # AVI Controller URL 
+      nsxtAlbControllerUrl: https://unknown-hostname.com
+      # AVI Controller username
+      nsxtAlbControllerUser: admin
+      # AVI Controller password
+      nsxtAlbControllerPassword: CHANGE-ME
+      # AVI Controller importable Cloud name 
+      nsxtAlbImportableCloud: NSXT AVI Cloud
+      # Service Engine Group name within (Should be configured in Active Standby mode)
+      nsxtAlbServiceEngineGroup: active-standby-service-engine-group
     # An Org catalog, possibly containing at least one item
     catalog:
         name: mycat

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1105,6 +1105,12 @@ type NsxtAlbVirtualService struct {
 	// VirtualIpAddress to be used for exposing this virtual service
 	VirtualIpAddress string `json:"virtualIpAddress"`
 
+	// TransparentModeEnabled allows to configure Preserve Client IP on a Virtual Service
+	// This field is only available for VCD 10.4.1+ (v37.1+)
+	// Note. `types.NsxtAlbConfig.TransparentModeEnabled` must be set to `true` for this field to be
+	// available.
+	TransparentModeEnabled *bool `json:"transparentModeEnabled,omitempty"`
+
 	// HealthStatus contains status of the Load Balancer Cloud. Possible values are:
 	// UP - The cloud is healthy and ready to enable Load Balancer for an Edge Gateway.
 	// DOWN - The cloud is in a failure state. Enabling Load balancer on an Edge Gateway may not be possible.

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -962,7 +962,17 @@ type NsxtAlbPool struct {
 
 	// Members field defines list of destination servers which are used by the Load Balancer Pool to direct load balanced
 	// traffic.
+	//
+	// Note. Only one of Members or MemberGroupRef can be specified
 	Members []NsxtAlbPoolMember `json:"members,omitempty"`
+
+	// MemberGroupRef contains reference to the Edge Firewall Group (`types.NsxtFirewallGroup`)
+	// representing destination servers which are used by the Load Balancer Pool to direct load
+	// balanced traffic.
+	//
+	// This field is only available in VCD 10.4.1+ (v37.1+)
+	// Note. Only one of Members or MemberGroupRef can be specified
+	MemberGroupRef *OpenApiReference `json:"memberGroupRef,omitempty"`
 
 	// CaCertificateRefs point to root certificates to use when validating certificates presented by the pool members.
 	CaCertificateRefs []OpenApiReference `json:"caCertificateRefs,omitempty"`


### PR DESCRIPTION
This PR continues on #549 and further catches up with latest NSX-T ALB features (requiring VCD 10.4.1+). 

In this PR there are two features:
* ALB Pool support for `MemberGroupRef` (which are NSX-T IP Sets)
* ALB Virtual Service support for Transparent mode (#549 added Transparent mode support for Edge Gateway settings).
**Note** that transparent mode can only be enabled when ALB Pools are configured to use above mentioned `MemberGroupRef` and the backing Service Engine Group inside AVI is configured to use Service Engine Group configured in "Active-Standby" mode

Side note:
This PR includes a generic function `addrOf` which should be a solution to replace all our type-limited functions `takeBoolPointer`, `takeIntAddress`, `takeStringPointer`. I did not pollute this PR with replacements as that can be done at a later time