### PR TITLE
Add support for NSX-T Edge Gateway External Uplink configuration

### DIFF
--- a/.changes/v2.22.0/610-improvements.md
+++ b/.changes/v2.22.0/610-improvements.md
@@ -2,3 +2,7 @@
   `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types [GH-610]
 * New field `types.EdgeGatewayUplinks.BackingType` that defines backing type of NSX-T Edge Gateway
   Uplink [GH-610]
+* NSX-T Edge Gateway functions `GetNsxtEdgeGatewayById`, `GetNsxtEdgeGatewayByName`,
+  `GetNsxtEdgeGatewayByNameAndOwnerId`, `GetAllNsxtEdgeGateways`, `CreateNsxtEdgeGateway`,
+  `Refresh`, `Update` will additionally sort uplinks to ensure that element 0 contains primary
+  network (T0 or T0 VRF) [GH-610]

--- a/.changes/v2.22.0/610-improvements.md
+++ b/.changes/v2.22.0/610-improvements.md
@@ -1,0 +1,5 @@
+* New method `NsxtEdgeGateway.ReorderUplinks()` that will ensure that NSX-T Tier0 Gateway backed
+  uplink is at position 0 in the slice of uplinks. All NSX-T Edge Gateway retrieval functions will
+  call it implicitly [GH-610]
+* New method `NsxtEdgeGateway.GetAllocatedIpCountByUplinkType` complementing existing
+  `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types [GH-610]

