### PR TITLE
VappTestSuite consistent undeploy

### DIFF
--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -389,7 +389,7 @@ func (vcd *TestVCD) ensureVMIsSuitableForVMTest(vm *VM) error {
 		if status == types.VAppStatuses[4] {
 			// Prevent affect Test_ChangeMemorySize
 			// because TestVCD.Test_AttachedVMDisk is run before Test_ChangeMemorySize and Test_ChangeMemorySize will fail the test if the VM is powered on,
-			task, err := vm.PowerOff()
+			task, err := vm.Undeploy()
 			if err != nil {
 				return err
 			}

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -750,7 +750,6 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 			break
 		}
 
-		fmt.Println(time.Now())
 		time.Sleep(3 * time.Second)
 	}
 	printVerbose("Shuting down VM:\n")
@@ -765,14 +764,6 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 	check.Assert(err, IsNil)
 	printVerbose("New VM status: %s\n", newStatus)
 	check.Assert(newStatus, Equals, "POWERED_OFF")
-
-	// End of test - power on the VM to leave it running
-	if vmStatus == "POWERED_ON" {
-		task, err = vm.PowerOn()
-		check.Assert(err, IsNil)
-		err = task.WaitTaskCompletion()
-		check.Assert(err, IsNil)
-	}
 }
 
 func (vcd *TestVCD) Test_GetNetworkConnectionSection(check *C) {
@@ -891,14 +882,12 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
 	check.Assert(err, IsNil)
 
-	// If the VM was powered off before the test, undeploy it.
-	if vmStatus == "POWERED_OFF" {
-		task, err = vm.Undeploy()
-		check.Assert(err, IsNil)
-		err = task.WaitTaskCompletion()
-		check.Assert(err, IsNil)
-		check.Assert(task.Task.Status, Equals, "success")
-	}
+	// All of the vApp TestSuite tests expect the VM to be in POWERED_OFF state
+	task, err = vm.Undeploy()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	check.Assert(task.Task.Status, Equals, "success")
 }
 
 func (vcd *TestVCD) Test_BlockWhileGuestCustomizationStatus(check *C) {
@@ -2329,14 +2318,13 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 		check.Assert(p.Mac, Not(Equals), "")
 	}
 
-	// Undeploy so the VM is in POWERED_OFF state
-	task, _ := vm.Undeploy()
+	// Undeploy so the VM is in POWERED_OFF statPowerOffe
+	task, err := vm.Undeploy()
+	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
 	ovfenv, err = vm.GetEnvironment()
 	check.Assert(strings.Contains(err.Error(), "OVF environment is only available when VM is powered on"), Equals, true)
 	check.Assert(ovfenv, IsNil)
-	// PowerOff
-
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2261,6 +2261,12 @@ func createNsxtVAppAndVm(vcd *TestVCD, check *C) (*VApp, *VM) {
 
 func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 
+	version, err := vcd.client.Client.GetVcdShortVersion()
+	check.Assert(err, IsNil)
+	if version == "10.5.0" {
+		check.Skip("There is a known bug with the OVF environment on 10.5.0")
+	}
+
 	_, vm := createNsxtVAppAndVm(vcd, check)
 	check.Assert(vm, NotNil)
 

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -881,13 +881,6 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
 	check.Assert(err, IsNil)
 
-	// All of the vApp TestSuite tests expect the VM to be in POWERED_OFF state
-	task, err = vm.Undeploy()
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
-	check.Assert(err, IsNil)
-	check.Assert(task.Task.Status, Equals, "success")
-
 	err = deleteVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }
@@ -2278,6 +2271,11 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 
 	_, vm := createNsxtVAppAndVm(vcd, check)
 	check.Assert(vm, NotNil)
+
+	task, err := vm.PowerOn()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 
 	// Read ovfenv when VM is started
 	ovfenv, err := vm.GetEnvironment()

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -702,7 +702,7 @@ func (vcd *TestVCD) Test_VMPowerOnPowerOff(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(vmStatus == "POWERED_OFF" || vmStatus == "PARTIALLY_POWERED_OFF", Equals, true)
 
-	err = deleteVapp(vcd, check.TestName())
+	err = deleteNsxtVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }
 
