### PR TITLE
Add functions for generic OpenAPI CRUD handling

### DIFF
--- a/.changes/v2.23.0/644-notes.md
+++ b/.changes/v2.23.0/644-notes.md
@@ -1,1 +1,7 @@
 * Add internal generic functions to handle CRUD operations for inner and outer entities [GH-644]
+* Add section about CRUD functions to `CODING_GUIDELINES.md` [GH-644]
+* Convert `DefinedEntityType`, `DefinedEntity`, `DefinedInterface`, `IpSpace`, `IpSpaceUplink`,
+  `DistributedFirewall`, `DistributedFirewallRule`, `NsxtSegmentProfileTemplate`,
+  `GetAllIpDiscoveryProfiles`, `GetAllMacDiscoveryProfiles`, `GetAllSpoofGuardProfiles`,
+  `GetAllQoSProfiles`, `GetAllSegmentSecurityProfiles` to use newly introduced generic CRUD
+  functions [GH-644]

--- a/.changes/v2.23.0/644-notes.md
+++ b/.changes/v2.23.0/644-notes.md
@@ -1,0 +1,1 @@
+* Add internal generic functions to handle CRUD operations for inner and outer entities [GH-644]

--- a/.changes/v2.23.0/644-notes.md
+++ b/.changes/v2.23.0/644-notes.md
@@ -1,5 +1,5 @@
 * Add internal generic functions to handle CRUD operations for inner and outer entities [GH-644]
-* Add section about CRUD functions to `CODING_GUIDELINES.md` [GH-644]
+* Add section about OpenAPI CRUD functions to `CODING_GUIDELINES.md` [GH-644] 
 * Convert `DefinedEntityType`, `DefinedEntity`, `DefinedInterface`, `IpSpace`, `IpSpaceUplink`,
   `DistributedFirewall`, `DistributedFirewallRule`, `NsxtSegmentProfileTemplate`,
   `GetAllIpDiscoveryProfiles`, `GetAllMacDiscoveryProfiles`, `GetAllSpoofGuardProfiles`,

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -477,7 +477,10 @@ When the tenant context is not needed (system administration calls), we just pas
 
 ## Generic CRUD functions for OpenAPI entity implementation
 
-Generic CRUD functions are used to minimize boilerplate for entity implementation in the SDK.
+Generic CRUD functions are used to minimize boilerplate for entity implementation in the SDK. They
+might not always be the way to go when there are very specific operation needs as it is not worth
+having a generic function for single use case. In such cases, low level API client function set,
+that is located in `openapi.go` can help to perform such operations.
 
 ### Terminology
 
@@ -551,11 +554,13 @@ The entities that match below criteria are usually going to use `inner` crud fun
 * Read only entities (e.g. NSX-T Segment Profiles `VCDClient.GetAllIpDiscoveryProfiles`)
 
 Inner types are more simple as they can be directly used without any additional overhead. There are
-5 functions that can be used:
+7 functions that can be used:
 
 * `createInnerEntity`
 * `updateInnerEntity`
+* `updateInnerEntityWithHeaders`
 * `getInnerEntity`
+* `getInnerEntityWithHeaders`
 * `deleteEntityById`
 * `getAllInnerEntities`
 
