### PR TITLE
Fix govcd org user tests

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1099,6 +1099,11 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 			return
 		}
 
+		_, err = adminCatalog.GetMediaByName(entity.Name, true)
+		if ContainsNotFound(err) {
+			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name, err)
+			return
+		}
 		err = adminCatalog.RemoveMediaIfExists(entity.Name)
 		if err == nil {
 			vcd.infoCleanup(removedMsg, entity.EntityType, entity.Name, entity.CreatedBy)
@@ -2018,4 +2023,10 @@ func newOrgUserConnection(adminOrg *AdminOrg, userName, password, href string, i
 	}
 
 	return vcdClient, newUser, nil
+}
+
+func (vcd *TestVCD) skipIfNotSysAdmin(check *C) {
+	if !vcd.client.Client.IsSysAdmin {
+		check.Skip(fmt.Sprintf("Skipping %s: requires system administrator privileges", check.TestName()))
+	}
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1101,7 +1101,7 @@ func (vcd *TestVCD) removeLeftoverEntities(entity CleanupEntity) {
 
 		_, err = adminCatalog.GetMediaByName(entity.Name, true)
 		if ContainsNotFound(err) {
-			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name, err)
+			vcd.infoCleanup(notFoundMsg, entity.EntityType, entity.Name)
 			return
 		}
 		err = adminCatalog.RemoveMediaIfExists(entity.Name)

--- a/govcd/catalog_subscription_test.go
+++ b/govcd/catalog_subscription_test.go
@@ -40,7 +40,7 @@ type subscriptionTestData struct {
 // $ go test -tags catalog -check.f Test_SubscribedCatalog -vcd-verbose -check.vv -timeout 0
 // When running this way, you will see the tasks originated by the catalogs and the ones started by the catalog items
 func (vcd *TestVCD) Test_SubscribedCatalog(check *C) {
-
+	vcd.skipIfNotSysAdmin(check)
 	fromOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
 	toOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org + "-1")

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -765,7 +765,7 @@ func (vcd *TestVCD) TestGetVappTemplateByHref(check *C) {
 // One should be able to find shared catalogs from different Organizations
 func (vcd *TestVCD) Test_GetCatalogByNameSharedCatalog(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-
+	vcd.skipIfNotSysAdmin(check)
 	newOrg1, vdc, sharedCatalog := createSharedCatalogInNewOrg(vcd, check, check.TestName())
 
 	// Try to find the catalog inside Org which owns it - newOrg1
@@ -785,6 +785,7 @@ func (vcd *TestVCD) Test_GetCatalogByNameSharedCatalog(check *C) {
 // One should be able to find shared catalogs from different Organizations
 func (vcd *TestVCD) Test_GetCatalogByIdSharedCatalog(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 
 	newOrg1, vdc, sharedCatalog := createSharedCatalogInNewOrg(vcd, check, check.TestName())
 
@@ -805,7 +806,7 @@ func (vcd *TestVCD) Test_GetCatalogByIdSharedCatalog(check *C) {
 // in other Orgs. It does so by creating another Org with shared Catalog named just like the one in testing catalog
 func (vcd *TestVCD) Test_GetCatalogByNamePrefersLocal(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
-
+	vcd.skipIfNotSysAdmin(check)
 	// Create a catalog  in new org with exactly the same name as in vcd.Org
 	newOrg1, vdc, sharedCatalog := createSharedCatalogInNewOrg(vcd, check, vcd.config.VCD.Catalog.Name)
 
@@ -830,6 +831,7 @@ func (vcd *TestVCD) Test_GetCatalogByNamePrefersLocal(check *C) {
 // * Org admin user must not be able to retrieve unshared catalog from another Org
 func (vcd *TestVCD) Test_GetCatalogByXSharedCatalogOrgUser(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 	newOrg1, vdc, sharedCatalog := createSharedCatalogInNewOrg(vcd, check, check.TestName())
 
 	// Create one more additional catalog which is not shared

--- a/govcd/disk_test.go
+++ b/govcd/disk_test.go
@@ -709,6 +709,11 @@ func (vcd *TestVCD) Test_GetDiskByHref(check *C) {
 	invalidDiskHREF := strings.ReplaceAll(diskHREF, uuid, "1abcbdb3-1111-1111-a1c2-85d261e22fcf")
 	disk, err = vcd.vdc.GetDiskByHref(invalidDiskHREF)
 	check.Assert(err, NotNil)
-	check.Assert(IsNotFound(err), Equals, true)
+	if vcd.client.Client.IsSysAdmin {
+		check.Assert(IsNotFound(err), Equals, true)
+	} else {
+		// The errors returned for non-existing disk are different for system administrator and org user
+		check.Assert(strings.Contains(err.Error(), "API Error: 403:"), Equals, true)
+	}
 	check.Assert(disk, IsNil)
 }

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -554,6 +554,7 @@ func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
 // 4. Compare the XML text and structs before configuration and after configuration - they should be
 // identical except <version></version> tag which is versioning the configuration
 func (vcd *TestVCD) TestEdgeGateway_UpdateLBGeneralParams(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}
@@ -627,6 +628,7 @@ func (vcd *TestVCD) TestEdgeGateway_UpdateFwGeneralParams(check *C) {
 }
 
 func (vcd *TestVCD) TestEdgeGateway_GetVdcNetworks(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}

--- a/govcd/edgegateway_test.go
+++ b/govcd/edgegateway_test.go
@@ -285,6 +285,7 @@ func (vcd *TestVCD) TestEdgeGateway_GetNetworks(check *C) {
 }
 
 func (vcd *TestVCD) Test_AddSNATRule(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
@@ -356,6 +357,7 @@ func (vcd *TestVCD) Test_AddSNATRule(check *C) {
 }
 
 func (vcd *TestVCD) Test_AddDNATRule(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
@@ -436,6 +438,7 @@ func (vcd *TestVCD) Test_AddDNATRule(check *C) {
 }
 
 func (vcd *TestVCD) Test_UpdateNATRule(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ExternalIp == "" || vcd.config.VCD.InternalIp == "" {
 		check.Skip("Skipping test because no valid ip given")
 	}
@@ -745,6 +748,7 @@ func (vcd *TestVCD) TestListEdgeGateway(check *C) {
 }
 
 func (vcd *TestVCD) Test_UpdateEdgeGateway(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.EdgeGateway == "" {
 		check.Skip("Skipping test because no edge gateway given")
 	}

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -104,6 +104,7 @@ func getBackingIdByNameAndType(check *C, backingName string, backingType string,
 }
 
 func (vcd *TestVCD) Test_CreateExternalNetworkV2Nsxv(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalNetworks
 	skipOpenApiEndpointTest(vcd, check, endpoint)
 

--- a/govcd/filter_engine_test.go
+++ b/govcd/filter_engine_test.go
@@ -311,6 +311,7 @@ func (vcd *TestVCD) Test_SearchMediaItem(check *C) {
 }
 
 func (vcd *TestVCD) Test_SearchOrgVdc(check *C) {
+	vcd.skipIfNotSysAdmin(check) // this test creates another VDC
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("no VDC provided. Skipping test")
 	}

--- a/govcd/media_test.go
+++ b/govcd/media_test.go
@@ -40,7 +40,7 @@ func (vcd *TestVCD) Test_DeleteMedia(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_DeleteMediaImage")
+	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, check.TestName())
 
 	media, err := catalog.GetMediaByName(itemName, true)
 	check.Assert(err, IsNil)

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -18,6 +18,7 @@ import (
 // TODO: All tests here are deprecated in favor of those present in "metadata_v2_test". Remove this file once go-vcloud-director v3.0 is released.
 
 func (vcd *TestVCD) Test_AddAndDeleteMetadataForVdc(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")
 	}
@@ -203,7 +204,7 @@ func (vcd *TestVCD) Test_AddAndDeleteMetadataOnMediaRecord(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_AddMetadataOnMediaRecord")
+	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, check.TestName())
 
 	err = vcd.org.Refresh()
 	check.Assert(err, IsNil)
@@ -272,9 +273,12 @@ func (vcd *TestVCD) Test_MetadataOnAdminCatalogCRUD(check *C) {
 		check.Assert(foundEntry.Key, Equals, "key")
 		check.Assert(foundEntry.TypedValue.Value, Equals, "value")
 	})
+	err = catalog.Delete(true, true)
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_MetadataEntryForVdcCRUD(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")
 	}
@@ -364,7 +368,7 @@ func (vcd *TestVCD) Test_MetadataEntryOnMediaRecordCRUD(check *C) {
 	err = uploadTask.WaitTaskCompletion()
 	check.Assert(err, IsNil)
 
-	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, "Test_AddMetadataOnMediaRecord")
+	AddToCleanupList(itemName, "mediaCatalogImage", vcd.org.Org.Name+"|"+vcd.config.VCD.Catalog.Name, check.TestName())
 
 	err = vcd.org.Refresh()
 	check.Assert(err, IsNil)
@@ -375,6 +379,10 @@ func (vcd *TestVCD) Test_MetadataEntryOnMediaRecordCRUD(check *C) {
 	check.Assert(mediaRecord.MediaRecord.Name, Equals, itemName)
 
 	testMetadataCRUDActionsDeprecated(mediaRecord, check, nil)
+	task, err := mediaRecord.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_MetadataOnAdminOrgCRUD(check *C) {
@@ -466,6 +474,7 @@ func (vcd *TestVCD) Test_MetadataOnCatalogItemCRUD(check *C) {
 
 func (vcd *TestVCD) Test_MetadataOnProviderVdcCRUD(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 	providerVdc, err := vcd.client.GetProviderVdcByName(vcd.config.VCD.NsxtProviderVdc.Name)
 	if err != nil {
 		check.Skip(fmt.Sprintf("%s: Provider VDC %s not found. Test can't proceed", check.TestName(), vcd.config.VCD.NsxtProviderVdc.Name))
@@ -488,6 +497,7 @@ func (vcd *TestVCD) Test_MetadataOnOpenApiOrgVdcNetworkCRUD(check *C) {
 
 func (vcd *TestVCD) Test_MetadataByHrefCRUD(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 	storageProfileRef, err := vcd.vdc.FindStorageProfileReference(vcd.config.VCD.StorageProfile.SP1)
 	if err != nil {
 		check.Skip(fmt.Sprintf("%s: Storage Profile %s not found. Test can't proceed", check.TestName(), vcd.config.VCD.StorageProfile.SP1))

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -38,12 +38,13 @@ func (vcd *TestVCD) TestVmMetadata(check *C) {
 	vm := NewVM(&vcd.client.Client)
 	vm.VM = &vmType
 
-	testMetadataCRUDActions(vm, check, nil)
+	vcd.testMetadataCRUDActions(vm, check, nil)
 	vcd.testMetadataIgnore(vm, "vApp", vm.VM.Name, check)
 }
 
 func (vcd *TestVCD) TestAdminVdcMetadata(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.Nsxt.Vdc == "" {
 		check.Skip("skipping test because VDC name is empty")
 	}
@@ -56,7 +57,7 @@ func (vcd *TestVCD) TestAdminVdcMetadata(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminVdc, NotNil)
 
-	testMetadataCRUDActions(adminVdc, check, func(testCase metadataTest) {
+	vcd.testMetadataCRUDActions(adminVdc, check, func(testCase metadataTest) {
 		testVdcMetadata(vcd, check, testCase)
 	})
 	vcd.testMetadataIgnore(adminVdc, "vdc", adminVdc.AdminVdc.Name, check)
@@ -79,12 +80,13 @@ func testVdcMetadata(vcd *TestVCD, check *C, testCase metadataTest) {
 
 func (vcd *TestVCD) TestProviderVdcMetadata(check *C) {
 	fmt.Printf("Running: %s\n", check.TestName())
+	vcd.skipIfNotSysAdmin(check)
 	providerVdc, err := vcd.client.GetProviderVdcByName(vcd.config.VCD.NsxtProviderVdc.Name)
 	if err != nil {
 		check.Skip(fmt.Sprintf("%s: Provider VDC %s not found. Test can't proceed", check.TestName(), vcd.config.VCD.NsxtProviderVdc.Name))
 		return
 	}
-	testMetadataCRUDActions(providerVdc, check, nil)
+	vcd.testMetadataCRUDActions(providerVdc, check, nil)
 	vcd.testMetadataIgnore(providerVdc, "providervdc", providerVdc.ProviderVdc.Name, check)
 }
 
@@ -93,7 +95,7 @@ func (vcd *TestVCD) TestVAppMetadata(check *C) {
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp was not successfully created at setup")
 	}
-	testMetadataCRUDActions(vcd.vapp, check, nil)
+	vcd.testMetadataCRUDActions(vcd.vapp, check, nil)
 	vcd.testMetadataIgnore(vcd.vapp, "vApp", vcd.vapp.VApp.Name, check)
 }
 
@@ -107,7 +109,7 @@ func (vcd *TestVCD) TestVAppTemplateMetadata(check *C) {
 	check.Assert(vAppTemplate, NotNil)
 	check.Assert(vAppTemplate.VAppTemplate.Name, Equals, vcd.config.VCD.Catalog.NsxtCatalogItem)
 
-	testMetadataCRUDActions(vAppTemplate, check, nil)
+	vcd.testMetadataCRUDActions(vAppTemplate, check, nil)
 	vcd.testMetadataIgnore(vAppTemplate, "vAppTemplate", vAppTemplate.VAppTemplate.Name, check)
 }
 
@@ -153,7 +155,7 @@ func (vcd *TestVCD) TestMediaRecordMetadata(check *C) {
 	check.Assert(mediaRecord, NotNil)
 	check.Assert(mediaRecord.MediaRecord.Name, Equals, check.TestName())
 
-	testMetadataCRUDActions(mediaRecord, check, nil)
+	vcd.testMetadataCRUDActions(mediaRecord, check, nil)
 	vcd.testMetadataIgnore(mediaRecord, "media", mediaRecord.MediaRecord.Name, check)
 }
 
@@ -174,7 +176,7 @@ func (vcd *TestVCD) TestMediaMetadata(check *C) {
 	media, err := catalog.GetMediaByName(vcd.config.Media.Media, false)
 	check.Assert(err, IsNil)
 
-	testMetadataCRUDActions(media, check, nil)
+	vcd.testMetadataCRUDActions(media, check, nil)
 	vcd.testMetadataIgnore(media, "media", media.Media.Name, check)
 }
 
@@ -190,7 +192,7 @@ func (vcd *TestVCD) TestAdminCatalogMetadata(check *C) {
 	check.Assert(adminCatalog, NotNil)
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, vcd.config.VCD.Catalog.NsxtBackedCatalogName)
 
-	testMetadataCRUDActions(adminCatalog, check, func(testCase metadataTest) {
+	vcd.testMetadataCRUDActions(adminCatalog, check, func(testCase metadataTest) {
 		testCatalogMetadata(vcd, check, testCase)
 	})
 	vcd.testMetadataIgnore(adminCatalog, "catalog", adminCatalog.AdminCatalog.Name, check)
@@ -218,7 +220,7 @@ func (vcd *TestVCD) TestAdminOrgMetadata(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(adminOrg, NotNil)
 
-	testMetadataCRUDActions(adminOrg, check, func(testCase metadataTest) {
+	vcd.testMetadataCRUDActions(adminOrg, check, func(testCase metadataTest) {
 		testOrgMetadata(vcd, check, testCase)
 	})
 	vcd.testMetadataIgnore(adminOrg, "org", adminOrg.AdminOrg.Name, check)
@@ -257,7 +259,7 @@ func (vcd *TestVCD) TestDiskMetadata(check *C) {
 	disk, err := vcd.vdc.GetDiskByHref(diskHREF)
 	check.Assert(err, IsNil)
 
-	testMetadataCRUDActions(disk, check, nil)
+	vcd.testMetadataCRUDActions(disk, check, nil)
 	vcd.testMetadataIgnore(disk, "disk", disk.Disk.Name, check)
 }
 
@@ -268,7 +270,7 @@ func (vcd *TestVCD) TestOrgVDCNetworkMetadata(check *C) {
 		check.Skip(fmt.Sprintf("network %s not found. Test can't proceed", vcd.config.VCD.Network.Net1))
 		return
 	}
-	testMetadataCRUDActions(net, check, nil)
+	vcd.testMetadataCRUDActions(net, check, nil)
 	vcd.testMetadataIgnore(net, "network", net.OrgVDCNetwork.Name, check)
 }
 
@@ -286,7 +288,7 @@ func (vcd *TestVCD) TestCatalogItemMetadata(check *C) {
 		return
 	}
 
-	testMetadataCRUDActions(catalogItem, check, nil)
+	vcd.testMetadataCRUDActions(catalogItem, check, nil)
 	vcd.testMetadataIgnore(catalogItem, "catalogItem", catalogItem.CatalogItem.Name, check)
 }
 
@@ -442,7 +444,7 @@ type metadataTest struct {
 // The function parameter extraReadStep performs an extra read step that can be passed as a function. Useful to perform a test
 // on "admin+not admin" resource combinations, where the "not admin" only has a GetMetadata function.
 // For example, AdminOrg and Org, where Org only has GetMetadata.
-func testMetadataCRUDActions(resource metadataCompatible, check *C, extraReadStep func(testCase metadataTest)) {
+func (vcd *TestVCD) testMetadataCRUDActions(resource metadataCompatible, check *C, extraReadStep func(testCase metadataTest)) {
 	// Check how much metadata exists
 	metadata, err := resource.GetMetadata()
 	check.Assert(err, IsNil)
@@ -539,6 +541,10 @@ func testMetadataCRUDActions(resource metadataCompatible, check *C, extraReadSte
 	}
 
 	for _, testCase := range testCases {
+
+		if !vcd.client.Client.IsSysAdmin && testCase.IsSystem {
+			continue
+		}
 
 		err = resource.AddMetadataEntryWithVisibility(testCase.Key, testCase.Value, testCase.Type, testCase.Visibility, testCase.IsSystem)
 		if testCase.ExpectErrorOnFirstAdd {

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -542,6 +542,8 @@ func (vcd *TestVCD) testMetadataCRUDActions(resource metadataCompatible, check *
 
 	for _, testCase := range testCases {
 
+		// The SYSTEM domain can only be set by a system administrator.
+		// If this test runs as org user, we skip the cases containing 'IsSystem' constraints
 		if !vcd.client.Client.IsSysAdmin && testCase.IsSystem {
 			continue
 		}

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -20,6 +20,7 @@ func (vcd *TestVCD) Test_NsxtApplicationPortProfileProvider(check *C) {
 }
 
 func (vcd *TestVCD) Test_NsxtApplicationPortProfileTenant(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointAppPortProfiles)
 

--- a/govcd/nsxt_application_profile_test.go
+++ b/govcd/nsxt_application_profile_test.go
@@ -13,6 +13,7 @@ import (
 func (vcd *TestVCD) Test_NsxtApplicationPortProfileProvider(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointAppPortProfiles)
+	vcd.skipIfNotSysAdmin(check)
 
 	appPortProfileConfig := getAppProfileProvider(vcd, check)
 	testAppPortProfile(appPortProfileConfig, types.ApplicationPortProfileScopeProvider, vcd, check)

--- a/govcd/nsxt_distributed_firewall_test.go
+++ b/govcd/nsxt_distributed_firewall_test.go
@@ -22,14 +22,15 @@ import (
 func (vcd *TestVCD) Test_NsxtDistributedFirewallRules(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGateways)
+	vcd.skipIfNotSysAdmin(check)
 
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(adminOrg, NotNil)
 	check.Assert(err, IsNil)
 
 	nsxtExternalNetwork, err := GetExternalNetworkV2ByName(vcd.client, vcd.config.VCD.Nsxt.ExternalNetwork)
-	check.Assert(nsxtExternalNetwork, NotNil)
 	check.Assert(err, IsNil)
+	check.Assert(nsxtExternalNetwork, NotNil)
 
 	vdc, vdcGroup := test_CreateVdcGroup(check, adminOrg, vcd)
 	check.Assert(vdc, NotNil)

--- a/govcd/nsxt_edgegateway_bgp_configuration_test.go
+++ b/govcd/nsxt_edgegateway_bgp_configuration_test.go
@@ -10,6 +10,7 @@ import (
 func (vcd *TestVCD) Test_NsxEdgeBgpConfiguration(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpConfig)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
+++ b/govcd/nsxt_edgegateway_bgp_ip_prefix_list_test.go
@@ -11,6 +11,7 @@ import (
 func (vcd *TestVCD) Test_NsxEdgeBgpIpPrefixList(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpConfigPrefixLists)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_edgegateway_bgp_neighbor_test.go
+++ b/govcd/nsxt_edgegateway_bgp_neighbor_test.go
@@ -10,6 +10,7 @@ import (
 func (vcd *TestVCD) Test_NsxEdgeBgpNeighbor(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeBgpNeighbor)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_edgegateway_static_route_test.go
+++ b/govcd/nsxt_edgegateway_static_route_test.go
@@ -10,6 +10,7 @@ import (
 func (vcd *TestVCD) Test_NsxEdgeStaticRoute(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGatewayStaticRoutes)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -14,6 +14,7 @@ import (
 func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGateways)
+	vcd.skipIfNotSysAdmin(check)
 
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
@@ -132,6 +133,7 @@ func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 func (vcd *TestVCD) Test_NsxtEdgeVdcGroup(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGateways)
+	vcd.skipIfNotSysAdmin(check)
 
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)
@@ -228,6 +230,7 @@ func (vcd *TestVCD) Test_NsxtEdgeVdcGroup(check *C) {
 func (vcd *TestVCD) Test_NsxtEdgeGatewayUsedAndUnusedIPs(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGateways)
+	vcd.skipIfNotSysAdmin(check)
 
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_firewall_group_ip_set_test.go
+++ b/govcd/nsxt_firewall_group_ip_set_test.go
@@ -11,6 +11,7 @@ import (
 func (vcd *TestVCD) Test_NsxtIpSet(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_firewall_group_static_security_group_test.go
+++ b/govcd/nsxt_firewall_group_static_security_group_test.go
@@ -125,7 +125,7 @@ func (vcd *TestVCD) Test_NsxtSecurityGroupGetAssociatedVms(check *C) {
 
 	// VMs are prependend to cleanup list to make sure they are removed before routed network
 	standaloneVm := createStandaloneVm(check, vcd, nsxtVdc, routedNet)
-	PrependToCleanupList(standaloneVm.VM.ID, "standaloneVm", "", standaloneVm.VM.Name)
+	PrependToCleanupList(standaloneVm.VM.ID, "standaloneVm", "", check.TestName())
 
 	secGroupDefinition := &types.NsxtFirewallGroup{
 		Name:           check.TestName(),
@@ -164,6 +164,16 @@ func (vcd *TestVCD) Test_NsxtSecurityGroupGetAssociatedVms(check *C) {
 
 	check.Assert(foundStandalone, Equals, true)
 	check.Assert(foundVappVm, Equals, true)
+	task, err := vapp.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+	err = standaloneVm.Delete()
+	check.Assert(err, IsNil)
+	err = routedNet.Delete()
+	check.Assert(err, IsNil)
+	err = createdSecGroup.Delete()
+	check.Assert(err, IsNil)
 }
 
 func createNsxtRoutedNetwork(check *C, vcd *TestVCD, vdc *Vdc, edgeGatewayId string) *OpenApiOrgVdcNetwork {

--- a/govcd/nsxt_firewall_test.go
+++ b/govcd/nsxt_firewall_test.go
@@ -58,7 +58,10 @@ func (vcd *TestVCD) Test_NsxtFirewall(check *C) {
 		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].IpProtocol, Equals, randomizedFwRuleDefs[index].IpProtocol)
 		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Enabled, Equals, randomizedFwRuleDefs[index].Enabled)
 		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Action, Equals, randomizedFwRuleDefs[index].Action)
-		check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Logging, Equals, randomizedFwRuleDefs[index].Logging)
+		if vcd.client.Client.IsSysAdmin {
+			// Only system administrator can handle logging
+			check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].Logging, Equals, randomizedFwRuleDefs[index].Logging)
+		}
 
 		for fwGroupIndex := range fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].SourceFirewallGroups {
 			check.Assert(fwCreated.NsxtFirewallRuleContainer.UserDefinedRules[index].SourceFirewallGroups[fwGroupIndex].ID, Equals, randomizedFwRuleDefs[index].SourceFirewallGroups[fwGroupIndex].ID)

--- a/govcd/nsxt_ipsec_vpn_tunnel_test.go
+++ b/govcd/nsxt_ipsec_vpn_tunnel_test.go
@@ -239,6 +239,7 @@ func runIpSecVpnTests(check *C, edge *NsxtEdgeGateway, ipSecDef *types.NsxtIpSec
 func (vcd *TestVCD) Test_NsxtIpSecVpnCertificateAuth(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointFirewallGroups)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -42,7 +42,7 @@ func (vcd *TestVCD) Test_NsxtNatDnat(check *C) {
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
 			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
 		SnatDestinationAddresses: "",
-		Logging:                  true,
+		Logging:                  vcd.client.Client.IsSysAdmin,
 		DnatExternalPort:         "",
 	}
 
@@ -82,7 +82,7 @@ func (vcd *TestVCD) Test_NsxtNatDnatExternalPortPort(check *C) {
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
 			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
 		SnatDestinationAddresses: "",
-		Logging:                  true,
+		Logging:                  vcd.client.Client.IsSysAdmin,
 		DnatExternalPort:         "9898",
 	}
 
@@ -122,7 +122,7 @@ func (vcd *TestVCD) Test_NsxtNatDnatFirewallMatchPriority(check *C) {
 			ID:   appPortProfiles[0].NsxtAppPortProfile.ID,
 			Name: appPortProfiles[0].NsxtAppPortProfile.Name},
 		SnatDestinationAddresses: "",
-		Logging:                  true,
+		Logging:                  vcd.client.Client.IsSysAdmin,
 		FirewallMatch:            types.NsxtNatRuleFirewallMatchExternalAddress,
 		Priority:                 addrOf(248),
 	}

--- a/govcd/nsxt_nat_rule_test.go
+++ b/govcd/nsxt_nat_rule_test.go
@@ -250,7 +250,7 @@ func (vcd *TestVCD) Test_NsxtNatPriorityAndFirewallMatch(check *C) {
 		ExternalAddresses:        edgeGatewayPrimaryIp,
 		InternalAddresses:        "11.11.11.2",
 		SnatDestinationAddresses: "",
-		Logging:                  true,
+		Logging:                  vcd.client.Client.IsSysAdmin,
 		DnatExternalPort:         "",
 		Priority:                 addrOf(100),
 		FirewallMatch:            types.NsxtNatRuleFirewallMatchExternalAddress,

--- a/govcd/nsxt_network_context_profile_test.go
+++ b/govcd/nsxt_network_context_profile_test.go
@@ -32,6 +32,7 @@ func (vcd *TestVCD) Test_GetAllNetworkContextProfiles(check *C) {
 }
 
 func (vcd *TestVCD) Test_GetNetworkContextProfilesByNameScopeAndContext(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointNetworkContextProfiles)
 

--- a/govcd/nsxt_route_advertisement_test.go
+++ b/govcd/nsxt_route_advertisement_test.go
@@ -15,6 +15,7 @@ import (
 func (vcd *TestVCD) Test_NsxtEdgeRouteAdvertisement(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointNsxtRouteAdvertisement)
+	vcd.skipIfNotSysAdmin(check)
 
 	org, err := vcd.client.GetOrgByName(vcd.config.VCD.Org)
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_test.go
+++ b/govcd/nsxt_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (vcd *TestVCD) Test_QueryNsxtManagerByName(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	skipNoNsxtConfiguration(vcd, check)
 	nsxtManagers, err := vcd.client.QueryNsxtManagerByName(vcd.config.VCD.Nsxt.Manager)
 	check.Assert(err, IsNil)

--- a/govcd/openapi_org_network_test.go
+++ b/govcd/openapi_org_network_test.go
@@ -16,6 +16,7 @@ import (
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	skipNoNsxtConfiguration(vcd, check)
+	vcd.skipIfNotSysAdmin(check) // this test uses GetNsxtEdgeClusterByName, which requires system administrator privileges
 
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
 		Name:        check.TestName(),
@@ -57,6 +58,7 @@ func (vcd *TestVCD) Test_NsxtOrgVdcNetworkIsolated(check *C) {
 func (vcd *TestVCD) Test_NsxtOrgVdcNetworkRouted(check *C) {
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgVdcNetworks)
 	skipNoNsxtConfiguration(vcd, check)
+	vcd.skipIfNotSysAdmin(check) // this test uses GetNsxtEdgeClusterByName, which requires system administrator privileges
 
 	egw, err := vcd.org.GetNsxtEdgeGatewayByName(vcd.config.VCD.Nsxt.EdgeGateway)
 	check.Assert(err, IsNil)
@@ -507,7 +509,7 @@ func nsxtDhcpConfigNetworkMode(check *C, vcd *TestVCD, vdc *Vdc, orgNetId string
 
 	printVerbose("## Testing DHCP in NETWORK mode\n")
 
-	// DHCP in NETWORK mode requires Edge Cluster to be set for VDC and cleaned up afterwards
+	// DHCP in NETWORK mode requires Edge Cluster to be set for VDC and cleaned up afterward
 	edgeCluster, err := vdc.GetNsxtEdgeClusterByName(vcd.config.VCD.Nsxt.NsxtEdgeCluster)
 	check.Assert(err, IsNil)
 	vdcNetworkProfile := &types.VdcNetworkProfile{

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -711,6 +711,9 @@ func (vcd *TestVCD) Test_QueryStorageProfiles(check *C) {
 	adminVdc, err := adminOrg.GetAdminVDCByName(vcd.config.VCD.Vdc, false)
 	check.Assert(err, IsNil)
 
+	if adminVdc.AdminVdc.ProviderVdcReference == nil {
+		check.Skip(fmt.Sprintf("test %s requires system administrator privileges", check.TestName()))
+	}
 	// Gets the Provider VDC from the AdminVdc structure
 	providerVdcName := adminVdc.AdminVdc.ProviderVdcReference.Name
 	check.Assert(providerVdcName, Not(Equals), "")
@@ -785,7 +788,7 @@ func (vcd *TestVCD) Test_QueryStorageProfiles(check *C) {
 }
 
 func (vcd *TestVCD) Test_AddRemoveVdcStorageProfiles(check *C) {
-
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ProviderVdc.Name == "" {
 		check.Skip("No provider VDC found in configuration")
 	}

--- a/govcd/query_metadata_test.go
+++ b/govcd/query_metadata_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (vcd *TestVCD) Test_CheckCumulativeQuery(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	pvdcs, err := vcd.client.QueryProviderVdcs()
 	check.Assert(err, IsNil)
 	var storageProfileMap = make(map[string]bool)

--- a/govcd/rights_test.go
+++ b/govcd/rights_test.go
@@ -96,8 +96,10 @@ func (vcd *TestVCD) Test_Rights(check *C) {
 		"VCD Extension: Register, Unregister, Refresh, Associate or Disassociate",
 		"UI Plugins: Define, Upload, Modify, Delete, Associate or Disassociate",
 	}
-	for _, name := range rigthNamesWithCommas {
-		searchRight(adminOrg.client, name, "", check)
+	if vcd.client.Client.IsSysAdmin {
+		for _, name := range rigthNamesWithCommas {
+			searchRight(adminOrg.client, name, "", check)
+		}
 	}
 
 	rightsCategories, err := adminOrg.client.GetAllRightsCategories(nil)

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -156,7 +156,7 @@ func (vcd *TestVCD) Test_CreateOrg(check *C) {
 }
 
 func (vcd *TestVCD) Test_CreateDeleteEdgeGateway(check *C) {
-
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ExternalNetwork == "" {
 		check.Skip("No external network provided")
 	}
@@ -380,6 +380,7 @@ func (vcd *TestVCD) Test_FindBadlyNamedStorageProfile(check *C) {
 
 // Test getting network pool by href and vdc client
 func (vcd *TestVCD) Test_GetNetworkPoolByHREF(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ProviderVdc.NetworkPool == "" {
 		check.Skip("Skipping test because network pool is not configured")
 	}
@@ -476,6 +477,7 @@ func (vcd *TestVCD) Test_QueryOrgVdcNetworkByNameWithSpace(check *C) {
 }
 
 func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	providerVdcName := vcd.config.VCD.ProviderVdc.Name
 	networkPoolName := vcd.config.VCD.ProviderVdc.NetworkPool
 	storageProfileName := vcd.config.VCD.ProviderVdc.StorageProfile
@@ -548,6 +550,7 @@ func (vcd *TestVCD) Test_QueryProviderVdcEntities(check *C) {
 }
 
 func (vcd *TestVCD) Test_QueryProviderVdcByName(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ProviderVdc.Name == "" {
 		check.Skip("Skipping Provider VDC query: no provider VDC was given")
 	}
@@ -643,6 +646,7 @@ func (vcd *TestVCD) Test_QueryOrgVdcStorageProfileByID(check *C) {
 }
 
 func (vcd *TestVCD) Test_QueryNetworkPoolByName(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.config.VCD.ProviderVdc.NetworkPool == "" {
 		check.Skip("Skipping Provider VDC network pool query: no provider VDC network pool was given")
 	}

--- a/govcd/vapp_clone_test.go
+++ b/govcd/vapp_clone_test.go
@@ -29,7 +29,12 @@ func (vcd *TestVCD) TestVappfromTemplateAndClone(check *C) {
 
 	catalog, err := org.GetCatalogByName(vcd.config.VCD.Catalog.NsxtBackedCatalogName, false)
 	check.Assert(err, IsNil)
-	vappTemplateName := "three-vms"
+	vappTemplateName := vcd.config.VCD.Catalog.CatalogItemWithMultiVms
+	if vappTemplateName == "" {
+		check.Skip(fmt.Sprintf("vApp template missing in configuration - Make sure there is such template in catalog %s -"+
+			" Using test_resources/vapp_with_3_vms.ova",
+			vcd.config.VCD.Catalog.NsxtBackedCatalogName))
+	}
 	vappTemplate, err := catalog.GetVAppTemplateByName(vappTemplateName)
 	if err != nil {
 		if ContainsNotFound(err) {

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -1576,6 +1576,7 @@ func (vcd *TestVCD) Test_AddNewVMFromMultiVmTemplate(check *C) {
 
 // Test_AddNewVMWithComputeCapacity creates a new VM in vApp with VM using compute capacity
 func (vcd *TestVCD) Test_AddNewVMWithComputeCapacity(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	if vcd.skipVappTests {
 		check.Skip("Skipping test because vApp was not successfully created at setup")
 	}

--- a/govcd/vdc_group_common_test.go
+++ b/govcd/vdc_group_common_test.go
@@ -17,6 +17,7 @@ import (
 func (vcd *TestVCD) Test_NsxtVdcGroupOrgNetworks(check *C) {
 	skipNoNsxtConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointEdgeGateways)
+	vcd.skipIfNotSysAdmin(check)
 
 	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
 	check.Assert(adminOrg, NotNil)
@@ -27,8 +28,8 @@ func (vcd *TestVCD) Test_NsxtVdcGroupOrgNetworks(check *C) {
 	check.Assert(err, IsNil)
 
 	nsxtExternalNetwork, err := GetExternalNetworkV2ByName(vcd.client, vcd.config.VCD.Nsxt.ExternalNetwork)
-	check.Assert(nsxtExternalNetwork, NotNil)
 	check.Assert(err, IsNil)
+	check.Assert(nsxtExternalNetwork, NotNil)
 
 	vdc, vdcGroup := test_CreateVdcGroup(check, adminOrg, vcd)
 	check.Assert(vdc, NotNil)

--- a/govcd/vdc_network_profile_test.go
+++ b/govcd/vdc_network_profile_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (vcd *TestVCD) Test_VdcNetworkProfile(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	skipNoNsxtConfiguration(vcd, check)
 	if vcd.config.VCD.Nsxt.NsxtEdgeCluster == "" {
 		check.Skip("missing value for vcd.config.VCD.Nsxt.NsxtEdgeCluster")

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -263,8 +263,10 @@ func (vcd *TestVCD) Test_QueryVM(check *C) {
 
 	check.Assert(vm.VM.Name, Equals, vmName)
 
-	check.Assert(vm.VM.Moref, Not(Equals), "")
-	check.Assert(strings.HasPrefix(vm.VM.Moref, "vm-"), Equals, true)
+	if vcd.client.Client.IsSysAdmin {
+		check.Assert(vm.VM.Moref, Not(Equals), "")
+		check.Assert(strings.HasPrefix(vm.VM.Moref, "vm-"), Equals, true)
+	}
 }
 
 func init() {

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -1656,7 +1656,10 @@ func (client *Client) QueryVmList(filter types.VmQueryFilter) ([]*types.QueryRes
 
 // QueryVmList returns a list of all VMs in a given Org
 func (org *Org) QueryVmList(filter types.VmQueryFilter) ([]*types.QueryResultVMRecordType, error) {
-	return queryVmList(filter, org.client, "org", org.Org.HREF)
+	if org.client.IsSysAdmin {
+		return queryVmList(filter, org.client, "org", org.Org.HREF)
+	}
+	return queryVmList(filter, org.client, "", "")
 }
 
 // QueryVmList returns a list of all VMs in a given VDC
@@ -1676,12 +1679,14 @@ func queryVmList(filter types.VmQueryFilter, client *Client, filterParent, filte
 	if filter.String() != "" {
 		filterText = filter.String()
 	}
-	if filterText == "" {
-		filterText = fmt.Sprintf("%s==%s", filterParent, filterParentHref)
-	} else {
-		filterText = fmt.Sprintf("%s;%s==%s", filterText, filterParent, filterParentHref)
+	if filterParent != "" {
+		if filterText == "" {
+			filterText = fmt.Sprintf("%s==%s", filterParent, filterParentHref)
+		} else {
+			filterText = fmt.Sprintf("%s;%s==%s", filterText, filterParent, filterParentHref)
+		}
+		params["filter"] = filterText
 	}
-	params["filter"] = filterText
 	vmResult, err := client.cumulativeQuery(queryType, nil, params)
 	if err != nil {
 		return nil, fmt.Errorf("error getting VM list : %s", err)

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -1507,6 +1507,7 @@ func (vcd *TestVCD) Test_UpdateVmCpuAndMemoryHotAdd(check *C) {
 }
 
 func (vcd *TestVCD) Test_AddNewEmptyVMWithVmComputePolicyAndUpdate(check *C) {
+	vcd.skipIfNotSysAdmin(check)
 	vapp, err := deployVappForTest(vcd, "Test_AddNewEmptyVMWithVmComputePolicy")
 	check.Assert(err, IsNil)
 	check.Assert(vapp, NotNil)
@@ -1702,7 +1703,7 @@ func (vcd *TestVCD) Test_VMUpdateStorageProfile(check *C) {
 }
 
 func (vcd *TestVCD) Test_VMUpdateComputePolicies(check *C) {
-
+	vcd.skipIfNotSysAdmin(check)
 	providerVdc, err := vcd.client.GetProviderVdcByName(vcd.config.VCD.NsxtProviderVdc.Name)
 	check.Assert(err, IsNil)
 	check.Assert(providerVdc, NotNil)


### PR DESCRIPTION
Improve govcd tests run as Org user, by doing the following:

* Add a conditional skip for those tests that require system administrator privileges;
* When the need for system administrator is limited to just a few checks in the test, protect those checks with a condition;
* If some input depends on the user privileges, apply a condition to define it (for example, logging in firewalls requires sysadmin powers: if that's the only item, the test can continue without skipping, with just the logging variables being tied to a condition).