### PR TITLE
Fix CSE cluster creation when using VDC Groups

### DIFF
--- a/.changes/v2.25.0/674-bug-fixes.md
+++ b/.changes/v2.25.0/674-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixed a bug that caused CSE Kubernetes cluster creation to fail when the configured Organization VDC Network belongs to
+  a VDC Group [GH-674]

--- a/govcd/cse_util.go
+++ b/govcd/cse_util.go
@@ -286,7 +286,8 @@ func cseConvertToCseKubernetesClusterType(rde *DefinedEntity) (*CseKubernetesClu
 	// Retrieve the Network ID
 	params := url.Values{}
 	params.Add("filter", fmt.Sprintf("name==%s", result.capvcdType.Status.Capvcd.VcdProperties.OrgVdcs[0].OvdcNetworkName))
-	params = queryParameterFilterAnd("ownerRef.id=="+result.VdcId, params)
+	params = queryParameterFilterAnd("orgVdc.id=="+result.VdcId, params)
+	params = queryParameterFilterAnd("_context==includeAccessible", params)
 	networks, err := getAllOpenApiOrgVdcNetworks(rde.client, params)
 	if err != nil {
 		return nil, fmt.Errorf("could not read Org VDC Network from Capvcd type: %s", err)


### PR DESCRIPTION
Related to https://github.com/vmware/terraform-provider-vcd/issues/1258, fixing it in PR https://github.com/vmware/terraform-provider-vcd/pull/1266

The filter to retrieve the networks with the target VDC was wrong, as it was using `ownerRef.id` instead of `orgVdc.id`:

* UI plugin uses `orgVdc.id` and `_context==includeAccessible` so this patch mimics this logic here
* The problem was, when the network is from an Edge Gateway that belongs to a VDC Group, the `ownerRef.id` is not a VDC anymore (`urn:vcloud:vdc`), but a VDC Group (`urn:vcloud:vdcGroup`). Hence the filter returned 0 networks with the desired VDC ID.

CSE tests passed in VCD 10.5.1 with CSE 4.2.1