### PR TITLE
Support Edge Gateway DHCP Forwarding endpoint

### DIFF
--- a/.changes/v2.21.0/573-features.md
+++ b/.changes/v2.21.0/573-features.md
@@ -1,0 +1,2 @@
+* Added NSX-T Edge Gateway DHCP forwarding configuration support `NsxtEdgeGateway.GetDhcpForwarder` and
+  `NsxtEdgeGateway.UpdateDhcpForwarder` [GH-573]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1615,6 +1615,24 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 		}
 		return
 
+	case "nsxtDhcpForwarder":
+		edge, err := vcd.nsxtVdc.GetNsxtEdgeGatewayByName(entity.Name)
+		if err != nil {
+			vcd.infoCleanup("removeLeftoverEntries: [ERROR] %s \n", err)
+		}
+
+		if IsNotFound(err) {
+			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name)
+			return
+		}
+		_, err = edge.UpdateDhcpForwarder(&types.NsxtEdgeGatewayDhcpForwarder{})
+		if err != nil {
+			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)
+		}
+
+		vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
+		return
+
 	default:
 		// If we reach this point, we are trying to clean up an entity that
 		// we aren't prepared for yet.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1621,10 +1621,16 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			vcd.infoCleanup("removeLeftoverEntries: [ERROR] %s \n", err)
 		}
 
-		if IsNotFound(err) {
-			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name)
+		dhcpForwarder, err := edge.GetDhcpForwarder()
+		if err != nil {
+			vcd.infoCleanup("removeLeftoverEntries: [ERROR] %s \n", err)
+		}
+
+		if dhcpForwarder.Enabled == false && len(dhcpForwarder.DhcpServers) == 0 {
+			vcd.infoCleanup(notFoundMsg, "dhcpForwarder", entity.Name)
 			return
 		}
