### PR TITLE
add UDF file format reader to support solutions add-on installation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,11 @@ require (
 )
 
 require (
+	github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6
 	github.com/kr/text v0.1.0 // indirect
 	github.com/stretchr/testify v1.5.1 // indirect
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
+	golang.org/x/text v0.14.0
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/go-yaml/yaml/v2 v2.2.2 h1:uw2m9KuKRscWGAkuyoBGQcZSdibhmuXKSJ3+9Tj3zXc
 github.com/go-yaml/yaml/v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6 h1:IIVxLyDUYErC950b8kecjoqDet8P5S4lcVRUOM6rdkU=
+github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6/go.mod h1:JslaLRrzGsOKJgFEPBP65Whn+rdwDQSk0I0MCRFe2Zw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -20,3 +22,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/exp v0.0.0-20240119083558-1b970713d09a h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=
+golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/internal/udf/cdrom.go
+++ b/internal/udf/cdrom.go
@@ -1,0 +1,114 @@
+package udf
+
+import (
+	"fmt"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	cdromVolumeDescriptorSectorNumber = 16
+
+	cdromVolumeIdentifierBEA01 = "BEA01"
+	cdromVolumeIdentifierBOOT2 = "BOOT2"
+	cdromVolumeIdentifierCD001 = "CD001"
+	cdromVolumeIdentifierCDW02 = "CDW02"
+	cdromVolumeIdentifierNSR02 = "NSR02"
+	cdromVolumeIdentifierNSR03 = "NSR03"
+	cdromVolumeIdentifierTEA01 = "TEA01"
+)
+
+type CdromDescriptor interface {
+	GetHeader() *CdromVolumeDescriptorHeader
+}
+
+type CdromDescriptorList []CdromDescriptor
+
+func (list CdromDescriptorList) hasAnyIdentifier(identifiers ...string) bool {
+	for idx := 0; idx < len(list); idx++ {
+		identifier := list[idx].GetHeader().Identifier
+		if slices.Contains(identifiers, identifier) {
+			return true
+		}
+	}
+	return false
+}
+
+func (list CdromDescriptorList) getByType(descType uint8) CdromDescriptor {
+	if desc := list.findByType(descType); desc != nil {
+		return desc
+	} else {
+		panic(fmt.Sprintf("CDROM descriptor with type %d does not exist in sequence", descType))
+	}
+}
+
+func (list CdromDescriptorList) findByType(descType uint8) CdromDescriptor {
+	for idx := 0; idx < len(list); idx++ {
+		if list[idx].GetHeader().Type == descType {
+			return list[idx]
+		}
+	}
+	return nil
+}
+
+func (list CdromDescriptorList) getByIdentifier(identifier string) CdromDescriptor {
+	if desc := list.findByIdentifier(identifier); desc != nil {
+		return desc
+	} else {
+		panic(fmt.Sprintf("CDROM descriptor with identifier %s does not exist in sequence", identifier))
+	}
+}
+
+func (list CdromDescriptorList) findByIdentifier(identifier string) CdromDescriptor {
+	for idx := 0; idx < len(list); idx++ {
+		if list[idx].GetHeader().Identifier == identifier {
+			return list[idx]
+		}
+	}
+	return nil
+}
+
+type CdromVolumeDescriptorHeader struct {
+	Type       uint8
+	Identifier string
+	Version    uint8
+}
+
+type CdromExtendedAreaVolumeDescriptor struct {
+	Header CdromVolumeDescriptorHeader
+}
+
+func (d *CdromExtendedAreaVolumeDescriptor) GetHeader() *CdromVolumeDescriptorHeader {
+	return &d.Header
+}
+
+type CdromBootVolumeDescriptor struct {
+	Header CdromVolumeDescriptorHeader
+}
+
+func (d *CdromBootVolumeDescriptor) GetHeader() *CdromVolumeDescriptorHeader {
+	return &d.Header
+}
+
+type CdromCdwVolumeDescriptor struct {
+	Header CdromVolumeDescriptorHeader
+}
+
+func (d *CdromCdwVolumeDescriptor) GetHeader() *CdromVolumeDescriptorHeader {
+	return &d.Header
+}
+
+type CdromNsrVolumeDescriptor struct {
+	Header CdromVolumeDescriptorHeader
+}
+
+func (d *CdromNsrVolumeDescriptor) GetHeader() *CdromVolumeDescriptorHeader {
+	return &d.Header
+}
+
+type CdromTerminalVolumeDescriptor struct {
+	Header CdromVolumeDescriptorHeader
+}
+
+func (d *CdromTerminalVolumeDescriptor) GetHeader() *CdromVolumeDescriptorHeader {
+	return &d.Header
+}

--- a/internal/udf/perms.go
+++ b/internal/udf/perms.go
@@ -1,0 +1,124 @@
+package udf
+
+import "io/fs"
+
+// Permissions (BP 44)
+// Bit 0: Other: If set to ZERO, shall mean that the user may not execute the file; If set to ONE, shall mean that
+// the user may execute the file.
+// Bit 1: Other: If set to ZERO, shall mean that the user may not write the file; If set to ONE, shall mean that
+// the user may write the file.
+// Bit 2: Other: If set to ZERO, shall mean that the user may not read the file; If set to ONE, shall mean that the
+// user may read the file.
+// Bit 3: Other: If set to ZERO, shall mean that the user may not change any attributes of the file; If set to
+// ONE, shall mean that the user may change attributes of the file.
+// Bit 4: Other: If set to ZERO, shall mean that the user may not delete the file; If set to ONE, shall mean that
+// the user may delete the file.
+// Bit 5: Group: If set to ZERO, shall mean that the user may not execute the file; If set to ONE, shall mean
+// that the user may execute the file.
+// Bit 6: Group: If set to ZERO, shall mean that the user may not write the file; If set to ONE, shall mean that
+// the user may write the file.
+// Bit 7: Group: If set to ZERO, shall mean that the user may not read the file; If set to ONE, shall mean that
+// the user may read the file.
+// Bit 8: Group: If set to ZERO, shall mean that the user may not change any attributes of the file; If set to
+// ONE, shall mean that the user may change attributes of the file.
+// Bit 9: Group: If set to ZERO, shall mean that the user may not delete the file; If set to ONE, shall mean that
+// the user may delete the file.
+// Bit 10: Owner: If set to ZERO, shall mean that the user may not execute the file; If set to ONE, shall mean
+// that the user may execute the file.
+// Bit 11: Owner: If set to ZERO, shall mean that the user may not write the file; If set to ONE, shall mean that
+// the user may write the file.
+// Bit 12: Owner: If set to ZERO, shall mean that the user may not read the file; If set to ONE, shall mean that
+// the user may read the file.
+// Bit 13: Owner: If set to ZERO, shall mean that the user may not change any attributes of the file; If set to
+// ONE, shall mean that the user may change attributes of the file.
+// Bit 14: Owner: If set to ZERO, shall mean that the user may not delete the file; If set to ONE, shall mean that
+// the user may delete the file.
+// 15-31 Reserved: Shall be set to ZERO.
+
+type FilePerm uint32
+
+const (
+	FilePermExecute FilePerm = 1 << iota
+	FilePermWrite
+	FilePermRead
+	FilePermChange
+	FilePermDelete
+)
+
+const (
+	FileModeOtherOffset = 5 * iota
+	FileModeGroupOffset
+	FileModeOwnerOffset
+)
+
+const (
+	FileModeOtherMask = ((1 << 5) - 1) << (5 * iota)
+	FileModeGroupMask
+	FileModeOwnerMask
+)
+
+type FileMode uint32
+
+func ToFileMode(mode fs.FileMode) FileMode {
+	mode = mode.Perm()
+	var r FileMode
+	r |= FileMode(mode & 7)              // Other
+	r |= FileMode((mode >> 3) & 7 << 5)  // Group
+	r |= FileMode((mode >> 6) & 7 << 10) // Owner
+	return r
+}
+
+func FromFileMode(mode FileMode) fs.FileMode {
+	var r fs.FileMode
+	r |= fs.FileMode(mode & 7)                // Other
+	r |= fs.FileMode(((mode >> 5) & 7) << 3)  // Group
+	r |= fs.FileMode(((mode >> 10) & 7) << 6) // Owner
+	return r
+}
+
+func (m FileMode) Other() FileMode {
+	return m & FileModeOtherMask
+}
+
+func (m FileMode) HasOther(perms FilePerm) bool {
+	return (m>>FileModeOtherOffset)&FileMode(perms) == FileMode(perms)
+}
+
+func (m FileMode) SetOther(perms FilePerm) FileMode {
+	return m | (FileMode(perms) << FileModeOtherOffset)
+}
+
+func (m FileMode) UnsetOther(perms FilePerm) FileMode {
+	return m &^ (FileMode(perms) << FileModeOtherOffset)
+}
+
+func (m FileMode) Group() FileMode {
+	return m & FileModeGroupMask
+}
+
+func (m FileMode) HasGroup(perms FilePerm) bool {
+	return (m>>FileModeGroupOffset)&FileMode(perms) == FileMode(perms)
+}
+
+func (m FileMode) SetGroup(perms FilePerm) FileMode {
+	return m | (FileMode(perms) << FileModeGroupOffset)
+}
+
+func (m FileMode) UnsetGroup(perms FilePerm) FileMode {
+	return m &^ (FileMode(perms) << FileModeGroupOffset)
+}
+func (m FileMode) Owner() FileMode {
+	return m & FileModeOwnerMask
+}
+
+func (m FileMode) HasOwner(perms FilePerm) bool {
+	return (m>>FileModeOwnerOffset)&FileMode(perms) == FileMode(perms)
+}
+
+func (m FileMode) SetOwner(perms FilePerm) FileMode {
+	return m | (FileMode(perms) << FileModeOwnerOffset)
+}
+
+func (m FileMode) UnsetOwner(perms FilePerm) FileMode {
+	return m &^ (FileMode(perms) << FileModeOwnerOffset)
+}

--- a/internal/udf/reader.go
+++ b/internal/udf/reader.go
@@ -1,0 +1,736 @@
+package udf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+func Open(reader io.ReaderAt) (r *ImageReader, err error) {
+	defer func() {
+		if fatalErr := recover(); fatalErr != nil {
+			err = fmt.Errorf("%v", fatalErr)
+		}
+	}()
+	r = &ImageReader{inner: reader}
+
+	r.cdromVolumeDescriptors = r.readCdromVolumeDescriptorSequence(cdromVolumeDescriptorSectorNumber)
+
+	// Validate image is UDF
+	if !r.cdromVolumeDescriptors.hasAnyIdentifier(cdromVolumeIdentifierNSR02, cdromVolumeIdentifierNSR03) {
+		err = fmt.Errorf("unsupported image format")
+		return
+	}
+
+	r.anchorVolumeDescriptor = r.readDescriptorFromSectorWithTag(
+		anchorVolumeDescriptorSectorNumber, tagAnchorVolumeDescriptorPointer).(*AnchorVolumeDescriptorPointer)
+	r.mainVolumeDescriptors = r.readDescriptorSequence(&r.anchorVolumeDescriptor.MainVolumeDescriptorSequence)
+	r.primaryVolume = r.mainVolumeDescriptors.get(tagPrimaryVolumeDescriptor).(*PrimaryVolumeDescriptor)
+	r.partition = r.mainVolumeDescriptors.get(tagPartitionDescriptor).(*PartitionDescriptor)
+	r.logicalVolume = r.mainVolumeDescriptors.get(tagLogicalVolumeDescriptor).(*LogicalVolumeDescriptor)
+	r.fileSet = r.readDescriptorFromSectorWithTag(int64(r.partition.PartitionStartingLocation), tagFileSetDescriptor).(*FileSetDescriptor)
+	return
+}
+
+type descriptorReader interface {
+	Descriptor
+	read(reader *bufferReader)
+}
+
+type ImageReader struct {
+	inner                  io.ReaderAt
+	cdromVolumeDescriptors CdromDescriptorList
+	anchorVolumeDescriptor *AnchorVolumeDescriptorPointer
+	mainVolumeDescriptors  DescriptorList
+	primaryVolume          *PrimaryVolumeDescriptor
+	partition              *PartitionDescriptor
+	logicalVolume          *LogicalVolumeDescriptor
+	fileSet                *FileSetDescriptor
+}
+
+func (r *ImageReader) RootDir() (fi *FileInfo, err error) {
+	defer func() {
+		if fatalErr := recover(); fatalErr != nil {
+			err = fmt.Errorf("unable to read UDF root directory: %v", fatalErr)
+		}
+	}()
+	partitionStart := int64(r.partition.PartitionStartingLocation)
+	fileEntrySector := partitionStart + int64(r.fileSet.RootDirectoryICB.Location)
+	fileEntry := r.readDescriptorFromSectorWithTag(fileEntrySector, tagFileEntry).(*FileEntryDescriptor)
+	fi = &FileInfo{
+		entry:         fileEntry,
+		logicalVolume: r.logicalVolume,
+	}
+	return
+}
+
+func (r *ImageReader) ReadDir(parent *FileInfo) (children []FileInfo, err error) {
+	defer func() {
+		if fatalErr := recover(); fatalErr != nil {
+			err = fmt.Errorf("unable to read UDF directory: %v", fatalErr)
+		}
+	}()
+
+	if !parent.IsDir() {
+		err = fmt.Errorf("entry %s is not a directory", parent.Name())
+		return
+	}
+
+	if len(parent.entry.AllocationDescriptors) == 0 {
+		children = []FileInfo{}
+		return
+	}
+
+	children = make([]FileInfo, 0, 8)
+
+	for idx := range parent.entry.AllocationDescriptors {
+		allocDesc := &parent.entry.AllocationDescriptors[idx]
+		bufSize := int(allocDesc.Length)
+		partitionStart := int64(r.partition.PartitionStartingLocation)
+		fileBufReader := r.readSectors(partitionStart+int64(allocDesc.Location), (bufSize+sectorSize-1)/sectorSize)
+
+		for fileBufReader.off < bufSize {
+			fid := r.readDescriptorWithTag(fileBufReader, tagFileIdentifierDescriptor).(*FileIdentifierDescriptor)
+			if len(fid.FileIdentifier) > 0 {
+				fileEntrySector := partitionStart + int64(fid.ICB.Location)
+				fileEntry := r.readDescriptorFromSectorWithTag(fileEntrySector, tagFileEntry).(*FileEntryDescriptor)
+
+				var filePath string
+				if parent.IsRoot() {
+					filePath = fid.FileIdentifier
+				} else {
+					filePath = filepath.Join(parent.path, fid.FileIdentifier)
+				}
+
+				children = append(children, FileInfo{
+					entry:  fileEntry,
+					fid:    fid,
+					parent: parent,
+					path:   filePath,
+				})
+			}
+		}
+	}
+
+	return
+}
+
+func (r *ImageReader) NewFileReader(file *FileInfo) (fileReader io.Reader, err error) {
+	if file.IsDir() {
+		err = fmt.Errorf("entry %s is not a file", file.Name())
+		return
+	}
+
+	defer func() {
+		if fatalErr := recover(); fatalErr != nil {
+			err = fmt.Errorf("unable to open UDF file: %v", fatalErr)
+		}
+	}()
+
+	partitionStart := int64(r.partition.PartitionStartingLocation)
+	readers := make([]io.Reader, len(file.entry.AllocationDescriptors))
+
+	for idx := range file.entry.AllocationDescriptors {
+		allocDesc := &file.entry.AllocationDescriptors[idx]
+		location := int64(allocDesc.Location)
+		offset := sectorSize * (location + partitionStart)
+		readers[idx] = io.NewSectionReader(r.inner, offset, int64(allocDesc.Length))
+	}
+
+	fileReader = io.MultiReader(readers...)
+	return
+}
+
+func (r *ImageReader) readDescriptorSequence(ref *Extent) DescriptorList {
+	descriptors := make(DescriptorList, 0, 8)
+	for sector := int64(ref.Location); ; sector++ {
+		descriptor := r.readDescriptorFromSector(sector)
+		descriptors = append(descriptors, descriptor)
+		if descriptor.GetIdentifier() == tagTerminatingDescriptor {
+			break
+		}
+	}
+	return descriptors
+}
+
+func (r *ImageReader) readDescriptor(bufferReader *bufferReader) Descriptor {
+	tagId := bufferReader.peekUint16()
+	descriptor := NewDescriptor(tagId)
+	descriptor.(descriptorReader).read(bufferReader)
+	return descriptor
+}
+
+func (r *ImageReader) readDescriptorWithTag(bufferReader *bufferReader, tagId int) Descriptor {
+	descriptor := r.readDescriptor(bufferReader)
+	if descriptor.GetIdentifier() != tagId {
+		panic(fmt.Errorf("expected descriptor with tag ID %d but was %d", tagId, descriptor.GetIdentifier()))
+	}
+	return descriptor
+}
+
+func (r *ImageReader) readDescriptorFromSector(sector int64) Descriptor {
+	return r.readDescriptor(r.readSector(sector))
+}
+
+func (r *ImageReader) readDescriptorFromSectorWithTag(sector int64, tagId int) Descriptor {
+	descriptor := r.readDescriptorFromSector(sector)
+	if descriptor.GetIdentifier() != tagId {
+		panic(fmt.Errorf("expected descriptor with tag ID %d but was %d at sector %d",
+			tagId, descriptor.GetIdentifier(), sector))
+	}
+	return descriptor
+}
+
+func (r *ImageReader) readCdromVolumeDescriptorSequence(sector int64) CdromDescriptorList {
+	descriptors := make(CdromDescriptorList, 0, 8)
+	for n := sector; ; n++ {
+		descriptor := r.readCdromVolumeDescriptorFromSector(n)
+		descriptors = append(descriptors, descriptor)
+		if descriptor.GetHeader().Identifier == cdromVolumeIdentifierTEA01 {
+			break
+		}
+	}
+	return descriptors
+}
+
+func (r *ImageReader) readCdromVolumeDescriptor(bufferReader *bufferReader) CdromDescriptor {
+	header := CdromVolumeDescriptorHeader{}
+	header.read(bufferReader)
+
+	switch header.Identifier {
+	case cdromVolumeIdentifierBEA01:
+		return &CdromExtendedAreaVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierBOOT2:
+		return &CdromBootVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierCD001:
+		return &CdromCdwVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierCDW02:
+		return &CdromCdwVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierNSR02:
+		return &CdromNsrVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierNSR03:
+		return &CdromNsrVolumeDescriptor{
+			Header: header,
+		}
+	case cdromVolumeIdentifierTEA01:
+		return &CdromTerminalVolumeDescriptor{
+			Header: header,
+		}
+	default:
+		panic(fmt.Sprintf("unrecognized file system '%s'", header.Identifier))
+	}
+}
+
+func (r *ImageReader) readCdromVolumeDescriptorFromSector(sector int64) CdromDescriptor {
+	return r.readCdromVolumeDescriptor(r.readSector(sector))
+}
+
+func (r *ImageReader) readSector(sector int64) *bufferReader {
+	return r.read(sector*sectorSize, sectorSize)
+}
+
+func (r *ImageReader) readSectors(sector int64, count int) *bufferReader {
+	return r.read(sector*sectorSize, sectorSize*count)
+}
+
+func (r *ImageReader) read(offset int64, size int) *bufferReader {
+	data := make([]byte, size)
+	if n, err := r.inner.ReadAt(data, offset); err != nil {
+		panic(err)
+	} else if n != size {
+		panic(io.ErrUnexpectedEOF)
+	}
+	return &bufferReader{buf: data}
+}
+
+func (e *Extent) read(reader *bufferReader) {
+	e.Length = reader.readUint32()
+	e.Location = reader.readUint32()
+}
+
+func (e *ExtentLong) read(reader *bufferReader) {
+	e.Length = reader.readUint32()
+	e.Location = reader.readUint48()
+	reader.skipBytes(6) // Reserved
+}
+
+func (e *EntityID) read(reader *bufferReader) {
+	e.Flags = reader.readUint8()
+	e.Identifier = reader.readString(23)
+	e.IdentifierSuffix = reader.readString(8)
+}
+
+func (iu *ImplementationUse) read(reader *bufferReader, size int) {
+	iu.Entity.read(reader)
+	size = size - entityIdSize // ImplementationUse - EntityID
+	if size > 0 {
+		iu.Implementation = reader.readBytes(size)
+	}
+}
+
+func (c *Charspec) read(reader *bufferReader) {
+	c.CharacterSetType = reader.readUint8()
+	c.CharacterSetInfo = reader.readBytes(63)
+}
+
+func (tag *DescriptorTag) read(reader *bufferReader) {
+	tag.TagIdentifier = reader.readUint16()
+	tag.DescriptorVersion = reader.readUint16()
+	tag.TagChecksum = reader.readUint8()
+	reader.skipBytes(1) // Reserved
+	tag.TagSerialNumber = reader.readUint16()
+	tag.DescriptorCRC = reader.readUint16()
+	tag.DescriptorCRCLength = reader.readUint16()
+	tag.TagLocation = reader.readUint32()
+}
+
+func (d *AnchorVolumeDescriptorPointer) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.MainVolumeDescriptorSequence.read(reader)
+	d.ReserveVolumeDescriptorSequence.read(reader)
+	reader.skipBytes(480) // Reserved
+}
+
+func (d *VolumeDescriptorPointer) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.NextVolumeDescriptorSequenceExtent.read(reader)
+	// This field shall be reserved for future standardisation and all bytes shall be set to #00
+	reader.skipBytes(484)
+}
+
+func (d *PrimaryVolumeDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.PrimaryVolumeDescriptorNumber = reader.readUint32()
+	d.VolumeIdentifier = reader.readDString(32)
+	d.VolumeSequenceNumber = reader.readUint16()
+	d.MaximumVolumeSequenceNumber = reader.readUint16()
+	d.InterchangeLevel = reader.readUint16()
+	d.MaximumInterchangeLevel = reader.readUint16()
+	d.CharacterSetList = reader.readUint32()
+	d.MaximumCharacterSetList = reader.readUint32()
+	d.VolumeSetIdentifier = reader.readDString(128)
+	d.DescriptorCharacterSet.read(reader)
+	d.ExplanatoryCharacterSet.read(reader)
+	d.VolumeAbstract.read(reader)
+	d.VolumeCopyrightNoticeExtent.read(reader)
+	d.ApplicationIdentifier.read(reader)
+	d.RecordingDateTime = reader.readTimestamp()
+	d.ImplementationIdentifier.read(reader)
+	d.ImplementationUse = reader.readBytes(64)
+	d.PredecessorVolumeDescriptorSequenceLocation = reader.readUint32()
+	d.Flags = reader.readUint16()
+	reader.skipBytes(22) // Reserved
+}
+
+func (d *ImplementationUseVolumeDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.ImplementationIdentifier.read(reader)
+	d.ImplementationUse.read(reader)
+}
+
+func (lvi *LVInformation) read(reader *bufferReader) {
+	lvi.LVICharset.read(reader)
+	lvi.LogicalVolumeIdentifier = reader.readDString(128)
+	lvi.LVInfo1 = reader.readDString(36)
+	lvi.LVInfo2 = reader.readDString(36)
+	lvi.LVInfo3 = reader.readDString(36)
+	lvi.ImplementationID.read(reader)
+	lvi.ImplementationUse = reader.readBytes(128)
+}
+
+func (d *PartitionDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.PartitionFlags = reader.readUint16()
+	d.PartitionNumber = reader.readUint16()
+	d.PartitionContents.read(reader)
+	d.PartitionContentsUse = reader.readBytes(128)
+	d.AccessType = reader.readUint32()
+	d.PartitionStartingLocation = reader.readUint32()
+	d.PartitionLength = reader.readUint32()
+	d.ImplementationIdentifier.read(reader)
+	d.ImplementationUse = reader.readBytes(128)
+	reader.skipBytes(156)
+}
+
+func (d *LogicalVolumeDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.DescriptorCharacterSet.read(reader)
+	d.LogicalVolumeIdentifier = reader.readDString(128)
+	d.LogicalBlockSize = reader.readUint32()
+	d.DomainIdentifier.read(reader)
+	d.LogicalVolumeContentsUse = reader.readBytes(16)
+	d.MapTableLength = reader.readUint32()
+	d.NumberOfPartitionMaps = reader.readUint32()
+	d.ImplementationIdentifier.read(reader)
+	d.ImplementationUse = reader.readBytes(128)
+	d.IntegritySequenceExtent.read(reader)
+	d.PartitionMaps = make([]PartitionMap, d.NumberOfPartitionMaps)
+	for idx := 0; idx < int(d.NumberOfPartitionMaps); idx++ {
+		d.PartitionMaps[idx].read(reader)
+	}
+}
+
+func (d *LogicalVolumeIntegrityDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.RecordingDateTime = reader.readTimestamp()
+	d.IntegrityType = reader.readUint32()
+	d.NextIntegrityExtent.read(reader)
+	d.LogicalVolumeContentsUse.read(reader)
+	d.NumberOfPartitions = reader.readUint32()
+	d.LengthOfImplementationUse = reader.readUint32()
+	d.FreeSpaceTable = make([]uint32, d.NumberOfPartitions)
+	for idx := range d.FreeSpaceTable {
+		d.FreeSpaceTable[idx] = reader.readUint32()
+	}
+	d.SizeTable = make([]uint32, d.NumberOfPartitions)
+	for idx := range d.SizeTable {
+		d.SizeTable[idx] = reader.readUint32()
+	}
+	d.ImplementationUse.read(reader, int(d.LengthOfImplementationUse))
+}
+
+func (h *LogicalVolumeHeaderDescriptor) read(reader *bufferReader) {
+	h.UniqueID = reader.readUint64()
+	reader.skipBytes(24) // Reserved
+}
+
+func (pm *PartitionMap) read(reader *bufferReader) {
+	pm.PartitionMapType = reader.readUint8()
+	if pm.PartitionMapType != 1 {
+		panic(fmt.Sprintf("expected partition map 1 but got %d", pm.PartitionMapType))
+	}
+	pm.PartitionMapLength = reader.readUint8()
+	if pm.PartitionMapLength != 6 {
+		panic(fmt.Sprintf("expected partition map 1 to be 6 bytes long but was %d", pm.PartitionMapLength))
+	}
+	pm.VolumeSequenceNumber = reader.readUint16()
+	pm.PartitionNumber = reader.readUint16()
+}
+
+func (d *UnallocatedSpaceDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.VolumeDescriptorSequenceNumber = reader.readUint32()
+	d.NumberOfAllocationDescriptors = reader.readUint32()
+	d.AllocationDescriptors = make([]Extent, d.NumberOfAllocationDescriptors)
+	for idx := 0; idx < int(d.NumberOfAllocationDescriptors); idx++ {
+		d.AllocationDescriptors[idx].read(reader)
+	}
+}
+
+func (d *TerminatingDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	reader.skipBytes(496) // Reserved
+}
+
+func (d *FileSetDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.RecordingDateTime = reader.readTimestamp()
+	d.InterchangeLevel = reader.readUint16()
+	d.MaximumInterchangeLevel = reader.readUint16()
+	d.CharacterSetList = reader.readUint32()
+	d.MaximumCharacterSetList = reader.readUint32()
+	d.FileSetNumber = reader.readUint32()
+	d.FileSetDescriptorNumber = reader.readUint32()
+	d.LogicalVolumeIdentifierCharacterSet.read(reader)
+	d.LogicalVolumeIdentifier = reader.readDString(128)
+	d.FileSetCharacterSet.read(reader)
+	d.FileSetIdentifier = reader.readDString(32)
+	d.CopyrightFileIdentifier = reader.readDString(32)
+	d.AbstractFileIdentifier = reader.readDString(32)
+	d.RootDirectoryICB.read(reader)
+	d.DomainIdentifier.read(reader)
+	d.NextExtent.read(reader)
+	d.SystemStreamDirectoryICB.read(reader)
+	reader.skipBytes(32) // Reserved
+}
+
+func (d *FileEntryDescriptor) read(reader *bufferReader) {
+	d.Tag.read(reader)
+	d.ICBTag.read(reader)
+	d.Uid = reader.readUint32()
+	d.Gid = reader.readUint32()
+	d.Permissions = FileMode(reader.readUint32())
+	d.FileLinkCount = reader.readUint16()
+	d.RecordFormat = reader.readUint8()
+	d.RecordDisplayAttributes = reader.readUint8()
+	d.RecordLength = reader.readUint32()
+	d.InformationLength = reader.readUint64()
+	d.LogicalBlocksRecorded = reader.readUint64()
+	d.AccessTime = reader.readTimestamp()
+	d.ModificationTime = reader.readTimestamp()
+	d.AttributeTime = reader.readTimestamp()
+	d.Checkpoint = reader.readUint32()
+	d.ExtendedAttributeICB.read(reader)
+	d.ImplementationIdentifier.read(reader)
+	d.UniqueID = reader.readUint64()
+	d.LengthOfExtendedAttributes = reader.readUint32()
+	d.LengthOfAllocationDescriptors = reader.readUint32()
+	d.ExtendedAttributes = reader.readBytes(int(d.LengthOfExtendedAttributes))
+	d.AllocationDescriptors = make([]Extent, d.LengthOfAllocationDescriptors/8)
+	for i := range d.AllocationDescriptors {
+		d.AllocationDescriptors[i].read(reader)
+	}
+}
+
+func (icb *ICBTag) read(reader *bufferReader) {
+	icb.PriorRecordedNumberOfDirectEntries = reader.readUint32()
+	icb.StrategyType = reader.readUint16()
+	icb.StrategyParameter = reader.readUint16()
+	icb.MaximumNumberOfEntries = reader.readUint16()
+	reader.skipBytes(1)
+	icb.FileType = reader.readUint8()
+	icb.ParentICBLocation.read(reader)
+	icb.Flags = reader.readUint16()
+}
+
+func (lba *LogicalBlockAddress) read(reader *bufferReader) {
+	lba.LogicalBlockNumber = reader.readUint32()
+	lba.PartitionReferenceNumber = reader.readUint16()
+}
+
+func (d *FileIdentifierDescriptor) read(reader *bufferReader) {
+	start := reader.off
+	d.Tag.read(reader)
+	d.FileVersionNumber = reader.readUint16()
+	d.FileCharacteristics = FileCharacteristics(reader.readUint8())
+	d.LengthOfFileIdentifier = reader.readUint8()
+	d.ICB.read(reader)
+	d.LengthOfImplementationUse = reader.readUint16()
+	d.ImplementationUse = reader.readBytes(int(d.LengthOfImplementationUse))
+	d.FileIdentifier = reader.readDCharacters(int(d.LengthOfFileIdentifier))
+
+	// Padding: 4 x ip((L_FI+L_IU+38+3)/4) - (L_FI+L_IU+38) bytes long and shall contain all #00 bytes.
+	// L_FI: Length of File Identifier
+	// L_IU: Length of Implementation Use
+	currentSize := reader.off - start
+	paddingLen := 4*((currentSize+3)/4) - currentSize
+	reader.skipBytes(paddingLen)
+}
+
+func (d *CdromVolumeDescriptorHeader) read(reader *bufferReader) {
+	d.Type = reader.readUint8()
+	d.Identifier = string(reader.readBytes(5))
+	d.Version = reader.readUint8()
+}
+
+type bufferReader struct {
+	off int
+	buf []byte
+}
+
+func (r *bufferReader) eof() bool {
+	return r.off >= len(r.buf)
+}
+
+func (r *bufferReader) skipBytes(len int) {
+	r.off += len
+}
+
+func (r *bufferReader) readBytes(len int) []byte {
+	start := r.off
+	r.off += len
+	return r.buf[start:r.off]
+}
+
+func (r *bufferReader) readInt8() int8 {
+	return int8(r.readUint8())
+}
+
+func (r *bufferReader) readUint8() uint8 {
+	start := r.off
+	r.off += 1
+	return r.buf[start]
+}
+
+func (r *bufferReader) readInt16() int16 {
+	return int16(r.readUint16())
+}
+
+func (r *bufferReader) readUint16() uint16 {
+	start := r.off
+	r.off += 2
+	return binary.LittleEndian.Uint16(r.buf[start:r.off])
+}
+
+func (r *bufferReader) peekUint16() uint16 {
+	return binary.LittleEndian.Uint16(r.buf[r.off : r.off+2])
+}
+
+func (r *bufferReader) readInt32() int32 {
+	return int32(r.readUint32())
+}
+
+func (r *bufferReader) readUint32() uint32 {
+	start := r.off
+	r.off += 4
+	return binary.LittleEndian.Uint32(r.buf[start:r.off])
+}
+
+func (r *bufferReader) readUint48() uint64 {
+	start := r.off
+	r.off += 6
+	data := make([]byte, 8)
+	copy(data, r.buf[start:r.off])
+	return binary.LittleEndian.Uint64(data)
+}
+
+func (r *bufferReader) readInt64() int64 {
+	return int64(r.readUint64())
+}
+
+func (r *bufferReader) readUint64() uint64 {
+	start := r.off
+	r.off += 8
+	return binary.LittleEndian.Uint64(r.buf[start:r.off])
+}
+
+func (r *bufferReader) readString(size int) string {
+	if size == 0 {
+		return ""
+	}
+	start := r.off
+	r.off += size
+	return string(r.buf[start:r.off])
+}
+
+func (r *bufferReader) readDString(size int) string {
+	if size == 0 {
+		return ""
+	}
+	start := r.off
+	r.off += size
+	length := int(r.buf[r.off-1])
+	if length == 0 {
+		return ""
+	}
+
+	// The CompressionID shall identify the compression algorithm used to compress the CompressedBitStream field.
+	// 8: Value indicates there are 8 bits per character in the CompressedBitStream.
+	// 16: Value indicates there are 16 bits per character in the CompressedBitStream.
+	compressionId := r.buf[start]
+	if compressionId != 8 {
+		panic("expecting character length to be 8 bit long")
+	}
+
+	return string(r.buf[start+1 : start+length])
+}
+
+func (r *bufferReader) readDCharacters(length int) string {
+	if length == 0 {
+		return ""
+	}
+	encodingType := r.readUint8()
+	length--
+	switch encodingType {
+	case dcharEncodingType8:
+		win1252Dec := charmap.Windows1252.NewDecoder()
+		s, _, err := transform.Bytes(win1252Dec, r.readBytes(length))
+		if err != nil {
+			panic(err)
+		}
+		return string(s)
+	case dcharEncodingType16:
+		utf16Dec := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder()
+		s, _, err := transform.Bytes(utf16Dec, r.readBytes(length))
+		if err != nil {
+			panic(err)
+		}
+		return string(s)
+	default:
+		panic(fmt.Sprintf("unsupported string encoding type %d", encodingType))
+	}
+}
+
+func (r *bufferReader) readTimestamp() time.Time {
+	r.skipBytes(2) // TypeAndTimezone
+	year := r.readUint16()
+	month := r.readUint8()
+	day := r.readUint8()
+	hour := r.readUint8()
+	minute := r.readUint8()
+	second := r.readUint8()
+	r.skipBytes(3) // Centiseconds+HundredsofMicroseconds+Microseconds
+	return time.Date(int(year), time.Month(month), int(day), int(hour), int(minute), int(second), 0, time.UTC)
+}
+
+type FileInfo struct {
+	fid           *FileIdentifierDescriptor
+	logicalVolume *LogicalVolumeDescriptor
+	entry         *FileEntryDescriptor
+	parent        *FileInfo
+	path          string
+}
+
+func (f *FileInfo) Name() string {
+	if f.IsRoot() {
+		return f.logicalVolume.LogicalVolumeIdentifier
+	} else {
+		return f.fid.FileIdentifier
+	}
+}
+
+func (f *FileInfo) Path() string {
+	return f.path
+}
+
+func (f *FileInfo) Size() int64 {
+	return int64(f.entry.InformationLength)
+}
+
+func (f *FileInfo) Mode() FileMode {
+	return f.entry.Permissions
+}
+
+func (f *FileInfo) FileMode() fs.FileMode {
+	mode := FromFileMode(f.entry.Permissions)
+	if f.IsDir() {
+		mode |= fs.ModeDir
+	}
+	return mode
+}
+
+func (f *FileInfo) ModTime() time.Time {
+	return f.entry.ModificationTime
+}
+
+func (f *FileInfo) IsRoot() bool {
+	return f.fid == nil
+}
+
+func (f *FileInfo) IsDir() bool {
+	return f.entry.ICBTag.FileType == fileTypeDirectory
+}
+
+func (f *FileInfo) Uid() uint32 {
+	return f.entry.Uid
+}
+
+func (f *FileInfo) Gid() uint32 {
+	return f.entry.Gid
+}
+
+func (f *FileInfo) Sys() any {
+	return f
+}

