### PR TITLE
Add specific version for gosec in security checks

### DIFF
--- a/scripts/gosec-config.sh
+++ b/scripts/gosec-config.sh
@@ -1,2 +1,4 @@
+# GOSEC_URL is the address of the gosec installation script
 export GOSEC_URL=https://raw.githubusercontent.com/securego/gosec/master/install.sh
+# NOTE: if we want to get the latest version, we set the variable below to empty ("")
 export GOSEC_VERSION=v2.17.0

--- a/scripts/gosec-config.sh
+++ b/scripts/gosec-config.sh
@@ -1,0 +1,2 @@
+export GOSEC_URL=https://raw.githubusercontent.com/securego/gosec/master/install.sh
+export GOSEC_VERSION=v2.17.0

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -12,6 +12,14 @@ then
     exit 1
 fi
 
+if [ ! -f ./scripts/gosec-config.sh ]
+then
+    echo "file ./scripts/gosec-config.sh not found"
+    exit 1
+fi
+
+source ./scripts/gosec-config.sh
+
 function exists_in_path {
     what=$1
     for dir in $(echo $PATH | tr ':' ' ')
@@ -35,14 +43,14 @@ function get_gosec {
             echo "'curl' executable not found - Skipping gosec"
             exit 0
         fi
-        $curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh > gosec_install.sh
+        $curl -sfL $GOSEC_URL > gosec_install.sh
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then
           echo "Error downloading gosec installer"
           exit $exit_code
         fi
-        sh -x gosec_install.sh > gosec_install.log 2>&1
+        sh -x gosec_install.sh $GOSEC_VERSION > gosec_install.log 2>&1
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then


### PR DESCRIPTION
This PR fixes a bug in the latest version of `gosec`.
See [Issue #1046](https://github.com/securego/gosec/issues/1046).

To work around such problem, we add a specific version of `gosec` to use, rather than asking always for the latest one. 

Note: no change log added, as this only affects tests, and only (hopefully) temporarily.
