### PR TITLE
Fix catalog creation

### DIFF
--- a/.changes/v2.22.0/590-bug-fixes.md
+++ b/.changes/v2.22.0/590-bug-fixes.md
@@ -1,0 +1,1 @@
+* Added handling of catalog creation task, which was leaving the catalog not ready for action in some cases [GH-590] 

--- a/govcd/adminorg.go
+++ b/govcd/adminorg.go
@@ -35,7 +35,7 @@ func NewAdminOrg(cli *Client) *AdminOrg {
 	}
 }
 
-// CreateCatalog creates a catalog with given name and description under the
+// CreateCatalog creates a catalog with given name and description under
 // the given organization. Returns an AdminCatalog that contains a creation
 // task.
 // API Documentation: https://code.vmware.com/apis/220/vcloud#/doc/doc/operations/POST-CreateCatalog.html
@@ -45,6 +45,16 @@ func (adminOrg *AdminOrg) CreateCatalog(name, description string) (AdminCatalog,
 		return AdminCatalog{}, err
 	}
 	adminCatalog.parent = adminOrg
+
+	err = adminCatalog.Refresh()
+	if err != nil {
+		return AdminCatalog{}, err
+	}
+	// Make sure that the creation task is finished
+	err = adminCatalog.WaitForTasks()
+	if err != nil {
+		return AdminCatalog{}, err
+	}
 	return *adminCatalog, nil
 }
 

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -1205,3 +1205,18 @@ func (client *Client) GetCatalogByName(parentOrg, catalogName string) (*Catalog,
 	}
 	return nil, fmt.Errorf("no catalog '%s' found in Org %s%s", catalogName, parentOrg, parents)
 }
+
+// WaitForTasks waits for the catalog's tasks to complete
+func (cat *Catalog) WaitForTasks() error {
+	if ResourceInProgress(cat.Catalog.Tasks) {
+		err := WaitResource(func() (*types.TasksInProgress, error) {
+			err := cat.Refresh()
+			if err != nil {
+				return nil, err
+			}
+			return cat.Catalog.Tasks, nil
+		})
+		return err
+	}
+	return nil
+}

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1304,3 +1304,31 @@ func (vcd *TestVCD) Test_CatalogAccessAsOrgUsers(check *C) {
 	}
 	check.Assert(err, IsNil)
 }
+
+func (vcd *TestVCD) Test_CatalogCreateCompleteness(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	check.Assert(adminOrg, NotNil)
+	catalogName := "TestAdminCatalogCreate"
+	adminCatalog, err := adminOrg.CreateCatalog(catalogName, catalogName)
+	check.Assert(err, IsNil)
+	AddToCleanupList(catalogName, "catalog", vcd.config.VCD.Org, check.TestName())
+	metadataLink := adminCatalog.AdminCatalog.Link.ForType(types.MimeMetaData, "add")
+	check.Assert(metadataLink, NotNil)
+	err = adminCatalog.Delete(true, true)
+	check.Assert(err, IsNil)
+
+	catalogName = "TestCatalogCreate"
+	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+	catalog, err := org.CreateCatalog(catalogName, catalogName)
+	check.Assert(err, IsNil)
+	AddToCleanupList(catalogName, "catalog", vcd.config.VCD.Org, check.TestName())
+	metadataLink = nil
+	metadataLink = catalog.Catalog.Link.ForType(types.MimeMetaData, "add")
+	check.Assert(metadataLink, NotNil)
+	err = catalog.Delete(true, true)
+	check.Assert(err, IsNil)
+}

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -143,6 +143,17 @@ func (org *Org) CreateCatalog(name, description string) (Catalog, error) {
 	if err != nil {
 		return Catalog{}, err
 	}
+	catalog.parent = org
+
+	err = catalog.Refresh()
+	if err != nil {
+		return Catalog{}, err
+	}
+	// Make sure that the creation task is finished
+	err = catalog.WaitForTasks()
+	if err != nil {
+		return Catalog{}, err
+	}
 	return *catalog, nil
 }
 


### PR DESCRIPTION
This PR makes sure that the created catalog runs its creation tasks completely, and it is ready to perform operations, such as updating or adding metadata.
This change will be completed in `terraform-provider-vcd` by removing the function `waitForMetadataReadiness`, which will become redundant.