### PR TITLE
Add vm.ConsolidateDisks and vm.ConsolidateDisksAsync

### DIFF
--- a/.changes/v2.23.0/650-improvements.md
+++ b/.changes/v2.23.0/650-improvements.md
@@ -1,0 +1,2 @@
+* Add support for VM disk consolidation using `vm.ConsolidateDisksAsync` and `vm.ConsolidateDisks`
+  [GH-650]

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -2056,3 +2056,22 @@ func (vm *VM) ChangeCPUAndCoreCount(cpus, cpuCores *int) error {
 	}
 	return nil
 }
+
+// ConsolidateDisksAsync triggers VM disk consolidation task
+func (vm *VM) ConsolidateDisksAsync() (Task, error) {
+	if vm.VM.HREF == "" {
+		return Task{}, fmt.Errorf("cannot consolidate disks, VM HREF is unset")
+	}
+
+	return vm.client.ExecuteTaskRequest(vm.VM.HREF+"/action/consolidate", http.MethodPost,
+		types.AnyXMLMime, "error consolidating VM disks: %s", nil)
+}
+
+// ConsolidateDisks triggers VM disk consolidation task and waits until it is completed
+func (vm *VM) ConsolidateDisks() error {
+	task, err := vm.ConsolidateDisksAsync()
+	if err != nil {
+		return err
+	}
+	return task.WaitTaskCompletion()
+}


### PR DESCRIPTION
This PR adds support for VM disk consolidation `vm.ConsolidateDisks` and `vm.ConsolidateDisksAsync` that is required for Terraform https://github.com/vmware/terraform-provider-vcd/pull/1206