### PR TITLE
Fix NSX-V Edge Gateway nil pointer dereference

### DIFF
--- a/.changes/v2.22.0/594-bug-fixes.md
+++ b/.changes/v2.22.0/594-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix nil pointer dereference bug while fetching a NSX-V Backed Edge Gateway [GH-594]

--- a/govcd/vdc.go
+++ b/govcd/vdc.go
@@ -389,6 +389,14 @@ func (vdc *Vdc) GetEdgeGatewayByHref(href string) (*EdgeGateway, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Edge gateways can sometimes come without any configured services which
+	// lead to nil pointer dereference when adding e.g a DNAT rule
+	// https://github.com/vmware/go-vcloud-director/issues/585
+	if edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration == nil {
+		edge.EdgeGateway.Configuration.EdgeGatewayServiceConfiguration = &types.GatewayFeatures{}
+	}
+
 	return edge, nil
 }
 


### PR DESCRIPTION
NSX-V Edge gateways can come without any services configured so we need to check for nil pointers.

Closes Issue #585 
