### PR TITLE
Start v2.21.0 release cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.21.0 (TBC)
+
+Changes in progress for v2.21.0 are available at [.changes/v2.21.0](https://github.com/vmware/go-vcloud-director/tree/main/.changes/v2.21.0) until the release.
+
 ## 2.20.0 (April 27, 2023)
 
 ### FEATURES


### PR DESCRIPTION
This PR starts the next release cycle of SDK - `v2.21.0`