### PR TITLE
Vapp network lists

### DIFF
--- a/.changes/v2.24.0/657-features.md
+++ b/.changes/v2.24.0/657-features.md
@@ -1,0 +1,2 @@
+Added method `Client.QueryVappNetworks` to retrieve all vApp networks [GH-657]
+Added `VApp` methods `QueryAllVappNetworks`, `QueryVappNetworks`, `QueryVappOrgNetworks` to retrieve various types of vApp networks [GH-657]

--- a/govcd/query_metadata.go
+++ b/govcd/query_metadata.go
@@ -175,6 +175,12 @@ func addResults(queryType string, cumulativeResults, newResults Results) (Result
 	case types.QtResourcePool:
 		cumulativeResults.Results.ResourcePoolRecord = append(cumulativeResults.Results.ResourcePoolRecord, newResults.Results.ResourcePoolRecord...)
 		size = len(newResults.Results.ResourcePoolRecord)
+	case types.QtVappNetwork:
+		cumulativeResults.Results.VappNetworkRecord = append(cumulativeResults.Results.VappNetworkRecord, newResults.Results.VappNetworkRecord...)
+		size = len(newResults.Results.VappNetworkRecord)
+	case types.QtAdminVappNetwork:
+		cumulativeResults.Results.AdminVappNetworkRecord = append(cumulativeResults.Results.AdminVappNetworkRecord, newResults.Results.AdminVappNetworkRecord...)
+		size = len(newResults.Results.AdminVappNetworkRecord)
 
 	default:
 		return Results{}, 0, fmt.Errorf("query type %s not supported", queryType)
@@ -212,6 +218,8 @@ func (client *Client) cumulativeQueryWithHeaders(queryType string, params, notEn
 		types.QtResourcePool,
 		types.QtNetworkPool,
 		types.QtProviderVdcStorageProfile,
+		types.QtVappNetwork,
+		types.QtAdminVappNetwork,
 	}
 	// Make sure the query type is supported
 	// We need to check early, as queries that would return less than 25 items (default page size) would succeed,

--- a/govcd/vapp_network.go
+++ b/govcd/vapp_network.go
@@ -302,7 +302,7 @@ func (vapp *VApp) RemoveAllNetworkStaticRoutes(networkId string) error {
 	return nil
 }
 
-// queryVappNetwork returns a list of vApp networks with an optional filter
+// queryVappNetworks returns a list of vApp networks with an optional filter
 func queryVappNetworks(client *Client, values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
 
 	vAppNetworkType := types.QtVappNetwork
@@ -336,13 +336,43 @@ func queryVappNetworks(client *Client, values map[string]string) ([]*types.Query
 	return results.Results.VappNetworkRecord, nil
 }
 
-// QueryVappNetwork returns all vApp networks visible to the client
-func (client *Client) QueryVappNetworks() ([]*types.QueryResultVappNetworkRecordType, error) {
-	return queryVappNetworks(client, nil)
+// QueryVappNetworks returns all vApp networks visible to the client
+func (client *Client) QueryVappNetworks(values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
+	return queryVappNetworks(client, values)
 }
 
-// QueryVappNetwork returns all vApp networks belonging to the current vApp
-func (vapp *VApp) QueryVappNetworks() ([]*types.QueryResultVappNetworkRecordType, error) {
+// QueryAllVappNetworks returns all vApp networks and vApp Org Networks belonging to the current vApp
+func (vapp *VApp) QueryAllVappNetworks(values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
 	// Note: when querying a field that contains a UUID, the system compares only the UUIDs, even if the full field contains more than that.
-	return queryVappNetworks(vapp.client, map[string]string{"vApp": extractUuid(vapp.VApp.ID)})
+	allValues := map[string]string{"vApp": extractUuid(vapp.VApp.ID)}
+	for k, v := range values {
+		allValues[k] = v
+	}
+	return queryVappNetworks(vapp.client, allValues)
+}
+
+// QueryVappNetworks returns all vApp networks belonging to the current vApp
+func (vapp *VApp) QueryVappNetworks(values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
+	// Note: when querying a field that contains a UUID, the system compares only the UUIDs, even if the full field contains more than that.
+	allValues := map[string]string{
+		"vApp":     extractUuid(vapp.VApp.ID),
+		"isLinked": "false",
+	}
+	for k, v := range values {
+		allValues[k] = v
+	}
+	return queryVappNetworks(vapp.client, allValues)
+}
+
+// QueryVappOrgNetworks returns all vApp networks belonging to the current vApp
+func (vapp *VApp) QueryVappOrgNetworks(values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
+	// Note: when querying a field that contains a UUID, the system compares only the UUIDs, even if the full field contains more than that.
+	allValues := map[string]string{
+		"vApp":     extractUuid(vapp.VApp.ID),
+		"isLinked": "true",
+	}
+	for k, v := range values {
+		allValues[k] = v
+	}
+	return queryVappNetworks(vapp.client, allValues)
 }

--- a/govcd/vapp_network.go
+++ b/govcd/vapp_network.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"github.com/vmware/go-vcloud-director/v2/util"
 	"net/http"
+	"strings"
 )
 
 // UpdateNetworkFirewallRules updates vApp networks firewall rules. It will overwrite existing ones as there is
@@ -299,4 +300,49 @@ func (vapp *VApp) RemoveAllNetworkStaticRoutes(networkId string) error {
 		return fmt.Errorf("%s", combinedTaskErrorMessage(task.Task, err))
 	}
 	return nil
+}
+
+// queryVappNetwork returns a list of vApp networks with an optional filter
+func queryVappNetworks(client *Client, values map[string]string) ([]*types.QueryResultVappNetworkRecordType, error) {
+
+	vAppNetworkType := types.QtVappNetwork
+	if client.IsSysAdmin {
+		vAppNetworkType = types.QtAdminVappNetwork
+	}
+
+	params := map[string]string{
+		"type": vAppNetworkType,
+	}
+	filterValue := ""
+	if len(values) > 0 {
+		var filterElements []string
+		for k, v := range values {
+			item := fmt.Sprintf("%s==%s", k, v)
+			filterElements = append(filterElements, item)
+		}
+		filterValue = strings.Join(filterElements, ";")
+	}
+	if filterValue != "" {
+		params["filter"] = filterValue
+	}
+	results, err := client.cumulativeQuery(vAppNetworkType, nil, params)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving vApp networks %s", err)
+	}
+
+	if client.IsSysAdmin {
+		return results.Results.AdminVappNetworkRecord, nil
+	}
+	return results.Results.VappNetworkRecord, nil
+}
+
+// QueryVappNetwork returns all vApp networks visible to the client
+func (client *Client) QueryVappNetworks() ([]*types.QueryResultVappNetworkRecordType, error) {
+	return queryVappNetworks(client, nil)
+}
+
+// QueryVappNetwork returns all vApp networks belonging to the current vApp
+func (vapp *VApp) QueryVappNetworks() ([]*types.QueryResultVappNetworkRecordType, error) {
+	// Note: when querying a field that contains a UUID, the system compares only the UUIDs, even if the full field contains more than that.
+	return queryVappNetworks(vapp.client, map[string]string{"vApp": extractUuid(vapp.VApp.ID)})
 }

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -386,7 +386,7 @@ func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
 
 func (vcd *TestVCD) Test_QueryVappNetwork(check *C) {
 
-	vappNetworks, err := vcd.client.Client.QueryVappNetworks()
+	vappNetworks, err := vcd.client.Client.QueryVappNetworks(nil)
 	check.Assert(err, IsNil)
 	check.Assert(vappNetworks, NotNil)
 	for i, net := range vappNetworks {
@@ -400,7 +400,7 @@ func (vcd *TestVCD) Test_QueryVappNetwork(check *C) {
 		check.Assert(err, IsNil)
 		vapp, err := vdc.GetVAppByName(TestSetUpSuite, false)
 		check.Assert(err, IsNil)
-		vappNetworks, err = vapp.QueryVappNetworks()
+		vappNetworks, err = vapp.QueryAllVappNetworks(nil)
 		check.Assert(err, IsNil)
 		check.Assert(vappNetworks, NotNil)
 		check.Assert(len(vappNetworks) > 0, Equals, true)

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -8,6 +8,7 @@ package govcd
 
 import (
 	"fmt"
+	"github.com/kr/pretty"
 
 	. "gopkg.in/check.v1"
 
@@ -381,4 +382,30 @@ func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
+}
+
+func (vcd *TestVCD) Test_QueryVappNetwork(check *C) {
+
+	vappNetworks, err := vcd.client.Client.QueryVappNetworks()
+	check.Assert(err, IsNil)
+	check.Assert(vappNetworks, NotNil)
+	for i, net := range vappNetworks {
+		printVerbose("%d %# v\n", i, pretty.Formatter(net))
+	}
+
+	if !skipVappCreation && vcd.config.VCD.Org != "" && vcd.config.VCD.Vdc != "" {
+		org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+		check.Assert(err, IsNil)
+		vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
+		check.Assert(err, IsNil)
+		vapp, err := vdc.GetVAppByName(TestSetUpSuite, false)
+		check.Assert(err, IsNil)
+		vappNetworks, err = vapp.QueryVappNetworks()
+		check.Assert(err, IsNil)
+		check.Assert(vappNetworks, NotNil)
+		check.Assert(len(vappNetworks) > 0, Equals, true)
+		for i, net := range vappNetworks {
+			printVerbose("%d %# v\n", i, pretty.Formatter(net))
+		}
+	}
 }

--- a/govcd/vapp_network_test.go
+++ b/govcd/vapp_network_test.go
@@ -8,8 +8,6 @@ package govcd
 
 import (
 	"fmt"
-	"github.com/kr/pretty"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -382,30 +380,4 @@ func (vcd *TestVCD) Test_UpdateNetworkStaticRoutes(check *C) {
 	check.Assert(err, IsNil)
 	err = task.WaitTaskCompletion()
 	check.Assert(err, IsNil)
-}
-
-func (vcd *TestVCD) Test_QueryVappNetwork(check *C) {
-
-	vappNetworks, err := vcd.client.Client.QueryVappNetworks(nil)
-	check.Assert(err, IsNil)
-	check.Assert(vappNetworks, NotNil)
-	for i, net := range vappNetworks {
-		printVerbose("%d %# v\n", i, pretty.Formatter(net))
-	}
-
-	if !skipVappCreation && vcd.config.VCD.Org != "" && vcd.config.VCD.Vdc != "" {
-		org, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
-		check.Assert(err, IsNil)
-		vdc, err := org.GetVDCByName(vcd.config.VCD.Vdc, false)
-		check.Assert(err, IsNil)
-		vapp, err := vdc.GetVAppByName(TestSetUpSuite, false)
-		check.Assert(err, IsNil)
-		vappNetworks, err = vapp.QueryAllVappNetworks(nil)
-		check.Assert(err, IsNil)
-		check.Assert(vappNetworks, NotNil)
-		check.Assert(len(vappNetworks) > 0, Equals, true)
-		for i, net := range vappNetworks {
-			printVerbose("%d %# v\n", i, pretty.Formatter(net))
-		}
-	}
 }

--- a/govcd/vapp_test.go
+++ b/govcd/vapp_test.go
@@ -8,6 +8,7 @@ package govcd
 
 import (
 	"fmt"
+	"github.com/kr/pretty"
 	"regexp"
 	"time"
 
@@ -610,6 +611,20 @@ func (vcd *TestVCD) Test_AddNewVMMultiNIC(check *C) {
 
 	verifyNetworkConnectionSection(check, actualNetConfig, desiredNetConfig)
 
+	allVappNetworks, err := vapp.QueryAllVappNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(allVappNetworks))
+	check.Assert(len(allVappNetworks), Equals, 2)
+
+	vappNetworks, err := vapp.QueryVappNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(vappNetworks))
+	check.Assert(len(vappNetworks), Equals, 0)
+	vappOrgNetworks, err := vapp.QueryVappOrgNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(vappOrgNetworks))
+	check.Assert(len(vappOrgNetworks), Equals, 2)
+
 	// Cleanup
 	err = vapp.RemoveVM(*vm)
 	check.Assert(err, IsNil)
@@ -686,6 +701,20 @@ func (vcd *TestVCD) Test_RemoveAllNetworks(check *C) {
 	// network removal, but ignore error as it might already be powered off
 	vappStatus, err := vcd.vapp.GetStatus()
 	check.Assert(err, IsNil)
+
+	allVappNetworks, err := vcd.vapp.QueryAllVappNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(allVappNetworks))
+	check.Assert(len(allVappNetworks), Equals, 2)
+
+	vappNetworks, err := vcd.vapp.QueryVappNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(vappNetworks))
+	check.Assert(len(vappNetworks), Equals, 1)
+	vappOrgNetworks, err := vcd.vapp.QueryVappOrgNetworks(nil)
+	check.Assert(err, IsNil)
+	printVerbose("%# v\n", pretty.Formatter(vappOrgNetworks))
+	check.Assert(len(vappOrgNetworks), Equals, 1)
 
 	if vappStatus != "POWERED_OFF" {
 		task, err := vcd.vapp.Undeploy()

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -284,6 +284,8 @@ const (
 	QtResourcePool              = "resourcePool"              // Resource Pool
 	QtNetworkPool               = "networkPool"               // Network Pool
 	QtProviderVdcStorageProfile = "providerVdcStorageProfile" // StorageProfile of Provider VDC
+	QtVappNetwork               = "vAppNetwork"
+	QtAdminVappNetwork          = "adminVAppNetwork"
 )
 
 // AdminQueryTypes returns the corresponding "admin" query type for each regular type

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2419,6 +2419,8 @@ type QueryResultRecordsType struct {
 	VmGroupsRecord                  []*QueryResultVmGroupsRecordType                  `xml:"VmGroupsRecord"`                  // A record representing a VM Group
 	TaskRecord                      []*QueryResultTaskRecordType                      `xml:"TaskRecord"`                      // A record representing a Task
 	AdminTaskRecord                 []*QueryResultTaskRecordType                      `xml:"AdminTaskRecord"`                 // A record representing an Admin Task
+	VappNetworkRecord               []*QueryResultVappNetworkRecordType               `xml:"VAppNetworkRecord"`               // A record representing a vApp network
+	AdminVappNetworkRecord          []*QueryResultVappNetworkRecordType               `xml:"AdminVAppNetworkRecord"`          // A record representing an admin vApp network
 }
 
 // QueryResultVmGroupsRecordType represent a VM Groups record
@@ -2430,6 +2432,32 @@ type QueryResultVmGroupsRecordType struct {
 	ClusterName    string `xml:"clusterName,attr,omitempty"`
 	VcenterId      string `xml:"vcId,attr,omitempty"`
 	NamedVmGroupId string `xml:"namedVmGroupId,attr,omitempty"`
+}
+
+type QueryResultVappNetworkRecordType struct {
+	HREF                   string    `xml:"href,attr,omitempty"`
+	ID                     string    `xml:"id,attr,omitempty"`
+	Name                   string    `xml:"name,attr,omitempty"`
+	Type                   string    `xml:"linkType,attr,omitempty"`
+	IpScopeId              string    `xml:"ipScopeId,attr,omitempty"`
+	IpScopeInherited       bool      `xml:"ipScopeInherited,attr,omitempty"`
+	Gateway                string    `xml:"gateway,attr,omitempty"`
+	Netmask                string    `xml:"netmask,attr,omitempty"`
+	SubnetPrefixLength     int       `xml:"subnetPrefixLength,attr,omitempty"`
+	Dns1                   string    `xml:"dns1,attr,omitempty"`
+	Dns2                   string    `xml:"dns2,attr,omitempty"`
+	DnsSuffix              string    `xml:"dnsSuffix,attr,omitempty"`
+	Vapp                   string    `xml:"vApp,attr,omitempty"`            // the HREF of the parent vApp
+	VappName               string    `xml:"vAppName,attr,omitempty"`        // the name of the parent vApp
+	LinkNetworkName        string    `xml:"linkNetworkName,attr,omitempty"` // this field is filled when called in tenant context
+	RealNetworkName        string    `xml:"realNetworkName,attr,omitempty"`
+	RealNetworkPortgroupId string    `xml:"realNetworkPortgroupId,attr,omitempty"`
+	VCenterName            string    `xml:"vcName,attr,omitempty"`
+	VCenter                string    `xml:"vc,attr,omitempty"`
+	IsBusy                 bool      `xml:"isBusy,attr,omitempty"`
+	IsLinked               bool      `xml:"isLinked,attr,omitempty"`
+	RetainNicResources     bool      `xml:"retainNicResources,attr,omitempty"`
+	Metadata               *Metadata `xml:"Metadata,omitempty"`
 }
 
 // QueryResultResourcePoolRecordType represent a Resource Pool record


### PR DESCRIPTION
Add methods to list vApp networks


## Implementation remarks

1. The API to retrieve vApp networks doesn't expose information about Org and VDC. The only ancestors mentioned in the returned data structure are the vApp and the vCenter.
2. Consequently, we can retrieve the networks associated with a vApp, but not the ones belonging to a VDC.
3. Association with an Org is obtained indirectly by running the request as tenant.
4. When running as Org user, the API populates a field named `linkNetworkName`, which points to the network linked to. But when running as System administrator, the API fills instead a field `realNetworkName` , which points to the name of the **network in vCenter**.