@@ -579,10 +584,11 @@ func (o OuterEntity) wrap(inner *InnerEntity) *OuterEntity {
 	return &o
 }
 ```
-There are 4 functions for handling CRU(D). 
+There are 5 functions for handling CRU(D). 
 * `createOuterEntity`
 * `updateOuterEntity`
 * `getOuterEntity`
+* `getOuterEntityWithHeaders`
 * `getAllOuterEntities`
 
 *Note*: `D` (deletion) in `CRUD` is a simple operation that does not additionally handle data and
@@ -594,6 +600,9 @@ Existing examples of the implementation are:
 * `DistributedFirewall`
 * `DistributedFirewallRule`
 * `NsxtSegmentProfileTemplate`
+* `DefinedEntityType`
+* `DefinedInterface`
+* `DefinedEntity`
 
 ## Testing
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -475,7 +475,125 @@ the request header.
 
 When the tenant context is not needed (system administration calls), we just pass `nil` as `additionalHeader`.
 
+## Generic CRUD functions for OpenAPI entity implementation
 
+Generic CRUD functions are used to minimize boilerplate for entity implementation in the SDK.
+
+### Terminology
+
+#### inner vs outer types
+
+For the context of generic CRUD function implementation (mainly in files
+`govcd/openapi_generic_outer_entities.go`, `govcd/openapi_generic_inner_entities.go`), such terms
+are commonly used:
+
+* `inner` type is the type that is responsible for marshaling/unmarshaling API
+  request payload and is usually inside `types` package. (e.g. `types.IpSpace`,
+  `types.NsxtAlbPoolMember`, etc.)
+* `outer` (type) - this is the type that wraps `inner` type and possibly any other entities that are
+  required to perform operations for a particular VCD entity. It will almost always include some
+  reference to client (`VCDClient` or `Client`), which is required to perform API operations. It may
+  contain additional fields.
+
+Here are the entities mapped in the example below: 
+
+* `DistributedFirewall` is the **`outer`** type
+* `types.DistributedFirewallRules` is the **`inner`** type (specified in
+  `DistributedFirewall.DistributedFirewallRuleContainer` field)
+* `client` field contains the client that is required for perfoming API operations
+* `VdcGroup` field contains additional data (VDC Group reference) that is required for
+implementation of this particular entity
+
+```go
+type DistributedFirewall struct {
+	DistributedFirewallRuleContainer *types.DistributedFirewallRules
+	client                           *Client
+	VdcGroup                         *VdcGroup
+}
+```
+
+#### crudConfig
+
+A special type `govcd.crudConfig` is used for passing configuration to both - `inner` and `outer`
+generic CRUD functions. It also has an internal `validate()` method, which is called upon execution
+of any `inner` and `outer` CRUD functions.
+
+See documentation of `govcd.crudConfig` for the options it provides.
+
+### Use cases
+
+The main consideration when to use which functions depends on whether one is dealing with `inner`
+types or `outer` types. Both types can be used for quicker development.
+
+Usually, `outer` type is used for a full featured entity (e.g. `IpSpace`, `NsxtEdgeGateway`), while
+`inner` suits cases where one needs to perform operations on an already existing or a read-only
+entity.
+
+**Hint:** return value of your entity method will always hint whether it is `inner` or `outer` one:
+
+`inner` type function signature example (returns `*types.VdcNetworkProfile`):
+
+```
+func (adminVdc *AdminVdc) UpdateVdcNetworkProfile(vdcNetworkProfileConfig *types.VdcNetworkProfile) (*types.VdcNetworkProfile, error) {
+```
+
+`outer` type function signature example (returns `*IpSpace`):
+
+```
+func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
+```
+
+#### inner CRUD functions
+
+The entities that match below criteria are usually going to use `inner` crud functions:
+* API property manipulation with separate API endpoints for an already existing entity (e.g. VDC
+  Network Profiles `Vdc.UpdateVdcNetworkProfile`)
+* Read only entities (e.g. NSX-T Segment Profiles `VCDClient.GetAllIpDiscoveryProfiles`)
+
+Inner types are more simple as they can be directly used without any additional overhead. There are
+5 functions that can be used:
+
+* `createInnerEntity`
+* `updateInnerEntity`
+* `getInnerEntity`
+* `deleteEntityById`
+* `getAllInnerEntities`
+
+Existing examples of the implementation are:
+
+* `Vdc.GetVdcNetworkProfile`
+* `Vdc.UpdateVdcNetworkProfile`
+* `Vdc.DeleteVdcNetworkProfile`
+* `VCDClient.GetAllIpDiscoveryProfiles`
+
+#### outer CRUD functions
+
+The entities, that implement complete management of a VCD entity will usually rely on `outer` CRUD
+functions. Any `outer` type *must* implement `wrap` method (example signature provided below). It is
+required to satisfy generic interface constraint (so that generic functions are able to wrap `inner`
+type into `outer` type)
+
+```go
+func (o OuterEntity) wrap(inner *InnerEntity) *OuterEntity {
+	o.OuterEntity = inner
+	return &o
+}
+```
+There are 4 functions for handling CRU(D). 
+* `createOuterEntity`
+* `updateOuterEntity`
+* `getOuterEntity`
+* `getAllOuterEntities`
+
+*Note*: `D` (deletion) in `CRUD` is a simple operation that does not additionally handle data and
+`deleteEntityById` is sufficient.
+
+Existing examples of the implementation are:
+* `IpSpace`
+* `IpSpaceUplink`
+* `DistributedFirewall`
+* `DistributedFirewallRule`
+* `NsxtSegmentProfileTemplate`
 
 ## Testing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/go-vcloud-director/v2
 
-go 1.19
+go 1.21
 
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195

--- a/govcd/adminorg_ldap_test.go
+++ b/govcd/adminorg_ldap_test.go
@@ -8,7 +8,6 @@ package govcd
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
@@ -61,10 +60,6 @@ func (vcd *TestVCD) Test_LDAP(check *C) {
 		err = task.WaitTaskCompletion()
 		check.Assert(err, IsNil)
 	}()
-
-	sleepTime := 10 * time.Second
-	fmt.Printf("# Sleeping %s to prevent 'LDAP context not initialized' errors\n", sleepTime.String())
-	time.Sleep(sleepTime)
 
 	// Run tests requiring LDAP from here.
 	vcd.test_GroupCRUD(check)

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -28,7 +28,7 @@ type DefinedEntityType struct {
 	client            *Client
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (d DefinedEntityType) wrap(inner *types.DefinedEntityType) *DefinedEntityType {
@@ -43,7 +43,7 @@ type DefinedEntity struct {
 	client        *Client
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (d DefinedEntity) wrap(inner *types.DefinedEntity) *DefinedEntity {

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	labelDefinedEntity             = "Defined Entity"
-	labelDefinedEntityType         = "Defined Entity Type"
-	labelRdeBehavior               = "RDE Behavior"
-	labelRdeBehaviorOverride       = "RDE Behavior Override"
-	labelRdeBehaviorAccessControls = "RDE Behavior Access Controls"
+	labelDefinedEntity            = "Defined Entity"
+	labelDefinedEntityType        = "Defined Entity Type"
+	labelRdeBehavior              = "RDE Behavior"
+	labelRdeBehaviorOverride      = "RDE Behavior Override"
+	labelRdeBehaviorAccessControl = "RDE Behavior Access Control"
 )
 
 // DefinedEntityType is a type for handling Runtime Defined Entity (RDE) Type definitions.
@@ -250,7 +250,7 @@ func (det *DefinedEntityType) SetBehaviorAccessControls(acls []*types.BehaviorAc
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviorAccessControls,
 		endpointParams: []string{det.DefinedEntityType.ID},
-		entityLabel:    labelRdeBehaviorAccessControls,
+		entityLabel:    labelRdeBehaviorAccessControl,
 	}
 	_, err = updateInnerEntity(det.client, c, &payload)
 	if err != nil {
@@ -267,7 +267,7 @@ func (det *DefinedEntityType) GetAllBehaviorsAccessControls(queryParameters url.
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviorAccessControls,
 		queryParameters: queryParameters,
 		endpointParams:  []string{det.DefinedEntityType.ID},
-		entityLabel:     labelRdeBehaviorAccessControls,
+		entityLabel:     labelRdeBehaviorAccessControl,
 	}
 	return getAllInnerEntities[types.BehaviorAccess](det.client, c)
 }

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -189,8 +189,8 @@ func (rdeType *DefinedEntityType) GetBehaviorByName(name string) (*types.Behavio
 	if err != nil {
 		return nil, fmt.Errorf("could not get the Behaviors of the Defined Entity Type with ID '%s': %s", rdeType.DefinedEntityType.ID, err)
 	}
-	infoMessage := fmt.Sprintf("Defined Entity Behavior with name '%s' in Defined Entity Type with ID '%s': %s", name, rdeType.DefinedEntityType.ID, ErrorEntityNotFound)
-	return localFilterOneOrError(behaviors, "Name", name, infoMessage)
+	label := fmt.Sprintf("Defined Entity Behavior with name '%s' in Defined Entity Type with ID '%s': %s", name, rdeType.DefinedEntityType.ID, ErrorEntityNotFound)
+	return localFilterOneOrError(label, behaviors, "Name", name)
 }
 
 // UpdateBehaviorOverride overrides an Interface Behavior. Only Behavior description and execution can be overridden.

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -13,6 +13,14 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const (
+	labelDefinedEntity             = "Defined Entity"
+	labelDefinedEntityType         = "Defined Entity Type"
+	labelRdeBehavior               = "RDE Behavior"
+	labelRdeBehaviorOverride       = "RDE Behavior Override"
+	labelRdeBehaviorAccessControls = "RDE Behavior Access Controls"
+)
+
 // DefinedEntityType is a type for handling Runtime Defined Entity (RDE) Type definitions.
 // Note. Running a few of these operations in parallel may corrupt database in VCD (at least <= 10.4.2)
 type DefinedEntityType struct {
@@ -48,7 +56,7 @@ func (d DefinedEntity) wrap(inner *types.DefinedEntity) *DefinedEntity {
 func (vcdClient *VCDClient) CreateRdeType(rde *types.DefinedEntityType) (*DefinedEntityType, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes,
-		entityLabel: "RDE Type",
+		entityLabel: labelDefinedEntityType,
 	}
 	outerType := DefinedEntityType{client: &vcdClient.Client}
 	return createOuterEntity(&vcdClient.Client, outerType, c, rde)
@@ -58,7 +66,7 @@ func (vcdClient *VCDClient) CreateRdeType(rde *types.DefinedEntityType) (*Define
 func (vcdClient *VCDClient) GetAllRdeTypes(queryParameters url.Values) ([]*DefinedEntityType, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes,
-		entityLabel:     "RDE Type",
+		entityLabel:     labelDefinedEntityType,
 		queryParameters: queryParameters,
 	}
 
@@ -89,7 +97,7 @@ func (vcdClient *VCDClient) GetRdeType(vendor, nss, version string) (*DefinedEnt
 // GetRdeTypeById gets a Runtime Defined Entity Type by its ID.
 func (vcdClient *VCDClient) GetRdeTypeById(id string) (*DefinedEntityType, error) {
 	c := crudConfig{
-		entityLabel:    "RDE Type",
+		entityLabel:    labelDefinedEntityType,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes,
 		endpointParams: []string{id},
 	}
@@ -124,7 +132,7 @@ func (rdeType *DefinedEntityType) Update(rdeTypeToUpdate types.DefinedEntityType
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes,
 		endpointParams: []string{rdeType.DefinedEntityType.ID},
-		entityLabel:    "Runtime Defined Entity Type",
+		entityLabel:    labelDefinedEntityType,
 	}
 
 	resultDefinedEntityType, err := updateInnerEntity(rdeType.client, c, &rdeTypeToUpdate)
@@ -144,7 +152,7 @@ func (rdeType *DefinedEntityType) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntityTypes,
 		endpointParams: []string{rdeType.DefinedEntityType.ID},
-		entityLabel:    "RDE Type",
+		entityLabel:    labelDefinedEntityType,
 	}
 
 	if err := deleteEntityById(rdeType.client, c); err != nil {
@@ -169,7 +177,7 @@ func (rdeType *DefinedEntityType) GetBehaviorById(id string) (*types.Behavior, e
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviors,
 		endpointParams: []string{rdeType.DefinedEntityType.ID, id},
-		entityLabel:    "RDE Behavior",
+		entityLabel:    labelRdeBehavior,
 	}
 	return getInnerEntity[types.Behavior](rdeType.client, c)
 }
@@ -198,7 +206,7 @@ func (rdeType *DefinedEntityType) UpdateBehaviorOverride(behavior types.Behavior
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviors,
 		endpointParams: []string{rdeType.DefinedEntityType.ID, behavior.ID},
-		entityLabel:    "Behavior override",
+		entityLabel:    labelRdeBehaviorOverride,
 	}
 	return updateInnerEntity(rdeType.client, c, &behavior)
 }
@@ -213,7 +221,7 @@ func (rdeType *DefinedEntityType) DeleteBehaviorOverride(behaviorId string) erro
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviors,
 		endpointParams: []string{rdeType.DefinedEntityType.ID, behaviorId},
-		entityLabel:    "Behavior override",
+		entityLabel:    labelRdeBehaviorOverride,
 	}
 	return deleteEntityById(rdeType.client, c)
 }
@@ -242,7 +250,7 @@ func (det *DefinedEntityType) SetBehaviorAccessControls(acls []*types.BehaviorAc
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviorAccessControls,
 		endpointParams: []string{det.DefinedEntityType.ID},
-		entityLabel:    "RDE Behavior Access Controls",
+		entityLabel:    labelRdeBehaviorAccessControls,
 	}
 	_, err = updateInnerEntity(det.client, c, &payload)
 	if err != nil {
@@ -259,7 +267,7 @@ func (det *DefinedEntityType) GetAllBehaviorsAccessControls(queryParameters url.
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeTypeBehaviorAccessControls,
 		queryParameters: queryParameters,
 		endpointParams:  []string{det.DefinedEntityType.ID},
-		entityLabel:     "Behavior Access Controls",
+		entityLabel:     labelRdeBehaviorAccessControls,
 	}
 	return getAllInnerEntities[types.BehaviorAccess](det.client, c)
 }
@@ -279,7 +287,7 @@ func (rdeType *DefinedEntityType) GetAllRdes(queryParameters url.Values) ([]*Def
 func getAllRdes(client *Client, vendor, nss, version string, queryParameters url.Values) ([]*DefinedEntity, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesTypes,
-		entityLabel:     "RDE",
+		entityLabel:     labelDefinedEntityType,
 		queryParameters: queryParameters,
 		endpointParams:  []string{vendor, "/", nss, "/", version},
 	}
@@ -333,7 +341,7 @@ func (vcdClient *VCDClient) GetRdeById(id string) (*DefinedEntity, error) {
 // Getting a RDE by ID populates the ETag field in the returned object.
 func getRdeById(client *Client, id string) (*DefinedEntity, error) {
 	c := crudConfig{
-		entityLabel:    "RDE",
+		entityLabel:    labelDefinedEntityType,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntities,
 		endpointParams: []string{id},
 	}
@@ -481,7 +489,7 @@ func (rde *DefinedEntity) Update(rdeToUpdate types.DefinedEntity) error {
 	}
 
 	c := crudConfig{
-		entityLabel:      "RDE",
+		entityLabel:      labelDefinedEntity,
 		endpoint:         types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntities,
 		endpointParams:   []string{rde.DefinedEntity.ID},
 		additionalHeader: map[string]string{"If-Match": rde.Etag},
@@ -504,7 +512,7 @@ func (rde *DefinedEntity) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntities,
 		endpointParams: []string{rde.DefinedEntity.ID},
-		entityLabel:    "RDE",
+		entityLabel:    labelDefinedEntity,
 	}
 
 	if err := deleteEntityById(rde.client, c); err != nil {

--- a/govcd/defined_interface.go
+++ b/govcd/defined_interface.go
@@ -12,6 +12,11 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const (
+	labelDefinedInterface         = "Defined Interface"
+	labelDefinedInterfaceBehavior = "Defined Interface Behavior"
+)
+
 // DefinedInterface is a type for handling Defined Interfaces, from the Runtime Defined Entities framework, in VCD.
 // This is often referred as Runtime Defined Entity Interface or RDE Interface in documentation.
 type DefinedInterface struct {
@@ -32,7 +37,7 @@ func (d DefinedInterface) wrap(inner *types.DefinedInterface) *DefinedInterface 
 func (vcdClient *VCDClient) CreateDefinedInterface(definedInterface *types.DefinedInterface) (*DefinedInterface, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
-		entityLabel: "Defined Interface",
+		entityLabel: labelDefinedInterface,
 	}
 	outerType := DefinedInterface{client: &vcdClient.Client}
 	return createOuterEntity(&vcdClient.Client, outerType, c, definedInterface)
@@ -42,7 +47,7 @@ func (vcdClient *VCDClient) CreateDefinedInterface(definedInterface *types.Defin
 func (vcdClient *VCDClient) GetAllDefinedInterfaces(queryParameters url.Values) ([]*DefinedInterface, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
-		entityLabel:     "Defined Interface",
+		entityLabel:     labelDefinedInterface,
 		queryParameters: queryParameters,
 	}
 
@@ -73,7 +78,7 @@ func (vcdClient *VCDClient) GetDefinedInterface(vendor, nss, version string) (*D
 // GetDefinedInterfaceById gets a Defined Interface identified by its unique URN.
 func (vcdClient *VCDClient) GetDefinedInterfaceById(id string) (*DefinedInterface, error) {
 	c := crudConfig{
-		entityLabel:    "Define Interface",
+		entityLabel:    labelDefinedInterface,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
 		endpointParams: []string{id},
 	}
@@ -101,7 +106,7 @@ func (di *DefinedInterface) Update(definedInterface types.DefinedInterface) erro
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
 		endpointParams: []string{di.DefinedInterface.ID},
-		entityLabel:    "Defined Interface",
+		entityLabel:    labelDefinedInterface,
 	}
 	resultDefinedInterface, err := updateInnerEntity(di.client, c, &definedInterface)
 	if err != nil {
@@ -123,7 +128,7 @@ func (di *DefinedInterface) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
 		endpointParams: []string{di.DefinedInterface.ID},
-		entityLabel:    "Defined Interface",
+		entityLabel:    labelDefinedInterface,
 	}
 
 	err := deleteEntityById(di.client, c)
@@ -145,7 +150,7 @@ func (di *DefinedInterface) AddBehavior(behavior types.Behavior) (*types.Behavio
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
 		endpointParams: []string{di.DefinedInterface.ID},
-		entityLabel:    "Defined Interface Behavior",
+		entityLabel:    labelDefinedInterfaceBehavior,
 	}
 	return createInnerEntity(di.client, c, &behavior)
 }
@@ -162,7 +167,7 @@ func (di *DefinedInterface) GetAllBehaviors(queryParameters url.Values) ([]*type
 func getAllBehaviors(client *Client, objectId, openApiEndpoint string, queryParameters url.Values) ([]*types.Behavior, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + openApiEndpoint,
-		entityLabel:     "Defined Entity Behavior",
+		entityLabel:     labelDefinedInterfaceBehavior,
 		endpointParams:  []string{objectId},
 		queryParameters: queryParameters,
 	}
@@ -175,7 +180,7 @@ func (di *DefinedInterface) GetBehaviorById(id string) (*types.Behavior, error) 
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
 		endpointParams: []string{di.DefinedInterface.ID, id},
-		entityLabel:    "Defined Interface Behavior",
+		entityLabel:    labelDefinedInterfaceBehavior,
 	}
 	return getInnerEntity[types.Behavior](di.client, c)
 }
@@ -203,7 +208,7 @@ func (di *DefinedInterface) UpdateBehavior(behavior types.Behavior) (*types.Beha
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
 		endpointParams: []string{di.DefinedInterface.ID, behavior.ID},
-		entityLabel:    "Defined Interface Behavior",
+		entityLabel:    labelDefinedInterfaceBehavior,
 	}
 	return updateInnerEntity(di.client, c, &behavior)
 }
@@ -217,7 +222,7 @@ func (di *DefinedInterface) DeleteBehavior(behaviorId string) error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
 		endpointParams: []string{di.DefinedInterface.ID, behaviorId},
-		entityLabel:    "Defined Interface Behavior",
+		entityLabel:    labelDefinedInterfaceBehavior,
 	}
 	return deleteEntityById(di.client, c)
 }

--- a/govcd/defined_interface.go
+++ b/govcd/defined_interface.go
@@ -6,9 +6,10 @@ package govcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"net/url"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // DefinedInterface is a type for handling Defined Interfaces, from the Runtime Defined Entities framework, in VCD.
@@ -18,64 +19,35 @@ type DefinedInterface struct {
 	client           *Client
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (d DefinedInterface) wrap(inner *types.DefinedInterface) *DefinedInterface {
+	d.DefinedInterface = inner
+	return &d
+}
+
 // CreateDefinedInterface creates a Defined Interface.
 // Only System administrator can create Defined Interfaces.
 func (vcdClient *VCDClient) CreateDefinedInterface(definedInterface *types.DefinedInterface) (*DefinedInterface, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
+		entityLabel: "Defined Interface",
 	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &DefinedInterface{
-		DefinedInterface: &types.DefinedInterface{},
-		client:           &vcdClient.Client,
-	}
-
-	err = client.OpenApiPostItem(apiVersion, urlRef, nil, definedInterface, result.DefinedInterface, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	outerType := DefinedInterface{client: &vcdClient.Client}
+	return createOuterEntity(&vcdClient.Client, outerType, c, definedInterface)
 }
 
 // GetAllDefinedInterfaces retrieves all Defined Interfaces. Query parameters can be supplied to perform additional filtering.
 func (vcdClient *VCDClient) GetAllDefinedInterfaces(queryParameters url.Values) ([]*DefinedInterface, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
+		entityLabel:     "Defined Interface",
+		queryParameters: queryParameters,
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.DefinedInterface{{}}
-	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, amendRdeApiError(&client, err)
-	}
-
-	// Wrap all typeResponses into DefinedEntityType types with client
-	returnRDEs := make([]*DefinedInterface, len(typeResponses))
-	for sliceIndex := range typeResponses {
-		returnRDEs[sliceIndex] = &DefinedInterface{
-			DefinedInterface: typeResponses[sliceIndex],
-			client:           &vcdClient.Client,
-		}
-	}
-
-	return returnRDEs, nil
+	outerType := DefinedInterface{client: &vcdClient.Client}
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
 }
 
 // GetDefinedInterface retrieves a single Defined Interface defined by its unique combination of vendor, nss and version.
@@ -100,37 +72,19 @@ func (vcdClient *VCDClient) GetDefinedInterface(vendor, nss, version string) (*D
 
 // GetDefinedInterfaceById gets a Defined Interface identified by its unique URN.
 func (vcdClient *VCDClient) GetDefinedInterfaceById(id string) (*DefinedInterface, error) {
-	client := vcdClient.Client
-
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		entityLabel:    "Define Interface",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
+		endpointParams: []string{id},
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, id)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &DefinedInterface{
-		DefinedInterface: &types.DefinedInterface{},
-		client:           &vcdClient.Client,
-	}
-
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, result.DefinedInterface, nil)
-	if err != nil {
-		return nil, amendRdeApiError(&client, err)
-	}
-
-	return result, nil
+	outerType := DefinedInterface{client: &vcdClient.Client}
+	return getOuterEntity(&vcdClient.Client, outerType, c)
 }
 
 // Update updates the receiver Defined Interface with the values given by the input.
 // Only System administrator can update Defined Interfaces.
 func (di *DefinedInterface) Update(definedInterface types.DefinedInterface) error {
-	client := di.client
-
 	if di.DefinedInterface.ID == "" {
 		return fmt.Errorf("ID of the receiver Defined Interface is empty")
 	}
@@ -144,48 +98,37 @@ func (di *DefinedInterface) Update(definedInterface types.DefinedInterface) erro
 	definedInterface.Nss = di.DefinedInterface.Nss
 	definedInterface.Vendor = di.DefinedInterface.Vendor
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
+		endpointParams: []string{di.DefinedInterface.ID},
+		entityLabel:    "Defined Interface",
+	}
+	resultDefinedInterface, err := updateInnerEntity(di.client, c, &definedInterface)
 	if err != nil {
 		return err
 	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, di.DefinedInterface.ID)
-	if err != nil {
-		return err
-	}
-
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, definedInterface, di.DefinedInterface, nil)
-	if err != nil {
-		return amendRdeApiError(client, err)
-	}
-
-	return nil
+	// Only if there was no error in request we overwrite pointer receiver as otherwise it would
+	// wipe out existing data
+	di.DefinedInterface = resultDefinedInterface
+	return err
 }
 
 // Delete deletes the receiver Defined Interface.
 // Only System administrator can delete Defined Interfaces.
 func (di *DefinedInterface) Delete() error {
-	client := di.client
-
 	if di.DefinedInterface.ID == "" {
 		return fmt.Errorf("ID of the receiver Defined Interface is empty")
 	}
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaces,
+		endpointParams: []string{di.DefinedInterface.ID},
+		entityLabel:    "Defined Interface",
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, di.DefinedInterface.ID)
+	err := deleteEntityById(di.client, c)
 	if err != nil {
 		return err
-	}
-
-	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-	if err != nil {
-		return amendRdeApiError(client, err)
 	}
 
 	di.DefinedInterface = &types.DefinedInterface{}
@@ -199,24 +142,12 @@ func (di *DefinedInterface) AddBehavior(behavior types.Behavior) (*types.Behavio
 		return nil, fmt.Errorf("ID of the receiver Defined Interface is empty")
 	}
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors
-	apiVersion, err := di.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
+		endpointParams: []string{di.DefinedInterface.ID},
+		entityLabel:    "Defined Interface Behavior",
 	}
-
-	urlRef, err := di.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, di.DefinedInterface.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	result := &types.Behavior{}
-	err = di.client.OpenApiPostItem(apiVersion, urlRef, nil, behavior, result, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return createInnerEntity(di.client, c, &behavior)
 }
 
 // GetAllBehaviors retrieves all the Behaviors of the receiver Defined Interface.
@@ -229,47 +160,24 @@ func (di *DefinedInterface) GetAllBehaviors(queryParameters url.Values) ([]*type
 
 // getAllBehaviors gets all the Behaviors from the object referenced by the input Object ID with the given OpenAPI endpoint.
 func getAllBehaviors(client *Client, objectId, openApiEndpoint string, queryParameters url.Values) ([]*types.Behavior, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + openApiEndpoint
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + openApiEndpoint,
+		entityLabel:     "Defined Entity Behavior",
+		endpointParams:  []string{objectId},
+		queryParameters: queryParameters,
 	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, objectId))
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.Behavior{{}}
-	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.Behavior](client, c)
 }
 
 // GetBehaviorById retrieves a unique Behavior that belongs to the receiver Defined Interface and is determined by the
 // input ID.
 func (di *DefinedInterface) GetBehaviorById(id string) (*types.Behavior, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors
-	apiVersion, err := di.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
+		endpointParams: []string{di.DefinedInterface.ID, id},
+		entityLabel:    "Defined Interface Behavior",
 	}
-
-	urlRef, err := di.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, di.DefinedInterface.ID), id)
-	if err != nil {
-		return nil, err
-	}
-
-	response := types.Behavior{}
-	err = di.client.OpenApiGetItem(apiVersion, urlRef, nil, &response, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &response, nil
+	return getInnerEntity[types.Behavior](di.client, c)
 }
 
 // GetBehaviorByName retrieves a unique Behavior that belongs to the receiver Defined Interface and is named after
@@ -279,12 +187,8 @@ func (di *DefinedInterface) GetBehaviorByName(name string) (*types.Behavior, err
 	if err != nil {
 		return nil, fmt.Errorf("could not get the Behaviors of the Defined Interface with ID '%s': %s", di.DefinedInterface.ID, err)
 	}
-	for _, b := range behaviors {
-		if b.Name == name {
-			return b, nil
-		}
-	}
-	return nil, fmt.Errorf("could not find any Behavior with name '%s' in Defined Interface with ID '%s': %s", name, di.DefinedInterface.ID, ErrorEntityNotFound)
+	infoMessage := fmt.Sprintf("Defined Interface Behavior with name '%s' in Defined Interface with ID '%s': %s", name, di.DefinedInterface.ID, ErrorEntityNotFound)
+	return localFilterOneOrError(behaviors, "Name", name, infoMessage)
 }
 
 // UpdateBehavior updates a Behavior specified by the input.
@@ -296,23 +200,12 @@ func (di *DefinedInterface) UpdateBehavior(behavior types.Behavior) (*types.Beha
 		return nil, fmt.Errorf("ID of the Behavior to update is empty")
 	}
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors
-	apiVersion, err := di.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
+		endpointParams: []string{di.DefinedInterface.ID, behavior.ID},
+		entityLabel:    "Defined Interface Behavior",
 	}
-
-	urlRef, err := di.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, di.DefinedInterface.ID), behavior.ID)
-	if err != nil {
-		return nil, err
-	}
-	response := types.Behavior{}
-	err = di.client.OpenApiPutItem(apiVersion, urlRef, nil, behavior, &response, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &response, nil
+	return updateInnerEntity(di.client, c, &behavior)
 }
 
 // DeleteBehavior removes a Behavior specified by its ID from the receiver Defined Interface.
@@ -321,22 +214,12 @@ func (di *DefinedInterface) DeleteBehavior(behaviorId string) error {
 		return fmt.Errorf("ID of the receiver Defined Interface is empty")
 	}
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors
-	apiVersion, err := di.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeInterfaceBehaviors,
+		endpointParams: []string{di.DefinedInterface.ID, behaviorId},
+		entityLabel:    "Defined Interface Behavior",
 	}
-
-	urlRef, err := di.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, di.DefinedInterface.ID), behaviorId)
-	if err != nil {
-		return err
-	}
-	err = di.client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return deleteEntityById(di.client, c)
 }
 
 // amendRdeApiError fixes a wrong type of error returned by VCD API <= v36.0 on GET operations

--- a/govcd/defined_interface.go
+++ b/govcd/defined_interface.go
@@ -192,8 +192,8 @@ func (di *DefinedInterface) GetBehaviorByName(name string) (*types.Behavior, err
 	if err != nil {
 		return nil, fmt.Errorf("could not get the Behaviors of the Defined Interface with ID '%s': %s", di.DefinedInterface.ID, err)
 	}
-	infoMessage := fmt.Sprintf("Defined Interface Behavior with name '%s' in Defined Interface with ID '%s': %s", name, di.DefinedInterface.ID, ErrorEntityNotFound)
-	return localFilterOneOrError(behaviors, "Name", name, infoMessage)
+	label := fmt.Sprintf("Defined Interface Behavior with name '%s' in Defined Interface with ID '%s': %s", name, di.DefinedInterface.ID, ErrorEntityNotFound)
+	return localFilterOneOrError(label, behaviors, "Name", name)
 }
 
 // UpdateBehavior updates a Behavior specified by the input.

--- a/govcd/defined_interface.go
+++ b/govcd/defined_interface.go
@@ -24,7 +24,7 @@ type DefinedInterface struct {
 	client           *Client
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (d DefinedInterface) wrap(inner *types.DefinedInterface) *DefinedInterface {

--- a/govcd/generic_functions.go
+++ b/govcd/generic_functions.go
@@ -84,7 +84,7 @@ func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, ent
 // localFilterOneOrError performs local filtering using `genericLocalFilter()` and
 // additionally verifies that only a single result is present using `oneOrError()`. Common use case
 // for GetXByName methods where API does not support filtering and it must be done on client side.
-func localFilterOneOrError[E any](entities []*E, fieldName, expectedFieldValue string, entityLabel string) (*E, error) {
+func localFilterOneOrError[E any](entityLabel string, entities []*E, fieldName, expectedFieldValue string) (*E, error) {
 	if fieldName == "" || expectedFieldValue == "" {
 		return nil, fmt.Errorf("expected field name and value must be specified to filter %s", entityLabel)
 	}

--- a/govcd/generic_functions.go
+++ b/govcd/generic_functions.go
@@ -27,14 +27,14 @@ import (
 //	        return nil, fmt.Errorf("more than one (%d) NSX-T Edge Cluster with name '%s' for Org VDC with id '%s' found",
 //	                len(nsxtEdgeClusters), name, vdc.Vdc.ID)
 //	}
-func oneOrError[E any](key, name string, entitySlice []*E) (*E, error) {
+func oneOrError[E any](key, value string, entitySlice []*E) (*E, error) {
 	if len(entitySlice) > 1 {
-		return nil, fmt.Errorf("got more than one entity by %s '%s' %d", key, name, len(entitySlice))
+		return nil, fmt.Errorf("got more than one entity by %s '%s' %d", key, value, len(entitySlice))
 	}
 
 	if len(entitySlice) == 0 {
 		// No entity found - returning ErrorEntityNotFound as it must be wrapped in the returned error
-		return nil, fmt.Errorf("%s: got zero entities by %s '%s'", ErrorEntityNotFound, key, name)
+		return nil, fmt.Errorf("%s: got zero entities by %s '%s'", ErrorEntityNotFound, key, value)
 	}
 
 	return entitySlice[0], nil
@@ -45,7 +45,7 @@ func oneOrError[E any](key, name string, entitySlice []*E) (*E, error) {
 // not support filtering and it must be done on client side.
 //
 // Note. The field name `fieldName` must be present in a given type E (letter casing is important)
-func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) ([]*E, error) {
+func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, entityLabel string) ([]*E, error) {
 	if len(entities) == 0 {
 		return nil, fmt.Errorf("zero entities provided for filtering")
 	}
@@ -59,14 +59,14 @@ func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, ent
 		if entity != nil {
 			entityValue = *entity
 		} else {
-			return nil, fmt.Errorf("given entity for %s is a nil pointer", entityName)
+			return nil, fmt.Errorf("given entity for %s is a nil pointer", entityLabel)
 		}
 
 		value := reflect.ValueOf(entityValue)
 		field := value.FieldByName(fieldName)
 
 		if !field.IsValid() {
-			return nil, fmt.Errorf("the struct for %s does not have the field '%s'", entityName, fieldName)
+			return nil, fmt.Errorf("the struct for %s does not have the field '%s'", entityLabel, fieldName)
 		}
 
 		if field.Type().Name() != "string" {
@@ -84,12 +84,12 @@ func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, ent
 // localFilterOneOrError performs local filtering using `genericLocalFilter()` and
 // additionally verifies that only a single result is present using `oneOrError()`. Common use case
 // for GetXByName methods where API does not support filtering and it must be done on client side.
-func localFilterOneOrError[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) (*E, error) {
+func localFilterOneOrError[E any](entities []*E, fieldName, expectedFieldValue string, entityLabel string) (*E, error) {
 	if fieldName == "" || expectedFieldValue == "" {
-		return nil, fmt.Errorf("expected field name and value must be specified to filter %s", entityName)
+		return nil, fmt.Errorf("expected field name and value must be specified to filter %s", entityLabel)
 	}
 
-	filteredValues, err := localFilter(entities, fieldName, expectedFieldValue, entityName)
+	filteredValues, err := localFilter(entities, fieldName, expectedFieldValue, entityLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/generic_functions.go
+++ b/govcd/generic_functions.go
@@ -45,7 +45,7 @@ func oneOrError[E any](key, value string, entitySlice []*E) (*E, error) {
 // not support filtering and it must be done on client side.
 //
 // Note. The field name `fieldName` must be present in a given type E (letter casing is important)
-func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, entityLabel string) ([]*E, error) {
+func localFilter[E any](entityLabel string, entities []*E, fieldName, expectedFieldValue string) ([]*E, error) {
 	if len(entities) == 0 {
 		return nil, fmt.Errorf("zero entities provided for filtering")
 	}
@@ -89,7 +89,7 @@ func localFilterOneOrError[E any](entityLabel string, entities []*E, fieldName, 
 		return nil, fmt.Errorf("expected field name and value must be specified to filter %s", entityLabel)
 	}
 
-	filteredValues, err := localFilter(entities, fieldName, expectedFieldValue, entityLabel)
+	filteredValues, err := localFilter(entityLabel, entities, fieldName, expectedFieldValue)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/generic_functions.go
+++ b/govcd/generic_functions.go
@@ -42,7 +42,7 @@ func oneOrError[E any](key, value string, entitySlice []*E) (*E, error) {
 
 // localFilter performs filtering of a type E based on a field name `fieldName` and its
 // expected string value `expectedFieldValue`. Common use case for GetAllX methods where API does
-// not support filtering and it must be done on client side.
+// not support filtering and it must be done on the client side.
 //
 // Note. The field name `fieldName` must be present in a given type E (letter casing is important)
 func localFilter[E any](entityLabel string, entities []*E, fieldName, expectedFieldValue string) ([]*E, error) {

--- a/govcd/generic_functions.go
+++ b/govcd/generic_functions.go
@@ -40,18 +40,17 @@ func oneOrError[E any](key, name string, entitySlice []*E) (*E, error) {
 	return entitySlice[0], nil
 }
 
-// genericLocalFilter performs filtering of a type E based on a field name `fieldName` and its
+// localFilter performs filtering of a type E based on a field name `fieldName` and its
 // expected string value `expectedFieldValue`. Common use case for GetAllX methods where API does
 // not support filtering and it must be done on client side.
 //
 // Note. The field name `fieldName` must be present in a given type E (letter casing is important)
-func genericLocalFilter[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) ([]*E, error) {
+func localFilter[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) ([]*E, error) {
 	if len(entities) == 0 {
 		return nil, fmt.Errorf("zero entities provided for filtering")
 	}
 
 	filteredValues := make([]*E, 0)
-
 	for _, entity := range entities {
 
 		// Need to deference pointer because `reflect` package requires to work with types and not
@@ -82,15 +81,15 @@ func genericLocalFilter[E any](entities []*E, fieldName, expectedFieldValue stri
 	return filteredValues, nil
 }
 
-// genericLocalFilterOneOrError performs local filtering using `genericLocalFilter()` and
+// localFilterOneOrError performs local filtering using `genericLocalFilter()` and
 // additionally verifies that only a single result is present using `oneOrError()`. Common use case
 // for GetXByName methods where API does not support filtering and it must be done on client side.
-func genericLocalFilterOneOrError[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) (*E, error) {
+func localFilterOneOrError[E any](entities []*E, fieldName, expectedFieldValue string, entityName string) (*E, error) {
 	if fieldName == "" || expectedFieldValue == "" {
 		return nil, fmt.Errorf("expected field name and value must be specified to filter %s", entityName)
 	}
 
-	filteredValues, err := genericLocalFilter(entities, fieldName, expectedFieldValue, entityName)
+	filteredValues, err := localFilter(entities, fieldName, expectedFieldValue, entityName)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/ip_space.go
+++ b/govcd/ip_space.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
@@ -27,31 +27,22 @@ type IpSpace struct {
 	vcdClient *VCDClient
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (g IpSpace) wrap(inner *types.IpSpace) *IpSpace {
+	g.IpSpace = inner
+	return &g
+}
+
 // CreateIpSpace creates IP Space with desired configuration
 func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
+		entityName: "IP Space",
 	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &IpSpace{
-		IpSpace:   &types.IpSpace{},
-		vcdClient: vcdClient,
-	}
-
-	err = client.OpenApiPostItem(apiVersion, urlRef, nil, ipSpaceConfig, result.IpSpace, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	outerType := IpSpace{vcdClient: vcdClient}
+	return createOuterEntity(&vcdClient.Client, outerType, c, ipSpaceConfig)
 }
 
 // GetAllIpSpaceSummaries retrieve summaries of all IP Spaces with an optional filter
@@ -59,65 +50,14 @@ func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpac
 // "summaries" endpoint exists, but it does not include all fields. To retrieve complete structure
 // one can use `GetIpSpaceById` or `GetIpSpaceByName`
 func (vcdClient *VCDClient) GetAllIpSpaceSummaries(queryParameters url.Values) ([]*IpSpace, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceSummaries
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceSummaries,
+		entityName:      "IP Space",
+		queryParameters: queryParameters,
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.IpSpace{{}}
-	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Wrap all typeResponses into IpSpace types with client
-	results := make([]*IpSpace, len(typeResponses))
-	for sliceIndex := range typeResponses {
-		results[sliceIndex] = &IpSpace{
-			IpSpace:   typeResponses[sliceIndex],
-			vcdClient: vcdClient,
-		}
-	}
-
-	return results, nil
-}
-
-// GetIpSpaceById retrieves IP Space with a given ID
-func (vcdClient *VCDClient) GetIpSpaceById(id string) (*IpSpace, error) {
-	if id == "" {
-		return nil, fmt.Errorf("IP Space lookup requires ID")
-	}
-
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, id)
-	if err != nil {
-		return nil, err
-	}
-
-	response := &IpSpace{
-		vcdClient: vcdClient,
-		IpSpace:   &types.IpSpace{},
-	}
-
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, response.IpSpace, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
+	outerType := IpSpace{vcdClient: vcdClient}
+	return getAllOuterEntities[IpSpace, types.IpSpace](&vcdClient.Client, outerType, c)
 }
 
 // GetIpSpaceByName retrieves IP Space with a given name
@@ -127,20 +67,31 @@ func (vcdClient *VCDClient) GetIpSpaceByName(name string) (*IpSpace, error) {
 		return nil, fmt.Errorf("IP Space lookup requires name")
 	}
 
-	queryParameters := url.Values{}
-	queryParameters.Add("filter", "name=="+name)
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
 
-	filteredIpSpaces, err := vcdClient.GetAllIpSpaceSummaries(queryParameters)
+	filteredEntities, err := vcdClient.GetAllIpSpaceSummaries(queryParams)
 	if err != nil {
-		return nil, fmt.Errorf("error getting IP Spaces: %s", err)
+		return nil, err
 	}
 
-	singleIpSpace, err := oneOrError("name", name, filteredIpSpaces)
+	singleIpSpace, err := oneOrError("name", name, filteredEntities)
 	if err != nil {
 		return nil, err
 	}
 
 	return vcdClient.GetIpSpaceById(singleIpSpace.IpSpace.ID)
+}
+
+func (vcdClient *VCDClient) GetIpSpaceById(id string) (*IpSpace, error) {
+	c := crudConfig{
+		entityName:     "IP Space",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
+		endpointParams: []string{id},
+	}
+
+	outerType := IpSpace{vcdClient: vcdClient}
+	return getOuterEntity[IpSpace, types.IpSpace](&vcdClient.Client, outerType, c)
 }
 
 // GetIpSpaceByNameAndOrgId retrieves IP Space with a given name in a particular Org
@@ -150,16 +101,16 @@ func (vcdClient *VCDClient) GetIpSpaceByNameAndOrgId(name, orgId string) (*IpSpa
 		return nil, fmt.Errorf("IP Space lookup requires name and Org ID")
 	}
 
-	queryParameters := url.Values{}
-	queryParameters.Add("filter", "name=="+name)
-	queryParameters = queryParameterFilterAnd("orgRef.id=="+orgId, queryParameters)
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
+	queryParams = queryParameterFilterAnd("orgRef.id=="+orgId, queryParams)
 
-	filteredIpSpaces, err := vcdClient.GetAllIpSpaceSummaries(queryParameters)
+	filteredEntities, err := vcdClient.GetAllIpSpaceSummaries(queryParams)
 	if err != nil {
-		return nil, fmt.Errorf("error getting IP Spaces: %s", err)
+		return nil, err
 	}
 
-	singleIpSpace, err := oneOrError("name", name, filteredIpSpaces)
+	singleIpSpace, err := oneOrError("name", name, filteredEntities)
 	if err != nil {
 		return nil, err
 	}
@@ -169,58 +120,21 @@ func (vcdClient *VCDClient) GetIpSpaceByNameAndOrgId(name, orgId string) (*IpSpa
 
 // Update updates IP Space with new config
 func (ipSpace *IpSpace) Update(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
-	client := ipSpace.vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
+		endpointParams: []string{ipSpace.IpSpace.ID},
+		entityName:     "IP Space",
 	}
-
-	ipSpaceConfig.ID = ipSpace.IpSpace.ID
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, ipSpaceConfig.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	returnIpSpace := &IpSpace{
-		IpSpace:   &types.IpSpace{},
-		vcdClient: ipSpace.vcdClient,
-	}
-
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, ipSpaceConfig, returnIpSpace.IpSpace, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating IP Space: %s", err)
-	}
-
-	return returnIpSpace, nil
+	outerType := IpSpace{vcdClient: ipSpace.vcdClient}
+	return updateOuterEntity(&ipSpace.vcdClient.Client, outerType, c, ipSpaceConfig)
 }
 
 // Delete deletes IP Space
 func (ipSpace *IpSpace) Delete() error {
-	if ipSpace == nil || ipSpace.IpSpace == nil || ipSpace.IpSpace.ID == "" {
-		return fmt.Errorf("IP Space must have ID")
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
+		endpointParams: []string{ipSpace.IpSpace.ID},
+		entityName:     "IP Space",
 	}
-
-	client := ipSpace.vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
-	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, ipSpace.IpSpace.ID)
-	if err != nil {
-		return err
-	}
-
-	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	if err != nil {
-		return fmt.Errorf("error deleting IP space: %s", err)
-	}
-
-	return nil
+	return deleteEntityById(&ipSpace.vcdClient.Client, c)
 }

--- a/govcd/ip_space.go
+++ b/govcd/ip_space.go
@@ -29,7 +29,7 @@ type IpSpace struct {
 	vcdClient *VCDClient
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (g IpSpace) wrap(inner *types.IpSpace) *IpSpace {

--- a/govcd/ip_space.go
+++ b/govcd/ip_space.go
@@ -38,8 +38,8 @@ func (g IpSpace) wrap(inner *types.IpSpace) *IpSpace {
 // CreateIpSpace creates IP Space with desired configuration
 func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
 	c := crudConfig{
-		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
-		entityName: "IP Space",
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
+		entityLabel: "IP Space",
 	}
 	outerType := IpSpace{vcdClient: vcdClient}
 	return createOuterEntity(&vcdClient.Client, outerType, c, ipSpaceConfig)
@@ -52,7 +52,7 @@ func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpac
 func (vcdClient *VCDClient) GetAllIpSpaceSummaries(queryParameters url.Values) ([]*IpSpace, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceSummaries,
-		entityName:      "IP Space",
+		entityLabel:     "IP Space",
 		queryParameters: queryParameters,
 	}
 
@@ -85,7 +85,7 @@ func (vcdClient *VCDClient) GetIpSpaceByName(name string) (*IpSpace, error) {
 
 func (vcdClient *VCDClient) GetIpSpaceById(id string) (*IpSpace, error) {
 	c := crudConfig{
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{id},
 	}
@@ -123,7 +123,7 @@ func (ipSpace *IpSpace) Update(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{ipSpace.IpSpace.ID},
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 	}
 	outerType := IpSpace{vcdClient: ipSpace.vcdClient}
 	return updateOuterEntity(&ipSpace.vcdClient.Client, outerType, c, ipSpaceConfig)
@@ -134,7 +134,7 @@ func (ipSpace *IpSpace) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{ipSpace.IpSpace.ID},
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 	}
 	return deleteEntityById(&ipSpace.vcdClient.Client, c)
 }

--- a/govcd/ip_space.go
+++ b/govcd/ip_space.go
@@ -11,6 +11,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const labelIpSpace = "IP Space"
+
 // IpSpace provides structured approach to allocating public and private IP addresses by preventing
 // the use of overlapping IP addresses across organizations and organization VDCs.
 //
@@ -39,7 +41,7 @@ func (g IpSpace) wrap(inner *types.IpSpace) *IpSpace {
 func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
-		entityLabel: "IP Space",
+		entityLabel: labelIpSpace,
 	}
 	outerType := IpSpace{vcdClient: vcdClient}
 	return createOuterEntity(&vcdClient.Client, outerType, c, ipSpaceConfig)
@@ -52,7 +54,7 @@ func (vcdClient *VCDClient) CreateIpSpace(ipSpaceConfig *types.IpSpace) (*IpSpac
 func (vcdClient *VCDClient) GetAllIpSpaceSummaries(queryParameters url.Values) ([]*IpSpace, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceSummaries,
-		entityLabel:     "IP Space",
+		entityLabel:     labelIpSpace,
 		queryParameters: queryParameters,
 	}
 
@@ -85,7 +87,7 @@ func (vcdClient *VCDClient) GetIpSpaceByName(name string) (*IpSpace, error) {
 
 func (vcdClient *VCDClient) GetIpSpaceById(id string) (*IpSpace, error) {
 	c := crudConfig{
-		entityLabel:    "IP Space",
+		entityLabel:    labelIpSpace,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{id},
 	}
@@ -123,7 +125,7 @@ func (ipSpace *IpSpace) Update(ipSpaceConfig *types.IpSpace) (*IpSpace, error) {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{ipSpace.IpSpace.ID},
-		entityLabel:    "IP Space",
+		entityLabel:    labelIpSpace,
 	}
 	outerType := IpSpace{vcdClient: ipSpace.vcdClient}
 	return updateOuterEntity(&ipSpace.vcdClient.Client, outerType, c, ipSpaceConfig)
@@ -134,7 +136,7 @@ func (ipSpace *IpSpace) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces,
 		endpointParams: []string{ipSpace.IpSpace.ID},
-		entityLabel:    "IP Space",
+		entityLabel:    labelIpSpace,
 	}
 	return deleteEntityById(&ipSpace.vcdClient.Client, c)
 }

--- a/govcd/ip_space_uplink.go
+++ b/govcd/ip_space_uplink.go
@@ -18,31 +18,23 @@ type IpSpaceUplink struct {
 	vcdClient     *VCDClient
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (i IpSpaceUplink) wrap(inner *types.IpSpaceUplink) *IpSpaceUplink {
+	i.IpSpaceUplink = inner
+	return &i
+}
+
 // CreateIpSpaceUplink creates an IP Space Uplink with a given configuration
 func (vcdClient *VCDClient) CreateIpSpaceUplink(ipSpaceUplinkConfig *types.IpSpaceUplink) (*IpSpaceUplink, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		entityName: "IP Space Uplink",
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &IpSpaceUplink{
-		IpSpaceUplink: &types.IpSpaceUplink{},
-		vcdClient:     vcdClient,
-	}
-
-	err = client.OpenApiPostItem(apiVersion, urlRef, nil, ipSpaceUplinkConfig, result.IpSpaceUplink, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	outerType := IpSpaceUplink{vcdClient: vcdClient}
+	return createOuterEntity(&vcdClient.Client, outerType, c, ipSpaceUplinkConfig)
 }
 
 // GetAllIpSpaceUplinks retrieves all IP Space Uplinks for a given External Network ID
@@ -54,35 +46,14 @@ func (vcdClient *VCDClient) GetAllIpSpaceUplinks(externalNetworkId string, query
 	}
 
 	queryparams := queryParameterFilterAnd(fmt.Sprintf("externalNetworkRef.id==%s", externalNetworkId), queryParameters)
-
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		entityName:      "IP Space Uplink",
+		queryParameters: queryparams,
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.IpSpaceUplink{{}}
-	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryparams, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Wrap all typeResponses into IpSpaceUplink types with client
-	results := make([]*IpSpaceUplink, len(typeResponses))
-	for sliceIndex := range typeResponses {
-		results[sliceIndex] = &IpSpaceUplink{
-			IpSpaceUplink: typeResponses[sliceIndex],
-			vcdClient:     vcdClient,
-		}
-	}
-
-	return results, nil
+	outerType := IpSpaceUplink{vcdClient: vcdClient}
+	return getAllOuterEntities[IpSpaceUplink, types.IpSpaceUplink](&vcdClient.Client, outerType, c)
 }
 
 // GetIpSpaceUplinkByName retrieves a single IP Space Uplink by Name in a given External Network
@@ -98,61 +69,26 @@ func (vcdClient *VCDClient) GetIpSpaceUplinkByName(externalNetworkId, name strin
 
 // GetIpSpaceUplinkById retrieves IP Space Uplink with a given ID
 func (vcdClient *VCDClient) GetIpSpaceUplinkById(id string) (*IpSpaceUplink, error) {
-	if id == "" {
-		return nil, fmt.Errorf("IP Space Uplink lookup requires ID")
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		endpointParams: []string{id},
+		entityName:     "IP Space Uplink",
 	}
 
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, id)
-	if err != nil {
-		return nil, err
-	}
-
-	response := &IpSpaceUplink{
-		vcdClient:     vcdClient,
-		IpSpaceUplink: &types.IpSpaceUplink{},
-	}
-
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, response.IpSpaceUplink, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
+	outerType := IpSpaceUplink{vcdClient: vcdClient}
+	return getOuterEntity[IpSpaceUplink, types.IpSpaceUplink](&vcdClient.Client, outerType, c)
 }
 
 // Update IP Space Uplink
 func (ipSpaceUplink *IpSpaceUplink) Update(ipSpaceUplinkConfig *types.IpSpaceUplink) (*IpSpaceUplink, error) {
-	client := ipSpaceUplink.vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
+		entityName:     "IP Space Uplink",
 	}
 
-	ipSpaceUplinkConfig.ID = ipSpaceUplink.IpSpaceUplink.ID
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, ipSpaceUplinkConfig.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &IpSpaceUplink{
-		IpSpaceUplink: &types.IpSpaceUplink{},
-		vcdClient:     ipSpaceUplink.vcdClient,
-	}
-
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, ipSpaceUplinkConfig, result.IpSpaceUplink, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating IP Space: %s", err)
-	}
-
-	return result, nil
+	outerType := IpSpaceUplink{vcdClient: ipSpaceUplink.vcdClient}
+	return updateOuterEntity(&ipSpaceUplink.vcdClient.Client, outerType, c, ipSpaceUplinkConfig)
 }
 
 // Delete IP Space Uplink
@@ -161,26 +97,11 @@ func (ipSpaceUplink *IpSpaceUplink) Delete() error {
 		return fmt.Errorf("IP Space Uplink must have ID")
 	}
 
-	client := ipSpaceUplink.vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
+		entityName:     "IP Space Uplink",
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint, ipSpaceUplink.IpSpaceUplink.ID)
-	if err != nil {
-		return err
-	}
-
-	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	if err != nil {
-		return fmt.Errorf("error deleting IP Space Uplink: %s", err)
-	}
-
-	return nil
+	return deleteEntityById(&ipSpaceUplink.vcdClient.Client, c)
 }

--- a/govcd/ip_space_uplink.go
+++ b/govcd/ip_space_uplink.go
@@ -20,7 +20,7 @@ type IpSpaceUplink struct {
 	vcdClient     *VCDClient
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (i IpSpaceUplink) wrap(inner *types.IpSpaceUplink) *IpSpaceUplink {

--- a/govcd/ip_space_uplink.go
+++ b/govcd/ip_space_uplink.go
@@ -29,8 +29,8 @@ func (i IpSpaceUplink) wrap(inner *types.IpSpaceUplink) *IpSpaceUplink {
 // CreateIpSpaceUplink creates an IP Space Uplink with a given configuration
 func (vcdClient *VCDClient) CreateIpSpaceUplink(ipSpaceUplinkConfig *types.IpSpaceUplink) (*IpSpaceUplink, error) {
 	c := crudConfig{
-		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
-		entityName: "IP Space Uplink",
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
+		entityLabel: "IP Space Uplink",
 	}
 
 	outerType := IpSpaceUplink{vcdClient: vcdClient}
@@ -48,7 +48,7 @@ func (vcdClient *VCDClient) GetAllIpSpaceUplinks(externalNetworkId string, query
 	queryparams := queryParameterFilterAnd(fmt.Sprintf("externalNetworkRef.id==%s", externalNetworkId), queryParameters)
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
-		entityName:      "IP Space Uplink",
+		entityLabel:     "IP Space Uplink",
 		queryParameters: queryparams,
 	}
 
@@ -72,7 +72,7 @@ func (vcdClient *VCDClient) GetIpSpaceUplinkById(id string) (*IpSpaceUplink, err
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{id},
-		entityName:     "IP Space Uplink",
+		entityLabel:    "IP Space Uplink",
 	}
 
 	outerType := IpSpaceUplink{vcdClient: vcdClient}
@@ -84,7 +84,7 @@ func (ipSpaceUplink *IpSpaceUplink) Update(ipSpaceUplinkConfig *types.IpSpaceUpl
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
-		entityName:     "IP Space Uplink",
+		entityLabel:    "IP Space Uplink",
 	}
 
 	outerType := IpSpaceUplink{vcdClient: ipSpaceUplink.vcdClient}
@@ -100,7 +100,7 @@ func (ipSpaceUplink *IpSpaceUplink) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
-		entityName:     "IP Space Uplink",
+		entityLabel:    "IP Space Uplink",
 	}
 
 	return deleteEntityById(&ipSpaceUplink.vcdClient.Client, c)

--- a/govcd/ip_space_uplink.go
+++ b/govcd/ip_space_uplink.go
@@ -11,6 +11,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const labelIpSpaceUplink = "IP Space Uplink"
+
 // IpSpaceUplink provides the capability to assign one or more IP Spaces as Uplinks to External
 // Networks
 type IpSpaceUplink struct {
@@ -30,7 +32,7 @@ func (i IpSpaceUplink) wrap(inner *types.IpSpaceUplink) *IpSpaceUplink {
 func (vcdClient *VCDClient) CreateIpSpaceUplink(ipSpaceUplinkConfig *types.IpSpaceUplink) (*IpSpaceUplink, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
-		entityLabel: "IP Space Uplink",
+		entityLabel: labelIpSpaceUplink,
 	}
 
 	outerType := IpSpaceUplink{vcdClient: vcdClient}
@@ -48,7 +50,7 @@ func (vcdClient *VCDClient) GetAllIpSpaceUplinks(externalNetworkId string, query
 	queryparams := queryParameterFilterAnd(fmt.Sprintf("externalNetworkRef.id==%s", externalNetworkId), queryParameters)
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
-		entityLabel:     "IP Space Uplink",
+		entityLabel:     labelIpSpaceUplink,
 		queryParameters: queryparams,
 	}
 
@@ -72,7 +74,7 @@ func (vcdClient *VCDClient) GetIpSpaceUplinkById(id string) (*IpSpaceUplink, err
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{id},
-		entityLabel:    "IP Space Uplink",
+		entityLabel:    labelIpSpaceUplink,
 	}
 
 	outerType := IpSpaceUplink{vcdClient: vcdClient}
@@ -84,7 +86,7 @@ func (ipSpaceUplink *IpSpaceUplink) Update(ipSpaceUplinkConfig *types.IpSpaceUpl
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
-		entityLabel:    "IP Space Uplink",
+		entityLabel:    labelIpSpaceUplink,
 	}
 
 	outerType := IpSpaceUplink{vcdClient: ipSpaceUplink.vcdClient}
@@ -100,7 +102,7 @@ func (ipSpaceUplink *IpSpaceUplink) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks,
 		endpointParams: []string{ipSpaceUplink.IpSpaceUplink.ID},
-		entityLabel:    "IP Space Uplink",
+		entityLabel:    labelIpSpaceUplink,
 	}
 
 	return deleteEntityById(&ipSpaceUplink.vcdClient.Client, c)

--- a/govcd/nsxt_distributed_firewall.go
+++ b/govcd/nsxt_distributed_firewall.go
@@ -10,6 +10,11 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
+const (
+	labelDistributedFirewall     = "NSX-T Distributed Firewall"
+	labelDistributedFirewallRule = "NSX-T Distributed Firewall Rule"
+)
+
 // DistributedFirewall contains a types.DistributedFirewallRules which handles Distributed Firewall
 // rules in a VDC Group
 type DistributedFirewall struct {
@@ -47,7 +52,7 @@ func (d DistributedFirewallRule) wrap(inner *types.DistributedFirewallRule) *Dis
 // functions was created
 func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error) {
 	c := crudConfig{
-		entityLabel:    "NSX-T Distributed Firewall",
+		entityLabel:    labelDistributedFirewall,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -62,7 +67,7 @@ func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error)
 // functions was created
 func (vdcGroup *VdcGroup) UpdateDistributedFirewall(dfwRules *types.DistributedFirewallRules) (*DistributedFirewall, error) {
 	c := crudConfig{
-		entityLabel:    "NSX-T Distributed Firewall",
+		entityLabel:    labelDistributedFirewall,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -95,7 +100,7 @@ func (firewall *DistributedFirewall) DeleteAllRules() error {
 // GetDistributedFirewallRuleById retrieves single Distributed Firewall Rule by ID
 func (vdcGroup *VdcGroup) GetDistributedFirewallRuleById(id string) (*DistributedFirewallRule, error) {
 	c := crudConfig{
-		entityLabel:    "NSX-T Distributed Firewall Rule",
+		entityLabel:    labelDistributedFirewallRule,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", id},
 	}
@@ -115,7 +120,7 @@ func (vdcGroup *VdcGroup) GetDistributedFirewallRuleByName(name string) (*Distri
 		return nil, fmt.Errorf("error returning distributed firewall rules: %s", err)
 	}
 
-	singleRuleByName, err := localFilterOneOrError(dfw.DistributedFirewallRuleContainer.Values, "Name", name, "NSX-T Distributed Firewall Rule")
+	singleRuleByName, err := localFilterOneOrError(dfw.DistributedFirewallRuleContainer.Values, "Name", name, labelDistributedFirewallRule)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +158,7 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 	// schema in future VCD versions)
 
 	c := crudConfig{
-		entityLabel:    "NSX-T Distributed Firewall Rule",
+		entityLabel:    labelDistributedFirewallRule,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -212,7 +217,7 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 	}
 
 	c2 := crudConfig{
-		entityLabel:    "NSX-T Distributed Firewall Rule",
+		entityLabel:    labelDistributedFirewallRule,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -247,7 +252,7 @@ func (dfwRule *DistributedFirewallRule) Update(rule *types.DistributedFirewallRu
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
-		entityLabel:    "NSX-T Distribute Firewall Rule",
+		entityLabel:    labelDistributedFirewallRule,
 	}
 	outerType := DistributedFirewallRule{client: dfwRule.client, VdcGroup: dfwRule.VdcGroup}
 	return updateOuterEntity(dfwRule.client, outerType, c, rule)
@@ -256,7 +261,7 @@ func (dfwRule *DistributedFirewallRule) Update(rule *types.DistributedFirewallRu
 // Delete a single Distributed Firewall Rule
 func (dfwRule *DistributedFirewallRule) Delete() error {
 	c := crudConfig{
-		entityLabel:    "NSX-T Distribute Firewall Rule",
+		entityLabel:    labelDistributedFirewallRule,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
 	}

--- a/govcd/nsxt_distributed_firewall.go
+++ b/govcd/nsxt_distributed_firewall.go
@@ -120,7 +120,7 @@ func (vdcGroup *VdcGroup) GetDistributedFirewallRuleByName(name string) (*Distri
 		return nil, fmt.Errorf("error returning distributed firewall rules: %s", err)
 	}
 
-	singleRuleByName, err := localFilterOneOrError(dfw.DistributedFirewallRuleContainer.Values, "Name", name, labelDistributedFirewallRule)
+	singleRuleByName, err := localFilterOneOrError(labelDistributedFirewallRule, dfw.DistributedFirewallRuleContainer.Values, "Name", name)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/nsxt_distributed_firewall.go
+++ b/govcd/nsxt_distributed_firewall.go
@@ -23,7 +23,7 @@ type DistributedFirewall struct {
 	VdcGroup                         *VdcGroup
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (d DistributedFirewall) wrap(inner *types.DistributedFirewallRules) *DistributedFirewall {
@@ -38,7 +38,7 @@ type DistributedFirewallRule struct {
 	VdcGroup *VdcGroup
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (d DistributedFirewallRule) wrap(inner *types.DistributedFirewallRule) *DistributedFirewallRule {

--- a/govcd/nsxt_distributed_firewall.go
+++ b/govcd/nsxt_distributed_firewall.go
@@ -47,7 +47,7 @@ func (d DistributedFirewallRule) wrap(inner *types.DistributedFirewallRule) *Dis
 // functions was created
 func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error) {
 	c := crudConfig{
-		entityName:     "NSX-T Distributed Firewall",
+		entityLabel:    "NSX-T Distributed Firewall",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -62,7 +62,7 @@ func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error)
 // functions was created
 func (vdcGroup *VdcGroup) UpdateDistributedFirewall(dfwRules *types.DistributedFirewallRules) (*DistributedFirewall, error) {
 	c := crudConfig{
-		entityName:     "NSX-T Distributed Firewall",
+		entityLabel:    "NSX-T Distributed Firewall",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -95,7 +95,7 @@ func (firewall *DistributedFirewall) DeleteAllRules() error {
 // GetDistributedFirewallRuleById retrieves single Distributed Firewall Rule by ID
 func (vdcGroup *VdcGroup) GetDistributedFirewallRuleById(id string) (*DistributedFirewallRule, error) {
 	c := crudConfig{
-		entityName:     "NSX-T Distributed Firewall Rule",
+		entityLabel:    "NSX-T Distributed Firewall Rule",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", id},
 	}
@@ -153,7 +153,7 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 	// schema in future VCD versions)
 
 	c := crudConfig{
-		entityName:     "NSX-T Distributed Firewall Rule",
+		entityLabel:    "NSX-T Distributed Firewall Rule",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -212,7 +212,7 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 	}
 
 	c2 := crudConfig{
-		entityName:     "NSX-T Distributed Firewall Rule",
+		entityLabel:    "NSX-T Distributed Firewall Rule",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
@@ -247,7 +247,7 @@ func (dfwRule *DistributedFirewallRule) Update(rule *types.DistributedFirewallRu
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
-		entityName:     "NSX-T Distribute Firewall Rule",
+		entityLabel:    "NSX-T Distribute Firewall Rule",
 	}
 	outerType := DistributedFirewallRule{client: dfwRule.client, VdcGroup: dfwRule.VdcGroup}
 	return updateOuterEntity(dfwRule.client, outerType, c, rule)
@@ -256,7 +256,7 @@ func (dfwRule *DistributedFirewallRule) Update(rule *types.DistributedFirewallRu
 // Delete a single Distributed Firewall Rule
 func (dfwRule *DistributedFirewallRule) Delete() error {
 	c := crudConfig{
-		entityName:     "NSX-T Distribute Firewall Rule",
+		entityLabel:    "NSX-T Distribute Firewall Rule",
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
 		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
 	}

--- a/govcd/nsxt_distributed_firewall.go
+++ b/govcd/nsxt_distributed_firewall.go
@@ -18,6 +18,14 @@ type DistributedFirewall struct {
 	VdcGroup                         *VdcGroup
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (d DistributedFirewall) wrap(inner *types.DistributedFirewallRules) *DistributedFirewall {
+	d.DistributedFirewallRuleContainer = inner
+	return &d
+}
+
 // DistributedFirewallRule is a representation of a single rule
 type DistributedFirewallRule struct {
 	Rule     *types.DistributedFirewallRule
@@ -25,36 +33,27 @@ type DistributedFirewallRule struct {
 	VdcGroup *VdcGroup
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (d DistributedFirewallRule) wrap(inner *types.DistributedFirewallRule) *DistributedFirewallRule {
+	d.Rule = inner
+	return &d
+}
+
 // GetDistributedFirewall retrieves Distributed Firewall in a VDC Group which contains all rules
 //
 // Note. This function works only with `default` policy as this was the only supported when this
 // functions was created
 func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error) {
-	client := vdcGroup.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		entityName:     "NSX-T Distributed Firewall",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
 
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault))
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &DistributedFirewall{
-		DistributedFirewallRuleContainer: &types.DistributedFirewallRules{},
-		client:                           client,
-		VdcGroup:                         vdcGroup,
-	}
-
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.DistributedFirewallRuleContainer, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Distributed Firewall rules: %s", err)
-	}
-
-	return returnObject, nil
+	outerType := DistributedFirewall{client: vdcGroup.client, VdcGroup: vdcGroup}
+	return getOuterEntity[DistributedFirewall, types.DistributedFirewallRules](vdcGroup.client, outerType, c)
 }
 
 // UpdateDistributedFirewall updates Distributed Firewall in a VDC Group
@@ -62,31 +61,14 @@ func (vdcGroup *VdcGroup) GetDistributedFirewall() (*DistributedFirewall, error)
 // Note. This function works only with `default` policy as this was the only supported when this
 // functions was created
 func (vdcGroup *VdcGroup) UpdateDistributedFirewall(dfwRules *types.DistributedFirewallRules) (*DistributedFirewall, error) {
-	client := vdcGroup.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		entityName:     "NSX-T Distributed Firewall",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
 
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault))
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &DistributedFirewall{
-		DistributedFirewallRuleContainer: &types.DistributedFirewallRules{},
-		client:                           client,
-		VdcGroup:                         vdcGroup,
-	}
-
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, dfwRules, returnObject.DistributedFirewallRuleContainer, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating Distributed Firewall rules: %s", err)
-	}
-
-	return returnObject, nil
+	outerType := DistributedFirewall{client: vdcGroup.client, VdcGroup: vdcGroup}
+	return updateOuterEntity[DistributedFirewall, types.DistributedFirewallRules](vdcGroup.client, outerType, c, dfwRules)
 }
 
 // DeleteAllDistributedFirewallRules removes all Distributed Firewall rules
@@ -112,35 +94,14 @@ func (firewall *DistributedFirewall) DeleteAllRules() error {
 
 // GetDistributedFirewallRuleById retrieves single Distributed Firewall Rule by ID
 func (vdcGroup *VdcGroup) GetDistributedFirewallRuleById(id string) (*DistributedFirewallRule, error) {
-	if id == "" {
-		return nil, fmt.Errorf("id must be specified")
+	c := crudConfig{
+		entityName:     "NSX-T Distributed Firewall Rule",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", id},
 	}
 
-	client := vdcGroup.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault), "/", id)
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &DistributedFirewallRule{
-		Rule:     &types.DistributedFirewallRule{},
-		client:   client,
-		VdcGroup: vdcGroup,
-	}
-
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject.Rule, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving Distributed Firewall rule: %s", err)
-	}
-
-	return returnObject, nil
+	outerType := DistributedFirewallRule{client: vdcGroup.client, VdcGroup: vdcGroup}
+	return getOuterEntity[DistributedFirewallRule, types.DistributedFirewallRule](vdcGroup.client, outerType, c)
 }
 
 // GetDistributedFirewallRuleByName retrieves single firewall rule by name
@@ -154,19 +115,12 @@ func (vdcGroup *VdcGroup) GetDistributedFirewallRuleByName(name string) (*Distri
 		return nil, fmt.Errorf("error returning distributed firewall rules: %s", err)
 	}
 
-	var filteredByName []*types.DistributedFirewallRule
-	for _, rule := range dfw.DistributedFirewallRuleContainer.Values {
-		if rule.Name == name {
-			filteredByName = append(filteredByName, rule)
-		}
-	}
-
-	oneByName, err := oneOrError("name", name, filteredByName)
+	singleRuleByName, err := localFilterOneOrError(dfw.DistributedFirewallRuleContainer.Values, "Name", name, "NSX-T Distributed Firewall Rule")
 	if err != nil {
 		return nil, err
 	}
 
-	return vdcGroup.GetDistributedFirewallRuleById(oneByName.ID)
+	return vdcGroup.GetDistributedFirewallRuleById(singleRuleByName.ID)
 }
 
 // CreateDistributedFirewallRule is a non-thread safe wrapper around
@@ -193,27 +147,19 @@ func (vdcGroup *VdcGroup) GetDistributedFirewallRuleByName(name string) (*Distri
 // Note. Running this function concurrently will corrupt firewall rules as it uses an endpoint that
 // manages all rules ("vdcGroups/%s/dfwPolicies/%s/rules")
 func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId string, rule *types.DistributedFirewallRule) (*DistributedFirewall, *DistributedFirewallRule, error) {
-	client := vdcGroup.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault))
-	if err != nil {
-		return nil, nil, err
-	}
-
 	// 1. Getting all Distributed Firewall Rules and storing them in private intermediate
 	// type`distributedFirewallRulesRaw` which holds a []json.RawMessage (text) instead of exact types.
 	// This will prevent altering existing rules in any way (for example if a new field appears in
 	// schema in future VCD versions)
-	rawJsonExistingFirewallRules := &distributedFirewallRulesRaw{}
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, rawJsonExistingFirewallRules, nil)
+
+	c := crudConfig{
+		entityName:     "NSX-T Distributed Firewall Rule",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
+	}
+	rawJsonExistingFirewallRules, err := getInnerEntity[distributedFirewallRulesRaw](vdcGroup.client, c)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error retrieving Distributed Firewall rules in raw format: %s", err)
+		return nil, nil, err
 	}
 
 	// 2. Converting the give `rule` (*types.DistributedFirewallRule) into json.RawMessage so that
@@ -265,22 +211,32 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 		Values: dfwRuleUpdatePayload,
 	}
 
-	returnAllFirewallRules := &DistributedFirewall{
-		DistributedFirewallRuleContainer: &types.DistributedFirewallRules{},
-		client:                           client,
-		VdcGroup:                         vdcGroup,
+	c2 := crudConfig{
+		entityName:     "NSX-T Distributed Firewall Rule",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{vdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault},
 	}
 
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, updateRequestPayload, returnAllFirewallRules.DistributedFirewallRuleContainer, nil)
+	updatedFirewallRules, err := updateInnerEntity(vdcGroup.client, c2, updateRequestPayload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error updating Distributed Firewall rules: %s", err)
+		return nil, nil, err
 	}
 
-	// Create an entity for single firewall rule (which can be updated and deleted using their own endpoints)
+	dfwResults, err := convertRawJsonToFirewallRules(updatedFirewallRules)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	returnObjectSingleRule := &DistributedFirewallRule{
-		Rule:     returnAllFirewallRules.DistributedFirewallRuleContainer.Values[newRuleSlicePosition],
-		client:   client,
+		client:   vdcGroup.client,
 		VdcGroup: vdcGroup,
+		Rule:     dfwResults.Values[newRuleSlicePosition],
+	}
+
+	returnAllFirewallRules := &DistributedFirewall{
+		DistributedFirewallRuleContainer: dfwResults,
+		client:                           vdcGroup.client,
+		VdcGroup:                         vdcGroup,
 	}
 
 	return returnAllFirewallRules, returnObjectSingleRule, nil
@@ -288,63 +244,23 @@ func (vdcGroup *VdcGroup) CreateDistributedFirewallRule(optionalAboveRuleId stri
 
 // Update a single Distributed Firewall Rule
 func (dfwRule *DistributedFirewallRule) Update(rule *types.DistributedFirewallRule) (*DistributedFirewallRule, error) {
-	if dfwRule.Rule.ID == "" {
-		return nil, fmt.Errorf("cannot update NSX-T Distribute Firewall Rule without ID")
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
+		entityName:     "NSX-T Distribute Firewall Rule",
 	}
-
-	client := dfwRule.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault), "/", dfwRule.Rule.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	returnObjectSingleRule := &DistributedFirewallRule{
-		Rule:     &types.DistributedFirewallRule{},
-		client:   client,
-		VdcGroup: dfwRule.VdcGroup,
-	}
-
-	rule.ID = dfwRule.Rule.ID
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, rule, returnObjectSingleRule.Rule, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating Distributed Firewall rules: %s", err)
-	}
-
-	return returnObjectSingleRule, nil
+	outerType := DistributedFirewallRule{client: dfwRule.client, VdcGroup: dfwRule.VdcGroup}
+	return updateOuterEntity(dfwRule.client, outerType, c, rule)
 }
 
 // Delete a single Distributed Firewall Rule
 func (dfwRule *DistributedFirewallRule) Delete() error {
-	if dfwRule.Rule.ID == "" {
-		return fmt.Errorf("cannot delete NSX-T Distribute Firewall Rule without ID")
+	c := crudConfig{
+		entityName:     "NSX-T Distribute Firewall Rule",
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules,
+		endpointParams: []string{dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault, "/", dfwRule.Rule.ID},
 	}
-
-	client := dfwRule.client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcGroupsDfwRules
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
-	}
-
-	// "default" policy is hardcoded because there is no other policy supported
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, dfwRule.VdcGroup.VdcGroup.Id, types.DistributedFirewallPolicyDefault), "/", dfwRule.Rule.ID)
-	if err != nil {
-		return err
-	}
-
-	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-	if err != nil {
-		return fmt.Errorf("error deleting NSX-T Distribute Firewall Rule with ID '%s': %s", dfwRule.Rule.ID, err)
-	}
-
-	return nil
+	return deleteEntityById(dfwRule.client, c)
 }
 
 // getFirewallRuleIndexById searches for 'firewallRuleId' going through a list of available firewall

--- a/govcd/nsxt_segment_profile_template.go
+++ b/govcd/nsxt_segment_profile_template.go
@@ -17,93 +17,47 @@ type NsxtSegmentProfileTemplate struct {
 	VCDClient                  *VCDClient
 }
 
+// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (n NsxtSegmentProfileTemplate) wrap(inner *types.NsxtSegmentProfileTemplate) *NsxtSegmentProfileTemplate {
+	n.NsxtSegmentProfileTemplate = inner
+	return &n
+}
+
 // CreateSegmentProfileTemplate creates a Segment Profile Template that can later be assigned to
 // global VCD configuration, Org VDC or Org VDC Network
 func (vcdClient *VCDClient) CreateSegmentProfileTemplate(segmentProfileConfig *types.NsxtSegmentProfileTemplate) (*NsxtSegmentProfileTemplate, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		entityName: "NSX-T Segment Profile Template",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	returnSegmentProfile := &NsxtSegmentProfileTemplate{
-		NsxtSegmentProfileTemplate: &types.NsxtSegmentProfileTemplate{},
-		VCDClient:                  vcdClient,
-	}
-
-	err = vcdClient.Client.OpenApiPostItem(apiVersion, urlRef, nil, segmentProfileConfig, returnSegmentProfile.NsxtSegmentProfileTemplate, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating Segment Profile Template: %s", err)
-	}
-
-	return returnSegmentProfile, nil
+	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
+	return createOuterEntity(&vcdClient.Client, outerType, c, segmentProfileConfig)
 }
 
 // GetAllSegmentProfileTemplates retrieves all Segment Profile Templates
 func (vcdClient *VCDClient) GetAllSegmentProfileTemplates(queryFilter url.Values) ([]*NsxtSegmentProfileTemplate, error) {
-	client := vcdClient.Client
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates
-
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		entityName:      "NSX-T Segment Profile Template",
+		queryParameters: queryFilter,
 	}
 
-	urlRef, err := client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileTemplate{{}}
-	err = client.OpenApiGetAllItems(apiVersion, urlRef, queryFilter, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	wrappedResponses := make([]*NsxtSegmentProfileTemplate, len(typeResponses))
-	for sliceIndex, singleSegmentProfileTemplate := range typeResponses {
-		wrappedResponses[sliceIndex] = &NsxtSegmentProfileTemplate{
-			NsxtSegmentProfileTemplate: singleSegmentProfileTemplate,
-			VCDClient:                  vcdClient,
-		}
-	}
-
-	return wrappedResponses, nil
+	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
+	return getAllOuterEntities[NsxtSegmentProfileTemplate, types.NsxtSegmentProfileTemplate](&vcdClient.Client, outerType, c)
 }
 
 // GetSegmentProfileTemplateById retrieves Segment Profile Template by ID
 func (vcdClient *VCDClient) GetSegmentProfileTemplateById(id string) (*NsxtSegmentProfileTemplate, error) {
-	if id == "" {
-		return nil, fmt.Errorf("empty NSX-T Segment Profile Template ID")
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		endpointParams: []string{id},
+		entityName:     "IP Space",
 	}
 
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint, id)
-	if err != nil {
-		return nil, err
-	}
-
-	wrappedSegmentProfile := &NsxtSegmentProfileTemplate{
-		NsxtSegmentProfileTemplate: &types.NsxtSegmentProfileTemplate{},
-		VCDClient:                  vcdClient,
-	}
-
-	err = vcdClient.Client.OpenApiGetItem(apiVersion, urlRef, nil, wrappedSegmentProfile.NsxtSegmentProfileTemplate, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return wrappedSegmentProfile, nil
+	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
+	return getOuterEntity[NsxtSegmentProfileTemplate, types.NsxtSegmentProfileTemplate](&vcdClient.Client, outerType, c)
 }
 
 // GetSegmentProfileTemplateByName retrieves Segment Profile Template by ID
@@ -126,56 +80,21 @@ func (vcdClient *VCDClient) GetSegmentProfileTemplateByName(name string) (*NsxtS
 
 // Update Segment Profile Template
 func (spt *NsxtSegmentProfileTemplate) Update(nsxtSegmentProfileTemplateConfig *types.NsxtSegmentProfileTemplate) (*NsxtSegmentProfileTemplate, error) {
-	if nsxtSegmentProfileTemplateConfig.ID == "" {
-		return nil, fmt.Errorf("cannot update NSX-T Segment Profile Template without ID")
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		endpointParams: []string{nsxtSegmentProfileTemplateConfig.ID},
+		entityName:     "IP Space",
 	}
-
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates
-	apiVersion, err := spt.VCDClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	urlRef, err := spt.VCDClient.Client.OpenApiBuildEndpoint(endpoint, nsxtSegmentProfileTemplateConfig.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	returnSpt := &NsxtSegmentProfileTemplate{
-		NsxtSegmentProfileTemplate: &types.NsxtSegmentProfileTemplate{},
-		VCDClient:                  spt.VCDClient,
-	}
-
-	err = spt.VCDClient.Client.OpenApiPutItem(apiVersion, urlRef, nil, nsxtSegmentProfileTemplateConfig, returnSpt.NsxtSegmentProfileTemplate, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating Edge Gateway: %s", err)
-	}
-
-	return returnSpt, nil
+	outerType := NsxtSegmentProfileTemplate{VCDClient: spt.VCDClient}
+	return updateOuterEntity(&spt.VCDClient.Client, outerType, c, nsxtSegmentProfileTemplateConfig)
 }
 
 // Delete allows deleting NSX-T Segment Profile Template
 func (spt *NsxtSegmentProfileTemplate) Delete() error {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates
-	apiVersion, err := spt.VCDClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		endpointParams: []string{spt.NsxtSegmentProfileTemplate.ID},
+		entityName:     "IP Space",
 	}
-
-	if spt.NsxtSegmentProfileTemplate.ID == "" {
-		return fmt.Errorf("cannot delete Segment Profile Template without ID")
-	}
-
-	urlRef, err := spt.VCDClient.Client.OpenApiBuildEndpoint(endpoint, spt.NsxtSegmentProfileTemplate.ID)
-	if err != nil {
-		return err
-	}
-
-	err = spt.VCDClient.Client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-
-	if err != nil {
-		return fmt.Errorf("error deleting Segment Profile Template: %s", err)
-	}
-
-	return nil
+	return deleteEntityById(&spt.VCDClient.Client, c)
 }

--- a/govcd/nsxt_segment_profile_template.go
+++ b/govcd/nsxt_segment_profile_template.go
@@ -11,6 +11,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const labelNsxtSegmentProfileTemplate = "NSX-T Segment Profile Template"
+
 // NsxtSegmentProfileTemplate contains a structure for configuring Segment Profile Templates
 type NsxtSegmentProfileTemplate struct {
 	NsxtSegmentProfileTemplate *types.NsxtSegmentProfileTemplate
@@ -30,7 +32,7 @@ func (n NsxtSegmentProfileTemplate) wrap(inner *types.NsxtSegmentProfileTemplate
 func (vcdClient *VCDClient) CreateSegmentProfileTemplate(segmentProfileConfig *types.NsxtSegmentProfileTemplate) (*NsxtSegmentProfileTemplate, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
-		entityLabel: "NSX-T Segment Profile Template",
+		entityLabel: labelNsxtSegmentProfileTemplate,
 	}
 	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
 	return createOuterEntity(&vcdClient.Client, outerType, c, segmentProfileConfig)
@@ -40,7 +42,7 @@ func (vcdClient *VCDClient) CreateSegmentProfileTemplate(segmentProfileConfig *t
 func (vcdClient *VCDClient) GetAllSegmentProfileTemplates(queryFilter url.Values) ([]*NsxtSegmentProfileTemplate, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
-		entityLabel:     "NSX-T Segment Profile Template",
+		entityLabel:     labelNsxtSegmentProfileTemplate,
 		queryParameters: queryFilter,
 	}
 
@@ -53,7 +55,7 @@ func (vcdClient *VCDClient) GetSegmentProfileTemplateById(id string) (*NsxtSegme
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{id},
-		entityLabel:    "IP Space",
+		entityLabel:    labelNsxtSegmentProfileTemplate,
 	}
 
 	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
@@ -83,7 +85,7 @@ func (spt *NsxtSegmentProfileTemplate) Update(nsxtSegmentProfileTemplateConfig *
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{nsxtSegmentProfileTemplateConfig.ID},
-		entityLabel:    "IP Space",
+		entityLabel:    labelNsxtSegmentProfileTemplate,
 	}
 	outerType := NsxtSegmentProfileTemplate{VCDClient: spt.VCDClient}
 	return updateOuterEntity(&spt.VCDClient.Client, outerType, c, nsxtSegmentProfileTemplateConfig)
@@ -94,7 +96,7 @@ func (spt *NsxtSegmentProfileTemplate) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{spt.NsxtSegmentProfileTemplate.ID},
-		entityLabel:    "IP Space",
+		entityLabel:    labelNsxtSegmentProfileTemplate,
 	}
 	return deleteEntityById(&spt.VCDClient.Client, c)
 }

--- a/govcd/nsxt_segment_profile_template.go
+++ b/govcd/nsxt_segment_profile_template.go
@@ -29,8 +29,8 @@ func (n NsxtSegmentProfileTemplate) wrap(inner *types.NsxtSegmentProfileTemplate
 // global VCD configuration, Org VDC or Org VDC Network
 func (vcdClient *VCDClient) CreateSegmentProfileTemplate(segmentProfileConfig *types.NsxtSegmentProfileTemplate) (*NsxtSegmentProfileTemplate, error) {
 	c := crudConfig{
-		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
-		entityName: "NSX-T Segment Profile Template",
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
+		entityLabel: "NSX-T Segment Profile Template",
 	}
 	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
 	return createOuterEntity(&vcdClient.Client, outerType, c, segmentProfileConfig)
@@ -40,7 +40,7 @@ func (vcdClient *VCDClient) CreateSegmentProfileTemplate(segmentProfileConfig *t
 func (vcdClient *VCDClient) GetAllSegmentProfileTemplates(queryFilter url.Values) ([]*NsxtSegmentProfileTemplate, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
-		entityName:      "NSX-T Segment Profile Template",
+		entityLabel:     "NSX-T Segment Profile Template",
 		queryParameters: queryFilter,
 	}
 
@@ -53,7 +53,7 @@ func (vcdClient *VCDClient) GetSegmentProfileTemplateById(id string) (*NsxtSegme
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{id},
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 	}
 
 	outerType := NsxtSegmentProfileTemplate{VCDClient: vcdClient}
@@ -83,7 +83,7 @@ func (spt *NsxtSegmentProfileTemplate) Update(nsxtSegmentProfileTemplateConfig *
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{nsxtSegmentProfileTemplateConfig.ID},
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 	}
 	outerType := NsxtSegmentProfileTemplate{VCDClient: spt.VCDClient}
 	return updateOuterEntity(&spt.VCDClient.Client, outerType, c, nsxtSegmentProfileTemplateConfig)
@@ -94,7 +94,7 @@ func (spt *NsxtSegmentProfileTemplate) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentProfileTemplates,
 		endpointParams: []string{spt.NsxtSegmentProfileTemplate.ID},
-		entityName:     "IP Space",
+		entityLabel:    "IP Space",
 	}
 	return deleteEntityById(&spt.VCDClient.Client, c)
 }

--- a/govcd/nsxt_segment_profile_template.go
+++ b/govcd/nsxt_segment_profile_template.go
@@ -19,7 +19,7 @@ type NsxtSegmentProfileTemplate struct {
 	VCDClient                  *VCDClient
 }
 
-// wrap is a hidden helper that helps to facilitate usage of generic CRUD function
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
 //
 //lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
 func (n NsxtSegmentProfileTemplate) wrap(inner *types.NsxtSegmentProfileTemplate) *NsxtSegmentProfileTemplate {

--- a/govcd/nsxt_segment_profiles.go
+++ b/govcd/nsxt_segment_profiles.go
@@ -10,6 +10,14 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const (
+	labelIpDiscoveryProfiles     = "IP Discovery Profiles"
+	labelMacDiscoveryProfiles    = "MAC Discovery Profiles"
+	labelSpoofGuardProfiles      = "Spoof Guard Profiles"
+	labelQosProfiles             = "QoS Profiles"
+	labelSegmentSecurityProfiles = "Segment Security Profiles"
+)
+
 // GetAllIpDiscoveryProfiles retrieves all IP Discovery Profiles configured in an NSX-T manager.
 // NSX-T manager ID (nsxTManagerRef.id), Org VDC ID (orgVdcId) or VDC Group ID (vdcGroupId) must be
 // supplied as a filter. Results can also be filtered by a single profile ID
@@ -18,7 +26,7 @@ func (vcdClient *VCDClient) GetAllIpDiscoveryProfiles(queryParameters url.Values
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles,
 		queryParameters: queryParameters,
-		entityLabel:     "IP Discovery Profiles",
+		entityLabel:     labelIpDiscoveryProfiles,
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileIpDiscovery](&vcdClient.Client, c)
 }
@@ -29,7 +37,7 @@ func (vcdClient *VCDClient) GetIpDiscoveryProfileByName(name string, queryParame
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment IP Discovery Profile")
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelIpDiscoveryProfiles)
 }
 
 // GetAllMacDiscoveryProfiles retrieves all MAC Discovery Profiles configured in an NSX-T manager.
@@ -40,7 +48,7 @@ func (vcdClient *VCDClient) GetAllMacDiscoveryProfiles(queryParameters url.Value
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentMacDiscoveryProfiles,
 		queryParameters: queryParameters,
-		entityLabel:     "MAC Discovery Profiles",
+		entityLabel:     labelMacDiscoveryProfiles,
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileMacDiscovery](&vcdClient.Client, c)
 }
@@ -51,7 +59,7 @@ func (vcdClient *VCDClient) GetMacDiscoveryProfileByName(name string, queryParam
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment MAC Discovery Profile")
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelMacDiscoveryProfiles)
 }
 
 // GetAllSpoofGuardProfiles retrieves all Spoof Guard Profiles configured in an NSX-T manager.
@@ -62,7 +70,7 @@ func (vcdClient *VCDClient) GetAllSpoofGuardProfiles(queryParameters url.Values)
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSpoofGuardProfiles,
 		queryParameters: queryParameters,
-		entityLabel:     "Spoof Guard Profiles",
+		entityLabel:     labelSpoofGuardProfiles,
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSpoofGuard](&vcdClient.Client, c)
 }
@@ -73,7 +81,7 @@ func (vcdClient *VCDClient) GetSpoofGuardProfileByName(name string, queryParamet
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment Spoof Guard Profile")
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelSpoofGuardProfiles)
 }
 
 // GetAllQoSProfiles retrieves all QoS Profiles configured in an NSX-T manager.
@@ -84,7 +92,7 @@ func (vcdClient *VCDClient) GetAllQoSProfiles(queryParameters url.Values) ([]*ty
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentQosProfiles,
 		queryParameters: queryParameters,
-		entityLabel:     "QoS Profiles",
+		entityLabel:     labelQosProfiles,
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentQosProfile](&vcdClient.Client, c)
 }
@@ -95,7 +103,7 @@ func (vcdClient *VCDClient) GetQoSProfileByName(name string, queryParameters url
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment QoS Profile")
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelQosProfiles)
 }
 
 // GetAllSegmentSecurityProfiles retrieves all Segment Security Profiles configured in an NSX-T manager.
@@ -106,7 +114,7 @@ func (vcdClient *VCDClient) GetAllSegmentSecurityProfiles(queryParameters url.Va
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSecurityProfiles,
 		queryParameters: queryParameters,
-		entityLabel:     "Segment Security Profiles",
+		entityLabel:     labelSegmentSecurityProfiles,
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSecurity](&vcdClient.Client, c)
 }
@@ -117,5 +125,5 @@ func (vcdClient *VCDClient) GetSegmentSecurityProfileByName(name string, queryPa
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment Security Profile")
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelSegmentSecurityProfiles)
 }

--- a/govcd/nsxt_segment_profiles.go
+++ b/govcd/nsxt_segment_profiles.go
@@ -37,7 +37,7 @@ func (vcdClient *VCDClient) GetIpDiscoveryProfileByName(name string, queryParame
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelIpDiscoveryProfiles)
+	return localFilterOneOrError(labelIpDiscoveryProfiles, apiFilteredEntities, "DisplayName", name)
 }
 
 // GetAllMacDiscoveryProfiles retrieves all MAC Discovery Profiles configured in an NSX-T manager.
@@ -59,7 +59,7 @@ func (vcdClient *VCDClient) GetMacDiscoveryProfileByName(name string, queryParam
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelMacDiscoveryProfiles)
+	return localFilterOneOrError(labelMacDiscoveryProfiles, apiFilteredEntities, "DisplayName", name)
 }
 
 // GetAllSpoofGuardProfiles retrieves all Spoof Guard Profiles configured in an NSX-T manager.
@@ -81,7 +81,7 @@ func (vcdClient *VCDClient) GetSpoofGuardProfileByName(name string, queryParamet
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelSpoofGuardProfiles)
+	return localFilterOneOrError(labelSpoofGuardProfiles, apiFilteredEntities, "DisplayName", name)
 }
 
 // GetAllQoSProfiles retrieves all QoS Profiles configured in an NSX-T manager.
@@ -103,7 +103,7 @@ func (vcdClient *VCDClient) GetQoSProfileByName(name string, queryParameters url
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelQosProfiles)
+	return localFilterOneOrError(labelQosProfiles, apiFilteredEntities, "DisplayName", name)
 }
 
 // GetAllSegmentSecurityProfiles retrieves all Segment Security Profiles configured in an NSX-T manager.
@@ -125,5 +125,5 @@ func (vcdClient *VCDClient) GetSegmentSecurityProfileByName(name string, queryPa
 		return nil, err
 	}
 
-	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, labelSegmentSecurityProfiles)
+	return localFilterOneOrError(labelSegmentSecurityProfiles, apiFilteredEntities, "DisplayName", name)
 }

--- a/govcd/nsxt_segment_profiles.go
+++ b/govcd/nsxt_segment_profiles.go
@@ -15,41 +15,21 @@ import (
 // supplied as a filter. Results can also be filtered by a single profile ID
 // (filter=nsxTManagerRef.id==nsxTManagerUrn;id==profileId).
 func (vcdClient *VCDClient) GetAllIpDiscoveryProfiles(queryParameters url.Values) ([]*types.NsxtSegmentProfileIpDiscovery, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles,
+		queryParameters: queryParameters,
+		entityName:      "IP Discovery Profiles",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileIpDiscovery{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.NsxtSegmentProfileIpDiscovery](&vcdClient.Client, c)
 }
 
-// GetIpDiscoveryProfileByName retrieves an NSX-T Segment IP Discovery Profile by given name
 func (vcdClient *VCDClient) GetIpDiscoveryProfileByName(name string, queryParameters url.Values) (*types.NsxtSegmentProfileIpDiscovery, error) {
 	apiFilteredEntities, err := vcdClient.GetAllIpDiscoveryProfiles(queryParameters) // API filtering by 'displayName' field is not supported
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName := make([]*types.NsxtSegmentProfileIpDiscovery, 0)
-	for _, v := range apiFilteredEntities {
-		if v.DisplayName == name {
-			filteredByName = append(filteredByName, v)
-		}
-	}
-
-	return oneOrError("displayName", name, filteredByName)
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment IP Discovery Profile")
 }
 
 // GetAllMacDiscoveryProfiles retrieves all MAC Discovery Profiles configured in an NSX-T manager.
@@ -57,41 +37,21 @@ func (vcdClient *VCDClient) GetIpDiscoveryProfileByName(name string, queryParame
 // supplied as a filter. Results can also be filtered by a single profile ID
 // (filter=nsxTManagerRef.id==nsxTManagerUrn;id==profileId).
 func (vcdClient *VCDClient) GetAllMacDiscoveryProfiles(queryParameters url.Values) ([]*types.NsxtSegmentProfileMacDiscovery, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentMacDiscoveryProfiles
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentMacDiscoveryProfiles,
+		queryParameters: queryParameters,
+		entityName:      "MAC Discovery Profiles",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileMacDiscovery{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.NsxtSegmentProfileMacDiscovery](&vcdClient.Client, c)
 }
 
-// GetMacDiscoveryProfileByName retrieves an NSX-T Segment MAC Discovery Profile by given name
 func (vcdClient *VCDClient) GetMacDiscoveryProfileByName(name string, queryParameters url.Values) (*types.NsxtSegmentProfileMacDiscovery, error) {
 	apiFilteredEntities, err := vcdClient.GetAllMacDiscoveryProfiles(queryParameters) // API filtering by 'displayName' field is not supported
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName := make([]*types.NsxtSegmentProfileMacDiscovery, 0)
-	for _, v := range apiFilteredEntities {
-		if v.DisplayName == name {
-			filteredByName = append(filteredByName, v)
-		}
-	}
-
-	return oneOrError("displayName", name, filteredByName)
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment MAC Discovery Profile")
 }
 
 // GetAllSpoofGuardProfiles retrieves all Spoof Guard Profiles configured in an NSX-T manager.
@@ -99,41 +59,21 @@ func (vcdClient *VCDClient) GetMacDiscoveryProfileByName(name string, queryParam
 // supplied as a filter. Results can also be filtered by a single profile ID
 // (filter=nsxTManagerRef.id==nsxTManagerUrn;id==profileId).
 func (vcdClient *VCDClient) GetAllSpoofGuardProfiles(queryParameters url.Values) ([]*types.NsxtSegmentProfileSegmentSpoofGuard, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSpoofGuardProfiles
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSpoofGuardProfiles,
+		queryParameters: queryParameters,
+		entityName:      "Spoof Guard Profiles",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileSegmentSpoofGuard{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSpoofGuard](&vcdClient.Client, c)
 }
 
-// GetSpoofGuardProfileByName retrieves an NSX-T Segment Spoof Guard Profile by given name
 func (vcdClient *VCDClient) GetSpoofGuardProfileByName(name string, queryParameters url.Values) (*types.NsxtSegmentProfileSegmentSpoofGuard, error) {
 	apiFilteredEntities, err := vcdClient.GetAllSpoofGuardProfiles(queryParameters) // API filtering by 'displayName' field is not supported
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName := make([]*types.NsxtSegmentProfileSegmentSpoofGuard, 0)
-	for _, v := range apiFilteredEntities {
-		if v.DisplayName == name {
-			filteredByName = append(filteredByName, v)
-		}
-	}
-
-	return oneOrError("displayName", name, filteredByName)
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment Spoof Guard Profile")
 }
 
 // GetAllQoSProfiles retrieves all QoS Profiles configured in an NSX-T manager.
@@ -141,41 +81,21 @@ func (vcdClient *VCDClient) GetSpoofGuardProfileByName(name string, queryParamet
 // supplied as a filter. Results can also be filtered by a single profile ID
 // (filter=nsxTManagerRef.id==nsxTManagerUrn;id==profileId).
 func (vcdClient *VCDClient) GetAllQoSProfiles(queryParameters url.Values) ([]*types.NsxtSegmentProfileSegmentQosProfile, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentQosProfiles
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentQosProfiles,
+		queryParameters: queryParameters,
+		entityName:      "QoS Profiles",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileSegmentQosProfile{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.NsxtSegmentProfileSegmentQosProfile](&vcdClient.Client, c)
 }
 
-// GetQoSProfileByName retrieves an NSX-T Segment QoS Profile by given name
 func (vcdClient *VCDClient) GetQoSProfileByName(name string, queryParameters url.Values) (*types.NsxtSegmentProfileSegmentQosProfile, error) {
 	apiFilteredEntities, err := vcdClient.GetAllQoSProfiles(queryParameters) // API filtering by 'displayName' field is not supported
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName := make([]*types.NsxtSegmentProfileSegmentQosProfile, 0)
-	for _, v := range apiFilteredEntities {
-		if v.DisplayName == name {
-			filteredByName = append(filteredByName, v)
-		}
-	}
-
-	return oneOrError("displayName", name, filteredByName)
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment QoS Profile")
 }
 
 // GetAllSegmentSecurityProfiles retrieves all Segment Security Profiles configured in an NSX-T manager.
@@ -183,39 +103,19 @@ func (vcdClient *VCDClient) GetQoSProfileByName(name string, queryParameters url
 // supplied as a filter. Results can also be filtered by a single profile ID
 // (filter=nsxTManagerRef.id==nsxTManagerUrn;id==profileId).
 func (vcdClient *VCDClient) GetAllSegmentSecurityProfiles(queryParameters url.Values) ([]*types.NsxtSegmentProfileSegmentSecurity, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSecurityProfiles
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSecurityProfiles,
+		queryParameters: queryParameters,
+		entityName:      "Segment Security Profiles",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponses := []*types.NsxtSegmentProfileSegmentSecurity{{}}
-	err = vcdClient.Client.OpenApiGetAllItems(apiVersion, urlRef, queryParameters, &typeResponses, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponses, nil
+	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSecurity](&vcdClient.Client, c)
 }
 
-// GetSegmentSecurityProfileByName retrieves an NSX-T Segment Security Profile by given name
 func (vcdClient *VCDClient) GetSegmentSecurityProfileByName(name string, queryParameters url.Values) (*types.NsxtSegmentProfileSegmentSecurity, error) {
 	apiFilteredEntities, err := vcdClient.GetAllSegmentSecurityProfiles(queryParameters) // API filtering by 'displayName' field is not supported
 	if err != nil {
 		return nil, err
 	}
 
-	filteredByName := make([]*types.NsxtSegmentProfileSegmentSecurity, 0)
-	for _, v := range apiFilteredEntities {
-		if v.DisplayName == name {
-			filteredByName = append(filteredByName, v)
-		}
-	}
-
-	return oneOrError("displayName", name, filteredByName)
+	return localFilterOneOrError(apiFilteredEntities, "DisplayName", name, "Segment Security Profile")
 }

--- a/govcd/nsxt_segment_profiles.go
+++ b/govcd/nsxt_segment_profiles.go
@@ -18,7 +18,7 @@ func (vcdClient *VCDClient) GetAllIpDiscoveryProfiles(queryParameters url.Values
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles,
 		queryParameters: queryParameters,
-		entityName:      "IP Discovery Profiles",
+		entityLabel:     "IP Discovery Profiles",
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileIpDiscovery](&vcdClient.Client, c)
 }
@@ -40,7 +40,7 @@ func (vcdClient *VCDClient) GetAllMacDiscoveryProfiles(queryParameters url.Value
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentMacDiscoveryProfiles,
 		queryParameters: queryParameters,
-		entityName:      "MAC Discovery Profiles",
+		entityLabel:     "MAC Discovery Profiles",
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileMacDiscovery](&vcdClient.Client, c)
 }
@@ -62,7 +62,7 @@ func (vcdClient *VCDClient) GetAllSpoofGuardProfiles(queryParameters url.Values)
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSpoofGuardProfiles,
 		queryParameters: queryParameters,
-		entityName:      "Spoof Guard Profiles",
+		entityLabel:     "Spoof Guard Profiles",
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSpoofGuard](&vcdClient.Client, c)
 }
@@ -84,7 +84,7 @@ func (vcdClient *VCDClient) GetAllQoSProfiles(queryParameters url.Values) ([]*ty
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentQosProfiles,
 		queryParameters: queryParameters,
-		entityName:      "QoS Profiles",
+		entityLabel:     "QoS Profiles",
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentQosProfile](&vcdClient.Client, c)
 }
@@ -106,7 +106,7 @@ func (vcdClient *VCDClient) GetAllSegmentSecurityProfiles(queryParameters url.Va
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentSecurityProfiles,
 		queryParameters: queryParameters,
-		entityName:      "Segment Security Profiles",
+		entityLabel:     "Segment Security Profiles",
 	}
 	return getAllInnerEntities[types.NsxtSegmentProfileSegmentSecurity](&vcdClient.Client, c)
 }

--- a/govcd/openapi_generic_inner_entities.go
+++ b/govcd/openapi_generic_inner_entities.go
@@ -20,7 +20,7 @@ type crudConfig struct {
 
 	// Optional parameters
 
-	// endpointParams contains a slice of strings that will be used to construct request URL. It will
+	// endpointParams contains a slice of strings that will be used to construct the request URL. It will
 	// initially replace '%s' placeholders in the `endpoint` (if any) and will add them as suffix
 	// afterwards
 	endpointParams []string

--- a/govcd/openapi_generic_inner_entities.go
+++ b/govcd/openapi_generic_inner_entities.go
@@ -1,0 +1,264 @@
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// crudConfig contains configuration that must be supplied when invoking generic functions that are defined
+// in `openapi_generic_inner_entities.go` and `openapi_generic_outer_entities.go`
+type crudConfig struct {
+	// Mandatory parameters
+
+	// entityName contains friendly entity name that is used for logging meaningful errors
+	entityName string
+
+	// endpoint in the usual format (e.g. types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles)
+	endpoint string
+
+	// Optional parameters
+
+	// endpointParams contains a slice of strings that will be used to contruct request URL. It will
+	// initially replace '%s' placeholders in the `endpoint` (if any) and will add them as suffix
+	// afterwards
+	endpointParams []string
+
+	// queryParameters will be passed as GET queries to the URL. Usually they are used for API filtering parameters
+	queryParameters url.Values
+	// additionalHeader can be used to pass additional headers for API calls. One of the common purposes is to pass
+	// tenant context
+	additionalHeader map[string]string
+}
+
+// validate should catch errors in consuming generic CRUD functions and should never produce false
+// positives.
+func (c crudConfig) validate() error {
+	// crudConfig misconfiguration - we can panic so that developer catches the problem during
+	// development of this SDK
+	if c.entityName == "" {
+		panic("'entityName' must always be specified when initializing crudConfig")
+	}
+
+	if c.endpoint == "" {
+		panic("'endpoint' must always be specified when initializing crudConfig")
+	}
+
+	// softer validations that consumers of this SDK can manipulate
+
+	// If `endpointParams` is specified in `crudConfig` (it is not nil), then it must contain at
+	// least a single non empty string parameter
+	// Such validation should prevent cases where some ID is not speficied upon function call.
+	// E.g.: endpointParams: []string{vdcId}, <--- vdcId comes from consumer of the SDK
+	// If the user specified empty `vdcId` - we'd validate this
+	for _, paramValue := range c.endpointParams {
+		if paramValue == "" {
+			return fmt.Errorf(`endpointParams were specified but they contain empty value "" for %s`, c.entityName)
+		}
+	}
+
+	return nil
+}
+
+// createInnerEntity implements a common pattern for creating an entity throughout codebase
+// Parameters:
+// * `client` is a *Client
+// * `c` holds settings for performing API call
+// * `innerConfig` is the new entity type
+func createInnerEntity[I any](client *Client, c crudConfig, innerConfig *I) (*I, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error getting API version for creating entity '%s': %s", c.entityName, err)
+	}
+
+	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
+	if err != nil {
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error building API endpoint for entity '%s' creation: %s", c.entityName, err)
+	}
+
+	createdInnerEntityConfig := new(I)
+	err = client.OpenApiPostItem(apiVersion, urlRef, c.queryParameters, innerConfig, createdInnerEntityConfig, c.additionalHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error creating entity of type '%s': %s", c.entityName, err)
+	}
+
+	return createdInnerEntityConfig, nil
+}
+
+// updateInnerEntity implements a common pattern for updating entity throughout codebase
+// Parameters:
+// * `client` is a *Client
+// * `c` holds settings for performing API call
+// * `innerConfig` is the new entity type
+func updateInnerEntity[I any](client *Client, c crudConfig, innerConfig *I) (*I, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error getting API version for updating entity '%s': %s", c.entityName, err)
+	}
+
+	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
+	if err != nil {
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error building API endpoint for entity '%s' update: %s", c.entityName, err)
+	}
+
+	updatedInnerEntityConfig := new(I)
+	err = client.OpenApiPutItem(apiVersion, urlRef, c.queryParameters, innerConfig, updatedInnerEntityConfig, c.additionalHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error updating entity of type '%s': %s", c.entityName, err)
+	}
+
+	return updatedInnerEntityConfig, nil
+}
+
+// getInnerEntity is an implementation for a common pattern in our code where we have to retrieve
+// outer entity (usually *types.XXXX) and does not need to be wrapped in an inner container entity.
+// Parameters:
+// * `client` is a *Client
+// * `c` holds settings for performing API call
+func getInnerEntity[I any](client *Client, c crudConfig) (*I, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityName, err)
+	}
+
+	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
+	if err != nil {
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityName, err)
+	}
+
+	typeResponse := new(I)
+	err = client.OpenApiGetItem(apiVersion, urlRef, c.queryParameters, typeResponse, c.additionalHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving entity of type '%s': %s", c.entityName, err)
+	}
+
+	return typeResponse, nil
+}
+
+// getAllInnerEntities can be used to retrieve a slice of any inner entities in the OpenAPI
+// endpoints that are not nested in outer types
+//
+// Parameters:
+// * `client` is a *Client
+// * `c` holds settings for performing API call
+func getAllInnerEntities[I any](client *Client, c crudConfig) ([]*I, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityName, err)
+	}
+
+	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
+	if err != nil {
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityName, err)
+	}
+
+	typeResponses := make([]*I, 0)
+	err = client.OpenApiGetAllItems(apiVersion, urlRef, c.queryParameters, &typeResponses, c.additionalHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving all entities of type '%s': %s", c.entityName, err)
+	}
+
+	return typeResponses, nil
+}
+
+// deleteEntityById performs a common operation for OpenAPI endpoints that calls DELETE method for a
+// given endpoint.
+// Note. It does not use generics for the operation, but is held in this file with other CRUD entries
+// Parameters:
+// * `client` is a *Client
+// * `c` holds settings for performing API call
+func deleteEntityById(client *Client, c crudConfig) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+
+	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
+	if err != nil {
+		return err
+	}
+
+	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
+	if err != nil {
+		return fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+	}
+
+	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
+	if err != nil {
+		return err
+	}
+
+	err = client.OpenApiDeleteItem(apiVersion, urlRef, c.queryParameters, c.additionalHeader)
+
+	if err != nil {
+		return fmt.Errorf("error deleting %s: %s", c.entityName, err)
+	}
+
+	return nil
+}
+
+func urlFromEndpoint(endpoint string, endpointParams []string) (string, error) {
+	// Count how many '%s' placeholders exist in the 'endpoint'
+	placeholderCount := strings.Count(endpoint, "%s")
+
+	// Validation. At the very minimum all placeholders must have their replacements - otherwise it
+	// is an error as we never want to query an endpoint that still has placeholders '%s'
+	if len(endpointParams) < placeholderCount {
+		return "", fmt.Errorf("endpoint '%s' has unpopulated placeholders", endpoint)
+	}
+
+	// if there are no 'endpointParams' - exit with the same endpoint
+	if len(endpointParams) == 0 {
+		return endpoint, nil
+	}
+
+	// Loop over given endpointParams and replace placeholders at first. Afterwards - amend any
+	// additional parameters to the end of endpoint
+	for _, v := range endpointParams {
+		// If there are placeholders '%s' to replace in the endpoint itself - do it
+		if placeholderCount > 0 {
+			endpoint = strings.Replace(endpoint, "%s", v, 1)
+			placeholderCount = placeholderCount - 1
+			continue
+		}
+
+		endpoint = endpoint + v
+	}
+
+	return endpoint, nil
+}

--- a/govcd/openapi_generic_inner_entities.go
+++ b/govcd/openapi_generic_inner_entities.go
@@ -53,7 +53,8 @@ func (c crudConfig) validate() error {
 	// If the user specified empty `vdcId` - we'd validate this
 	for _, paramValue := range c.endpointParams {
 		if paramValue == "" {
-			return fmt.Errorf(`endpointParams were specified but they contain empty value "" for %s`, c.entityName)
+			return fmt.Errorf(`endpointParams were specified but they contain empty value "" for %s. %#v`,
+				c.entityName, c.endpointParams)
 		}
 	}
 

