### PR TITLE
Improve 'ipSliceDifference' function memory footprint

### DIFF
--- a/.changes/v2.20.0/532-features.md
+++ b/.changes/v2.20.0/532-features.md
@@ -4,9 +4,9 @@
 * Added `NsxtEdgeGateway.GetUsedIpAddressSlice` method to fetch used IP addresses in a slice
   [GH-532]
 * Added `NsxtEdgeGateway.GetUnusedExternalIPAddresses` method that can help to find an unused
-  IP address in an Edge Gateway by given constraints [GH-532]
+  IP address in an Edge Gateway by given constraints [GH-532,GH-567]
 * Added `NsxtEdgeGateway.GetAllUnusedExternalIPAddresses` method that can return all unused IP
-  addresses in an Edge Gateway [GH-532]
+  addresses in an Edge Gateway [GH-532,GH-567]
 * Added `NsxtEdgeGateway.GetAllocatedIpCount` method that sums up `TotalIPCount` fields in all
   subnets [GH-532]
 * Added `NsxtEdgeGateway.QuickDeallocateIpCount` and `NsxtEdgeGateway.DeallocateIpCount`

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -749,57 +749,6 @@ func flattenEdgeGatewayUplinkToIpSlice(uplinks []types.EdgeGatewayUplinks) ([]ne
 	return assignedIpSlice, nil
 }
 
-// ipSliceDifferenceOld performs mathematical subtraction for two slices of IPs
-// The formula is (minuend − subtrahend = difference)
-//
-// Special behavior:
-// * Passing nil minuend results in nil
-// * Passing nil subtrahend will return minuendSlice
-func ipSliceDifferenceOld(minuendSlice, subtrahendSlice []netip.Addr) []netip.Addr {
-	if minuendSlice == nil {
-		return nil
-	}
-
-	if subtrahendSlice == nil {
-		return minuendSlice
-	}
-
-	// Removal of elements from an empty slice results in an empty slice
-	if len(minuendSlice) == 0 {
-		return []netip.Addr{}
-	}
-	// Having an empty subtrahendSlice results in minuendSlice
-	if len(subtrahendSlice) == 0 {
-		return minuendSlice
-	}
-
-	var difference []netip.Addr
-
-	// Loop over minuend IPs
-	for _, minuendIp := range minuendSlice {
-
-		// Check if subtrahend has minuend element listed
-		var foundSubtrahend bool
-
-		for _, subtrahendIp := range subtrahendSlice {
-			if subtrahendIp == minuendIp {
-				// IP found in subtrahend, therefore breaking inner loop early
-				foundSubtrahend = true
-				break
-			}
-
-		}
-
-		// Store the IP in difference when subtrahend does not contain IP of minuend
-		if !foundSubtrahend {
-			// Add IP to the resulting difference slice
-			difference = append(difference, minuendIp)
-		}
-	}
-
-	return difference
-}
-
 // ipSliceDifference performs mathematical subtraction for two slices of IPs
 // The formula is (minuend − subtrahend = difference)
 //

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -793,8 +793,7 @@ func ipSliceDifference(minuendSlice, subtrahendSlice []netip.Addr) []netip.Addr 
 
 		// Store the IP in `minuendSlice` at `resultIpCount` index and increment the index itself
 		if !foundSubtrahend {
-			// Add IP to the resulting difference slice
-			// difference = append(difference, minuendIp)
+			// Add IP to the 'resultIpCount' index position
 			minuendSlice[resultIpCount] = minuendIp
 			resultIpCount++
 		}


### PR DESCRIPTION
Methods `NsxtEdgeGateway.GetAllUnusedExternalIPAddresses` and `NsxtEdgeGateway.GetUnusedExternalIPAddresses` perform computations based on `netip.Addr` package.

The internal function `ipSliceDifference` is used to allocate a new slice to hold the final results. However, the operations become quite expensive memory wise having big subnets in Edge Gateway. Optimizing this function reduced memory consumption twice (see example below)


##### Example information

One example was allocation `/8` `IPv4` subnet (`16777213` IPs)

Before optimization 2 operations consumed such an amount of memory (`getAllUnusedExternalIPAddresses` - **7703.94MB**)
![image](https://user-images.githubusercontent.com/15804230/232455890-b9c42fef-9f7b-4201-b46c-ecc1e2b3c21d.png)

After optimization 2 operations of `getAllUnusedExternalIPAddresses` consume such amount (after **3853.80MB** vs before **7703.94MB**):
![image](https://user-images.githubusercontent.com/15804230/232456168-b3f67527-0176-4935-b431-d8c34c16f84a.png)

