### PR TITLE
Patch XML namespace problem for vm. UpdateNetworkConnectionSection

### DIFF
--- a/.changes/v2.25.0/677-bug-fixes.md
+++ b/.changes/v2.25.0/677-bug-fixes.md
@@ -1,0 +1,2 @@
+* Patched `vm.UpdateNetworkConnectionSection` method that could sometimes fail due to Go's XML
+  library mishandling XML namespaces when VCD returns irregular payload [GH-677]

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -126,6 +126,7 @@ func (vm *VM) UpdateNetworkConnectionSection(networks *types.NetworkConnectionSe
 	updateNetwork.PrimaryNetworkConnectionIndex = networks.PrimaryNetworkConnectionIndex
 	updateNetwork.NetworkConnection = networks.NetworkConnection
 	updateNetwork.Ovf = types.XMLNamespaceOVF
+	updateNetwork.Xmlns = types.XMLNamespaceVCloud
 
 	task, err := vm.client.ExecuteTaskRequest(vm.VM.HREF+"/networkConnectionSection/", http.MethodPut,
 		types.MimeNetworkConnectionSection, "error updating network connection: %s", updateNetwork)


### PR DESCRIPTION
Closes #429 

### Problem

In some cases, `vm.UpdateNetworkConnectionSection` fails with error similar to`HTTP 400 Bad Request - cvc-elt.1.a: Cannot find the declaration of element 'NetworkConnectionSection'`

### The cause

The `vm.UpdateNetworkConnectionSection` at first retrieves existing network configuration (`vm.GetNetworkConnectionSection`) and the modifies it.

In some environments, there is a problem that in some cases VCD randomly (not always) puts the payload for GET query into `ns2` namespace.
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<ns2:NetworkConnectionSection xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ns2="http://www.vmware.com/vcloud/v1.5" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:common=......
```

For reference, the regular normal payload that this call returns (not wrapped into `ns2` namespace)
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<NetworkConnectionSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:vmext="http://www.vmware.com/vcloud/extension/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="[http://schemas.dmtf.org/wbem/wscim/1/cim-schema/](http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData).....
```

Because Go XML library has issues with namespace handling (https://github.com/golang/go/issues/9519), the `Xmlns` attribute  value `http://www.vmware.com/vcloud/v1.5`  gets lost in translation and this causes the described error when update occurs.

### The fix

The fix is to set hardcoded setting for `Xmlns` to `http://www.vmware.com/vcloud/v1.5` for every update call. This will prevent malformed XML document query.


### Testing
I have triggered tests that include call to the method`vm.UpdateNetworkConnectionSection` and none of them failed:
* Test_AddNewEmptyVMMultiNIC
* Test_GetNetworkConnectionSection
* Test_VMGetDhcpAddress
* Test_NsxtSecurityGroupGetAssociatedVms