### PR TITLE
Update staticcheck version

### DIFF
--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,3 +1,3 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=2023.1
+export STATICCHECK_VERSION=2023.1.6
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz


### PR DESCRIPTION
Fixes a failed check that happens with an old `staticcheck` and a recent version of `go` (see https://github.com/vmware/go-vcloud-director/actions/runs/7262579579/job/19786016825)