### PR TITLE
Added necessary cookies to get valid ADFS endpoint for organization.

### DIFF
--- a/govcd/saml_auth.go
+++ b/govcd/saml_auth.go
@@ -153,6 +153,7 @@ func getSamlAdfsServer(vcdCli *VCDClient, org string) (string, error) {
 	// "?service=tenant:my-org"
 	req := vcdCli.Client.NewRequestWitNotEncodedParams(
 		nil, map[string]string{"service": "tenant:" + org}, http.MethodGet, *loginURL, nil)
+	req.Header.Add("Cookie", "sso-preferred=yes; sso_redirect_org=" + org)
 	httpResponse, err := checkResp(vcdCli.Client.Http.Do(req))
 	if err != nil {
 		return "", fmt.Errorf("SAML - ADFS server query failed: %s", err)


### PR DESCRIPTION
Closes #556.

- Added necessary cookies to get valid ADFS endpoint for organization.
- Tested with saml_auth_adfs and works fine
- Also tested with terraform-provider-vcd 3.10 and works fine

@dataclouder @Didainius 