### PR TITLE
add "expectingAction" status to make sure - in case of a locked media - the vmquestion is recognized and can be "forcefully" automatically answered again.

### DIFF
--- a/govcd/ejecttask.go
+++ b/govcd/ejecttask.go
@@ -51,7 +51,7 @@ func (ejectTask *EjectTask) WaitInspectTaskCompletion(isAnswerYes bool, delay ti
 		}
 
 		// If task is not in a waiting status we're done, check if there's an error and return it.
-		if ejectTask.Task.Task.Status != "queued" && ejectTask.Task.Task.Status != "preRunning" && ejectTask.Task.Task.Status != "running" {
+		if ejectTask.Task.Task.Status != "queued" && ejectTask.Task.Task.Status != "preRunning" && ejectTask.Task.Task.Status != "running" && ejectTask.Task.Task.Status != "expectingAction" {
 			if ejectTask.Task.Task.Status == "error" {
 				return fmt.Errorf("task did not complete succesfully: %s", ejectTask.Task.Task.Error.Message)
 			}


### PR DESCRIPTION
## IMPORTANT

## Issue
Simple fix for 1 additional, missing status - causing the automatic answering of vmquestions - which arise in case of "locked" media in vm - and therefore the media eject task to fail.

Very likely also fixes https://github.com/vmware/go-vcloud-director/issues/552


## Description

The "expectingAction" status is also missing from official "task type - status" documentation:
https://developer.vmware.com/apis/1260/doc/types/TaskType.html

Yet, it represents the status of an media eject task 
- in case of a locked virtual drive
- therefore while the vm is waiting for the vmquestion to be answered (by human or WaitTaskCompletion function), whether media shall be forcefully removed anyway

This PR 
- adds the "expectingAction" status 
- to make sure - in case of a locked media - the vmquestion is recognized and can be "forcefully" automatically answered again.

