### PR TITLE
Update types.go. Add DetectedGuestOS to QueryResultVMRecordType

### DIFF
--- a/.changes/v2.25.0/673-improvements.md
+++ b/.changes/v2.25.0/673-improvements.md
@@ -1,0 +1,1 @@
+* Added `DetectedGuestOS` to `QueryResultVMRecordType` [GH-673]

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2638,6 +2638,7 @@ type QueryResultVMRecordType struct {
 	VAppTemplate             bool      `xml:"isVAppTemplate,attr,omitempty"`
 	Deleted                  bool      `xml:"isDeleted,attr,omitempty"`
 	GuestOS                  string    `xml:"guestOs,attr,omitempty"`
+	DetectedGuestOS          string    `xml:"detectedGuestOs,attr,omitempty"`
 	Cpus                     int       `xml:"numberOfCpus,attr,omitempty"`
 	MemoryMB                 int       `xml:"memoryMB,attr,omitempty"`
 	Status                   string    `xml:"status,attr,omitempty"`


### PR DESCRIPTION
## Description

Related issue: (`#672`)

- Add DetectedGuestOS to the struct

- A proper Test for AdminVM doesn't exist, but its application it's tested with this modification and the DetectedGuestOS data can be accessed correctly. 