### PR TITLE
Add vGPU policy support

### DIFF
--- a/.changes/v2.22.0/633-features.md
+++ b/.changes/v2.22.0/633-features.md
@@ -1,0 +1,2 @@
+* Add type `VgpuProfile` and its methods `GetAllVgpuProfiles`, `GetVgpuProfilesByProviderVdc`, `GetVgpuProfileById`, `GetVgpuProfileByName`, `GetVgpuProfileByTenantFacingName`, `Update` and `Refresh` for managing vGPU profiles [GH-633]
+* Update `ComputePolicyV2` type with new fields for managing vGPU policies [GH-633]

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -137,6 +137,9 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointServiceAccountGrant:      "37.0", // VCD 10.4.0+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointImportableTransportZones: "33.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVCenterDistributedSwitch: "33.0",
+
+	// Endpoint for managing vGPU profiles
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVgpuProfile: "36.2",
 }
 
 // endpointElevatedApiVersions endpoint elevated API versions

--- a/govcd/vgpu_profile.go
+++ b/govcd/vgpu_profile.go
@@ -11,34 +11,40 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
-// VdcComputePolicyV2 defines a VDC Compute Policy, which can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy.
+// VgpuProfile defines a vGPU profile which is fetched from vCenter
 type VgpuProfile struct {
 	VgpuProfile *types.VgpuProfile
 	client      *Client
 }
 
+// GetAllVgpuProfiles gets all vGPU profiles that are available to VCD
 func (client *VCDClient) GetAllVgpuProfiles(queryParameters url.Values) ([]*VgpuProfile, error) {
 	return getAllVgpuProfiles(queryParameters, &client.Client)
 }
 
+// GetVgpuProfilesByProviderVdc gets all vGPU profiles that are available to a specific provider VDC
 func (client *VCDClient) GetVgpuProfilesByProviderVdc(providerVdcUrn string) ([]*VgpuProfile, error) {
 	queryParameters := url.Values{}
 	queryParameters = queryParameterFilterAnd(fmt.Sprintf("pvdcId==%s", providerVdcUrn), queryParameters)
 	return client.GetAllVgpuProfiles(queryParameters)
 }
 
+// GetVgpuProfileById gets a vGPU profile by ID
 func (client *VCDClient) GetVgpuProfileById(vgpuProfileId string) (*VgpuProfile, error) {
 	return getVgpuProfileById(vgpuProfileId, &client.Client)
 }
 
+// GetVgpuProfileByName gets a vGPU profile by name
 func (client *VCDClient) GetVgpuProfileByName(vgpuProfileName string) (*VgpuProfile, error) {
 	return getVgpuProfileByFilter("name", vgpuProfileName, &client.Client)
 }
 
+// GetVgpuProfileByTenantFacingName gets a vGPU profile by its tenant facing name
 func (client *VCDClient) GetVgpuProfileByTenantFacingName(tenantFacingName string) (*VgpuProfile, error) {
 	return getVgpuProfileByFilter("tenantFacingName", tenantFacingName, &client.Client)
 }
 
