### PR TITLE
Flaky test - Test_LDAP - sleep to wait for LDAP initialization

### DIFF
--- a/.changes/v2.23.0/643-notes.md
+++ b/.changes/v2.23.0/643-notes.md
@@ -1,0 +1,3 @@
+* Add a delay for all LDAP tests `Test_LDAP` after LDAP configuration, but before using them
+  [GH-643]
+ 

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -8,6 +8,7 @@ package govcd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
@@ -60,6 +61,10 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 		err = task.WaitTaskCompletion()
 		check.Assert(err, IsNil)
 	}()
+
+	sleepTime := 7 * time.Second
+	fmt.Printf("Sleeping %s to prevent 'LDAP context not initialized' errors\n", sleepTime.String())
+	time.Sleep(sleepTime)
 
 	// Run tests requiring LDAP from here.
 	vcd.test_GroupCRUD(check)

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -62,7 +62,7 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 		check.Assert(err, IsNil)
 	}()
 
-	sleepTime := 7 * time.Second
+	sleepTime := 10 * time.Second
 	fmt.Printf("# Sleeping %s to prevent 'LDAP context not initialized' errors\n", sleepTime.String())
 	time.Sleep(sleepTime)
 

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -63,7 +63,7 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 	}()
 
 	sleepTime := 7 * time.Second
-	fmt.Printf("Sleeping %s to prevent 'LDAP context not initialized' errors\n", sleepTime.String())
+	fmt.Printf("# Sleeping %s to prevent 'LDAP context not initialized' errors\n", sleepTime.String())
 	time.Sleep(sleepTime)
 
 	// Run tests requiring LDAP from here.


### PR DESCRIPTION
Running LDAP tests sometimes causes `LDAP context not initialized` which most probably occur due to LDAP is being used immediately after configuration. This PR adds a dumb sleep to see if this can iron out this problem.


```
START: adminorg_ldap_test.go:22: TestVCD.Test_LDAP
Setting up LDAP (IP: 10.196.34.229)
# Configuring LDAP settings for Org 'nightly_gosdk' Done
Running: test_GroupCRUD
Running: test_GroupFinderGetGenericEntity
adminorg_ldap_test.go:66:
vcd.test_GroupFinderGetGenericEntity(check)
group_test.go:147:
check.Assert(err, IsNil)
... value *errors.errorString = &errors.errorString{s:"error creating group: API Error: 500: [ 46c7f18e-f4da-408e-a597-08ef2f79eb6e ] LDAP context not initialized. Error connecting to LDAP."} ("error creating group: API Error: 500: [ 46c7f18e-f4da-408e-a597-08ef2f79eb6e ] LDAP context not initialized. Error connecting to LDAP.")

Unconfiguring LDAP
FAIL: adminorg_ldap_test.go:22: TestVCD.Test_LDAP
```