### PR TITLE
Remove conditional API calls with outdated API version

### DIFF
--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -85,7 +85,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 
 	_, err = vdc.client.ExecuteRequestWithApiVersion(createDiskLink.HREF, http.MethodPost,
 		createDiskLink.Type, "error create disk: %s", diskCreateParams, disk.Disk,
-		vdc.client.APIVersion)
+		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 	if err != nil {
 		return Task{}, err
 	}
@@ -167,7 +167,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	// Return the task
 	return disk.client.ExecuteTaskRequestWithApiVersion(updateDiskLink.HREF, http.MethodPut,
 		updateDiskLink.Type, "error updating disk: %s", xmlPayload,
-		disk.client.APIVersion)
+		disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 }
 
 // Remove an independent disk
@@ -228,7 +228,7 @@ func (disk *Disk) Refresh() error {
 
 	_, err := disk.client.ExecuteRequestWithApiVersion(disk.Disk.HREF, http.MethodGet,
 		"", "error refreshing independent disk: %s", nil, unmarshalledDisk,
-		disk.client.APIVersion)
+		disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
 
 	results, err := vdc.QueryWithNotEncodedParamsWithApiVersion(nil, map[string]string{"type": typeMedia,
 		"filter": "name==" + url.QueryEscape(diskName) + ";vdc==" + vdc.vdcId(), "filterEncoded": "true"},
-		vdc.client.APIVersion)
+		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 	if err != nil {
 		return DiskRecord{}, fmt.Errorf("error querying disk %s", err)
 	}
@@ -359,7 +359,7 @@ func (vdc *Vdc) QueryDisks(diskName string) (*[]*types.DiskRecordType, error) {
 
 	results, err := vdc.QueryWithNotEncodedParamsWithApiVersion(nil, map[string]string{"type": typeMedia,
 		"filter": "name==" + url.QueryEscape(diskName) + ";vdc==" + vdc.vdcId(), "filterEncoded": "true"},
-		vdc.client.APIVersion)
+		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 	if err != nil {
 		return nil, fmt.Errorf("error querying disks %s", err)
 	}
@@ -381,7 +381,7 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 
 	_, err := vdc.client.ExecuteRequestWithApiVersion(diskHref, http.MethodGet,
 		"", "error retrieving Disk: %s", nil, Disk.Disk,
-		vdc.client.APIVersion)
+		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
 	if err != nil && (strings.Contains(err.Error(), "MajorErrorCode:403") || strings.Contains(err.Error(), "does not exist")) {
 		return nil, ErrorEntityNotFound
 	}

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -85,7 +85,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 
 	_, err = vdc.client.ExecuteRequestWithApiVersion(createDiskLink.HREF, http.MethodPost,
 		createDiskLink.Type, "error create disk: %s", diskCreateParams, disk.Disk,
-		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		vdc.client.APIVersion)
 	if err != nil {
 		return Task{}, err
 	}
@@ -167,7 +167,7 @@ func (disk *Disk) Update(newDiskInfo *types.Disk) (Task, error) {
 	// Return the task
 	return disk.client.ExecuteTaskRequestWithApiVersion(updateDiskLink.HREF, http.MethodPut,
 		updateDiskLink.Type, "error updating disk: %s", xmlPayload,
-		disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		disk.client.APIVersion)
 }
 
 // Remove an independent disk
@@ -228,7 +228,7 @@ func (disk *Disk) Refresh() error {
 
 	_, err := disk.client.ExecuteRequestWithApiVersion(disk.Disk.HREF, http.MethodGet,
 		"", "error refreshing independent disk: %s", nil, unmarshalledDisk,
-		disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		disk.client.APIVersion)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (vdc *Vdc) QueryDisk(diskName string) (DiskRecord, error) {
 
 	results, err := vdc.QueryWithNotEncodedParamsWithApiVersion(nil, map[string]string{"type": typeMedia,
 		"filter": "name==" + url.QueryEscape(diskName) + ";vdc==" + vdc.vdcId(), "filterEncoded": "true"},
-		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		vdc.client.APIVersion)
 	if err != nil {
 		return DiskRecord{}, fmt.Errorf("error querying disk %s", err)
 	}
@@ -359,7 +359,7 @@ func (vdc *Vdc) QueryDisks(diskName string) (*[]*types.DiskRecordType, error) {
 
 	results, err := vdc.QueryWithNotEncodedParamsWithApiVersion(nil, map[string]string{"type": typeMedia,
 		"filter": "name==" + url.QueryEscape(diskName) + ";vdc==" + vdc.vdcId(), "filterEncoded": "true"},
-		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		vdc.client.APIVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error querying disks %s", err)
 	}
@@ -381,7 +381,7 @@ func (vdc *Vdc) GetDiskByHref(diskHref string) (*Disk, error) {
 
 	_, err := vdc.client.ExecuteRequestWithApiVersion(diskHref, http.MethodGet,
 		"", "error retrieving Disk: %s", nil, Disk.Disk,
-		vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
+		vdc.client.APIVersion)
 	if err != nil && (strings.Contains(err.Error(), "MajorErrorCode:403") || strings.Contains(err.Error(), "does not exist")) {
 		return nil, ErrorEntityNotFound
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -737,9 +737,8 @@ func (client *Client) GetStorageProfileByHref(url string) (*types.VdcStorageProf
 
 	vdcStorageProfile := &types.VdcStorageProfile{}
 
-	// only from 35.0 API version IOPS settings are added to response
 	_, err := client.ExecuteRequestWithApiVersion(url, http.MethodGet,
-		"", "error retrieving storage profile: %s", nil, vdcStorageProfile, client.GetSpecificApiVersionOnCondition(">= 35.0", "35.0"))
+		"", "error retrieving storage profile: %s", nil, vdcStorageProfile, client.APIVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -737,8 +737,8 @@ func (client *Client) GetStorageProfileByHref(url string) (*types.VdcStorageProf
 
 	vdcStorageProfile := &types.VdcStorageProfile{}
 
-	_, err := client.ExecuteRequestWithApiVersion(url, http.MethodGet,
-		"", "error retrieving storage profile: %s", nil, vdcStorageProfile, client.APIVersion)
+	_, err := client.ExecuteRequest(url, http.MethodGet,
+		"", "error retrieving storage profile: %s", nil, vdcStorageProfile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR removes conditional API version elevation for unsupported API versions (`< 37.0`). This SDK support only `37.0` going forward.


Old API calls were identified using `grep -Rin "GetSpecificApiVersionOnCondition(" *`. Only the ones that have versions `< 37.0` are patched to simply use default API versions `client.APIVersion` which is `37.0` now.

```
# grep -Rin "GetSpecificApiVersionOnCondition(" *                               
api_vcd_versions.go:237:func (client *Client) GetSpecificApiVersionOnCondition(vcdApiVersionCondition, wantedApiVersion string) string {
disk.go:88:             vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
disk.go:170:            disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
disk.go:231:            disk.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
disk.go:327:            vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
disk.go:362:            vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
disk.go:384:            vdc.client.GetSpecificApiVersionOnCondition(">= 36.0", "36.0"))
system.go:742:          "", "error retrieving storage profile: %s", nil, vdcStorageProfile, client.GetSpecificApiVersionOnCondition(">= 35.0", "35.0"))
vapp.go:164:            vAppComposition, vapp.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vdc.go:1044:            vdc.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vm.go:74:       _, err := vm.client.ExecuteRequestWithApiVersion(refreshUrl, http.MethodGet, "", "error refreshing VM: %s", nil, vm.VM, vm.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vm.go:1507:             vm.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vm.go:1794:             vapp.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vm.go:1842:             "", "error retrieving vm: %s", nil, newVm.VM, client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
vm.go:1966:             }, vm.client.GetSpecificApiVersionOnCondition(">=37.1", "37.1"))
```