--- a/govcd/openapi_generic_inner_entities.go
+++ b/govcd/openapi_generic_inner_entities.go
@@ -11,15 +11,15 @@ import (
 type crudConfig struct {
 	// Mandatory parameters
 
-	// entityName contains friendly entity name that is used for logging meaningful errors
-	entityName string
+	// entityLabel contains friendly entity name that is used for logging meaningful errors
+	entityLabel string
 
 	// endpoint in the usual format (e.g. types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtSegmentIpDiscoveryProfiles)
 	endpoint string
 
 	// Optional parameters
 
-	// endpointParams contains a slice of strings that will be used to contruct request URL. It will
+	// endpointParams contains a slice of strings that will be used to construct request URL. It will
 	// initially replace '%s' placeholders in the `endpoint` (if any) and will add them as suffix
 	// afterwards
 	endpointParams []string
@@ -36,7 +36,7 @@ type crudConfig struct {
 func (c crudConfig) validate() error {
 	// crudConfig misconfiguration - we can panic so that developer catches the problem during
 	// development of this SDK
-	if c.entityName == "" {
+	if c.entityLabel == "" {
 		panic("'entityName' must always be specified when initializing crudConfig")
 	}
 
@@ -54,7 +54,7 @@ func (c crudConfig) validate() error {
 	for _, paramValue := range c.endpointParams {
 		if paramValue == "" {
 			return fmt.Errorf(`endpointParams were specified but they contain empty value "" for %s. %#v`,
-				c.entityName, c.endpointParams)
+				c.entityLabel, c.endpointParams)
 		}
 	}
 
@@ -73,23 +73,23 @@ func createInnerEntity[I any](client *Client, c crudConfig, innerConfig *I) (*I,
 
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error getting API version for creating entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error getting API version for creating entity '%s': %s", c.entityLabel, err)
 	}
 
 	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
 	if err != nil {
-		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityLabel, err)
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error building API endpoint for entity '%s' creation: %s", c.entityName, err)
+		return nil, fmt.Errorf("error building API endpoint for entity '%s' creation: %s", c.entityLabel, err)
 	}
 
 	createdInnerEntityConfig := new(I)
 	err = client.OpenApiPostItem(apiVersion, urlRef, c.queryParameters, innerConfig, createdInnerEntityConfig, c.additionalHeader)
 	if err != nil {
-		return nil, fmt.Errorf("error creating entity of type '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error creating entity of type '%s': %s", c.entityLabel, err)
 	}
 
 	return createdInnerEntityConfig, nil
@@ -107,23 +107,23 @@ func updateInnerEntity[I any](client *Client, c crudConfig, innerConfig *I) (*I,
 
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error getting API version for updating entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error getting API version for updating entity '%s': %s", c.entityLabel, err)
 	}
 
 	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
 	if err != nil {
-		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityLabel, err)
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error building API endpoint for entity '%s' update: %s", c.entityName, err)
+		return nil, fmt.Errorf("error building API endpoint for entity '%s' update: %s", c.entityLabel, err)
 	}
 
 	updatedInnerEntityConfig := new(I)
 	err = client.OpenApiPutItem(apiVersion, urlRef, c.queryParameters, innerConfig, updatedInnerEntityConfig, c.additionalHeader)
 	if err != nil {
-		return nil, fmt.Errorf("error updating entity of type '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error updating entity of type '%s': %s", c.entityLabel, err)
 	}
 
 	return updatedInnerEntityConfig, nil
@@ -141,23 +141,23 @@ func getInnerEntity[I any](client *Client, c crudConfig) (*I, error) {
 
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityLabel, err)
 	}
 
 	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
 	if err != nil {
-		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityLabel, err)
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityLabel, err)
 	}
 
 	typeResponse := new(I)
 	err = client.OpenApiGetItem(apiVersion, urlRef, c.queryParameters, typeResponse, c.additionalHeader)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving entity of type '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error retrieving entity of type '%s': %s", c.entityLabel, err)
 	}
 
 	return typeResponse, nil