+
 		_, err = edge.UpdateDhcpForwarder(&types.NsxtEdgeGatewayDhcpForwarder{})
 		if err != nil {
 			vcd.infoCleanup(notDeletedMsg, entity.EntityType, entity.Name, err)

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -658,6 +658,61 @@ func (egw *NsxtEdgeGateway) UpdateQoS(qosConfig *types.NsxtEdgeGatewayQos) (*typ
 	return updatedQos, nil
 }
 
+// GetDhcpForwarder gets DHCP forwarder configuration for an NSX-T Edge Gateway
+func (egw *NsxtEdgeGateway) GetDhcpForwarder() (*types.NsxtEdgeGatewayDhcpForwarder, error) {
+	if egw.EdgeGateway == nil || egw.client == nil || egw.EdgeGateway.ID == "" {
+		return nil, fmt.Errorf("cannot get DHCP forwarder for NSX-T Edge Gateway without ID")
+	}
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGatewayDhcpForwarder
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	dhcpForwarder := &types.NsxtEdgeGatewayDhcpForwarder{}
+	err = client.OpenApiGetItem(apiVersion, urlRef, nil, dhcpForwarder, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return dhcpForwarder, nil
+}
+
+// UpdateDhcpForwarder updates DHCP forwarder configuration for an NSX-T Edge Gateway
+func (egw *NsxtEdgeGateway) UpdateDhcpForwarder(dhcpForwarderConfig *types.NsxtEdgeGatewayDhcpForwarder) (*types.NsxtEdgeGatewayDhcpForwarder, error) {
+	if egw.EdgeGateway == nil || egw.client == nil || egw.EdgeGateway.ID == "" {
+		return nil, fmt.Errorf("cannot get DHCP forwarder for NSX-T Edge Gateway without ID")
+	}
+
+	client := egw.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGatewayDhcpForwarder
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, egw.EdgeGateway.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	// update DHCP forwarder with given qosConfig
+	updatedDhcpForwarder := &types.NsxtEdgeGatewayDhcpForwarder{}
+	err = client.OpenApiPutItem(apiVersion, urlRef, nil, dhcpForwarderConfig, updatedDhcpForwarder, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedDhcpForwarder, nil
+}
+
 func getAllUnusedExternalIPAddresses(uplinks []types.EdgeGatewayUplinks, usedIpAddresses []*types.GatewayUsedIpAddress, optionalSubnet netip.Prefix) ([]netip.Addr, error) {
 	// 1. Flatten all IP ranges in Edge Gateway using Go's native 'netip.Addr' IP container instead
 	// of plain strings because it is more robust (supports IPv4 and IPv6 and also comparison

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -704,7 +704,12 @@ func (egw *NsxtEdgeGateway) UpdateDhcpForwarder(dhcpForwarderConfig *types.NsxtE
 	}
 
 	// update DHCP forwarder with given dhcpForwarderConfig
-	updatedDhcpForwarder := &types.NsxtEdgeGatewayDhcpForwarder{}
+	updatedDhcpForwarder, err := egw.GetDhcpForwarder()
+	if err != nil {
+		return nil, err
+	}
+	dhcpForwarderConfig.Version = updatedDhcpForwarder.Version
+
 	err = client.OpenApiPutItem(apiVersion, urlRef, nil, dhcpForwarderConfig, updatedDhcpForwarder, nil)
 	if err != nil {
 		return nil, err

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -703,7 +703,7 @@ func (egw *NsxtEdgeGateway) UpdateDhcpForwarder(dhcpForwarderConfig *types.NsxtE
 		return nil, err
 	}
 
-	// update DHCP forwarder with given qosConfig
+	// update DHCP forwarder with given dhcpForwarderConfig
 	updatedDhcpForwarder := &types.NsxtEdgeGatewayDhcpForwarder{}
 	err = client.OpenApiPutItem(apiVersion, urlRef, nil, dhcpForwarderConfig, updatedDhcpForwarder, nil)
 	if err != nil {

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -688,7 +688,7 @@ func (egw *NsxtEdgeGateway) GetDhcpForwarder() (*types.NsxtEdgeGatewayDhcpForwar
 // UpdateDhcpForwarder updates DHCP forwarder configuration for an NSX-T Edge Gateway
 func (egw *NsxtEdgeGateway) UpdateDhcpForwarder(dhcpForwarderConfig *types.NsxtEdgeGatewayDhcpForwarder) (*types.NsxtEdgeGatewayDhcpForwarder, error) {
 	if egw.EdgeGateway == nil || egw.client == nil || egw.EdgeGateway.ID == "" {
-		return nil, fmt.Errorf("cannot get DHCP forwarder for NSX-T Edge Gateway without ID")
+		return nil, fmt.Errorf("cannot update DHCP forwarder for NSX-T Edge Gateway without ID")
 	}
 
 	client := egw.client

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -550,4 +550,18 @@ func (vcd *TestVCD) Test_NsxtEdgeDhcpForwarder(check *C) {
 	// Check that updates were applied
 	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, true)
 	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
+
+	disabledDhcpForwarderConfig := &types.NsxtEdgeGatewayDhcpForwarder{
+		Enabled:     false,
+		DhcpServers: testDhcpServers,
+	}
+
+	// Update DHCP forwarder config
+	updatedEdgeDhcpForwarderConfig, err = edge.UpdateDhcpForwarder(disabledDhcpForwarderConfig)
+	check.Assert(err, IsNil)
+	check.Assert(updatedEdgeDhcpForwarderConfig, NotNil)
+
+	// Check that updates were applied
+	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, false)
+	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
 }

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -551,17 +551,42 @@ func (vcd *TestVCD) Test_NsxtEdgeDhcpForwarder(check *C) {
 	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, true)
 	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
 
-	disabledDhcpForwarderConfig := &types.NsxtEdgeGatewayDhcpForwarder{
-		Enabled:     false,
-		DhcpServers: testDhcpServers,
-	}
+	// remove the last dhcp server from the list
+	testDhcpServers = testDhcpServers[0:2]
+	newDhcpForwarderConfig.DhcpServers = testDhcpServers
+
+	updatedEdgeDhcpForwarderConfig, err = edge.UpdateDhcpForwarder(newDhcpForwarderConfig)
+	check.Assert(err, IsNil)
+	check.Assert(updatedEdgeDhcpForwarderConfig, NotNil)
+
+	// Check that updates were applied
+	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, true)
+	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
+
+	// Add servers to the list
+	testDhcpServers = append(testDhcpServers, "192.254.0.2")
+	newDhcpForwarderConfig.DhcpServers = testDhcpServers
+
+	updatedEdgeDhcpForwarderConfig, err = edge.UpdateDhcpForwarder(newDhcpForwarderConfig)
+	check.Assert(err, IsNil)
+	check.Assert(updatedEdgeDhcpForwarderConfig, NotNil)
+
+	// Check that updates were applied
+	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, true)
+	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
+
+	// Disable DHCP forwarder config
+	newDhcpForwarderConfig.Enabled = false
 
 	// Update DHCP forwarder config
-	updatedEdgeDhcpForwarderConfig, err = edge.UpdateDhcpForwarder(disabledDhcpForwarderConfig)
+	updatedEdgeDhcpForwarderConfig, err = edge.UpdateDhcpForwarder(newDhcpForwarderConfig)
 	check.Assert(err, IsNil)
 	check.Assert(updatedEdgeDhcpForwarderConfig, NotNil)
 
 	// Check that updates were applied
 	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, false)
 	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
+
+	updatedEdgeDhcpForwarderConfig.Enabled = true
+
 }

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -524,12 +524,6 @@ func (vcd *TestVCD) Test_NsxtEdgeDhcpForwarder(check *C) {
 	check.Assert(dhcpForwarderConfig.Enabled, Equals, false)
 	check.Assert(dhcpForwarderConfig.DhcpServers, DeepEquals, []string(nil))
 
-	// Defer removal of the DHCP forwarder config, so that it gets removed no matter the outcome of the test
-	defer func() {
-		_, err = edge.UpdateDhcpForwarder(&types.NsxtEdgeGatewayDhcpForwarder{})
-		check.Assert(err, IsNil)
-	}()
-
 	// Create new DHCP Forwarder config
 	testDhcpServers := []string{
 		"1.1.1.1",
@@ -587,6 +581,6 @@ func (vcd *TestVCD) Test_NsxtEdgeDhcpForwarder(check *C) {
 	check.Assert(updatedEdgeDhcpForwarderConfig.Enabled, Equals, false)
 	check.Assert(updatedEdgeDhcpForwarderConfig.DhcpServers, DeepEquals, testDhcpServers)
 
-	updatedEdgeDhcpForwarderConfig.Enabled = true
-
+	_, err = edge.UpdateDhcpForwarder(&types.NsxtEdgeGatewayDhcpForwarder{})
+	check.Assert(err, IsNil)
 }

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -37,6 +37,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeClusters:               "34.0", // VCD 10.1+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointQosProfiles:                "36.2", // VCD 10.3.2+ (NSX-T only)
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGatewayQos:             "36.2", // VCD 10.3.2+ (NSX-T only)
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGatewayDhcpForwarder:   "36.1", // VCD 10.3.1+ (NSX-T only)
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways:               "34.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGatewayUsedIpAddresses: "34.0",
 

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -367,6 +367,7 @@ const (
 	OpenApiEndpointVdcNetworkProfile                  = "vdcs/%s/networkProfile"
 	OpenApiEndpointEdgeGateways                       = "edgeGateways/"
 	OpenApiEndpointEdgeGatewayQos                     = "edgeGateways/%s/qos"
+	OpenApiEndpointEdgeGatewayDhcpForwarder           = "edgeGateways/%s/dhcpForwarder"
 	OpenApiEndpointEdgeGatewayUsedIpAddresses         = "edgeGateways/%s/usedIpAddresses"
 	OpenApiEndpointNsxtFirewallRules                  = "edgeGateways/%s/firewall/rules"
 	OpenApiEndpointFirewallGroups                     = "firewallGroups/"

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1687,8 +1687,9 @@ type NsxtEdgeGatewayQos struct {
 // NsxtEdgeGatewayDhcpForwarder provides DHCP forwarding configuration on an Edge Gateway by defining
 // DHCP servers
 type NsxtEdgeGatewayDhcpForwarder struct {
-	Enabled     bool     `json:"enabled"`
-	DhcpServers []string `json:"dhcpServers"`
+	Enabled     bool         `json:"enabled"`
+	DhcpServers []string     `json:"dhcpServers"`
+	Version     VersionField `json:"version,omitempty"`
 }
 
 // VcenterImportableDvpg defines a Distributed Port Group that can be imported into VCD

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1684,6 +1684,13 @@ type NsxtEdgeGatewayQos struct {
 	IngressProfile *OpenApiReference `json:"ingressProfile"`
 }
 
+// NsxtEdgeGatewayDhcpForwarder provides DHCP forwarding configuration on an Edge Gateway by defining
+// DHCP servers
+type NsxtEdgeGatewayDhcpForwarder struct {
+	Enabled     bool     `json:"enabled"`
+	DhcpServers []string `json:"dhcpServers"`
+}
+
 // VcenterImportableDvpg defines a Distributed Port Group that can be imported into VCD
 // from a vCenter Server.
 //


### PR DESCRIPTION
## Description

This PR adds Edge Gateway DHCP Forwarding support with two new methods `UpdateDhcpForwarder` and `GetDhcpForwarder`, supported in VCD versions v10.3.1+

