### PR TITLE
Amend metadata tests to be compatible with latest VCD

### DIFF
--- a/.changes/v2.22.0/629-notes.md
+++ b/.changes/v2.22.0/629-notes.md
@@ -1,0 +1,1 @@
+* Amended `testMetadataIgnore`, used by all metadata tests, to be compatible with VCD 10.5.1 [GH-629]

--- a/govcd/metadata_test.go
+++ b/govcd/metadata_test.go
@@ -442,6 +442,11 @@ func (vcd *TestVCD) Test_MetadataOnIndependentDiskCRUD(check *C) {
 	check.Assert(err, IsNil)
 
 	testMetadataCRUDActionsDeprecated(disk, check, nil)
+
+	task, err = disk.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) Test_MetadataOnVdcNetworkCRUD(check *C) {

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -388,11 +388,11 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 			check.Assert(singleMetadata.TypedValue.Value, Equals, "bar")
 		}
 
-		// We add a new entry that won't be filtered out
+		// Add a new entry that won't be filtered out
 		err = resource.AddMetadataEntryWithVisibility("test", "bar2", types.MetadataStringValue, types.MetadataReadWriteVisibility, false)
 		check.Assert(err, IsNil)
 
-		// We retrieve all metadata
+		// Retrieve all metadata
 		allMetadata, err := resource.GetMetadata()
 		check.Assert(err, IsNil)
 		check.Assert(allMetadata, NotNil)

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -261,6 +261,11 @@ func (vcd *TestVCD) TestDiskMetadata(check *C) {
 
 	vcd.testMetadataCRUDActions(disk, check, nil)
 	vcd.testMetadataIgnore(disk, "disk", disk.Disk.Name, check)
+
+	task, err = disk.Delete()
+	check.Assert(err, IsNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
 }
 
 func (vcd *TestVCD) TestOrgVDCNetworkMetadata(check *C) {

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -344,6 +344,22 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 			metadataIsIgnored: false,
 		},
 		{
+			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, KeyRegex: regexp.MustCompile(`^foo$`)}},
+			metadataIsIgnored: true,
+		},
+		{
+			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, ValueRegex: regexp.MustCompile(`^bar$`)}},
+			metadataIsIgnored: true,
+		},
+		{
+			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, KeyRegex: regexp.MustCompile(`^fizz$`)}},
+			metadataIsIgnored: false,
+		},
+		{
+			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, ValueRegex: regexp.MustCompile(`^buzz$`)}},
+			metadataIsIgnored: false,
+		},
+		{
 			ignoredMetadata:   []IgnoredMetadata{{ObjectType: &objectType, ObjectName: &objectName, KeyRegex: regexp.MustCompile(`foo`), ValueRegex: regexp.MustCompile(`bar`)}},
 			metadataIsIgnored: true,
 		},

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -293,7 +293,10 @@ func (vcd *TestVCD) TestCatalogItemMetadata(check *C) {
 }
 
 func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, objectName string, check *C) {
-	err := resource.AddMetadataEntryWithVisibility("foo", "bar", types.MetadataStringValue, types.MetadataReadWriteVisibility, false)
+	existingMetadata, err := resource.GetMetadata()
+	check.Assert(err, IsNil)
+
+	err = resource.AddMetadataEntryWithVisibility("foo", "bar", types.MetadataStringValue, types.MetadataReadWriteVisibility, false)
 	check.Assert(err, IsNil)
 
 	cleanup := func() {
@@ -301,13 +304,22 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 		metadata, err := resource.GetMetadata()
 		check.Assert(err, IsNil)
 		for _, entry := range metadata.MetadataEntry {
-			err = resource.DeleteMetadataEntryWithDomain(entry.Key, entry.Domain != nil && entry.Domain.Domain == "SYSTEM")
-			check.Assert(err, IsNil)
+			itWasAlreadyPresent := false
+			for _, existingEntry := range existingMetadata.MetadataEntry {
+				if existingEntry.Key == entry.Key && existingEntry.TypedValue.Value == entry.TypedValue.Value &&
+					existingEntry.Type == entry.Type {
+					itWasAlreadyPresent = true
+				}
+			}
+			if !itWasAlreadyPresent {
+				err = resource.DeleteMetadataEntryWithDomain(entry.Key, entry.Domain != nil && entry.Domain.Domain == "SYSTEM")
+				check.Assert(err, IsNil)
+			}
 		}
 		metadata, err = resource.GetMetadata()
 		check.Assert(err, IsNil)
 		check.Assert(metadata, NotNil)
-		check.Assert(len(metadata.MetadataEntry), Equals, 0)
+		check.Assert(len(metadata.MetadataEntry), Equals, len(existingMetadata.MetadataEntry))
 	}
 	defer cleanup()
 
@@ -332,29 +344,24 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 			metadataIsIgnored: false,
 		},
 		{
-			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, KeyRegex: regexp.MustCompile(`^foo$`)}},
-			metadataIsIgnored: true,
-		},
-		{
-			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, ValueRegex: regexp.MustCompile(`^bar$`)}},
-			metadataIsIgnored: true,
-		},
-		{
-			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, KeyRegex: regexp.MustCompile(`^fizz$`)}},
-			metadataIsIgnored: false,
-		},
-		{
-			ignoredMetadata:   []IgnoredMetadata{{ObjectName: &objectName, ValueRegex: regexp.MustCompile(`^buzz$`)}},
-			metadataIsIgnored: false,
-		},
-		{
 			ignoredMetadata:   []IgnoredMetadata{{ObjectType: &objectType, ObjectName: &objectName, KeyRegex: regexp.MustCompile(`foo`), ValueRegex: regexp.MustCompile(`bar`)}},
 			metadataIsIgnored: true,
 		},
 	}
 