@@ -176,23 +176,23 @@ func getAllInnerEntities[I any](client *Client, c crudConfig) ([]*I, error) {
 
 	apiVersion, err := client.getOpenApiHighestElevatedVersion(c.endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error getting API version for entity '%s': %s", c.entityLabel, err)
 	}
 
 	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
 	if err != nil {
-		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+		return nil, fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityLabel, err)
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error building API endpoint for entity '%s': %s", c.entityLabel, err)
 	}
 
 	typeResponses := make([]*I, 0)
 	err = client.OpenApiGetAllItems(apiVersion, urlRef, c.queryParameters, &typeResponses, c.additionalHeader)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving all entities of type '%s': %s", c.entityName, err)
+		return nil, fmt.Errorf("error retrieving all entities of type '%s': %s", c.entityLabel, err)
 	}
 
 	return typeResponses, nil
@@ -216,7 +216,7 @@ func deleteEntityById(client *Client, c crudConfig) error {
 
 	exactEndpoint, err := urlFromEndpoint(c.endpoint, c.endpointParams)
 	if err != nil {
-		return fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityName, err)
+		return fmt.Errorf("error building endpoint '%s' with given params '%s' for entity '%s': %s", c.endpoint, strings.Join(c.endpointParams, ","), c.entityLabel, err)
 	}
 
 	urlRef, err := client.OpenApiBuildEndpoint(exactEndpoint)