--- a/internal/udf/udf.go
+++ b/internal/udf/udf.go
@@ -1,0 +1,585 @@
+package udf
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/exp/utf8string"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+const (
+	sectorSize                         = 2048
+	anchorVolumeDescriptorSectorNumber = 256
+	tagSize                            = 16
+	tagVersion2                        = 2 // ECMA-167/2
+	entityIdSize                       = 32
+)
+
+const (
+	dcharEncodingType8  = 8
+	dcharEncodingType16 = 16
+)
+
+const (
+	// Indicates the contents of the specified logical volume or file set
+	// is complaint with domain defined by this document.
+	entityIdentifierOSTACompliant = "*OSTA UDF Compliant"
+	// Contains additional Logical Volume identification information.
+	entityIdentifierLVInfo = "*UDF LV Info"
+	// Contains free unused space within the implementation extended attribute space.
+	entityIdentifierFreeEASpace = "*UDF FreeEASpace"
+	entityIdentifierDvdCGMSInfo = "*UDF DVD CGMS Info"
+)
+
+const (
+	osClassUndefined uint8 = 0
+	osClassMac             = 3
+	osClassUnix            = 4
+	osClassWindows         = 6
+)
+
+const (
+	tagPrimaryVolumeDescriptor           = 0x0001
+	tagAnchorVolumeDescriptorPointer     = 0x0002
+	tagVolumeDescriptorPointer           = 0x0003
+	tagImplementationUseVolumeDescriptor = 0x0004
+	tagPartitionDescriptor               = 0x0005
+	tagLogicalVolumeDescriptor           = 0x0006
+	tagUnallocatedSpaceDescriptor        = 0x0007
+	tagTerminatingDescriptor             = 0x0008
+	tagLogicalVolumeIntegrityDescriptor  = 0x0009
+	tagFileSetDescriptor                 = 0x0100
+	tagFileIdentifierDescriptor          = 0x0101
+	tagAllocationExtentDescriptor        = 0x0102
+	tagIndirectEntry                     = 0x0103
+	tagTerminalEntry                     = 0x0104
+	tagFileEntry                         = 0x0105
+	tagExtendedAttributeHeaderDescriptor = 0x0106
+	tagUnallocatedSpaceEntry             = 0x0107
+	tagSpaceBitmapDescriptor             = 0x0108
+	tagPartitionIntegrityEntry           = 0x0109
+	tagExtendedFileEntry                 = 0x010a
+)
+
+const (
+	// Shall mean that this is an Unallocated Space Entry
+	fileTypeUnallocated uint8 = 1
+	// Shall mean that this is a Partition Integrity Entry
+	fileTypePartitionIntegrity = 2
+	// Shall mean that this is an Indirect Entry
+	fileTypeIndirect = 3
+	// Shall mean that the file is a directory
+	fileTypeDirectory = 4
+	// Shall mean that the file shall be interpreted as a sequence of bytes, each of which may be randomly accessed
+	fileTypeBytes = 5
+	// Shall mean that the file is a block special device file as specified by ISO/IEC 9945-1
+	fileTypeBlockDevice = 6
+)
+
+type FileCharacteristics uint8
+
+const (
+	// FileCharacteristicHidden If set to ZERO, shall mean that the existence of the file shall be made known
+	// to the user; If set to ONE, shall mean that the existence of the file need not be made known to the user.
+	FileCharacteristicHidden FileCharacteristics = 1 << (0 + iota)
+
+	// FileCharacteristicDirectory If set to ZERO, shall mean that the file is not a directory (see 4/14.6.6);
+	// If set to ONE, shall mean that the file is a directory.
+	FileCharacteristicDirectory
+
+	// FileCharacteristicDeleted If set to ONE, shall mean this File Identifier Descriptor identifies a file that
+	// has been deleted; If set to ZERO, shall mean that this File Identifier Descriptor identifies a file that
+	// has not been deleted.
+	FileCharacteristicDeleted
+
+	// FileCharacteristicParent If set to ONE, shall mean that the ICB field of this descriptor identifies the
+	// ICB associated with the file in which is recorded the parent directory of the directory that this
+	// descriptor is recorded in;
+	// If set to ZERO, shall mean that the ICB field identifies the ICB associated with the file specified
+	// by this descriptor
+	FileCharacteristicParent
+
+	// FileCharacteristicMetadata If this File Identifier Descriptor is not in a stream directory,
+	// this bit shall be set to ZERO. If this File Identifier Descriptor is in a stream directory,
+	// a value of ZERO shall indicate that this stream contains user data. A value of ONE shall indicate that the
+	// stream contains implementation use data.
+	FileCharacteristicMetadata
+)
+
+func (c FileCharacteristics) HasFlags(mask FileCharacteristics) bool {
+	return c&mask == mask
+}
+
+type Extent struct {
+	Length   uint32
+	Location uint32
+}
+
+type ExtentLong struct {
+	Length   uint32
+	Location uint64
+}
+
+type EntityID struct {
+	Flags            uint8
+	Identifier       string
+	IdentifierSuffix string
+}
+
+type ImplementationUse struct {
+	Entity EntityID
+	// Additional vendor-specific data
+	Implementation []byte
+}
+
+type Charspec struct {
+	// CharacterSetType field shall have the value of 0 to indicate the CS0 coded character set.
+	CharacterSetType uint8
+	// CharacterSetInfo field shall contain the following byte values with the remainder of the field set to a value of 0:
+	// #4F, #53, #54, #41, #20, #43, #6F, #6D, #70, #72, #65, #73, #73,
+	// #65, #64, #20, #55, #6E, #69, #63, #6F, #64, #65
+	CharacterSetInfo []byte
+}
+
+func NewDescriptor(tagId uint16) Descriptor {
+	switch tagId {
+	case tagPrimaryVolumeDescriptor:
+		return &PrimaryVolumeDescriptor{}
+	case tagAnchorVolumeDescriptorPointer:
+		return &AnchorVolumeDescriptorPointer{}
+	case tagVolumeDescriptorPointer:
+		return &VolumeDescriptorPointer{}
+	case tagImplementationUseVolumeDescriptor:
+		return &ImplementationUseVolumeDescriptor{}
+	case tagPartitionDescriptor:
+		return &PartitionDescriptor{}
+	case tagLogicalVolumeDescriptor:
+		return &LogicalVolumeDescriptor{}
+	case tagUnallocatedSpaceDescriptor:
+		return &UnallocatedSpaceDescriptor{}
+	case tagTerminatingDescriptor:
+		return &TerminatingDescriptor{}
+	case tagLogicalVolumeIntegrityDescriptor:
+		return &LogicalVolumeIntegrityDescriptor{}
+	case tagFileSetDescriptor:
+		return &FileSetDescriptor{}
+	case tagFileIdentifierDescriptor:
+		return &FileIdentifierDescriptor{}
+	case tagFileEntry:
+		return &FileEntryDescriptor{}
+	default:
+		panic(fmt.Errorf("unexpected tag identifier %d", tagId))
+	}
+}
+
+type Descriptor interface {
+	GetIdentifier() int
+	GetTag() *DescriptorTag
+}
+
+type DescriptorList []Descriptor
+
+func (list DescriptorList) get(tagId int) Descriptor {
+	if desc := list.find(tagId); desc != nil {
+		return desc
+	} else {
+		panic(fmt.Sprintf("descriptor with ID %d does not exist in sequence", tagId))
+	}
+}
+
+func (list DescriptorList) find(tagId int) Descriptor {
+	for idx := 0; idx < len(list); idx++ {
+		if list[idx].GetIdentifier() == tagId {
+			return list[idx]
+		}
+	}
+	return nil
+}
+
+// DescriptorTag Certain descriptors specified in Part 3 have a 16 byte structure, or tag,
+// recorded at the start of the descriptor.
+type DescriptorTag struct {
+	TagIdentifier     uint16
+	DescriptorVersion uint16
+	// This field shall specify the sum modulo 256 of bytes 0-3 and 5-15 of the tag.
+	TagChecksum     uint8
+	TagSerialNumber uint16
+	// This field shall specify the CRC of the bytes of the descriptor starting at the first byte after the descriptor tag.
+	// The CRC shall be 16 bits long and be generated by the CRC-ITU-T polynomial
+	DescriptorCRC uint16
+	// The number of bytes shall be specified by the Descriptor CRC Length field.
+	DescriptorCRCLength uint16
+	TagLocation         uint32
+}
+
+// AnchorVolumeDescriptorPointer structure shall only be recorded at 2 of the following 3 locations on the media:
+// * Logical Sector 256.
+// * Logical Sector (N - 256).
+// * N
+type AnchorVolumeDescriptorPointer struct {
+	Tag                             DescriptorTag
+	MainVolumeDescriptorSequence    Extent
+	ReserveVolumeDescriptorSequence Extent
+}
+
+func (d *AnchorVolumeDescriptorPointer) GetIdentifier() int {
+	return tagAnchorVolumeDescriptorPointer
+}
+
+func (d *AnchorVolumeDescriptorPointer) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type VolumeDescriptorPointer struct {
+	Tag DescriptorTag
+	// This field shall specify the Volume Descriptor Sequence Number for this descriptor.
+	VolumeDescriptorSequenceNumber uint32
+	// This field shall specify the next extent in the Volume Descriptor Sequence. If the extent's length is 0, no such
+	//extent is specified.
+	NextVolumeDescriptorSequenceExtent Extent
+}
+
+func (d *VolumeDescriptorPointer) GetIdentifier() int {
+	return tagVolumeDescriptorPointer
+}
+
+func (d *VolumeDescriptorPointer) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+// PrimaryVolumeDescriptor There shall be exactly one prevailing Primary Volume Descriptor recorded per volume.
+type PrimaryVolumeDescriptor struct {
+	Tag                                         DescriptorTag
+	VolumeDescriptorSequenceNumber              uint32
+	PrimaryVolumeDescriptorNumber               uint32
+	VolumeIdentifier                            string
+	VolumeSequenceNumber                        uint16
+	MaximumVolumeSequenceNumber                 uint16
+	InterchangeLevel                            uint16
+	MaximumInterchangeLevel                     uint16
+	CharacterSetList                            uint32
+	MaximumCharacterSetList                     uint32
+	VolumeSetIdentifier                         string
+	DescriptorCharacterSet                      Charspec
+	ExplanatoryCharacterSet                     Charspec
+	VolumeAbstract                              Extent
+	VolumeCopyrightNoticeExtent                 Extent
+	ApplicationIdentifier                       EntityID
+	RecordingDateTime                           time.Time
+	ImplementationIdentifier                    EntityID
+	ImplementationUse                           []byte
+	PredecessorVolumeDescriptorSequenceLocation uint32
+	Flags                                       uint16
+}
+
+func (d *PrimaryVolumeDescriptor) GetIdentifier() int {
+	return tagPrimaryVolumeDescriptor
+}
+
+func (d *PrimaryVolumeDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+// ImplementationUseVolumeDescriptor shall be recorded on every Volume of a Volume Set.
+// The Volume may also contain additional Implementation Use Volume Descriptors which are implementation specific.
+// The intended purpose of this descriptor is to aid in the identification of a Volume within a Volume Set
+// that belongs to a specific Logical Volume.
+type ImplementationUseVolumeDescriptor struct {
+	Tag                            DescriptorTag
+	VolumeDescriptorSequenceNumber uint32
+	ImplementationIdentifier       EntityID
+	ImplementationUse              LVInformation
+}
+
+func (d *ImplementationUseVolumeDescriptor) GetIdentifier() int {
+	return tagImplementationUseVolumeDescriptor
+}
+
+func (d *ImplementationUseVolumeDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type LVInformation struct {
+	LVICharset              Charspec
+	LogicalVolumeIdentifier string
+	LVInfo1                 string
+	LVInfo2                 string
+	LVInfo3                 string
+	ImplementationID        EntityID
+	ImplementationUse       []byte
+}
+
+// PartitionDescriptor A Partition Access Type of Read-Only , Rewritable, Overwritable and WORM shall be supported.
+// There shall be exactly one prevailing Partition Descriptor recorded per volume, with one exception.
+// For Volume Sets that consist of single volume, the  volume may contain 2 Partitions with 2 prevailing
+// Partition Descriptors only if one has an access type of read only and the other has an access type of Rewritable or Overwritable.
+// The Logical Volume for this volume would consist of the contents of both partitions.
+type PartitionDescriptor struct {
+	Tag                            DescriptorTag
+	VolumeDescriptorSequenceNumber uint32
+	PartitionFlags                 uint16
+	PartitionNumber                uint16
+	PartitionContents              EntityID
+	PartitionContentsUse           []byte
+	AccessType                     uint32
+	PartitionStartingLocation      uint32
+	PartitionLength                uint32
+	ImplementationIdentifier       EntityID
+	ImplementationUse              []byte
+}
+
+func (d *PartitionDescriptor) GetIdentifier() int {
+	return tagPartitionDescriptor
+}
+
+func (d *PartitionDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type LogicalVolumeDescriptor struct {
+	Tag                            DescriptorTag
+	VolumeDescriptorSequenceNumber uint32
+	DescriptorCharacterSet         Charspec
+	LogicalVolumeIdentifier        string
+	LogicalBlockSize               uint32
+	DomainIdentifier               EntityID
+	LogicalVolumeContentsUse       []byte
+	MapTableLength                 uint32
+	NumberOfPartitionMaps          uint32
+	ImplementationIdentifier       EntityID
+	ImplementationUse              []byte
+	IntegritySequenceExtent        Extent
+	PartitionMaps                  []PartitionMap
+}
+
+func (d *LogicalVolumeDescriptor) GetIdentifier() int {
+	return tagLogicalVolumeDescriptor
+}
+
+func (d *LogicalVolumeDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type LogicalVolumeHeaderDescriptor struct {
+	UniqueID uint64
+}
+
+type PartitionMap struct {
+	PartitionMapType     uint8
+	PartitionMapLength   uint8
+	VolumeSequenceNumber uint16
+	PartitionNumber      uint16
+}
+
+// UnallocatedSpaceDescriptor shall be recorded, even if there is no free volume space.
+// The first 32768 bytes of the Volume space shall not be used for the recording of ECMA 167 structures.
+// This area shall not be referenced by the Unallocated Space Descriptor or any other ECMA 167 descriptor.
+type UnallocatedSpaceDescriptor struct {
+	Tag                            DescriptorTag
+	VolumeDescriptorSequenceNumber uint32
+	NumberOfAllocationDescriptors  uint32
+	AllocationDescriptors          []Extent
+}
+
+func (d *UnallocatedSpaceDescriptor) GetIdentifier() int {
+	return tagUnallocatedSpaceDescriptor
+}
+
+func (d *UnallocatedSpaceDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+// TerminatingDescriptor may be recorded to terminate a Volume Descriptor Sequence
+type TerminatingDescriptor struct {
+	Tag DescriptorTag
+}
+
+func (d *TerminatingDescriptor) GetIdentifier() int {
+	return tagTerminatingDescriptor
+}
+
+func (d *TerminatingDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type LogicalVolumeIntegrityDescriptor struct {
+	Tag                       DescriptorTag
+	RecordingDateTime         time.Time
+	IntegrityType             uint32
+	NextIntegrityExtent       Extent
+	LogicalVolumeContentsUse  LogicalVolumeHeaderDescriptor
+	NumberOfPartitions        uint32
+	LengthOfImplementationUse uint32
+	FreeSpaceTable            []uint32
+	SizeTable                 []uint32
+	ImplementationUse         ImplementationUse
+}
+
+func (d *LogicalVolumeIntegrityDescriptor) GetIdentifier() int {
+	return tagLogicalVolumeIntegrityDescriptor
+}
+
+func (d *LogicalVolumeIntegrityDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+// FileSetDescriptor Only one File Set Descriptor shall be recorded. On WORM media, multiple File Sets may be recorded.
+type FileSetDescriptor struct {
+	Tag                                 DescriptorTag
+	RecordingDateTime                   time.Time
+	InterchangeLevel                    uint16
+	MaximumInterchangeLevel             uint16
+	CharacterSetList                    uint32
+	MaximumCharacterSetList             uint32
+	FileSetNumber                       uint32
+	FileSetDescriptorNumber             uint32
+	LogicalVolumeIdentifierCharacterSet Charspec
+	LogicalVolumeIdentifier             string
+	FileSetCharacterSet                 Charspec
+	FileSetIdentifier                   string
+	CopyrightFileIdentifier             string
+	AbstractFileIdentifier              string
+	RootDirectoryICB                    ExtentLong
+	DomainIdentifier                    EntityID
+	NextExtent                          ExtentLong
+	SystemStreamDirectoryICB            ExtentLong
+}
+
+func (d *FileSetDescriptor) GetIdentifier() int {
+	return tagFileSetDescriptor
+}
+
+func (d *FileSetDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type FileEntryDescriptor struct {
+	Tag                           DescriptorTag
+	ICBTag                        ICBTag
+	Uid                           uint32
+	Gid                           uint32
+	Permissions                   FileMode
+	FileLinkCount                 uint16
+	RecordFormat                  uint8
+	RecordDisplayAttributes       uint8
+	RecordLength                  uint32
+	InformationLength             uint64
+	LogicalBlocksRecorded         uint64
+	AccessTime                    time.Time
+	ModificationTime              time.Time
+	AttributeTime                 time.Time
+	Checkpoint                    uint32
+	ExtendedAttributeICB          ExtentLong
+	ImplementationIdentifier      EntityID
+	UniqueID                      uint64
+	LengthOfExtendedAttributes    uint32
+	LengthOfAllocationDescriptors uint32
+	ExtendedAttributes            []byte
+	AllocationDescriptors         []Extent
+}
+
+func (d *FileEntryDescriptor) GetIdentifier() int {
+	return tagFileEntry
+}
+
+func (d *FileEntryDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type ICBTag struct {
+	PriorRecordedNumberOfDirectEntries uint32
+	StrategyType                       uint16
+	StrategyParameter                  uint16
+	MaximumNumberOfEntries             uint16
+	FileType                           uint8
+	ParentICBLocation                  LogicalBlockAddress
+	Flags                              uint16
+}
+
+type LogicalBlockAddress struct {
+	LogicalBlockNumber       uint32
+	PartitionReferenceNumber uint16
+}
+
+// FileIdentifierDescriptor ECMA 167 4/14.4
+type FileIdentifierDescriptor struct {
+	Tag                       DescriptorTag
+	FileVersionNumber         uint16
+	FileCharacteristics       FileCharacteristics
+	LengthOfFileIdentifier    uint8
+	ICB                       ExtentLong
+	LengthOfImplementationUse uint16
+	ImplementationUse         []byte
+	FileIdentifier            string
+}
+
+func (d *FileIdentifierDescriptor) GetIdentifier() int {
+	return tagFileIdentifierDescriptor
+}
+
+func (d *FileIdentifierDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+func (d *FileIdentifierDescriptor) calculateSize() int {
+	fileIdentifierLen := len(encodeDCharacters(d.FileIdentifier))
+	size := 38 + int(d.LengthOfImplementationUse) + fileIdentifierLen
+	paddingLen := 4*((size+3)/4) - size
+	if paddingLen > 0 {
+		size += paddingLen
+	}
+	return size
+}
+
+type ExtendedAttributeHeaderDescriptor struct {
+	Tag                              DescriptorTag
+	ImplementationAttributesLocation uint32
+	ApplicationAttributesLocation    uint32
+}
+
+func (d *ExtendedAttributeHeaderDescriptor) GetIdentifier() int {
+	return tagExtendedAttributeHeaderDescriptor
+}
+
+func (d *ExtendedAttributeHeaderDescriptor) GetTag() *DescriptorTag {
+	return &d.Tag
+}
+
+type ImplementationUseExtendedAttribute struct {
+	AttributeType            uint32
+	AttributeSubtype         uint8
+	AttributeLength          uint32
+	ImplementationUseLength  uint32
+	ImplementationIdentifier EntityID
+	ImplementationData       []byte
+}
+
+func encodeDCharacters(value string) []byte {
+	if len(value) == 0 {
+		return []byte{}
+	}
+	var encodingType int
+	var buf []byte
+	var err error
+	if utf8string.NewString(value).IsASCII() {
+		encodingType = dcharEncodingType8
+		win1252Enc := charmap.Windows1252.NewEncoder()
+		if buf, _, err = transform.Bytes(win1252Enc, []byte(value)); err != nil {
+			panic(err)
+		}
+	} else {
+		encodingType = dcharEncodingType16
+		utf16Enc := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewEncoder()
+		if buf, _, err = transform.Bytes(utf16Enc, []byte(value)); err != nil {
+			panic(err)
+		}
+	}
+
+	res := make([]byte, len(buf)+1)
+	res[0] = byte(encodingType)
+	copy(res[1:], buf)
+	return res
+}


### PR DESCRIPTION
## Short Description
An internal package to support installation of  VCD Solution Add-ons

## Description
In this package a reader is implemented that supports extracting files from solutions add-on ISO without unpacking/mounting it advance. 
## Motivation
A new feature is being implemented where the vcd client and terraform provider should support installation of the  VCD solution add-ons. Solution add-ons are packaged as an ISO media. To support larger files and avoid other issues with simple CDROM file format, the .iso file is packaged as  UDF filesystem (specification: http://www.osta.org/specs/pdf/udf260.pdf ).
udf internal package implements partially that specification and enables read. Specifically, the code allows only reading of top level objects within a .ISO file.