### PR TITLE
Fix CustomUsersOu position in OrgLdapSettingsType

### DIFF
--- a/.changes/v2.22.0/625-bug-fixes.md
+++ b/.changes/v2.22.0/625-bug-fixes.md
@@ -1,0 +1,1 @@
+* Addressed Issue [1134](https://github.com/vmware/terraform-provider-vcd/issues/1134): Can't use SYSTEM `ldap_mode` [GH-625]

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -941,8 +941,8 @@ type OrgLdapSettingsType struct {
 	Type    string   `xml:"type,attr,omitempty"` // The MIME type of the entity.
 	Link    LinkList `xml:"Link,omitempty"`      // A reference to an entity or operation associated with this object.
 
-	CustomUsersOu         string                 `xml:"CustomUsersOu,omitempty"`         // If OrgLdapMode is SYSTEM, specifies an LDAP attribute=value pair to use for OU (organizational unit).
 	OrgLdapMode           string                 `xml:"OrgLdapMode,omitempty"`           // LDAP mode you want
+	CustomUsersOu         string                 `xml:"CustomUsersOu,omitempty"`         // If OrgLdapMode is SYSTEM, specifies an LDAP attribute=value pair to use for OU (organizational unit).
 	CustomOrgLdapSettings *CustomOrgLdapSettings `xml:"CustomOrgLdapSettings,omitempty"` // Needs to be set if user chooses custom mode
 }
 


### PR DESCRIPTION
Field `CustomUsersOu` was wrongly placed in `OrgLdapSettingsType`. 
Add test `Test_LDAPSystem` to prove its working

Addresses Issue [#1134](https://github.com/vmware/terraform-provider-vcd/issues/1134)