@@ -227,7 +227,7 @@ func deleteEntityById(client *Client, c crudConfig) error {
 	err = client.OpenApiDeleteItem(apiVersion, urlRef, c.queryParameters, c.additionalHeader)
 
 	if err != nil {
-		return fmt.Errorf("error deleting %s: %s", c.entityName, err)
+		return fmt.Errorf("error deleting %s: %s", c.entityLabel, err)
 	}
 
 	return nil

--- a/govcd/openapi_generic_outer_entities.go
+++ b/govcd/openapi_generic_outer_entities.go
@@ -1,6 +1,9 @@
 package govcd
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Generic type explanations
 // Common generic parameter names seen in this code
@@ -51,6 +54,16 @@ func getOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEnti
 	}
 
 	return outerEntity.wrap(retrievedInnerEntity), nil
+}
+
+// getOuterEntity retrieves a single outer entity
+func getOuterEntityWithHeaders[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig) (*O, http.Header, error) {
+	retrievedInnerEntity, headers, err := getInnerEntityWithHeaders[I](client, c)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return outerEntity.wrap(retrievedInnerEntity), headers, nil
 }
 
 // getAllOuterEntities retrieves all outer entities

--- a/govcd/openapi_generic_outer_entities.go
+++ b/govcd/openapi_generic_outer_entities.go
@@ -18,7 +18,7 @@ type outerEntityWrapper[O any, I any] interface {
 // createOuterEntity creates an outer entity with given inner entity config
 func createOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig, innerEntityConfig *I) (*O, error) {
 	if innerEntityConfig == nil {
-		return nil, fmt.Errorf("entity config '%s' cannot be empty for create operation", c.entityName)
+		return nil, fmt.Errorf("entity config '%s' cannot be empty for create operation", c.entityLabel)
 	}
 
 	createdInnerEntity, err := createInnerEntity(client, c, innerEntityConfig)
@@ -32,7 +32,7 @@ func createOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerE
 // updateOuterEntity updates an outer entity with given inner entity config
 func updateOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig, innerEntityConfig *I) (*O, error) {
 	if innerEntityConfig == nil {
-		return nil, fmt.Errorf("entity config '%s' cannot be empty for update operation", c.entityName)
+		return nil, fmt.Errorf("entity config '%s' cannot be empty for update operation", c.entityLabel)
 	}
 
 	updatedInnerEntity, err := updateInnerEntity(client, c, innerEntityConfig)

--- a/govcd/openapi_generic_outer_entities.go
+++ b/govcd/openapi_generic_outer_entities.go
@@ -1,0 +1,70 @@
+package govcd
+
+import "fmt"
+
+// Generic type explanations
+// Common generic parameter names seen in this code
+// O - Outer type that is in the `govcd` package. (e.g. 'IpSpace')
+// I - Inner type the type that is being marshalled/unmarshalled (usually in `types` package. E.g. `types.IpSpace`)
+
+// outerEntityWrapper is a type constraint that outer entities must implement in order to
+// use generic CRUD functions defined in this file
+type outerEntityWrapper[O any, I any] interface {
+	// wrap is a value receiver function that must implement one thing for a concrete type - wrap
+	// pointer to innter entity I and return pointer to outer entity O
+	wrap(inner *I) *O
+}
+
+// createOuterEntity creates an outer entity with given inner entity config
+func createOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig, innerEntityConfig *I) (*O, error) {
+	if innerEntityConfig == nil {
+		return nil, fmt.Errorf("entity config '%s' cannot be empty for create operation", c.entityName)
+	}
+
+	createdInnerEntity, err := createInnerEntity(client, c, innerEntityConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return outerEntity.wrap(createdInnerEntity), nil
+}
+
+// updateOuterEntity updates an outer entity with given inner entity config
+func updateOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig, innerEntityConfig *I) (*O, error) {
+	if innerEntityConfig == nil {
+		return nil, fmt.Errorf("entity config '%s' cannot be empty for update operation", c.entityName)
+	}
+
+	updatedInnerEntity, err := updateInnerEntity(client, c, innerEntityConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return outerEntity.wrap(updatedInnerEntity), nil
+}
+
+// getOuterEntity retrieves a single outer entity
+func getOuterEntity[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig) (*O, error) {
+	retrievedInnerEntity, err := getInnerEntity[I](client, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return outerEntity.wrap(retrievedInnerEntity), nil
+}
+
+// getAllOuterEntities retrieves all outer entities
+func getAllOuterEntities[O outerEntityWrapper[O, I], I any](client *Client, outerEntity O, c crudConfig) ([]*O, error) {
+	retrievedAllInnerEntities, err := getAllInnerEntities[I](client, c)
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedOuterEntities := make([]*O, len(retrievedAllInnerEntities))
+	for index, singleInnerEntity := range retrievedAllInnerEntities {
+		// outerEntity.wrap() is a value receiver, therefore it creates a shallow copy for each call
+		wrappedOuterEntities[index] = outerEntity.wrap(singleInnerEntity)
+	}
+
+	return wrappedOuterEntities, nil
+}

--- a/govcd/openapi_generic_unit_test.go
+++ b/govcd/openapi_generic_unit_test.go
@@ -1,0 +1,75 @@
+//go:build unit || ALL
+
+package govcd
+
+import (
+	"testing"
+)
+
+func Test_urlFromEndpoint(t *testing.T) {
+	type args struct {
+		endpoint       string
+		endpointParams []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "PlaceholderAndSuffix",
+			args:    args{endpoint: "1.0.0/edgeGateways/%s/ipsec/tunnels/", endpointParams: []string{"edgeGatewayId", "suffix"}},
+			want:    "1.0.0/edgeGateways/edgeGatewayId/ipsec/tunnels/suffix",
+			wantErr: false,
+		},
+		{
+			name:    "PlaceholderUnsatisfiedEmptySlice",
+			args:    args{endpoint: "1.0.0/edgeGateways/%s/ipsec/tunnels/", endpointParams: []string{}},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "PlaceholderUnsatisfiedNilSlice",
+			args:    args{endpoint: "1.0.0/edgeGateways/%s/ipsec/tunnels/", endpointParams: nil},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "NoPlaceholderNilSlice",
+			args:    args{endpoint: "1.0.0/edgeGateways/ipsec/tunnels/", endpointParams: nil},
+			want:    "1.0.0/edgeGateways/ipsec/tunnels/",
+			wantErr: false,
+		},
+		{
+			name:    "NoPlaceholderEmptySlice",
+			args:    args{endpoint: "1.0.0/edgeGateways/ipsec/tunnels/", endpointParams: []string{}},
+			want:    "1.0.0/edgeGateways/ipsec/tunnels/",
+			wantErr: false,
+		},
+		{
+			name:    "InsufficientPlaceholderReplacements",
+			args:    args{endpoint: "1.0.0/edgeGateways/%s/ipsec/%s/tunnels/", endpointParams: []string{"replacement-one"}},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "MultipleSuffixes",
+			args:    args{endpoint: "1.0.0/edgeGateways/%s/ipsec/%s/tunnels/", endpointParams: []string{"replacement-one", "replacement-two", "suffix-one", "/", "suffix-two"}},
+			want:    "1.0.0/edgeGateways/replacement-one/ipsec/replacement-two/tunnels/suffix-one/suffix-two",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := urlFromEndpoint(tt.args.endpoint, tt.args.endpointParams)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("urlFromEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("urlFromEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/govcd/openapi_org_network.go
+++ b/govcd/openapi_org_network.go
@@ -381,7 +381,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) GetSegmentProfile() (*types.OrgVdcNetwork
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
 		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
-		entityName:     "Org VDC Network Segment Profile",
+		entityLabel:    "Org VDC Network Segment Profile",
 	}
 	return getInnerEntity[types.OrgVdcNetworkSegmentProfiles](orgVdcNet.client, c)
 }
@@ -391,7 +391,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) UpdateSegmentProfile(entityConfig *types.
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
 		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
-		entityName:     "Org VDC Network Segment Profile",
+		entityLabel:    "Org VDC Network Segment Profile",
 	}
 	return updateInnerEntity(orgVdcNet.client, c, entityConfig)
 }

--- a/govcd/openapi_org_network.go
+++ b/govcd/openapi_org_network.go
@@ -12,6 +12,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const labelOrgVdcNetworkSegmentProfile = "Org VDC Network Segment Profile"
+
 // OpenApiOrgVdcNetwork uses OpenAPI endpoint to operate both - NSX-T and NSX-V Org VDC networks
 type OpenApiOrgVdcNetwork struct {
 	OpenApiOrgVdcNetwork *types.OpenApiOrgVdcNetwork
@@ -381,7 +383,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) GetSegmentProfile() (*types.OrgVdcNetwork
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
 		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
-		entityLabel:    "Org VDC Network Segment Profile",
+		entityLabel:    labelOrgVdcNetworkSegmentProfile,
 	}
 	return getInnerEntity[types.OrgVdcNetworkSegmentProfiles](orgVdcNet.client, c)
 }