--- a/.changes/v2.22.0/610-improvements.md
+++ b/.changes/v2.22.0/610-improvements.md
@@ -1,2 +1,4 @@
 * New method `NsxtEdgeGateway.GetAllocatedIpCountByUplinkType` complementing existing
   `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types [GH-610]
+* New field `types.EdgeGatewayUplinks.BackingType` that defines backing type of NSX-T Edge Gateway
+  Uplink [GH-610]

--- a/.changes/v2.22.0/610-improvements.md
+++ b/.changes/v2.22.0/610-improvements.md
@@ -1,5 +1,8 @@
 * New method `NsxtEdgeGateway.GetAllocatedIpCountByUplinkType` complementing existing
-  `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types [GH-610]
+  `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types (works
+  with VCD 10.4.1+) [GH-610]
+* New method `NsxtEdgeGateway.GetPrimaryNetworkAllocatedIpCount` that will return total allocated IP
+  count for primary uplink (T0 or T0 VRF) [GH-610]
 * New field `types.EdgeGatewayUplinks.BackingType` that defines backing type of NSX-T Edge Gateway
   Uplink [GH-610]
 * NSX-T Edge Gateway functions `GetNsxtEdgeGatewayById`, `GetNsxtEdgeGatewayByName`,

--- a/.changes/v2.22.0/610-improvements.md
+++ b/.changes/v2.22.0/610-improvements.md
@@ -1,5 +1,2 @@
-* New method `NsxtEdgeGateway.ReorderUplinks()` that will ensure that NSX-T Tier0 Gateway backed
-  uplink is at position 0 in the slice of uplinks. All NSX-T Edge Gateway retrieval functions will
-  call it implicitly [GH-610]
 * New method `NsxtEdgeGateway.GetAllocatedIpCountByUplinkType` complementing existing
   `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types [GH-610]

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -189,6 +189,7 @@ type TestConfig struct {
 			ExternalNetwork           string `yaml:"externalNetwork"`
 			EdgeGateway               string `yaml:"edgeGateway"`
 			NsxtImportSegment         string `yaml:"nsxtImportSegment"`
+			NsxtImportSegment2        string `yaml:"nsxtImportSegment2"`
 			VdcGroup                  string `yaml:"vdcGroup"`
 			VdcGroupEdgeGateway       string `yaml:"vdcGroupEdgeGateway"`
 			NsxtEdgeCluster           string `yaml:"nsxtEdgeCluster"`

--- a/govcd/external_network_v2_test.go
+++ b/govcd/external_network_v2_test.go
@@ -86,12 +86,12 @@ func (vcd *TestVCD) testCreateExternalNetworkV2Nsxt(check *C, backingName, backi
 // getBackingIdByNameAndType looks up Backing ID by name and type
 func getBackingIdByNameAndType(check *C, backingName string, backingType string, vcd *TestVCD, nsxtManagerId string) string {
 	var backingId string
-	switch backingType {
-	case types.ExternalNetworkBackingTypeNsxtTier0Router: // Lookup T0 router ID
+	switch {
+	case backingType == types.ExternalNetworkBackingTypeNsxtTier0Router || backingType == types.ExternalNetworkBackingTypeNsxtVrfTier0Router: // Lookup T0 or T0 VRF
 		tier0RouterVrf, err := vcd.client.GetImportableNsxtTier0RouterByName(backingName, nsxtManagerId)
 		check.Assert(err, IsNil)
 		backingId = tier0RouterVrf.NsxtTier0Router.ID
-	case types.ExternalNetworkBackingTypeNsxtSegment: // Lookup segment ID
+	case backingType == types.ExternalNetworkBackingTypeNsxtSegment: // Lookup segment ID
 		bareNsxtManagerId, err := getBareEntityUuid(nsxtManagerId)
 		check.Assert(err, IsNil)
 		filter := map[string]string{"nsxTManager": bareNsxtManagerId}

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -280,6 +280,25 @@ func (egw *NsxtEdgeGateway) MoveToVdcOrVdcGroup(vdcOrVdcGroupId string) (*NsxtEd
 	return egw.Update(edgeGatewayConfig)
 }
 
+// ReorderUplinks will ensure that uplink at slice index 0 is the one backed by NSX-T Tier0 External network.
+// NSX-T Edge Gateway can have many uplinks of different types (they are differentiated by 'backingType' field):
+// * MANDATORY - exactly 1 uplink to Tier0 Gateway (External network backed by NSX-T T0 Gateway) [backingType==NSXT_TIER0]
+// * OPTIONAL - one or more External Network Uplinks (backed by NSX-T Segment backed External networks) [backingType==IMPORTED_T_LOGICAL_SWITCH]
+// It is expected that the Tier0 gateway uplink is at index 0, but we have seen where VCD API shuffles response values therefore it
+// is important to ensure that uplink with backingType==NSXT_TIER0 the element 0 in types.EdgeGatewayUplinks
+func (egw *NsxtEdgeGateway) ReorderUplinks() error {
+	if egw == nil || egw.EdgeGateway == nil {
+		return fmt.Errorf("edge gateway cannot be nil ")
+	}
+
+	if len(egw.EdgeGateway.EdgeGatewayUplinks) == 0 {
+		return fmt.Errorf("no uplinks present in Edge Gateway")
+	}
+
+	egw.EdgeGateway.EdgeGatewayUplinks = reorderEdgeGatewayUplinks(egw.EdgeGateway.EdgeGatewayUplinks)
+	return nil
+}
+
 // getNsxtEdgeGatewayById is a private parent for wrapped functions:
 // func (adminOrg *AdminOrg) GetNsxtEdgeGatewayByName(id string) (*NsxtEdgeGateway, error)
 // func (org *Org) GetNsxtEdgeGatewayByName(id string) (*NsxtEdgeGateway, error)
@@ -970,4 +989,29 @@ func flattenGatewayUsedIpAddressesToIpSlice(usedIpAddresses []*types.GatewayUsed
 	}
 
 	return usedIpSlice, nil
+}
+
+func reorderEdgeGatewayUplinks(edgeGatewayUplinks []types.EdgeGatewayUplinks) []types.EdgeGatewayUplinks {
+	// If only 1 uplink is present - there is nothing to reorder, because only mandatory NSXT_TIER0 uplink is present
+	if len(edgeGatewayUplinks) == 1 {
+		return edgeGatewayUplinks
+	}
+
+	// Element 0 is External Network backed by Tier 0 gateway - nothing to do
+	if edgeGatewayUplinks[0].BackingType != nil && *edgeGatewayUplinks[0].BackingType == "NSXT_TIER0" {
+		return edgeGatewayUplinks
+	}
+
+	for index := range edgeGatewayUplinks {
+		if edgeGatewayUplinks[index].BackingType != nil && *edgeGatewayUplinks[index].BackingType == "NSXT_TIER0" {
+			// Swap two elements
+			t0BackedUplink := edgeGatewayUplinks[index]
+			edgeGatewayUplinks[index] = edgeGatewayUplinks[0]
+			edgeGatewayUplinks[0] = t0BackedUplink
+
+			return edgeGatewayUplinks
+		}
+	}
+
+	return edgeGatewayUplinks
 }

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -304,6 +304,9 @@ func (egw *NsxtEdgeGateway) MoveToVdcOrVdcGroup(vdcOrVdcGroupId string) (*NsxtEd
 // shuffles response values therefore it is important to ensure that uplink with
 // backingType==NSXT_TIER0 or backingType==NSXT_VRF_TIER0 the element 0 in types.EdgeGatewayUplinks to avoid breaking functionality
 // in upstream code.
+//
+// Note. This function wil be a noop in 10.4.0, because `backingType` was not present. However, this
+// poses no risks because the can be only 1 uplink up to 10.4.1, when `backingType` was introduced.
 func (egw *NsxtEdgeGateway) reorderUplinks() error {
 	if egw == nil || egw.EdgeGateway == nil {
 		return fmt.Errorf("edge gateway cannot be nil ")

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -297,7 +297,7 @@ func (egw *NsxtEdgeGateway) MoveToVdcOrVdcGroup(vdcOrVdcGroupId string) (*NsxtEd
 // * OPTIONAL - one or more External Network Uplinks (backed by NSX-T Segment backed External networks) [backingType==IMPORTED_T_LOGICAL_SWITCH]
 // It is expected that the Tier0 gateway uplink is always at index 0, but we have seen where VCD API
 // shuffles response values therefore it is important to ensure that uplink with
-// backingType==NSXT_TIER0 the element 0 in types.EdgeGatewayUplinks to avoid breaking functionality
+// backingType==NSXT_TIER0 or backingType==NSXT_VRF_TIER0 the element 0 in types.EdgeGatewayUplinks to avoid breaking functionality
 // in upstream code.
 func (egw *NsxtEdgeGateway) reorderUplinks() error {
 	if egw == nil || egw.EdgeGateway == nil {

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -183,6 +183,11 @@ func (adminOrg *AdminOrg) CreateNsxtEdgeGateway(edgeGatewayConfig *types.OpenAPI
 		return nil, fmt.Errorf("error creating Edge Gateway: %s", err)
 	}
 
+	err = returnEgw.reorderUplinks()
+	if err != nil {
+		return nil, fmt.Errorf("error reordering Edge Gateway Uplinks after update operation: %s", err)
+	}
+
 	return returnEgw, nil
 }
 

--- a/govcd/nsxt_edgegateway.go
+++ b/govcd/nsxt_edgegateway.go
@@ -1058,11 +1058,11 @@ func reorderEdgeGatewayUplinks(edgeGatewayUplinks []types.EdgeGatewayUplinks) []
 		return edgeGatewayUplinks
 	}
 
-	for index := range edgeGatewayUplinks {
-		if edgeGatewayUplinks[index].BackingType != nil && *edgeGatewayUplinks[index].BackingType == "NSXT_TIER0" {
-			// Swap two elements
-			t0BackedUplink := edgeGatewayUplinks[index]
-			edgeGatewayUplinks[index] = edgeGatewayUplinks[0]
+	for uplinkIndex := range edgeGatewayUplinks {
+		if edgeGatewayUplinks[uplinkIndex].BackingType != nil && *edgeGatewayUplinks[uplinkIndex].BackingType == "NSXT_TIER0" {
+			// Swap elements so that 'NSXT_TIER0' is at position 0
+			t0BackedUplink := edgeGatewayUplinks[uplinkIndex]
+			edgeGatewayUplinks[uplinkIndex] = edgeGatewayUplinks[0]
 			edgeGatewayUplinks[0] = t0BackedUplink
 
 			return edgeGatewayUplinks

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -764,13 +764,11 @@ func test_NsxtEdgeCreateWithExternalNetworks(vcd *TestVCD, check *C, backingRout
 	check.Assert(createdEdge.EdgeGateway.Name, Equals, egwDefinition.Name)
 	openApiEndpoint = types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways + createdEdge.EdgeGateway.ID
 	PrependToCleanupListOpenApi(createdEdge.EdgeGateway.Name, check.TestName(), openApiEndpoint)
-	// check.Assert(*createdEdge.EdgeGateway.EdgeGatewayUplinks[0].BackingType, Equals, types.ExternalNetworkBackingTypeNsxtTier0Router)
 
 	// Retrieve edge gateway
 	retrievedEdge, err := adminOrg.GetNsxtEdgeGatewayById(createdEdge.EdgeGateway.ID)
 	check.Assert(err, IsNil)
 	check.Assert(retrievedEdge, NotNil)
-	// check.Assert(*retrievedEdge.EdgeGateway.EdgeGatewayUplinks[0].BackingType, Equals, types.ExternalNetworkBackingTypeNsxtTier0Router)
 
 	// Check IP allocation in NSX-T Segment backed networks
 	totalAllocatedIpCountSegmentBacked, err := retrievedEdge.GetAllocatedIpCountByUplinkType(false, types.ExternalNetworkBackingTypeNsxtSegment)
@@ -781,6 +779,10 @@ func test_NsxtEdgeCreateWithExternalNetworks(vcd *TestVCD, check *C, backingRout
 	totalAllocatedIpCountT0backed, err := retrievedEdge.GetAllocatedIpCountByUplinkType(false, backingRouterType)
 	check.Assert(err, IsNil)
 	check.Assert(totalAllocatedIpCountT0backed, Equals, 1)
+
+	totalAllocatedIpCountForPrimaryUplink, err := retrievedEdge.GetPrimaryNetworkAllocatedIpCount(false)
+	check.Assert(err, IsNil)
+	check.Assert(totalAllocatedIpCountForPrimaryUplink, Equals, 1)
 
 	// Check IP allocation for all subnets
 	totalAllocatedIpCount, err := retrievedEdge.GetAllocatedIpCount(false)

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -810,6 +810,16 @@ func test_NsxtEdgeCreateWithExternalNetworks(vcd *TestVCD, check *C, backingRout
 	// Cleanup
 	err = updatedEdge.Delete()
 	check.Assert(err, IsNil)
+
+	err = segmentBackedNet2.Delete()
+	check.Assert(err, IsNil)
+
+	err = segmentBackedNet1.Delete()
+	check.Assert(err, IsNil)
+
+	err = nsxtExternalNetwork.Delete()
+	check.Assert(err, IsNil)
+
 }
 
 func t0vrfBackedExternalNetworkConfig(vcd *TestVCD, name, ipPrefix string, backingType, backingId, NetworkProviderId string) *types.ExternalNetworkV2 {

--- a/govcd/nsxt_edgegateway_unit_test.go
+++ b/govcd/nsxt_edgegateway_unit_test.go
@@ -1733,7 +1733,7 @@ func Test_reorderEdgeGatewayUplinks(t *testing.T) {
 				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
 			}},
 		},
-		// Commented on purpose
+		// A failing test example - commented on purpose
 		// {
 		// 	name: "FailingTest",
 		// 	args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{

--- a/govcd/nsxt_edgegateway_unit_test.go
+++ b/govcd/nsxt_edgegateway_unit_test.go
@@ -1716,6 +1716,23 @@ func Test_reorderEdgeGatewayUplinks(t *testing.T) {
 				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
 			}},
 		},
+		{
+			name: "ReverseOneT0ManySegmentUplinksVRF",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("NSXT_VRF_TIER0"), UplinkID: "5"},
+			}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_VRF_TIER0"), UplinkID: "5"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+			}},
+		},
 		// Commented on purpose
 		// {
 		// 	name: "FailingTest",

--- a/govcd/nsxt_edgegateway_unit_test.go
+++ b/govcd/nsxt_edgegateway_unit_test.go
@@ -1640,3 +1640,102 @@ func TestOpenAPIEdgeGateway_DeallocateIpCount(t *testing.T) {
 		})
 	}
 }
+
+func Test_reorderEdgeGatewayUplinks(t *testing.T) {
+	type args struct {
+		edgeGatewayUplinks []types.EdgeGatewayUplinks
+	}
+	tests := []struct {
+		name string
+		args args
+		want args
+	}{
+		{
+			name: "OneT0Uplink",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"}}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"}}},
+		},
+		{
+			name: "ImpossibleOneSegmentUplink",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"}}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"}}},
+		},
+		{
+			name: "OrderedOneT0OneSegmentUplink",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+			}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+			}},
+		},
+		{
+			name: "OrderedOneT0OneManySegments",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "5"},
+			}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "5"},
+			}},
+		},
+		{
+			name: "ReverseOneT0OneSegmentUplink",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "2"},
+			}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+			}},
+		},
+		{
+			name: "ReverseOneT0ManySegmentUplinks",
+			args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "5"},
+			}},
+			want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+				{BackingType: addrOf("NSXT_TIER0"), UplinkID: "5"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "2"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "3"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "4"},
+				{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH"), UplinkID: "1"},
+			}},
+		},
+		// Commented on purpose
+		// {
+		// 	name: "FailingTest",
+		// 	args: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+		// 		types.EdgeGatewayUplinks{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH")},
+		// 		types.EdgeGatewayUplinks{BackingType: addrOf("NSXT_TIER0")},
+		// 	}},
+		// 	want: args{edgeGatewayUplinks: []types.EdgeGatewayUplinks{
+		// 		types.EdgeGatewayUplinks{BackingType: addrOf("IMPORTED_T_LOGICAL_SWITCH")},
+		// 		types.EdgeGatewayUplinks{BackingType: addrOf("NSXT_TIER0")},
+		// 	}},
+		// },
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reorderedUplinks := reorderEdgeGatewayUplinks(tt.args.edgeGatewayUplinks)
+
+			if !reflect.DeepEqual(reorderedUplinks, tt.want.edgeGatewayUplinks) {
+				t.Errorf("Expected %+v, got %+v", tt.args.edgeGatewayUplinks, tt.want.edgeGatewayUplinks)
+			}
+		})
+	}
+}

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -97,6 +97,8 @@ vcd:
       edgeGateway: nsxt-gw-name
       # Existing NSX-T segment to test NSX-T Imported Org Vdc network
       nsxtImportSegment: vcd-org-vdc-imported-network-backing
