### PR TITLE
Fix Org user tests

### DIFF
--- a/govcd/adminvdc.go
+++ b/govcd/adminvdc.go
@@ -173,6 +173,9 @@ func (adminOrg *AdminOrg) CreateVdc(vdcConfiguration *types.VdcConfiguration) (T
 
 	// Return the task
 	task := NewTask(adminOrg.client)
+	if adminVdc.AdminVdc.Tasks == nil || len(adminVdc.AdminVdc.Tasks.Task) == 0 {
+		return Task{}, fmt.Errorf("no task found after VDC %s creation", vdcConfiguration.Name)
+	}
 	task.Task = adminVdc.AdminVdc.Tasks.Task[0]
 	return *task, nil
 }
@@ -376,6 +379,9 @@ func createVdcAsyncV97(adminOrg *AdminOrg, vdcConfiguration *types.VdcConfigurat
 
 	// Return the task
 	task := NewTask(adminOrg.client)
+	if adminVdc.AdminVdc.Tasks == nil || len(adminVdc.AdminVdc.Tasks.Task) == 0 {
+		return Task{}, fmt.Errorf("no task found after VDC %s creation", vdcConfiguration.Name)
+	}
 	task.Task = adminVdc.AdminVdc.Tasks.Task[0]
 	return *task, nil
 }

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -94,6 +94,9 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 		return Task{}, errors.New("error cannot find disk creation task in API response")
 	}
 	task := NewTask(vdc.client)
+	if disk.Disk.Tasks == nil || len(disk.Disk.Tasks.Task) == 0 {
+		return Task{}, fmt.Errorf("no task found after disk %s creation", diskCreateParams.Disk.Name)
+	}
 	task.Task = disk.Disk.Tasks.Task[0]
 
 	util.Logger.Printf("[TRACE] AFTER CREATE DISK\n %s\n", prettyDisk(*disk.Disk))

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -456,9 +456,8 @@ func (vcd *TestVCD) Test_AdminOrgCreateCatalogWithStorageProfile(check *C) {
 	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
 	check.Assert(adminCatalog.AdminCatalog.Name, Equals, check.TestName())
 	check.Assert(adminCatalog.AdminCatalog.Description, Equals, TestCreateCatalogDesc)
-	task := NewTask(&vcd.client.Client)
-	task.Task = adminCatalog.AdminCatalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	// Accessing the task directly with `adminCatalog.AdminCatalog.Tasks.Task[0]` is not safe for Org user
+	err = adminCatalog.WaitForTasks()
 	check.Assert(err, IsNil)
 	adminOrg, err = vcd.client.GetAdminOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -536,9 +536,7 @@ func (vcd *TestVCD) Test_OrgCreateCatalogWithStorageProfile(check *C) {
 	AddToCleanupList(check.TestName(), "catalog", vcd.org.Org.Name, check.TestName())
 	check.Assert(catalog.Catalog.Name, Equals, check.TestName())
 	check.Assert(catalog.Catalog.Description, Equals, TestCreateCatalogDesc)
-	task := NewTask(&vcd.client.Client)
-	task.Task = catalog.Catalog.Tasks.Task[0]
-	err = task.WaitTaskCompletion()
+	err = catalog.WaitForTasks()
 	check.Assert(err, IsNil)
 	org, err = vcd.client.GetOrgByName(vcd.org.Org.Name)
 	check.Assert(err, IsNil)

--- a/govcd/vdc_test.go
+++ b/govcd/vdc_test.go
@@ -200,6 +200,8 @@ func (vcd *TestVCD) Test_ComposeVApp(check *C) {
 	// Compose VApp
 	task, err := vcd.vdc.ComposeVApp(networks, vapptemplate, storageprofileref, TestComposeVapp, TestComposeVappDesc, true)
 	check.Assert(err, IsNil)
+	check.Assert(task.Task.Tasks, NotNil)
+	check.Assert(len(task.Task.Tasks.Task) > 0, Equals, true)
 	check.Assert(task.Task.Tasks.Task[0].OperationName, Equals, "vdcComposeVapp")
 	// Get VApp
 	vapp, err := vcd.vdc.GetVAppByName(TestComposeVapp, true)


### PR DESCRIPTION
Replacing task internals direct access with call to AdminCatalog.WaitForTasks