+// Update updates a vGPU profile with new parameters
 func (profile *VgpuProfile) Update(newProfile *types.VgpuProfile) error {
 	client := profile.client
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVgpuProfile
@@ -66,6 +72,7 @@ func (profile *VgpuProfile) Update(newProfile *types.VgpuProfile) error {
 	return nil
 }
 
+// Refresh updates the current state of the vGPU profile
 func (profile *VgpuProfile) Refresh() error {
 	var err error
 	newProfile, err := getVgpuProfileById(profile.VgpuProfile.Id, profile.client)

--- a/govcd/vgpu_profile.go
+++ b/govcd/vgpu_profile.go
@@ -1,0 +1,144 @@
+package govcd
+
+/*
+ * Copyright 2023 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// VdcComputePolicyV2 defines a VDC Compute Policy, which can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy.
+type VgpuProfile struct {
+	VgpuProfile *types.VgpuProfile
+	client      *Client
+}
+
+func (client *VCDClient) GetAllVgpuProfiles(queryParameters url.Values) ([]*VgpuProfile, error) {
+	return getAllVgpuProfiles(queryParameters, &client.Client)
+}
+
+func (client *VCDClient) GetVgpuProfilesByProviderVdc(providerVdcUrn string) ([]*VgpuProfile, error) {
+	queryParameters := url.Values{}
+	queryParameters = queryParameterFilterAnd(fmt.Sprintf("pvdcId==%s", providerVdcUrn), queryParameters)
+	return client.GetAllVgpuProfiles(queryParameters)
+}
+
+func (client *VCDClient) GetVgpuProfileById(vgpuProfileId string) (*VgpuProfile, error) {
+	return getVgpuProfileById(vgpuProfileId, &client.Client)
+}
+
+func (client *VCDClient) GetVgpuProfileByName(vgpuProfileName string) (*VgpuProfile, error) {
+	return getVgpuProfileByFilter("name", vgpuProfileName, &client.Client)
+}
+
+func (client *VCDClient) GetVgpuProfileByTenantFacingName(tenantFacingName string) (*VgpuProfile, error) {
+	return getVgpuProfileByFilter("tenantFacingName", tenantFacingName, &client.Client)
+}
+
+func (profile *VgpuProfile) Update(newTenantFacingName string, newInstructions string) (*VgpuProfile, error) {
+	client := profile.client
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVgpuProfile
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint, "/", profile.VgpuProfile.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	profile.VgpuProfile.TenantFacingName = newTenantFacingName
+	profile.VgpuProfile.Instructions = newInstructions
+	err = client.OpenApiPutItem(minimumApiVersion, urlRef, nil, profile.VgpuProfile, &profile.VgpuProfile, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
+}
+
+func (profile *VgpuProfile) Refresh() error {
+	var err error
+	newProfile, err := getVgpuProfileById(profile.VgpuProfile.Id, profile.client)
+	if err != nil {
+		return err
+	}
+	profile.VgpuProfile = newProfile.VgpuProfile
+
+	return nil
+}
+
+func getVgpuProfileByFilter(filter, filterValue string, client *Client) (*VgpuProfile, error) {
+	queryParameters := url.Values{}
+	queryParameters = queryParameterFilterAnd(fmt.Sprintf("%s==%s", filter, filterValue), queryParameters)
+	vgpuProfiles, err := getAllVgpuProfiles(queryParameters, client)
+	if err != nil {
+		return nil, err
+	}
+
+	vgpuProfile, err := oneOrError(filter, filterValue, vgpuProfiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return vgpuProfile, nil
+}
+
+func getVgpuProfileById(vgpuProfileId string, client *Client) (*VgpuProfile, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVgpuProfile
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint, "/", vgpuProfileId)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := &VgpuProfile{
+		client: client,
+	}
+	err = client.OpenApiGetItem(minimumApiVersion, urlRef, nil, &profile.VgpuProfile, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
+}
+
+func getAllVgpuProfiles(queryParameters url.Values, client *Client) ([]*VgpuProfile, error) {
+	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVgpuProfile
+	minimumApiVersion, err := client.checkOpenApiEndpointCompatibility(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := []*types.VgpuProfile{{}}
+
+	err = client.OpenApiGetAllItems(minimumApiVersion, urlRef, queryParameters, &responses, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedVgpuProfiles := make([]*VgpuProfile, len(responses))
+	for index, response := range responses {
+		wrappedVgpuProfile := &VgpuProfile{
+			client:      client,
+			VgpuProfile: response,
+		}
+		wrappedVgpuProfiles[index] = wrappedVgpuProfile
+	}
+
+	return wrappedVgpuProfiles, nil
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -481,6 +481,9 @@ const (
 	OpenApiEndpointServiceAccountGrant = "deviceLookup/grant"
 	OpenApiEndpointTokens              = "tokens/"
 	OpenApiEndpointServiceAccounts     = "serviceAccounts/"
+
+	// OpenApiEndpointVgpuProfile is used to query vGPU profiles
+	OpenApiEndpointVgpuProfile = "vgpuProfiles"
 )
 
 // Header keys to run operations in tenant context

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -650,3 +650,13 @@ type VcenterDistributedSwitch struct {
 	BackingRef    OpenApiReference `json:"backingRef"`
 	VirtualCenter OpenApiReference `json:"virtualCenter"`
 }
+
+// VgpuProfile uniquely represents a type of vGPU
+// vGPU Profiles are fetched from your NVIDIA GRID GPU enabled Clusters in vCenter.
+type VgpuProfile struct {
+	Id                 string `json:"id"`
+	Name               string `json:"name"`
+	TenantFacingName   string `json:"tenantFacingName"`
+	Instructions       string `json:"instructions"`
+	AllowMultiplePerVm bool   `json:"allowMultiplePerVm"`
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -221,6 +221,8 @@ type VdcComputePolicyV2 struct {
 	IsVgpuPolicy           bool                     `json:"isVgpuPolicy,omitempty"`
 	PvdcNamedVmGroupsMap   []PvdcNamedVmGroupsMap   `json:"pvdcNamedVmGroupsMap,omitempty"`
 	PvdcLogicalVmGroupsMap []PvdcLogicalVmGroupsMap `json:"pvdcLogicalVmGroupsMap,omitempty"`
+	PvdcVgpuClustersMap    []PvdcVgpuClustersMap    `json:"pvdcVgpuClustersMap,omitempty"`
+	VgpuProfiles           []VgpuProfile            `json:"vgpuProfiles,omitempty"`
 }
 
 // PvdcNamedVmGroupsMap is a combination of a reference to a Provider VDC and a list of references to Named VM Groups.
@@ -235,6 +237,11 @@ type PvdcNamedVmGroupsMap struct {
 type PvdcLogicalVmGroupsMap struct {
 	LogicalVmGroups OpenApiReferences `json:"logicalVmGroups,omitempty"`
 	Pvdc            OpenApiReference  `json:"pvdc,omitempty"`
+}
+
+type PvdcVgpuClustersMap struct {
+	Clusters []string         `json:"clusters,omitempty"`
+	Pvdc     OpenApiReference `json:"pvdc,omitempty"`
 }
 
 // OpenApiReference is a generic reference type commonly used throughout OpenAPI endpoints
@@ -657,6 +664,7 @@ type VgpuProfile struct {
 	Id                 string `json:"id"`
 	Name               string `json:"name"`
 	TenantFacingName   string `json:"tenantFacingName"`
-	Instructions       string `json:"instructions"`
+	Instructions       string `json:"instructions,omitempty"`
 	AllowMultiplePerVm bool   `json:"allowMultiplePerVm"`
+	Count              int    `json:"count,omitempty"`
 }


### PR DESCRIPTION
This is a simple PR that adds methods and types to read and manage vGPU profiles.

Also updates the `VdcComputePolicyV2` to support creation and management of vGPU policies.