@@ -770,7 +770,7 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 	printVerbose("New VM status: %s\n", newStatus)
 	check.Assert(newStatus, Equals, "POWERED_OFF")
 
-	err = deleteVapp(vcd, check.TestName())
+	err = deleteNsxtVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }
 
@@ -881,7 +881,7 @@ func (vcd *TestVCD) Test_PowerOnAndForceCustomization(check *C) {
 	err = vm.BlockWhileGuestCustomizationStatus(types.GuestCustStatusPending, 300)
 	check.Assert(err, IsNil)
 
-	err = deleteVapp(vcd, check.TestName())
+	err = deleteNsxtVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }
 
@@ -2301,6 +2301,6 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 		check.Assert(p.Mac, Not(Equals), "")
 	}
 
-	err = deleteVapp(vcd, check.TestName())
+	err = deleteNsxtVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -740,7 +740,12 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 
 	// Wait until Guest Tools gets to `REBOOT_PENDING` or `GC_COMPLETE` as there is no real way to
 	// check if VM has Guest Tools operating
+	i := 0
 	for {
+		i += 1
+		if i == 1000 {
+			panic("aaaaaaaaa")
+		}
 		err = vm.Refresh()
 		check.Assert(err, IsNil)
 
@@ -752,6 +757,7 @@ func (vcd *TestVCD) Test_VmShutdown(check *C) {
 			break
 		}
 
+		fmt.Println(time.Now())
 		time.Sleep(3 * time.Second)
 	}
 	printVerbose("Shuting down VM:\n")
@@ -1425,12 +1431,7 @@ func (vcd *TestVCD) Test_UpdateVmSpecSection(check *C) {
 	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
 	check.Assert(err, IsNil)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
-	check.Assert(err, IsNil)
-
-	task, err := vm.PowerOff()
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", false)
 	check.Assert(err, IsNil)
 
 	vmSpecSection := vm.VM.VmSpecSection
@@ -1505,12 +1506,7 @@ func (vcd *TestVCD) Test_UpdateVmCpuAndMemoryHotAdd(check *C) {
 	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
 	check.Assert(err, IsNil)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
-	check.Assert(err, IsNil)
-
-	task, err := vm.PowerOff()
-	check.Assert(err, IsNil)
-	err = task.WaitTaskCompletion()
+	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", false)
 	check.Assert(err, IsNil)
 
 	check.Assert(vm.VM.VMCapabilities.MemoryHotAddEnabled, Equals, false)
@@ -2329,7 +2325,7 @@ func (vcd *TestVCD) Test_GetOvfEnvironment(check *C) {
 	}
 
 	// PowerOff
-	task, err := vm.PowerOff()
+	task, err := vm.Undeploy()
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -611,16 +611,8 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 		check.Skip("Skipping test because vapp was not successfully created at setup")
 	}
 
-	vmName := check.TestName()
-	vdc, _, vappTemplate, vapp, desiredNetConfig, err := vcd.createAndGetResourcesForVmCreation(check, vmName)
-	check.Assert(err, IsNil)
+	_, vm := createNsxtVAppAndVm(vcd, check)
 
-	vm, err := spawnVM("FirstNode", 512, *vdc, *vapp, desiredNetConfig, vappTemplate, check, "", true)
-	check.Assert(err, IsNil)
-	if vmName == "" {
-		check.Skip("skipping test because no VM is found")
-	}
-	// Default nesting status should be false
 	nestingStatus := vm.VM.NestedHypervisorEnabled
 	check.Assert(nestingStatus, Equals, false)
 
@@ -663,7 +655,7 @@ func (vcd *TestVCD) Test_VMToggleHardwareVirtualization(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(vm.VM.NestedHypervisorEnabled, Equals, false)
 
-	err = deleteVapp(vcd, vmName)
+	err = deleteNsxtVapp(vcd, check.TestName())
 	check.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
This PR updates all the VappTestSuite tests that need it to be in `POWERED_ON` state.

At the end of them, the VM is now undeployed, as otherwise it ends up in `PARTIALLY_POWERED_OFF` for some time which causes unexpected behaviour when running other tests with the VM.
