### PR TITLE
Amend Defined Interface updates

### DIFF
--- a/.changes/v2.20.0/527-features.md
+++ b/.changes/v2.20.0/527-features.md
@@ -1,3 +1,3 @@
 * Added support for Runtime Defined Entity Interfaces with client methods `VCDClient.CreateDefinedInterface`, `VCDClient.GetAllDefinedInterfaces`,
   `VCDClient.GetDefinedInterface`, `VCDClient.GetDefinedInterfaceById` and methods to manipulate them `DefinedInterface.Update`,
-  `DefinedInterface.Delete` [GH-527], [GH-566]
+  `DefinedInterface.Delete` [GH-527, GH-566]

--- a/.changes/v2.20.0/527-features.md
+++ b/.changes/v2.20.0/527-features.md
@@ -1,3 +1,3 @@
 * Added support for Runtime Defined Entity Interfaces with client methods `VCDClient.CreateDefinedInterface`, `VCDClient.GetAllDefinedInterfaces`,
   `VCDClient.GetDefinedInterface`, `VCDClient.GetDefinedInterfaceById` and methods to manipulate them `DefinedInterface.Update`,
-  `DefinedInterface.Delete` [GH-527]
+  `DefinedInterface.Delete` [GH-527], [GH-566]

--- a/.changes/v2.20.0/545-features.md
+++ b/.changes/v2.20.0/545-features.md
@@ -1,3 +1,3 @@
 * Added support for Runtime Defined Entity Types with client methods `VCDClient.CreateRdeType`, `VCDClient.GetAllRdeTypes`,
   `VCDClient.GetRdeType`, `VCDClient.GetRdeTypeById` and methods to manipulate them `DefinedEntityType.Update`,
-  `DefinedEntityType.Delete` [GH-545], [GH-566]
+  `DefinedEntityType.Delete` [GH-545, GH-566]

--- a/.changes/v2.20.0/545-features.md
+++ b/.changes/v2.20.0/545-features.md
@@ -1,3 +1,3 @@
 * Added support for Runtime Defined Entity Types with client methods `VCDClient.CreateRdeType`, `VCDClient.GetAllRdeTypes`,
   `VCDClient.GetRdeType`, `VCDClient.GetRdeTypeById` and methods to manipulate them `DefinedEntityType.Update`,
-  `DefinedEntityType.Delete` [GH-545]
+  `DefinedEntityType.Delete` [GH-545], [GH-566]

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -153,6 +153,9 @@ func (rdeType *DefinedEntityType) Update(rdeTypeToUpdate types.DefinedEntityType
 	if rdeTypeToUpdate.Schema == nil || len(rdeTypeToUpdate.Schema) == 0 {
 		rdeTypeToUpdate.Schema = rdeType.DefinedEntityType.Schema
 	}
+	rdeTypeToUpdate.Version = rdeType.DefinedEntityType.Version
+	rdeTypeToUpdate.Nss = rdeType.DefinedEntityType.Nss
+	rdeTypeToUpdate.Vendor = rdeType.DefinedEntityType.Vendor
 
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)

--- a/govcd/defined_interface.go
+++ b/govcd/defined_interface.go
@@ -139,6 +139,11 @@ func (di *DefinedInterface) Update(definedInterface types.DefinedInterface) erro
 		return fmt.Errorf("ID of the receiver Defined Interface and the input ID don't match")
 	}
 
+	// We override these as they need to be always sent on updates
+	definedInterface.Version = di.DefinedInterface.Version
+	definedInterface.Nss = di.DefinedInterface.Nss
+	definedInterface.Vendor = di.DefinedInterface.Vendor
+
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
 	if err != nil {


### PR DESCRIPTION
## Description

It seems new versions of VCD require the `nss` and `version` to be sent back on Defined Interface **updates**.
This issue can be reproduced running the test `Test_DefinedInterface` in the latest VCD.
This patch fixes this situation.

This PR does the same patch for Defined Entity Types, despite this one doesn't fail, just to have the same behaviour in both places.