+	// Tests that the ignored metadata setter works as expected
+	vcd.client.Client.IgnoredMetadata = []IgnoredMetadata{{ObjectType: &objectType, ValueRegex: regexp.MustCompile(`dummy`)}}
+	previousIgnoredMetadata := vcd.client.SetMetadataToIgnore(nil)
+	check.Assert(vcd.client.Client.IgnoredMetadata, IsNil)
+	check.Assert(len(previousIgnoredMetadata) > 0, Equals, true)
+	previousIgnoredMetadata = vcd.client.SetMetadataToIgnore(previousIgnoredMetadata)
+	check.Assert(previousIgnoredMetadata, IsNil)
+	check.Assert(len(vcd.client.Client.IgnoredMetadata) > 0, Equals, true)
+
 	for _, tt := range tests {
 		vcd.client.Client.IgnoredMetadata = tt.ignoredMetadata
+
+		// Tests getting a simple metadata entry by its key
 		singleMetadata, err := resource.GetMetadataByKey("foo", false)
 		if tt.metadataIsIgnored {
 			check.Assert(err, NotNil)
@@ -364,29 +371,29 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 			check.Assert(singleMetadata, NotNil)
 			check.Assert(singleMetadata.TypedValue.Value, Equals, "bar")
 		}
+
+		// We add a new entry that won't be filtered out
+		err = resource.AddMetadataEntryWithVisibility("test", "bar2", types.MetadataStringValue, types.MetadataReadWriteVisibility, false)
+		check.Assert(err, IsNil)
+
+		// We retrieve all metadata
+		allMetadata, err := resource.GetMetadata()
+		check.Assert(err, IsNil)
+		check.Assert(allMetadata, NotNil)
+		if tt.metadataIsIgnored {
+			// If metadata is ignored, there should be an offset of 1 entry (with key "test")
+			check.Assert(len(allMetadata.MetadataEntry), Equals, len(existingMetadata.MetadataEntry)+1)
+			for _, entry := range allMetadata.MetadataEntry {
+				if tt.metadataIsIgnored {
+					check.Assert(entry.Key, Not(Equals), "foo")
+					check.Assert(entry.TypedValue.Value, Not(Equals), "bar")
+				}
+			}
+		} else {
+			// If metadata is NOT ignored, there should be an offset of 2 entry (with key "foo" and "test")
+			check.Assert(len(allMetadata.MetadataEntry), Equals, len(existingMetadata.MetadataEntry)+2)
+		}
 	}
