### PR TITLE
Use verbose retry function for ALB test cleanup

### DIFF
--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -747,6 +747,28 @@ func (vcd *TestVCD) getAdminOrgAndVdcFromCleanupEntity(entity CleanupEntity) (or
 	return org, vdc, nil
 }
 
+func (vcd *TestVCD) removeLeftoverEntitiesByTestName(check *C, testName string) {
+	// Gets the persistent cleanup list from file, if exists.
+	cleanupList, err := readCleanupList()
+	if err != nil {
+		check.Logf("failed to read cleanup list: %s", err)
+	}
+	if len(cleanupList) > 0 && err == nil {
+		fmt.Printf("*** Attempting to cleanup entities, created by this test '%s' in file '%s'\n",
+			testName, makePersistentCleanupFileName())
+
+		for i, cleanupEntity := range cleanupList {
+
+			// Ignoring entities, that are not created in the test with a given name
+			if cleanupEntity.CreatedBy != testName {
+				continue
+			}
+			fmt.Printf("# %d ", i+1)
+			vcd.removeLeftoverEntities(cleanupEntity)
+		}
+	}
+}
+
 // Removes leftover entities that may still exist after failed tests
 // or the ones that were explicitly created for several tests and
 // were relying on this procedure to clean up at the end.

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
@@ -2031,4 +2032,23 @@ func (vcd *TestVCD) skipIfNotSysAdmin(check *C) {
 	if !vcd.client.Client.IsSysAdmin {
 		check.Skip(fmt.Sprintf("Skipping %s: requires system administrator privileges", check.TestName()))
 	}
+}
+
+// retryOnError is a function that will attempt to execute function with signature `func() error`
+// multiple times (until maxRetries) and waiting given retryInterval between tries. It will return
+// original deletion error for troubleshooting.
+func retryOnError(operation func() error, maxRetries int, retryInterval time.Duration) error {
+	var err error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err = operation()
+		if err == nil {
+			return nil
+		}
+
+		fmt.Printf("# retrying after %v (Attempt %d/%d)\n", retryInterval, attempt+1, maxRetries)
+		fmt.Printf("# error was: %s", err)
+		time.Sleep(retryInterval)
+	}
+
+	return fmt.Errorf("exceeded maximum retries, final error: %s", err)
 }

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -747,28 +747,6 @@ func (vcd *TestVCD) getAdminOrgAndVdcFromCleanupEntity(entity CleanupEntity) (or
 	return org, vdc, nil
 }
 
-func (vcd *TestVCD) removeLeftoverEntitiesByTestName(check *C, testName string) {
-	// Gets the persistent cleanup list from file, if exists.
-	cleanupList, err := readCleanupList()
-	if err != nil {
-		check.Logf("failed to read cleanup list: %s", err)
-	}
-	if len(cleanupList) > 0 && err == nil {
-		fmt.Printf("*** Attempting to cleanup entities, created by this test '%s' in file '%s'\n",
-			testName, makePersistentCleanupFileName())
-
-		for i, cleanupEntity := range cleanupList {
-
-			// Ignoring entities, that are not created in the test with a given name
-			if cleanupEntity.CreatedBy != testName {
-				continue
-			}
-			fmt.Printf("# %d ", i+1)
-			vcd.removeLeftoverEntities(cleanupEntity)
-		}
-	}
-}
-
 // Removes leftover entities that may still exist after failed tests
 // or the ones that were explicitly created for several tests and
 // were relying on this procedure to clean up at the end.

--- a/govcd/nsxt_alb_virtual_service_test.go
+++ b/govcd/nsxt_alb_virtual_service_test.go
@@ -17,6 +17,13 @@ func (vcd *TestVCD) Test_AlbVirtualService(check *C) {
 	skipNoNsxtAlbConfiguration(vcd, check)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointAlbEdgeGateway)
 
+	failedAlbCleanup := true
+	defer func() {
+		if failedAlbCleanup {
+			vcd.removeLeftoverEntitiesByTestName(check, check.TestName())
+		}
+	}()
+
 	// Setup prerequisite components
 	controller, cloud, seGroup, edge, seGroupAssignment, albPool := setupAlbVirtualServicePrerequisites(check, vcd)
 
@@ -78,6 +85,8 @@ func (vcd *TestVCD) Test_AlbVirtualService(check *C) {
 	// cleanup Org user
 	err = orgUser.Delete(true)
 	check.Assert(err, IsNil)
+
+	failedAlbCleanup = false
 }
 
 func testMinimalVirtualServiceConfigHTTP(check *C, edge *NsxtEdgeGateway, pool *NsxtAlbPool, seGroup *NsxtAlbServiceEngineGroup, vcd *TestVCD, client *VCDClient) {
@@ -497,6 +506,8 @@ func testAlbVirtualServiceConfig(check *C, vcd *TestVCD, name string, setupConfi
 		check.Assert(updatedPool.NsxtAlbVirtualService.Name, NotNil)
 		check.Assert(updatedPool.NsxtAlbVirtualService.GatewayRef.ID, NotNil)
 	}
+
+	check.Errorf("Testing failure")
 
 	err = createdVirtualService.Delete()
 	check.Assert(err, IsNil)

--- a/govcd/nsxt_alb_virtual_service_test.go
+++ b/govcd/nsxt_alb_virtual_service_test.go
@@ -571,21 +571,3 @@ func tearDownAlbVirtualServicePrerequisites(check *C, albPool *NsxtAlbPool, assi
 	err = controller.Delete()
 	check.Assert(err, IsNil)
 }
-
-// retryOnError is a function that will attempt to execute function multiple times (until
-// maxRetries) and waiting given retryInterval between tries. It will return original deletion error
-// for troubleshooting.
-func retryOnError(operation func() error, maxRetries int, retryInterval time.Duration) error {
-	var err error
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		err = operation()
-		if err == nil {
-			return nil
-		}
-
-		fmt.Printf("Retrying after %v (Attempt %d/%d)\n", retryInterval, attempt+1, maxRetries)
-		time.Sleep(retryInterval)
-	}
-
-	return fmt.Errorf("exceeded maximum retries, original error: %s", err)
-}


### PR DESCRIPTION

~This PR attempts to improve on test cleanup for some cases by providing an experimental solution.~

~These cases for now are related to ALB, which sometimes (although very rarely) can fail in an unexpected place. These failures happen in unexpected places and it is not always possible to catch all of them.~

~I have looked at 2 ways of improving cleanup so that other tests are not impacted:~
~* build explicit cleanup code~
~* Reuse already existing cleanup list. This looks to be more universal and has less overhead.~



~The general idea is to build a similar function to `removeLeftoverEntities` which is being triggered at the end of test (unless prevented). A new function `removeLeftoverEntitiesByTestName` is made. The difference is that it accepts `testName` so that all items in the cleanup list can be filtered by test name (put into `createdBy` in `AddToCleanupListOpenApi` function). That way we can be sure that cleanup is performed only on the entities, that were created by that particular test.~

The above approach was tried in [2ba1109](https://github.com/vmware/go-vcloud-director/pull/614/commits/2ba11096d6cd73dd44902cf440e4a490723b253e).


Latest approach is to hit the problem at exact place were it occurred by trying to perform a verbose retry for operation using new function `retryOnError` which is used for testing.