+      # Existing NSX-T segment to test Edge Gateway Uplinks
+      nsxtImportSegment2: vcd-org-vdc-imported-network-backing2
       # Existing NSX-T Edge Cluster name
       nsxtEdgeCluster: existing-nsxt-edge-cluster
       # AVI Controller URL

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -73,7 +73,7 @@ type EdgeGatewayUplinks struct {
 	Dedicated bool `json:"dedicated,omitempty"`
 
 	// BackingType of uplink. This can be:
-	// * NSXT_TIER0 - The default and mandatory External Network backed by NSX-T ier0 Gateway
+	// * NSXT_TIER0 - The default and mandatory External Network backed by NSX-T Tier0 Gateway
 	// * IMPORTED_T_LOGICAL_SWITCH - External Network uplinks (External Networks backed by NSX-T Segment)
 	BackingType *string `json:"backingType,omitempty"`
 
@@ -114,7 +114,7 @@ type OpenAPIEdgeGatewaySubnetValue struct {
 	// UsedIPCount specifies used IP count
 	UsedIPCount int `json:"usedIpCount,omitempty"`
 
-	// PrimaryIP of the Edge Gateway. Can only be one in all subnets
+	// PrimaryIP of the Edge Gateway. Can only be one in all subnets of a single uplink
 	PrimaryIP string `json:"primaryIp,omitempty"`
 
 	// AutoAllocateIPRanges provides a way to automatically allocate

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -72,7 +72,7 @@ type EdgeGatewayUplinks struct {
 	// Advertisement for this Edge Gateway
 	Dedicated bool `json:"dedicated,omitempty"`
 
-	// BackingType of uplink. One of these 2 is a must:
+	// BackingType of uplink. Exactly one of these 2 is a must:
 	// * types.ExternalNetworkBackingTypeNsxtTier0Router (NSXT_TIER0)
 	// * types.ExternalNetworkBackingTypeNsxtVrfTier0Router (NSXT_VRF_TIER0)
 	// Additional External network uplinks

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -72,11 +72,13 @@ type EdgeGatewayUplinks struct {
 	// Advertisement for this Edge Gateway
 	Dedicated bool `json:"dedicated,omitempty"`
 
-	// BackingType of uplink. Exactly one of these 2 is a must:
+	// BackingType of uplink. Exactly one of these will be present:
 	// * types.ExternalNetworkBackingTypeNsxtTier0Router (NSXT_TIER0)
 	// * types.ExternalNetworkBackingTypeNsxtVrfTier0Router (NSXT_VRF_TIER0)
 	// Additional External network uplinks
 	// * types.ExternalNetworkBackingTypeNsxtSegment (IMPORTED_T_LOGICAL_SWITCH) - External Network uplinks (External Networks backed by NSX-T Segment)
+	//
+	// Note. VCD 10.4.1+. Not mandatory to set it - can be used as a read only value
 	BackingType *string `json:"backingType,omitempty"`
 
 	// UsingIpSpace is a boolean flag showing if the uplink uses IP Space

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -72,6 +72,11 @@ type EdgeGatewayUplinks struct {
 	// Advertisement for this Edge Gateway
 	Dedicated bool `json:"dedicated,omitempty"`
 
+	// BackingType of uplink. This can be:
+	// * NSXT_TIER0 - The default and mandatory External Network backed by NSX-T ier0 Gateway
+	// * IMPORTED_T_LOGICAL_SWITCH - External Network uplinks (External Networks backed by NSX-T Segment)
+	BackingType *string `json:backingType,omitempty`
+
 	// UsingIpSpace is a boolean flag showing if the uplink uses IP Space
 	UsingIpSpace *bool `json:"usingIpSpace,omitempty"`
 }

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -114,7 +114,7 @@ type OpenAPIEdgeGatewaySubnetValue struct {
 	// UsedIPCount specifies used IP count
 	UsedIPCount int `json:"usedIpCount,omitempty"`
 
-	// PrimaryIP of the Edge Gateway. Can only be one per Edge (from all subnets)
+	// PrimaryIP of the Edge Gateway. Can only be one in all subnets
 	PrimaryIP string `json:"primaryIp,omitempty"`
 
 	// AutoAllocateIPRanges provides a way to automatically allocate

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -72,9 +72,11 @@ type EdgeGatewayUplinks struct {
 	// Advertisement for this Edge Gateway
 	Dedicated bool `json:"dedicated,omitempty"`
 
-	// BackingType of uplink. This can be:
-	// * NSXT_TIER0 - The default and mandatory External Network backed by NSX-T Tier0 Gateway
-	// * IMPORTED_T_LOGICAL_SWITCH - External Network uplinks (External Networks backed by NSX-T Segment)
+	// BackingType of uplink. One of these 2 is a must:
+	// * types.ExternalNetworkBackingTypeNsxtTier0Router (NSXT_TIER0)
+	// * types.ExternalNetworkBackingTypeNsxtVrfTier0Router (NSXT_VRF_TIER0)
+	// Additional External network uplinks
+	// * types.ExternalNetworkBackingTypeNsxtSegment (IMPORTED_T_LOGICAL_SWITCH) - External Network uplinks (External Networks backed by NSX-T Segment)
 	BackingType *string `json:"backingType,omitempty"`
 
 	// UsingIpSpace is a boolean flag showing if the uplink uses IP Space

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -75,7 +75,7 @@ type EdgeGatewayUplinks struct {
 	// BackingType of uplink. This can be:
 	// * NSXT_TIER0 - The default and mandatory External Network backed by NSX-T ier0 Gateway
 	// * IMPORTED_T_LOGICAL_SWITCH - External Network uplinks (External Networks backed by NSX-T Segment)
-	BackingType *string `json:backingType,omitempty`
+	BackingType *string `json:"backingType,omitempty"`
 
 	// UsingIpSpace is a boolean flag showing if the uplink uses IP Space
 	UsingIpSpace *bool `json:"usingIpSpace,omitempty"`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1619,19 +1619,18 @@ type DiskSection struct {
 
 // DiskSettings from Vm/VmSpecSection/DiskSection struct
 type DiskSettings struct {
-	DiskId              string        `xml:"DiskId,omitempty"`          // Specifies a unique identifier for this disk in the scope of the corresponding VM. This element is optional when creating a VM, but if it is provided it should be unique. This element is mandatory when updating an existing disk.
-	SizeMb              int64         `xml:"SizeMb"`                    // The size of the disk in MB.
-	UnitNumber          int           `xml:"UnitNumber"`                // The device number on the SCSI or IDE controller of the disk.
-	BusNumber           int           `xml:"BusNumber"`                 //	The number of the SCSI or IDE controller itself.
-	AdapterType         string        `xml:"AdapterType"`               // The type of disk controller, e.g. IDE vs SCSI and if SCSI bus-logic vs LSI logic.
-	ThinProvisioned     *bool         `xml:"ThinProvisioned,omitempty"` // Specifies whether the disk storage is pre-allocated or allocated on demand.
-	Disk                *Reference    `xml:"Disk,omitempty"`            // Specifies reference to a named disk.
-	StorageProfile      *Reference    `xml:"StorageProfile,omitempty"`  // Specifies reference to a storage profile to be associated with the disk.
-	OverrideVmDefault   bool          `xml:"overrideVmDefault"`         // Specifies that the disk storage profile overrides the VM's default storage profile.
-	IopsAllocation      *IopsResource `xml:"IopsAllocation"`            // IOPS definition for the disk - added in 10.4 in replacement of 'iops'
-	Iops                *int64
-	VirtualQuantity     *int64 `xml:"VirtualQuantity,omitempty"`     // The actual size of the disk.
-	VirtualQuantityUnit string `xml:"VirtualQuantityUnit,omitempty"` // The units in which VirtualQuantity is measured.
+	DiskId              string        `xml:"DiskId,omitempty"`              // Specifies a unique identifier for this disk in the scope of the corresponding VM. This element is optional when creating a VM, but if it is provided it should be unique. This element is mandatory when updating an existing disk.
+	SizeMb              int64         `xml:"SizeMb"`                        // The size of the disk in MB.
+	UnitNumber          int           `xml:"UnitNumber"`                    // The device number on the SCSI or IDE controller of the disk.
+	BusNumber           int           `xml:"BusNumber"`                     //	The number of the SCSI or IDE controller itself.
+	AdapterType         string        `xml:"AdapterType"`                   // The type of disk controller, e.g. IDE vs SCSI and if SCSI bus-logic vs LSI logic.
+	ThinProvisioned     *bool         `xml:"ThinProvisioned,omitempty"`     // Specifies whether the disk storage is pre-allocated or allocated on demand.
+	Disk                *Reference    `xml:"Disk,omitempty"`                // Specifies reference to a named disk.
+	StorageProfile      *Reference    `xml:"StorageProfile,omitempty"`      // Specifies reference to a storage profile to be associated with the disk.
+	OverrideVmDefault   bool          `xml:"overrideVmDefault"`             // Specifies that the disk storage profile overrides the VM's default storage profile.
+	IopsAllocation      *IopsResource `xml:"IopsAllocation"`                // IOPS definition for the disk - added in 10.4 in replacement of 'iops'
+	VirtualQuantity     *int64        `xml:"VirtualQuantity,omitempty"`     // The actual size of the disk.
+	VirtualQuantityUnit string        `xml:"VirtualQuantityUnit,omitempty"` // The units in which VirtualQuantity is measured.
 }
 
 type IopsResource struct {

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1619,18 +1619,19 @@ type DiskSection struct {
 
 // DiskSettings from Vm/VmSpecSection/DiskSection struct
 type DiskSettings struct {
-	DiskId              string        `xml:"DiskId,omitempty"`              // Specifies a unique identifier for this disk in the scope of the corresponding VM. This element is optional when creating a VM, but if it is provided it should be unique. This element is mandatory when updating an existing disk.
-	SizeMb              int64         `xml:"SizeMb"`                        // The size of the disk in MB.
-	UnitNumber          int           `xml:"UnitNumber"`                    // The device number on the SCSI or IDE controller of the disk.
-	BusNumber           int           `xml:"BusNumber"`                     //	The number of the SCSI or IDE controller itself.
-	AdapterType         string        `xml:"AdapterType"`                   // The type of disk controller, e.g. IDE vs SCSI and if SCSI bus-logic vs LSI logic.
-	ThinProvisioned     *bool         `xml:"ThinProvisioned,omitempty"`     // Specifies whether the disk storage is pre-allocated or allocated on demand.
-	Disk                *Reference    `xml:"Disk,omitempty"`                // Specifies reference to a named disk.
-	StorageProfile      *Reference    `xml:"StorageProfile,omitempty"`      // Specifies reference to a storage profile to be associated with the disk.
-	OverrideVmDefault   bool          `xml:"overrideVmDefault"`             // Specifies that the disk storage profile overrides the VM's default storage profile.
-	IopsAllocation      *IopsResource `xml:"IopsAllocation"`                // IOPS definition for the disk - added in 10.4 in replacement of 'iops'
-	VirtualQuantity     *int64        `xml:"VirtualQuantity,omitempty"`     // The actual size of the disk.
-	VirtualQuantityUnit string        `xml:"VirtualQuantityUnit,omitempty"` // The units in which VirtualQuantity is measured.
+	DiskId              string        `xml:"DiskId,omitempty"`          // Specifies a unique identifier for this disk in the scope of the corresponding VM. This element is optional when creating a VM, but if it is provided it should be unique. This element is mandatory when updating an existing disk.
+	SizeMb              int64         `xml:"SizeMb"`                    // The size of the disk in MB.
+	UnitNumber          int           `xml:"UnitNumber"`                // The device number on the SCSI or IDE controller of the disk.
+	BusNumber           int           `xml:"BusNumber"`                 //	The number of the SCSI or IDE controller itself.
+	AdapterType         string        `xml:"AdapterType"`               // The type of disk controller, e.g. IDE vs SCSI and if SCSI bus-logic vs LSI logic.
+	ThinProvisioned     *bool         `xml:"ThinProvisioned,omitempty"` // Specifies whether the disk storage is pre-allocated or allocated on demand.
+	Disk                *Reference    `xml:"Disk,omitempty"`            // Specifies reference to a named disk.
+	StorageProfile      *Reference    `xml:"StorageProfile,omitempty"`  // Specifies reference to a storage profile to be associated with the disk.
+	OverrideVmDefault   bool          `xml:"overrideVmDefault"`         // Specifies that the disk storage profile overrides the VM's default storage profile.
+	IopsAllocation      *IopsResource `xml:"IopsAllocation"`            // IOPS definition for the disk - added in 10.4 in replacement of 'iops'
+	Iops                *int64
+	VirtualQuantity     *int64 `xml:"VirtualQuantity,omitempty"`     // The actual size of the disk.
+	VirtualQuantityUnit string `xml:"VirtualQuantityUnit,omitempty"` // The units in which VirtualQuantity is measured.
 }
 
 type IopsResource struct {


### PR DESCRIPTION
This PR adds missing pieces to support NSX-T Edge Gateway External Network uplinks (only for external networks backed by NSX-T Segments) (VCD 10.4.1+)

List of things added:
* New internal function `*NsxtEdgeGateway.reorderUplinks()` that will order NSX-T Edge Gateway uplinks. There are two major types of uplinks
  * `NSXT_TIER0` or `NSXT_VRF_TIER0` - Tier 0 gateway backed external network (mandatory and is required during creation)
  * `IMPORTED_T_LOGICAL_SWITCH ` NSX-T segment backed external network (this is optional, attached post creation in "External networks" tab)
* New method `NsxtEdgeGateway.GetAllocatedIpCountByUplinkType` complementing existing
  `NsxtEdgeGateway.GetAllocatedIpCount`. It will return allocated IP counts by uplink types (requires VCD 10.4.1+)
* New method `NsxtEdgeGateway.GetPrimaryNetworkAllocatedIpCount` that will return total allocated IP
  count for primary uplink (T0 or T0 VRF)
* New field `types.EdgeGatewayUplinks.BackingType` that defines backing type of NSX-T Edge Gateway
  Uplink (available in VCD 10.4.1+)

_Note on uplink ordering_. API usually returns the mandatory network as element 0 in the resulting slice, but there have been cases where VCD sometimes shuffles these responses (don't have a proof for this particular endpoint). As a result - the `reorderUplinks` function is here to ensure that `NSXT_TIER0` or `NSXT_VRF_TIER0`uplink is always at position 0. It is also used in all functions related to NSX-T Edge Gateway.

Tested with tags `nsxt gateway network`:
* 10.5.0
* 10.4.1
* 10.4.0
* 10.4.2

Tests are for admin mode only, skip directive for Org tests is in place. The test requires 10.4.1+.