### PR TITLE
Add explicit removal of many resources from tests

### DIFF
--- a/.changes/v2.22.0/605-notes.md
+++ b/.changes/v2.22.0/605-notes.md
@@ -1,0 +1,1 @@
+* Added explicit removal for many resources in tests [GH-605]

--- a/govcd/adminvdc_test.go
+++ b/govcd/adminvdc_test.go
@@ -273,6 +273,12 @@ func (vcd *TestVCD) Test_UpdateVdcFlex(check *C) {
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedMemory-guaranteed) < 0.001, Equals, true)
 	check.Assert(*updatedVdc.AdminVdc.IsElastic, Equals, true)
 	check.Assert(*updatedVdc.AdminVdc.IncludeMemoryOverhead, Equals, false)
+	vdc, err = adminOrg.GetVDCByName(updatedVdc.AdminVdc.Name, true)
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 // Tests VDC storage profile update
@@ -285,6 +291,9 @@ func (vcd *TestVCD) Test_VdcUpdateStorageProfile(check *C) {
 	check.Assert(err, IsNil)
 
 	adminVdc, err := adminOrg.GetAdminVDCByName(vdcConfiguration.Name, true)
+	check.Assert(err, IsNil)
+	check.Assert(adminVdc, NotNil)
+	vdc, err := adminOrg.GetVDCByName(vdcConfiguration.Name, true)
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
 
@@ -318,4 +327,8 @@ func (vcd *TestVCD) Test_VdcUpdateStorageProfile(check *C) {
 	check.Assert(updatedStorageProfile.Limit, Equals, int64(9081))
 	check.Assert(updatedStorageProfile.Default, Equals, true)
 	check.Assert(updatedStorageProfile.Units, Equals, "MB")
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }

--- a/govcd/filter_engine_test.go
+++ b/govcd/filter_engine_test.go
@@ -346,4 +346,8 @@ func (vcd *TestVCD) Test_SearchOrgVdc(check *C) {
 			printVerbose("( I) %2d %-10s %-20s %s\n\n", i, item.GetType(), item.GetParentName(), item.GetName())
 		}
 	}
+	task, err := anotherVdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }

--- a/govcd/global_role_test.go
+++ b/govcd/global_role_test.go
@@ -219,6 +219,8 @@ func testRightsContainerTenants(vcd *TestVCD, check *C, rpc rightsProviderCollec
 	tenants, err = rpc.GetTenants(nil)
 	check.Assert(err, IsNil)
 	check.Assert(len(tenants), Equals, 0)
+	err = newOrg.Delete(true, true)
+	check.Assert(err, IsNil)
 }
 
 // getRightsSet is a convenience function that retrieves a list of rights

--- a/govcd/nsxt_firewall_group_ip_set_test.go
+++ b/govcd/nsxt_firewall_group_ip_set_test.go
@@ -183,4 +183,12 @@ func (vcd *TestVCD) Test_NsxtIpSet(check *C) {
 	// Remove Edge Gateway
 	err = movedGateway.Delete()
 	check.Assert(err, IsNil)
+
+	// Remove VDC group and VDC
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }

