### PR TITLE
Don't assume minutes in Makefile timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOFMT_FILES?=$$(find . -name '*.go')
 maindir=$(PWD)
 timeout=0
 ifdef VCD_TIMEOUT
-timeout="$(VCD_TIMEOUT)m"
+timeout="$(VCD_TIMEOUT)"
 endif
 
 default: fmtcheck vet static security build


### PR DESCRIPTION
This PR just removes the `m` suffix in the Makefile timeout variable, to stop assuming that the timeout is in minutes, which can be misleading.

It also aligns with https://github.com/vmware/terraform-provider-vcd, which timeout can be defined in any unit.