### PR TITLE
Skip policy clean error test in 10.4.2

### DIFF
--- a/.changes/v2.21.0/574-notes.md
+++ b/.changes/v2.21.0/574-notes.md
@@ -1,0 +1,2 @@
+* Skipped test `Test_VdcDuplicatedVmPlacementPolicyGetsACleanError` in 10.4.2 as the relevant bug we check for is fixed in that version [GH-574]
+

--- a/govcd/vdccomputepolicy_v2_test.go
+++ b/govcd/vdccomputepolicy_v2_test.go
@@ -327,6 +327,9 @@ func (vcd *TestVCD) Test_VdcVmPlacementPoliciesV2(check *C) {
 // of the SDK get a nicely formatted error.
 // This test should not be needed once function `getFriendlyErrorIfVmPlacementPolicyAlreadyExists` is removed.
 func (vcd *TestVCD) Test_VdcDuplicatedVmPlacementPolicyGetsACleanError(check *C) {
+	if vcd.client.Client.APIVCDMaxVersionIs(">= 37.2") {
+		check.Skip("The bug that this test checks for is fixed in 10.4.2")
+	}
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}


### PR DESCRIPTION
The bug that the test checks for is fixed in 10.4.2, so we can skip the test safely.

