### PR TITLE
Remove conditional API calls with outdated API version

### DIFF
--- a/.changes/v2.23.0/639-notes.md
+++ b/.changes/v2.23.0/639-notes.md
@@ -1,0 +1,2 @@
+* Remove the conditional API call with outdated API version from `Client.GetStorageProfileByHref` so it works
+  with the newest VCD versions [GH-639]

--- a/.changes/v2.23.0/639-notes.md
+++ b/.changes/v2.23.0/639-notes.md
@@ -1,2 +1,2 @@
-* Remove the conditional API call with outdated API version from `Client.GetStorageProfileByHref` so it works
+* Removed the conditional API call with outdated API version from `Client.GetStorageProfileByHref` so it works
   with the newest VCD versions [GH-639]

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -737,9 +737,7 @@ func (client *Client) GetStorageProfileByHref(url string) (*types.VdcStorageProf
 
 	vdcStorageProfile := &types.VdcStorageProfile{}
 
-	// only from 35.0 API version IOPS settings are added to response
-	_, err := client.ExecuteRequestWithApiVersion(url, http.MethodGet,
-		"", "error retrieving storage profile: %s", nil, vdcStorageProfile, client.GetSpecificApiVersionOnCondition(">= 35.0", "35.0"))
+	_, err := client.ExecuteRequest(url, http.MethodGet, "", "error retrieving storage profile: %s", nil, vdcStorageProfile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is the same as #636. This bump is needed to avoid failures in the near future versions of VCD, as 35.0 is fairly outdated.