### PR TITLE
Improve correctnes

### DIFF
--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -84,7 +84,7 @@ func getAppProfileTenant(vcd *TestVCD, check *C) *types.NsxtAppPortProfile {
 		ApplicationPorts: []types.NsxtAppPortProfilePort{
 			types.NsxtAppPortProfilePort{
 				Protocol:         "ICMPv4",
-				DestinationPorts: []string{},
+				DestinationPorts: []string{"any"},
 			},
 		},
 		OrgRef: &types.OpenApiReference{ID: org.Org.ID, Name: org.Org.Name},


### PR DESCRIPTION
* `Test_NsxtApplicationPortProfileTenant` - VCD 10.5.0 added improvement and returns `any` for `DestinationPorts` even if an empty slice is specified. This PR adjusts the test to us `any` so that it is compatible with 10.3 <-> 10.5