-
-	// Test setter
-	previousIgnoredMetadata := vcd.client.SetMetadataToIgnore(nil)
-	check.Assert(vcd.client.Client.IgnoredMetadata, IsNil)
-	check.Assert(len(previousIgnoredMetadata) > 0, Equals, true)
-	allMetadataWithoutFiltering, err := resource.GetMetadata()
-	check.Assert(err, IsNil)
-	previousIgnoredMetadata = vcd.client.SetMetadataToIgnore(previousIgnoredMetadata)
-	check.Assert(previousIgnoredMetadata, IsNil)
-	check.Assert(len(vcd.client.Client.IgnoredMetadata) > 0, Equals, true)
-
-	// We add another entry and retrieve all metadata, then it should return the one that is not filtered out
-	err = resource.AddMetadataEntryWithVisibility("test", "bar2", types.MetadataStringValue, types.MetadataReadWriteVisibility, false)
-	check.Assert(err, IsNil)
-
-	vcd.client.Client.IgnoredMetadata = []IgnoredMetadata{{KeyRegex: regexp.MustCompile(`^fo[a-z]$`)}}
-	allMetadata, err := resource.GetMetadata()
-	check.Assert(err, IsNil)
-	check.Assert(allMetadata, NotNil)
-	check.Assert(len(allMetadata.MetadataEntry), Equals, len(allMetadataWithoutFiltering.MetadataEntry)-1) // There are N entries, but one should be filtered out
-	check.Assert(allMetadata.MetadataEntry[0], NotNil)
-	check.Assert(allMetadata.MetadataEntry[0].Key, Equals, "test")
 
 	// Tries to delete a metadata entry that is ignored, it should hence fail
 	err = resource.DeleteMetadataEntryWithDomain("foo", false)

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -411,7 +411,7 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 				}
 			}
 		} else {
-			// If metadata is NOT ignored, there should be an offset of 2 entry (with key "foo" and "test")
+			// If metadata is NOT ignored, there should be an offset of 2 entries (with key "foo" and "test")
 			check.Assert(len(allMetadata.MetadataEntry), Equals, len(existingMetadata.MetadataEntry)+2)
 		}
 	}

--- a/govcd/metadata_v2_test.go
+++ b/govcd/metadata_v2_test.go
@@ -370,6 +370,8 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 	previousIgnoredMetadata := vcd.client.SetMetadataToIgnore(nil)
 	check.Assert(vcd.client.Client.IgnoredMetadata, IsNil)
 	check.Assert(len(previousIgnoredMetadata) > 0, Equals, true)
+	allMetadataWithoutFiltering, err := resource.GetMetadata()
+	check.Assert(err, IsNil)
 	previousIgnoredMetadata = vcd.client.SetMetadataToIgnore(previousIgnoredMetadata)
 	check.Assert(previousIgnoredMetadata, IsNil)
 	check.Assert(len(vcd.client.Client.IgnoredMetadata) > 0, Equals, true)
@@ -382,7 +384,7 @@ func (vcd *TestVCD) testMetadataIgnore(resource metadataCompatible, objectType, 
 	allMetadata, err := resource.GetMetadata()
 	check.Assert(err, IsNil)
 	check.Assert(allMetadata, NotNil)
-	check.Assert(len(allMetadata.MetadataEntry), Equals, 1) // There are 2 entries, but one should be filtered out
+	check.Assert(len(allMetadata.MetadataEntry), Equals, len(allMetadataWithoutFiltering.MetadataEntry)-1) // There are N entries, but one should be filtered out
 	check.Assert(allMetadata.MetadataEntry[0], NotNil)
 	check.Assert(allMetadata.MetadataEntry[0].Key, Equals, "test")
 


### PR DESCRIPTION
In the latest VCD version, certain items such as vApps and VMs that are created via a vApp Template come with autogenerated metadata that needs to be considered.

In the metadata tests, there was an assert that expected a hardcoded value of 2, but this number may vary due to the reason stated above, or due to any other feature that may come in the future. In order to make the test more robust and flexible, instead of hardcoding we use a real calculated value that varies depending on the case.

This also fixes the cleanup function, that was removing all metadata, instead of respecting the already existent metadata.

- [x] 10.5.0 `go test -tags metadata -check.vv -timeout 0`
- [x] 10.5.1 `go test -tags metadata -check.vv -timeout 0`
