### PR TITLE
Add support for parsing vmNameInVc xml attribute on QueryResultVMRecordType struct

### DIFF
--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2597,7 +2597,7 @@ type QueryResultVMRecordType struct {
 	HostName                 string    `xml:"hostName,attr,omitempty"` // HostName=Hypervisor of virtual machine
 	Link                     []*Link   `xml:"Link,omitempty"`
 	MetaData                 *Metadata `xml:"Metadata,omitempty"`
-	VmNameInVc               string    `xml:"vmNameInVc,omitempty"`
+	VmNameInVc               string    `xml:"vmNameInVc,attr,omitempty"`
 }
 
 // QueryResultVAppRecordType represents a VM record as query result.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2597,6 +2597,7 @@ type QueryResultVMRecordType struct {
 	HostName                 string    `xml:"hostName,attr,omitempty"` // HostName=Hypervisor of virtual machine
 	Link                     []*Link   `xml:"Link,omitempty"`
 	MetaData                 *Metadata `xml:"Metadata,omitempty"`
+	VmNameInVc               string    `xml:"vmNameInVc,omitempty"`
 }
 
 // QueryResultVAppRecordType represents a VM record as query result.


### PR DESCRIPTION
## Description

Related issue:  #634

- Added support for parsing vmNameInVc attribute


Edited: closes #634 