--- a/govcd/nsxt_firewall_group_static_security_group_test.go
+++ b/govcd/nsxt_firewall_group_static_security_group_test.go
@@ -123,7 +123,7 @@ func (vcd *TestVCD) Test_NsxtSecurityGroupGetAssociatedVms(check *C) {
 	vapp, vappVm := createVappVmAndAttachNetwork(check, vcd, nsxtVdc, routedNet)
 	PrependToCleanupList(vapp.VApp.Name, "vapp", vcd.nsxtVdc.Vdc.Name, check.TestName())
 
-	// VMs are prependend to cleanup list to make sure they are removed before routed network
+	// VMs are prependend to clean up list to make sure they are removed before routed network
 	standaloneVm := createStandaloneVm(check, vcd, nsxtVdc, routedNet)
 	PrependToCleanupList(standaloneVm.VM.ID, "standaloneVm", "", standaloneVm.VM.Name)
 
@@ -164,6 +164,16 @@ func (vcd *TestVCD) Test_NsxtSecurityGroupGetAssociatedVms(check *C) {
 
 	check.Assert(foundStandalone, Equals, true)
 	check.Assert(foundVappVm, Equals, true)
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	err = standaloneVm.Delete()
+	check.Assert(err, IsNil)
+	err = createdSecGroup.Delete()
+	check.Assert(err, IsNil)
+	err = routedNet.Delete()
+	check.Assert(err, IsNil)
 }
 
 func createNsxtRoutedNetwork(check *C, vcd *TestVCD, vdc *Vdc, edgeGatewayId string) *OpenApiOrgVdcNetwork {

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -687,6 +687,14 @@ func runOpenApiOrgVdcNetworkWithVdcGroupTest(check *C, vcd *TestVCD, orgVdcNetwo
 	//cleanup
 	err = movedGateway.Delete()
 	check.Assert(err, IsNil)
+
+	// Remove VDC group and VDC
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func testNsxtDhcpBinding(check *C, vcd *TestVCD, orgNet *OpenApiOrgVdcNetwork) {

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -966,6 +966,12 @@ func (vcd *TestVCD) Test_UpdateVdc(check *C) {
 	check.Assert(*updatedVdc.AdminVdc.UsesFastProvisioning, Equals, false)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedCpu-guaranteed) < 0.001, Equals, true)
 	check.Assert(math.Abs(*updatedVdc.AdminVdc.ResourceGuaranteedMemory-guaranteed) < 0.001, Equals, true)
+	vdc, err := adminOrg.GetVDCByName(updatedVdc.AdminVdc.Name, true)
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 // Tests org function GetAdminVdcByName with the vdc specified
@@ -1257,6 +1263,19 @@ func (vcd *TestVCD) TestQueryOrgVdcList(check *C) {
 	// Main Org 'vcd.config.VCD.Org' is expected to have at least (expectedVdcCountInSystem). Might be more if there are
 	// more VDCs created manually
 	validateQueryOrgVdcResults(vcd, check, fmt.Sprintf("Should have %d VDCs or more", expectedVdcCountInSystem), vcd.config.VCD.Org, nil, &expectedVdcCountInSystem)
+
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	org1, err := vcd.client.GetAdminOrgByName(newOrgName1)
+	check.Assert(err, IsNil)
+	err = org1.Delete(true, true)
+	check.Assert(err, IsNil)
+	org2, err := vcd.client.GetAdminOrgByName(newOrgName2)
+	check.Assert(err, IsNil)
+	err = org2.Delete(true, true)
+	check.Assert(err, IsNil)
 }
 
 func validateQueryOrgVdcResults(vcd *TestVCD, check *C, name, orgName string, expectedVdcCount, expectedVdcCountOrMore *int) {

--- a/govcd/orgvdcnetwork_test.go
+++ b/govcd/orgvdcnetwork_test.go
@@ -395,6 +395,10 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkIso(check *C) {
 	check.Assert(len(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange), Not(Equals), 0)
 	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].StartAddress, Equals, updatedStartAddress)
 	check.Assert(network.OrgVDCNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange[0].EndAddress, Equals, updatedEndAddress)
+	task, err := network.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 
 }
 
@@ -448,7 +452,7 @@ func (vcd *TestVCD) Test_CreateUpdateOrgVdcNetworkDirect(check *C) {
 	}
 	check.Assert(task.Task.HREF, Not(Equals), "")
 
-	AddToCleanupList(networkName, "network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_CreateOrgVdcNetworkDirect")
+	AddToCleanupList(networkName, "network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, check.TestName())
 
 	// err = task.WaitTaskCompletion()
 	err = task.WaitInspectTaskCompletion(LogTask, 10)

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -459,7 +459,7 @@ func (vcd *TestVCD) Test_QueryOrgVdcNetworkByNameWithSpace(check *C) {
 	}
 	check.Assert(task.Task.HREF, Not(Equals), "")
 
-	AddToCleanupList(networkName, "network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, "Test_CreateOrgVdcNetworkDirect")
+	AddToCleanupList(networkName, "network", vcd.org.Org.Name+"|"+vcd.vdc.Vdc.Name, check.TestName())
 
 	// err = task.WaitTaskCompletion()
 	err = task.WaitInspectTaskCompletion(LogTask, 10)
@@ -473,6 +473,12 @@ func (vcd *TestVCD) Test_QueryOrgVdcNetworkByNameWithSpace(check *C) {
 	check.Assert(len(orgVdcNetwork), Not(Equals), 0)
 	check.Assert(orgVdcNetwork[0].Name, Equals, networkName)
 	check.Assert(orgVdcNetwork[0].ConnectedTo, Equals, externalNetwork.ExternalNetwork.Name)
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(networkName, true)
+	check.Assert(err, IsNil)
+	task, err = network.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -314,13 +314,14 @@ func createRoutedNetwork(vcd *TestVCD, check *C, networkName string) {
 }
 
 func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
-	createRoutedNetwork(vcd, check, "Test_UpdateNetworkStaticRoutes")
-	vapp, networkName, vappNetworkConfig, err := vcd.prepareVappWithVappNetwork(check, "Test_UpdateNetworkStaticRoutes", "Test_UpdateNetworkStaticRoutes")
+	testName := check.TestName()
+	createRoutedNetwork(vcd, check, testName)
+	vapp, vappNetworkName, vappNetworkConfig, err := vcd.prepareVappWithVappNetwork(check, testName, testName)
 	check.Assert(err, IsNil)
 
 	networkFound := types.VAppNetworkConfiguration{}
 	for _, networkConfig := range vappNetworkConfig.NetworkConfig {
-		if networkConfig.NetworkName == networkName {
+		if networkConfig.NetworkName == vappNetworkName {
 			networkFound = networkConfig
 		}
 	}
@@ -332,7 +333,7 @@ func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
 		&types.NetworkConnection{
 			IsConnected:             true,
 			IPAddressAllocationMode: types.IPAllocationModePool,
-			Network:                 "Test_UpdateNetworkStaticRoutes",
+			Network:                 vappNetworkName,
 			NetworkConnectionIndex:  0,
 		})
 
@@ -374,4 +375,10 @@ func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 	check.Assert(task.Task.Status, Equals, "success")
+	network, err := vcd.vdc.GetOrgVdcNetworkByName(testName, true)
+	check.Assert(err, IsNil)
+	task, err = network.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }

--- a/govcd/vdc_group_common_test.go
+++ b/govcd/vdc_group_common_test.go
@@ -112,6 +112,13 @@ func (vcd *TestVCD) Test_NsxtVdcGroupOrgNetworks(check *C) {
 	err = movedGateway.Delete()
 	check.Assert(err, IsNil)
 
+	// Remove VDC group and VDC
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func buildIsolatedOrgVdcNetworkConfig(check *C, vcd *TestVCD, ownerId string) *types.OpenApiOrgVdcNetwork {

--- a/govcd/vdc_group_test.go
+++ b/govcd/vdc_group_test.go
@@ -29,7 +29,13 @@ func (vcd *TestVCD) Test_CreateVdcGroup(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	test_CreateVdcGroup(check, adminOrg, vcd)
+	vdc, vdcGroup := test_CreateVdcGroup(check, adminOrg, vcd)
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 // tests creation of NSX-T VDCs group
@@ -46,10 +52,13 @@ func (vcd *TestVCD) Test_NsxtVdcGroup(check *C) {
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
-	test_NsxtVdcGroup(check, adminOrg, vcd)
+	vdcGroup := test_NsxtVdcGroup(check, adminOrg, vcd)
+
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
 }
 
-func test_NsxtVdcGroup(check *C, adminOrg *AdminOrg, vcd *TestVCD) {
+func test_NsxtVdcGroup(check *C, adminOrg *AdminOrg, vcd *TestVCD) *VdcGroup {
 	description := "vdc group created by test"
 
 	_, err := adminOrg.CreateNsxtVdcGroup(check.TestName(), description, vcd.nsxtVdc.vdcId(), []string{vcd.vdc.vdcId()})
@@ -147,7 +156,7 @@ func test_NsxtVdcGroup(check *C, adminOrg *AdminOrg, vcd *TestVCD) {
 	check.Assert(err, IsNil)
 	check.Assert(disabledVdcGroup, NotNil)
 	check.Assert(disabledVdcGroup.VdcGroup.DfwEnabled, Equals, false)
-
+	return vdcGroup
 }
 
 func (vcd *TestVCD) Test_GetVdcGroupByName_ValidatesSymbolsInName(check *C) {
@@ -221,10 +230,19 @@ func (vcd *TestVCD) Test_NsxtVdcGroupWithOrgAdmin(check *C) {
 	check.Assert(orgAsOrgAdminUser, NotNil)
 
 	//run tests ad org Admin with needed rights
-	test_NsxtVdcGroup(check, adminOrg, vcd)
-	test_CreateVdcGroup(check, adminOrg, vcd)
+	vdcGroup1 := test_NsxtVdcGroup(check, adminOrg, vcd)
+	vdc, vdcGroup := test_CreateVdcGroup(check, adminOrg, vcd)
 	test_GetVdcGroupByName_ValidatesSymbolsInName(check, orgAsOrgAdminUser, vcd.nsxtVdc.vdcId())
 
+	// Remove VDC group and VDC
+	err = vdcGroup1.Delete()
+	check.Assert(err, IsNil)
+	err = vdcGroup.Delete()
+	check.Assert(err, IsNil)
+	task, err := vdc.Delete(true, true)
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 // skipIfNeededRightsMissing checks if needed rights are configured


### PR DESCRIPTION
Several resources were left undeleted, waiting for the cleanup function to remove them, increasing the risk of interfering with other tests.
This PR removes the resources most likely to affect other tests:
- organizations
- VDCs
- group VDCs
- vApps
- networks


Testing:

```
go test -tags functional -check.vv  -timeout 0 -check.f 'TestCreateOrgVdcNetworkDhcp|TestVCD.TestQueryOrgVdcList|Test_CreateOrgVdcNetworkDirect|Test_CreateOrgVdcNetworkIso|Test_CreateUpdateOrgVdcNetworkDirect|Test_CreateUpdateOrgVdcNetworkIso|Test_CreateVdcGroup|Test_GlobalRoles|Test_NsxtIpSet|Test_NsxtOrgVdcNetworkImportedNsxtLogicalSwitch|Test_NsxtOrgVdcNetworkIsolated|Test_NsxtOrgVdcNetworkRouted|Test_NsxtSecurityGroupGetAssociatedVms|Test_NsxtVdcGroup|Test_NsxtVdcGroupOrgNetworks|Test_NsxtVdcGroupWithOrgAdmin|Test_QueryOrgVdcNetworkByNameWithSpace|Test_QueryProviderVdcEntities|Test_RightsBundle|Test_SearchOrgVdc|Test_UpdateNetworkStaticRoutes|Test_UpdateVdc|Test_UpdateVdcFlex|Test_VMGetDhcpAddress|Test_VdcUpdateStorageProfile'

```
