### PR TITLE
Fix UI Plugin failing tests

### DIFF
--- a/.changes/v2.21.0/583-notes.md
+++ b/.changes/v2.21.0/583-notes.md
@@ -1,0 +1,1 @@
+* Added `unit` step to GitHub Actions [GH-583]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -24,5 +24,8 @@ jobs:
     - name: static
       run: make static
 
-    - name: test
-      run: make test
+    - name: verify
+      run: make tagverify
+
+    - name: unit
+      run: make testunit

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -24,5 +24,5 @@ jobs:
     - name: static
       run: make static
 
-    - name: verify
-      run: make tagverify
+    - name: test
+      run: make test

--- a/govcd/ui_plugin_test.go
+++ b/govcd/ui_plugin_test.go
@@ -13,26 +13,18 @@ func init() {
 	testingTags["uiPlugin"] = "ui_plugin_test.go"
 }
 
-// This object is equivalent to the manifest.json that is inside the ../test-resources/ui_plugin.zip file
-var testUIPluginMetadata = &types.UIPluginMetadata{
-	Vendor:         "VMware",
-	License:        "BSD-2-Clause",
-	Link:           "http://www.vmware.com",
-	PluginName:     "Test Plugin",
-	Version:        "1.2.3",
-	Description:    "Test Plugin description",
-	ProviderScoped: true,
-	TenantScoped:   true,
-}
-
 // Test_UIPlugin tests all the possible operations that can be done with a UIPlugin object in VCD.
 func (vcd *TestVCD) Test_UIPlugin(check *C) {
 	if vcd.skipAdminTests {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
+	const uiPluginPath = "../test-resources/ui_plugin.zip"
+	testUIPluginMetadata, err := getPluginMetadata(uiPluginPath)
+	check.Assert(err, IsNil)
+
 	// Add a plugin present on disk
-	newUIPlugin, err := vcd.client.AddUIPlugin("../test-resources/ui_plugin.zip", true)
+	newUIPlugin, err := vcd.client.AddUIPlugin(uiPluginPath, true)
 	check.Assert(err, IsNil)
 	AddToCleanupListOpenApi(newUIPlugin.UIPluginMetadata.ID, check.TestName(), types.OpenApiEndpointExtensionsUi+newUIPlugin.UIPluginMetadata.ID)
 
@@ -49,7 +41,7 @@ func (vcd *TestVCD) Test_UIPlugin(check *C) {
 	check.Assert(newUIPlugin.UIPluginMetadata.Enabled, Equals, true)
 
 	// Try to add the same plugin twice, it should fail
-	_, err = vcd.client.AddUIPlugin("../test-resources/ui_plugin.zip", true)
+	_, err = vcd.client.AddUIPlugin(uiPluginPath, true)
 	check.Assert(err, NotNil)
 	check.Assert(true, Equals, strings.Contains(err.Error(), "same pluginName-version-vendor"))
 

--- a/govcd/ui_plugin_unit_test.go
+++ b/govcd/ui_plugin_unit_test.go
@@ -14,6 +14,19 @@ import (
 // Test_getPluginMetadata tests that getPluginMetadata can retrieve correctly the UI plugin metadata information
 // stored inside the ZIP file.
 func Test_getPluginMetadata(t *testing.T) {
+
+	// This object is equivalent to the manifest.json that is inside the ../test-resources/ui_plugin.zip file
+	var testUIPluginMetadata = &types.UIPluginMetadata{
+		Vendor:         "VMware",
+		License:        "BSD-2-Clause",
+		Link:           "http://www.vmware.com",
+		PluginName:     "Test Plugin",
+		Version:        "1.2.3",
+		Description:    "Test Plugin description",
+		ProviderScoped: true,
+		TenantScoped:   true,
+	}
+
 	tests := []struct {
 		name       string
 		pluginPath string


### PR DESCRIPTION
This PR complements #575 as it fixes a failing unit test.

The reason of the failure is that the unit test was referencing a variable defined in a regular test, which is not visible when using the `unit` tag.

I have refactored the code so the variable doesn't need to be global anymore.

I've also added the `unit` step to the GitHub Action, to run the unit tests in PRs with `make testunit`, so we minimize the chances of this happening again.