### PR TITLE
Add UI Plugin test configuration

### DIFF
--- a/.changes/v2.22.0/599-notes.md
+++ b/.changes/v2.22.0/599-notes.md
@@ -1,0 +1,1 @@
+* Improved the testing configuration to allow customizing the UI Plugin path [GH-599]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -226,6 +226,7 @@ type TestConfig struct {
 		NsxtMedia        string `yaml:"nsxtBackedMediaName,omitempty"`
 		PhotonOsOvaPath  string `yaml:"photonOsOvaPath,omitempty"`
 		MediaUdfTypePath string `yaml:"mediaUdfTypePath,omitempty"`
+		UiPluginPath     string `yaml:"uiPluginPath,omitempty"`
 	} `yaml:"media"`
 }
 

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -86,7 +86,7 @@ vcd:
       # NSX-T tier-0 VRF router used for external network tests
       tier0routerVrf: tier-0-router-vrf
       # Gateway QoS Profile used for NSX-T Edge Gateway Rate Limiting (defined in NSX-T Manager)
-      gatewayQosProfile: Gateway QoS Profile 1 
+      gatewayQosProfile: Gateway QoS Profile 1
       # Existing External Network with correct configuration
       externalNetwork: tier0-backed-external-network
       # Existing NSX-T based VDC
@@ -99,13 +99,13 @@ vcd:
       nsxtImportSegment: vcd-org-vdc-imported-network-backing
       # Existing NSX-T Edge Cluster name
       nsxtEdgeCluster: existing-nsxt-edge-cluster
-      # AVI Controller URL 
+      # AVI Controller URL
       nsxtAlbControllerUrl: https://unknown-hostname.com
       # AVI Controller username
       nsxtAlbControllerUser: admin
       # AVI Controller password
       nsxtAlbControllerPassword: CHANGE-ME
-      # AVI Controller importable Cloud name 
+      # AVI Controller importable Cloud name
       nsxtAlbImportableCloud: NSXT AVI Cloud
       # Service Engine Group name within (Should be configured in Active Standby mode)
       nsxtAlbServiceEngineGroup: active-standby-service-engine-group
@@ -237,3 +237,5 @@ media:
   mediaName: uploadedMediaName
   # Existing media in NSX-T backed VDC
   nsxtBackedMediaName: nsxtMediaName
+  # A valid UI Plugin to use in tests.
+  uiPluginPath: ../test-resources/ui_plugin.zip

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -237,5 +237,5 @@ media:
   mediaName: uploadedMediaName
   # Existing media in NSX-T backed VDC
   nsxtBackedMediaName: nsxtMediaName
-  # A valid UI Plugin to use in tests.
+  # A valid UI Plugin to use in tests
   uiPluginPath: ../test-resources/ui_plugin.zip

--- a/govcd/ui_plugin_test.go
+++ b/govcd/ui_plugin_test.go
@@ -19,12 +19,15 @@ func (vcd *TestVCD) Test_UIPlugin(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	const uiPluginPath = "../test-resources/ui_plugin.zip"
-	testUIPluginMetadata, err := getPluginMetadata(uiPluginPath)
+	if vcd.config.Media.UiPluginPath == "" {
+		check.Skip("The testing configuration property 'media.uiPluginPath' is empty")
+	}
+
+	testUIPluginMetadata, err := getPluginMetadata(vcd.config.Media.UiPluginPath)
 	check.Assert(err, IsNil)
 
 	// Add a plugin present on disk
-	newUIPlugin, err := vcd.client.AddUIPlugin(uiPluginPath, true)
+	newUIPlugin, err := vcd.client.AddUIPlugin(vcd.config.Media.UiPluginPath, true)
 	check.Assert(err, IsNil)
 	AddToCleanupListOpenApi(newUIPlugin.UIPluginMetadata.ID, check.TestName(), types.OpenApiEndpointExtensionsUi+newUIPlugin.UIPluginMetadata.ID)
 
@@ -41,7 +44,7 @@ func (vcd *TestVCD) Test_UIPlugin(check *C) {
 	check.Assert(newUIPlugin.UIPluginMetadata.Enabled, Equals, true)
 
 	// Try to add the same plugin twice, it should fail
-	_, err = vcd.client.AddUIPlugin(uiPluginPath, true)
+	_, err = vcd.client.AddUIPlugin(vcd.config.Media.UiPluginPath, true)
 	check.Assert(err, NotNil)
 	check.Assert(true, Equals, strings.Contains(err.Error(), "same pluginName-version-vendor"))
 


### PR DESCRIPTION
This PR aligns Go SDK project with [Terraform VCD Provider](https://github.com/vmware/terraform-provider-vcd/pull/1089/files#diff-553221ab6c64bf8e1e0f3f61fe1ab31210cf92b5e088a3aab5fa5bceb93678faR163), allowing to configure the location of the testing UI Plugin.

```
GOVCD_SKIP_VAPP_CREATION=1 go test -tags functional -check.f 'Test_UIPlugin' -check.vv -timeout=0
```
Passed in VCD 10.5.0