@@ -391,7 +393,7 @@ func (orgVdcNet *OpenApiOrgVdcNetwork) UpdateSegmentProfile(entityConfig *types.
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
 		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
-		entityLabel:    "Org VDC Network Segment Profile",
+		entityLabel:    labelOrgVdcNetworkSegmentProfile,
 	}
 	return updateInnerEntity(orgVdcNet.client, c, entityConfig)
 }

--- a/govcd/openapi_org_network.go
+++ b/govcd/openapi_org_network.go
@@ -378,44 +378,20 @@ func createOpenApiOrgVdcNetwork(client *Client, OrgVdcNetworkConfig *types.OpenA
 
 // GetSegmentProfile retrieves Segment Profile configuration for a single Org VDC Network
 func (orgVdcNet *OpenApiOrgVdcNetwork) GetSegmentProfile() (*types.OrgVdcNetworkSegmentProfiles, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles
-	apiVersion, err := orgVdcNet.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
+		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
+		entityName:     "Org VDC Network Segment Profile",
 	}
-
-	urlRef, err := orgVdcNet.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgVdcNet.OpenApiOrgVdcNetwork.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponse := &types.OrgVdcNetworkSegmentProfiles{}
-	err = orgVdcNet.client.OpenApiGetItem(apiVersion, urlRef, nil, typeResponse, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponse, nil
+	return getInnerEntity[types.OrgVdcNetworkSegmentProfiles](orgVdcNet.client, c)
 }
 
 // UpdateSegmentProfile updates a Segment Profile with a given configuration
 func (orgVdcNet *OpenApiOrgVdcNetwork) UpdateSegmentProfile(entityConfig *types.OrgVdcNetworkSegmentProfiles) (*types.OrgVdcNetworkSegmentProfiles, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles
-	apiVersion, err := orgVdcNet.client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgVdcNetworkSegmentProfiles,
+		endpointParams: []string{orgVdcNet.OpenApiOrgVdcNetwork.ID},
+		entityName:     "Org VDC Network Segment Profile",
 	}
-
-	urlRef, err := orgVdcNet.client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, orgVdcNet.OpenApiOrgVdcNetwork.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	updatedNetworkSegmentProfile := &types.OrgVdcNetworkSegmentProfiles{}
-	err = orgVdcNet.client.OpenApiPutItem(apiVersion, urlRef, nil, entityConfig, updatedNetworkSegmentProfile, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return updatedNetworkSegmentProfile, nil
+	return updateInnerEntity(orgVdcNet.client, c, entityConfig)
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -17,7 +17,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-const labelGlobalDefaultSegmentProfileTemplate = "Global Default Segment Profile Templates"
+const labelGlobalDefaultSegmentProfileTemplate = "Global Default Segment Profile Template"
 
 // Simple structure to pass Edge Gateway creation parameters.
 type EdgeGatewayCreation struct {

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -1178,8 +1178,8 @@ func QueryOrgVdcStorageProfileByID(vcdCli *VCDClient, id string) (*types.QueryRe
 // GetGlobalDefaultSegmentProfileTemplates retrieves VCD global configuration for Segment Profile Templates
 func (vcdClient *VCDClient) GetGlobalDefaultSegmentProfileTemplates() (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
 	c := crudConfig{
-		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
-		entityName: "Global Default Segment Profile Templates",
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
+		entityLabel: "Global Default Segment Profile Templates",
 	}
 
 	return getInnerEntity[types.NsxtGlobalDefaultSegmentProfileTemplate](&vcdClient.Client, c)
@@ -1188,8 +1188,8 @@ func (vcdClient *VCDClient) GetGlobalDefaultSegmentProfileTemplates() (*types.Ns
 // UpdateGlobalDefaultSegmentProfileTemplates updates VCD global configuration for Segment Profile Templates
 func (vcdClient *VCDClient) UpdateGlobalDefaultSegmentProfileTemplates(entityConfig *types.NsxtGlobalDefaultSegmentProfileTemplate) (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
 	c := crudConfig{
-		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
-		entityName: "Global Default Segment Profile Templates",
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
+		entityLabel: "Global Default Segment Profile Templates",
 	}
 	return updateInnerEntity(&vcdClient.Client, c, entityConfig)
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -1177,44 +1177,19 @@ func QueryOrgVdcStorageProfileByID(vcdCli *VCDClient, id string) (*types.QueryRe
 
 // GetGlobalDefaultSegmentProfileTemplates retrieves VCD global configuration for Segment Profile Templates
 func (vcdClient *VCDClient) GetGlobalDefaultSegmentProfileTemplates() (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
+		entityName: "Global Default Segment Profile Templates",
 	}
 
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	typeResponse := &types.NsxtGlobalDefaultSegmentProfileTemplate{}
-	err = vcdClient.Client.OpenApiGetItem(apiVersion, urlRef, nil, typeResponse, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return typeResponse, nil
+	return getInnerEntity[types.NsxtGlobalDefaultSegmentProfileTemplate](&vcdClient.Client, c)
 }
 
 // UpdateGlobalDefaultSegmentProfileTemplates updates VCD global configuration for Segment Profile Templates
 func (vcdClient *VCDClient) UpdateGlobalDefaultSegmentProfileTemplates(entityConfig *types.NsxtGlobalDefaultSegmentProfileTemplate) (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates
-	apiVersion, err := vcdClient.Client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:   types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
+		entityName: "Global Default Segment Profile Templates",
 	}
-
-	urlRef, err := vcdClient.Client.OpenApiBuildEndpoint(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	updatedDefaultNetworkSegmentProfile := &types.NsxtGlobalDefaultSegmentProfileTemplate{}
-	err = vcdClient.Client.OpenApiPutItem(apiVersion, urlRef, nil, entityConfig, updatedDefaultNetworkSegmentProfile, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return updatedDefaultNetworkSegmentProfile, nil
+	return updateInnerEntity(&vcdClient.Client, c, entityConfig)
 }

--- a/govcd/system.go
+++ b/govcd/system.go
@@ -17,6 +17,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
+const labelGlobalDefaultSegmentProfileTemplate = "Global Default Segment Profile Templates"
+
 // Simple structure to pass Edge Gateway creation parameters.
 type EdgeGatewayCreation struct {
 	ExternalNetworks           []string // List of external networks to be linked to this gateway
@@ -1179,7 +1181,7 @@ func QueryOrgVdcStorageProfileByID(vcdCli *VCDClient, id string) (*types.QueryRe
 func (vcdClient *VCDClient) GetGlobalDefaultSegmentProfileTemplates() (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
-		entityLabel: "Global Default Segment Profile Templates",
+		entityLabel: labelGlobalDefaultSegmentProfileTemplate,
 	}
 
 	return getInnerEntity[types.NsxtGlobalDefaultSegmentProfileTemplate](&vcdClient.Client, c)
@@ -1189,7 +1191,7 @@ func (vcdClient *VCDClient) GetGlobalDefaultSegmentProfileTemplates() (*types.Ns
 func (vcdClient *VCDClient) UpdateGlobalDefaultSegmentProfileTemplates(entityConfig *types.NsxtGlobalDefaultSegmentProfileTemplate) (*types.NsxtGlobalDefaultSegmentProfileTemplate, error) {
 	c := crudConfig{
 		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtGlobalDefaultSegmentProfileTemplates,
-		entityLabel: "Global Default Segment Profile Templates",
+		entityLabel: labelGlobalDefaultSegmentProfileTemplate,
 	}
 	return updateInnerEntity(&vcdClient.Client, c, entityConfig)
 }

--- a/govcd/vdc_network_profile.go
+++ b/govcd/vdc_network_profile.go
@@ -10,6 +10,8 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
+const labelVdcNetworkProfile = "VDC Network Profile"
+
 // VDC Network profiles have 1:1 mapping with VDC - each VDC has an option to configure VDC Network
 // Profiles. types.VdcNetworkProfile holds more information about possible configurations
 
@@ -78,7 +80,7 @@ func getVdcNetworkProfile(client *Client, vdcId string) (*types.VdcNetworkProfil
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityLabel:    "VDC Network Profile",
+		entityLabel:    labelVdcNetworkProfile,
 	}
 	return getInnerEntity[types.VdcNetworkProfile](client, c)
 }
@@ -87,7 +89,7 @@ func updateVdcNetworkProfile(client *Client, vdcId string, vdcNetworkProfileConf
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityLabel:    "VDC Network Profile",
+		entityLabel:    labelVdcNetworkProfile,
 	}
 	return updateInnerEntity(client, c, vdcNetworkProfileConfig)
 }
@@ -96,7 +98,7 @@ func deleteVdcNetworkProfile(client *Client, vdcId string) error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityLabel:    "VDC Network Profile",
+		entityLabel:    labelVdcNetworkProfile,
 	}
 	return deleteEntityById(client, c)
 }

--- a/govcd/vdc_network_profile.go
+++ b/govcd/vdc_network_profile.go
@@ -75,72 +75,28 @@ func (adminVdc *AdminVdc) DeleteVdcNetworkProfile() error {
 }
 
 func getVdcNetworkProfile(client *Client, vdcId string) (*types.VdcNetworkProfile, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
+		endpointParams: []string{vdcId},
+		entityName:     "VDC Network Profile",
 	}
-
-	if vdcId == "" {
-		return nil, fmt.Errorf("cannot lookup VDC Network Profile configuration without VDC ID")
-	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcId))
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &types.VdcNetworkProfile{}
-	err = client.OpenApiGetItem(apiVersion, urlRef, nil, returnObject, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return returnObject, nil
+	return getInnerEntity[types.VdcNetworkProfile](client, c)
 }
 
 func updateVdcNetworkProfile(client *Client, vdcId string, vdcNetworkProfileConfig *types.VdcNetworkProfile) (*types.VdcNetworkProfile, error) {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return nil, err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
+		endpointParams: []string{vdcId},
+		entityName:     "VDC Network Profile",
 	}
-
-	if vdcId == "" {
-		return nil, fmt.Errorf("cannot update VDC Network Profile configuration without ID")
-	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcId))
-	if err != nil {
-		return nil, err
-	}
-
-	returnObject := &types.VdcNetworkProfile{}
-	err = client.OpenApiPutItem(apiVersion, urlRef, nil, vdcNetworkProfileConfig, returnObject, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error updating VDC Network Profile configuration: %s", err)
-	}
-
-	return returnObject, nil
+	return updateInnerEntity(client, c, vdcNetworkProfileConfig)
 }
 
 func deleteVdcNetworkProfile(client *Client, vdcId string) error {
-	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile
-	apiVersion, err := client.getOpenApiHighestElevatedVersion(endpoint)
-	if err != nil {
-		return err
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
+		endpointParams: []string{vdcId},
+		entityName:     "VDC Network Profile",
 	}
-
-	urlRef, err := client.OpenApiBuildEndpoint(fmt.Sprintf(endpoint, vdcId))
-	if err != nil {
-		return err
-	}
-
-	err = client.OpenApiDeleteItem(apiVersion, urlRef, nil, nil)
-
-	if err != nil {
-		return fmt.Errorf("error deleting VDC Network Profile configuration: %s", err)
-	}
-
-	return nil
+	return deleteEntityById(client, c)
 }

--- a/govcd/vdc_network_profile.go
+++ b/govcd/vdc_network_profile.go
@@ -78,7 +78,7 @@ func getVdcNetworkProfile(client *Client, vdcId string) (*types.VdcNetworkProfil
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityName:     "VDC Network Profile",
+		entityLabel:    "VDC Network Profile",
 	}
 	return getInnerEntity[types.VdcNetworkProfile](client, c)
 }
@@ -87,7 +87,7 @@ func updateVdcNetworkProfile(client *Client, vdcId string, vdcNetworkProfileConf
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityName:     "VDC Network Profile",
+		entityLabel:    "VDC Network Profile",
 	}
 	return updateInnerEntity(client, c, vdcNetworkProfileConfig)
 }
@@ -96,7 +96,7 @@ func deleteVdcNetworkProfile(client *Client, vdcId string) error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVdcNetworkProfile,
 		endpointParams: []string{vdcId},
-		entityName:     "VDC Network Profile",
+		entityLabel:    "VDC Network Profile",
 	}
 	return deleteEntityById(client, c)
 }


### PR DESCRIPTION
### About
This PR is about an attempt to leverage Go generics (parametric polymorphism) to streamline SDK development.
As part of this PR, a few of the existing entities were converted to demonstrate the use of new functions.

### Terminology

These names are not set in stone and are subject to change.

* inner
* outer*

### Commits
* Commit https://github.com/vmware/go-vcloud-director/pull/644/commits/4d5a06a46611a22fecd7403a932edd85aedfed52 contains only introduction of generic CRUD entities (inner and outer)
* Commit https://github.com/vmware/go-vcloud-director/pull/644/commits/dc93038aed613c5fbcd30dbf55352ece63c05dea adds consumption examples throughout our codebase

Next PRs contain self review and fixed over all codebase.

### Testing
* Test suite passed on 10.5.1 for both SDK and Terraform (at commit https://github.com/vmware/go-vcloud-director/pull/644/commits/bfabfb0a024ad4875c1170404ad5af708b43e4db)