### PR TITLE
Fix Test_*OrgCreateCatalog

### DIFF
--- a/.changes/v2.22.0/590-bug-fixes.md
+++ b/.changes/v2.22.0/590-bug-fixes.md
@@ -1,1 +1,1 @@
-* Added handling of catalog creation task, which was leaving the catalog not ready for action in some cases [GH-590] 
+* Added handling of catalog creation task, which was leaving the catalog not ready for action in some cases [GH-590],[GH-602] 

--- a/.changes/v2.22.0/590-bug-fixes.md
+++ b/.changes/v2.22.0/590-bug-fixes.md
@@ -1,1 +1,1 @@
-* Added handling of catalog creation task, which was leaving the catalog not ready for action in some cases [GH-590],[GH-602] 
+* Added handling of catalog creation task, which was leaving the catalog not ready for action in some cases [GH-590, GH-602] 

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -419,10 +419,9 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalog(check *C) {
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, TestCreateCatalog)
 	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
-	task := NewTask(&vcd.client.Client)
-	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
+	// Immediately after the catalog creation, the creation task should be already complete
+	check.Assert(ResourceComplete(adminCatalog.AdminCatalog.Tasks), Equals, true)
+
 	adminOrg, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	copyAdminCatalog, err := adminOrg.GetAdminCatalogByName(TestCreateCatalog, false)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -503,10 +503,8 @@ func (vcd *TestVCD) Test_OrgCreateCatalog(check *C) {
 	AddToCleanupList(TestCreateCatalog, "catalog", vcd.org.Org.Name, "Test_CreateCatalog")
 	check.Assert(catalog.Catalog.Name, Equals, TestCreateCatalog)
 	check.Assert(catalog.Catalog.Description, Equals, TestCreateCatalogDesc)
-	task := NewTask(&vcd.client.Client)
-	task.Task = catalog.Catalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
+	// Immediately after the catalog creation, the creation task should be already complete
+	check.Assert(ResourceComplete(catalog.Catalog.Tasks), Equals, true)
 	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	copyCatalog, err := org.GetCatalogByName(TestCreateCatalog, false)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -736,25 +736,39 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 		err = task.WaitTaskCompletion()
 		check.Assert(err, IsNil)
 		check.Assert(task.Task.Status, Equals, "success")
+		err = vm.Refresh()
+		check.Assert(err, IsNil)
+		fmt.Println("VM status: ", vmStatus)
 	}
 
+	timeout := time.Minute * 5 // Avoiding infinite loops
+	startTime := time.Now()
+	elapsed := time.Since(startTime)
+	gcStatus := ""
+	statusFound := false
 	// Wait until Guest Tools gets to `REBOOT_PENDING` or `GC_COMPLETE` as there is no real way to
 	// check if VM has Guest Tools operating
-	for {
+	for elapsed < timeout {
 		err = vm.Refresh()
 		check.Assert(err, IsNil)
 
 		vmQuery, err := vdc.QueryVM(vapp.VApp.Name, vm.VM.Name)
 		check.Assert(err, IsNil)
 
-		printVerbose("VM Tools Status: %s\n", vmQuery.VM.GcStatus)
+		gcStatus = vmQuery.VM.GcStatus
+		printVerbose("VM Tools Status: %s (%s)\n", vmQuery.VM.GcStatus, elapsed)
 		if vmQuery.VM.GcStatus == "GC_COMPLETE" || vmQuery.VM.GcStatus == "REBOOT_PENDING" {
+			statusFound = true
 			break
 		}
 
-		time.Sleep(3 * time.Second)
+		time.Sleep(5 * time.Second)
+		elapsed = time.Since(startTime)
 	}
-	printVerbose("Shuting down VM:\n")
+	printVerbose("VM Tools Status: %s (%s)\n", gcStatus, elapsed)
+	check.Assert(statusFound, Equals, true)
+
+	printVerbose("Shutting down VM:\n")
 
 	task, err := vm.Shutdown()
 	check.Assert(err, IsNil)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -738,6 +738,8 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 		check.Assert(task.Task.Status, Equals, "success")
 		err = vm.Refresh()
 		check.Assert(err, IsNil)
+		vmStatus, err = vm.GetStatus()
+		check.Assert(err, IsNil)
 		fmt.Println("VM status: ", vmStatus)
 	}
 
@@ -765,7 +767,7 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 		time.Sleep(5 * time.Second)
 		elapsed = time.Since(startTime)
 	}
-	printVerbose("VM Tools Status: %s (%s)\n", gcStatus, elapsed)
+	fmt.Printf("VM Tools Status: %s (%s)\n", gcStatus, elapsed)
 	check.Assert(statusFound, Equals, true)
 
 	printVerbose("Shutting down VM:\n")


### PR DESCRIPTION
The creation task may not be available after a recent fix to catalog creation (PR #590). Accessing the task directly may lead to a panic. The check is replaced with a more resilient function call (ResourceComplete)

Also, remove chance of infinite loop from `Test_VmShutdown`

