### PR TITLE
Add Autoscaler to CSE

### DIFF
--- a/.changes/v2.25.0/674-bug-fixes.md
+++ b/.changes/v2.25.0/674-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixed a bug that caused CSE Kubernetes cluster creation to fail when the configured Organization VDC Network belongs to
+  a VDC Group [GH-674]

--- a/govcd/cse/4.1/capiyaml_workerpool.tmpl
+++ b/govcd/cse/4.1/capiyaml_workerpool.tmpl
@@ -19,9 +19,15 @@ kind: MachineDeployment
 metadata:
   name: "{{.NodePoolName}}"
   namespace: "{{.TargetNamespace}}"
+  {{- if and (gt .AutoscalerMaxSize -1) (gt .AutoscalerMinSize -1) }}
+  cluster.x-k8s.io/cluster-api-Autoscaler-node-group-max-size: "{{.AutoscalerMaxSize}}"
+  cluster.x-k8s.io/cluster-api-Autoscaler-node-group-min-size: "{{.AutoscalerMinSize}}"
+  {{- end}}
 spec:
   clusterName: "{{.ClusterName}}"
+  {{- if and (lt .AutoscalerMaxSize 0) (lt .AutoscalerMinSize 0) }}
   replicas: {{.NodePoolMachineCount}}
+  {{- end}}
   selector:
     matchLabels: null
   template:

--- a/govcd/cse/4.2/autoscaler.tmpl
+++ b/govcd/cse/4.2/autoscaler.tmpl
@@ -1,0 +1,173 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: ${AUTOSCALER_NS}
+  labels:
+    app: cluster-autoscaler
+spec:
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      containers:
+      - image: ${AUTOSCALER_IMAGE}
+        name: cluster-autoscaler
+        command:
+        - /cluster-autoscaler
+        args:
+        - --cloud-provider=clusterapi
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-workload
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-workload
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: ${AUTOSCALER_NS}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-management
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: ${AUTOSCALER_NS}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: ${AUTOSCALER_NS}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-workload
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    - persistentvolumeclaims
+    - persistentvolumes
+    - pods
+    - replicationcontrollers
+    - services
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods/eviction
+    verbs:
+    - create
+  - apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csinodes
+    - storageclasses
+    - csidrivers
+    - csistoragecapacities
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - replicasets
+    - statefulsets
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - delete
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - get
+    - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-management
+rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    resources:
+    - machinedeployments
+    - machinedeployments/scale
+    - machines
+    - machinesets
+    - machinepools
+    verbs:
+    - get
+    - list
+    - update
+    - watch

--- a/govcd/cse/4.2/autoscaler.tmpl
+++ b/govcd/cse/4.2/autoscaler.tmpl
@@ -3,21 +3,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-autoscaler
-  namespace: ${AUTOSCALER_NS}
+  namespace: kube-system
   labels:
     app: cluster-autoscaler
 spec:
   selector:
     matchLabels:
       app: cluster-autoscaler
-  replicas: 1
+  replicas: {{.AutoscalerReplicas}}
   template:
     metadata:
       labels:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: ${AUTOSCALER_IMAGE}
+      - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler
@@ -40,7 +40,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler
-  namespace: ${AUTOSCALER_NS}
+  namespace: kube-system
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,13 +53,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cluster-autoscaler
-  namespace: ${AUTOSCALER_NS}
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cluster-autoscaler
-  namespace: ${AUTOSCALER_NS}
+  namespace: kube-system
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/govcd/cse/4.2/capiyaml_workerpool.tmpl
+++ b/govcd/cse/4.2/capiyaml_workerpool.tmpl
@@ -19,9 +19,15 @@ kind: MachineDeployment
 metadata:
   name: "{{.NodePoolName}}"
   namespace: "{{.TargetNamespace}}"
+  {{- if and (gt .AutoscalerMaxSize -1) (gt .AutoscalerMinSize -1) }}
+  cluster.x-k8s.io/cluster-api-Autoscaler-node-group-max-size: "{{.AutoscalerMaxSize}}"
+  cluster.x-k8s.io/cluster-api-Autoscaler-node-group-min-size: "{{.AutoscalerMinSize}}"
+  {{- end}}
 spec:
   clusterName: "{{.ClusterName}}"
+  {{- if and (lt .AutoscalerMaxSize 0) (lt .AutoscalerMinSize 0) }}
   replicas: {{.NodePoolMachineCount}}
+  {{- end}}
   selector:
     matchLabels: null
   template:

--- a/govcd/cse_internal.go
+++ b/govcd/cse_internal.go
@@ -174,6 +174,17 @@ func (clusterSettings *cseClusterSettingsInternal) generateWorkerPoolsYaml() (st
 			placementPolicy = wp.VGpuPolicyName
 		}
 
+		// TODO AUTOSCALER
+		// If cluster.autoscaler is enabled
+		// Check if MaxReplicas, MinReplicas is set, MaxReplicas >= MinReplicas
+		// Set the metadata entries in YAML file
+		// Remove replicas fields from YAML file
+		//
+		// If cluster.autoscaler is disabled
+		// workerPools[workerPoolToUpdate].MachineCount < 0
+		// Remove metadata entries from YAML file
+		// Set replicas
+
 		if err := workerPools.Execute(buf, map[string]string{
 			"ClusterName":             clusterSettings.Name,
 			"NodePoolName":            wp.Name,

--- a/govcd/cse_type.go
+++ b/govcd/cse_type.go
@@ -44,6 +44,9 @@ type CseClusterSettings struct {
 	SshPublicKey            string
 	VirtualIpSubnet         string
 	AutoRepairOnErrors      bool
+
+	// If set to 'true' it will ignore the "MachineCount" of all the worker pools (on create and update) and use "Autoscaler" struct instead.
+	AutoscalerEnabled bool
 }
 
 // CseControlPlaneSettings defines the required configuration of a Control Plane of a Container Service Extension (CSE) Kubernetes cluster.
@@ -59,12 +62,19 @@ type CseControlPlaneSettings struct {
 // CseWorkerPoolSettings defines the required configuration of a Worker Pool of a Container Service Extension (CSE) Kubernetes cluster.
 type CseWorkerPoolSettings struct {
 	Name              string
-	MachineCount      int
+	MachineCount      int // If the Autoscaler is enabled, this field is ignored
 	DiskSizeGi        int
-	SizingPolicyId    string // Optional
-	PlacementPolicyId string // Optional
-	VGpuPolicyId      string // Optional
-	StorageProfileId  string // Optional
+	SizingPolicyId    string                   // Optional
+	PlacementPolicyId string                   // Optional
+	VGpuPolicyId      string                   // Optional
+	StorageProfileId  string                   // Optional
+	Autoscaler        *CseWorkerPoolAutoscaler // Optional, only taken into account if the autoscaler is enabled in the cluster
+}
+
+// CseWorkerPoolAutoscaler defines the required configuration of the Autoscaling capabilities of a CSE Kubernetes cluster Worker Pool.
+type CseWorkerPoolAutoscaler struct {
+	MaxSize int
+	MinSize int
 }
 
 // CseDefaultStorageClassSettings defines the required configuration of a Default Storage Class of a Container Service Extension (CSE) Kubernetes cluster.
@@ -104,7 +114,8 @@ type CseControlPlaneUpdateInput struct {
 // CseWorkerPoolUpdateInput defines the required configuration that a Worker Pool of the Container Service Extension (CSE) Kubernetes cluster
 // needs in order to be updated.
 type CseWorkerPoolUpdateInput struct {
-	MachineCount int
+	MachineCount int                      // If the Autoscaler is enabled, this field is ignored
+	Autoscaler   *CseWorkerPoolAutoscaler // Optional, only taken into account if the autoscaler is enabled in the cluster
 }
 
 // cseClusterSettingsInternal defines the required arguments that are required by the CSE Server used internally to specify

--- a/govcd/cse_type.go
+++ b/govcd/cse_type.go
@@ -147,6 +147,7 @@ type cseClusterSettingsInternal struct {
 	PodCidr                   string
 	ServiceCidr               string
 	AutoRepairOnErrors        bool
+	AutoscalerEnabled         bool
 }
 
 // tkgVersionBundle is a type that contains all the versions of the components of
@@ -179,6 +180,7 @@ type cseWorkerPoolSettingsInternal struct {
 	PlacementPolicyName string
 	VGpuPolicyName      string
 	StorageProfileName  string
+	Autoscaler          *CseWorkerPoolAutoscaler
 }
 
 // cseDefaultStorageClassInternal defines a Default Storage Class inside cseClusterSettingsInternal

--- a/govcd/cse_type.go
+++ b/govcd/cse_type.go
@@ -44,9 +44,6 @@ type CseClusterSettings struct {
 	SshPublicKey            string
 	VirtualIpSubnet         string
 	AutoRepairOnErrors      bool
-
-	// If set to 'true' it will ignore the "MachineCount" of all the worker pools (on create and update) and use "Autoscaler" struct instead.
-	AutoscalerEnabled bool
 }
 
 // CseControlPlaneSettings defines the required configuration of a Control Plane of a Container Service Extension (CSE) Kubernetes cluster.
@@ -147,7 +144,6 @@ type cseClusterSettingsInternal struct {
 	PodCidr                   string
 	ServiceCidr               string
 	AutoRepairOnErrors        bool
-	AutoscalerEnabled         bool
 }
 
 // tkgVersionBundle is a type that contains all the versions of the components of

--- a/govcd/cse_util.go
+++ b/govcd/cse_util.go
@@ -786,7 +786,6 @@ func (input *CseClusterSettings) toCseClusterSettingsInternal(org Org) (*cseClus
 	output.ServiceCidr = input.ServiceCidr
 	output.SshPublicKey = input.SshPublicKey
 	output.VirtualIpSubnet = input.VirtualIpSubnet
-	output.AutoscalerEnabled = input.AutoscalerEnabled
 
 	return output, nil
 }

--- a/govcd/cse_util.go
+++ b/govcd/cse_util.go
@@ -286,7 +286,8 @@ func cseConvertToCseKubernetesClusterType(rde *DefinedEntity) (*CseKubernetesClu
 	// Retrieve the Network ID
 	params := url.Values{}
 	params.Add("filter", fmt.Sprintf("name==%s", result.capvcdType.Status.Capvcd.VcdProperties.OrgVdcs[0].OvdcNetworkName))
-	params = queryParameterFilterAnd("ownerRef.id=="+result.VdcId, params)
+	params = queryParameterFilterAnd("orgVdc.id=="+result.VdcId, params)
+	params = queryParameterFilterAnd("_context==includeAccessible", params)
 	networks, err := getAllOpenApiOrgVdcNetworks(rde.client, params)
 	if err != nil {
 		return nil, fmt.Errorf("could not read Org VDC Network from Capvcd type: %s", err)

--- a/govcd/cse_yaml.go
+++ b/govcd/cse_yaml.go
@@ -35,6 +35,20 @@ func (cluster *CseKubernetesCluster) updateCapiYaml(input CseClusterUpdateInput)
 		}
 	}
 
+	if cluster.AutoscalerEnabled {
+		fmt.Println("")
+		// TODO AUTOSCALER
+		// Are YAML documents already present?
+		// If so, check that replicas of autoscaler deployment is 1
+		// Otherwise, increase to 1
+		// If no documents are there, add them
+	} else {
+		fmt.Println("")
+		// Are YAML documents already present?
+		// If so, set deployment replicas to 0
+		// If no documents are there, do nothing
+	}
+
 	if input.WorkerPools != nil {
 		err := cseUpdateWorkerPoolsInYaml(yamlDocs, *input.WorkerPools)
 		if err != nil {
@@ -200,6 +214,17 @@ func cseUpdateWorkerPoolsInYaml(yamlDocuments []map[string]interface{}, workerPo
 		if workerPoolToUpdate == "" {
 			continue
 		}
+
+		// TODO AUTOSCALER
+		// If cluster.autoscaler is enabled
+		// Check if MaxReplicas, MinReplicas is set, MaxReplicas >= MinReplicas
+		// Set the metadata entries in YAML file
+		// Remove replicas fields from YAML file
+		//
+		// If cluster.autoscaler is disabled
+		// workerPools[workerPoolToUpdate].MachineCount < 0
+		// Remove metadata entries from YAML file
+		// Set replicas
 
 		if workerPools[workerPoolToUpdate].MachineCount < 0 {
 			return fmt.Errorf("incorrect machine count for worker pool %s: %d. Should be at least 0", workerPoolToUpdate, workerPools[workerPoolToUpdate].MachineCount)

--- a/govcd/cse_yaml.go
+++ b/govcd/cse_yaml.go
@@ -38,6 +38,7 @@ func (cluster *CseKubernetesCluster) updateCapiYaml(input CseClusterUpdateInput)
 	if cluster.AutoscalerEnabled {
 		fmt.Println("")
 		// TODO AUTOSCALER
+		// https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/docs/vmw-whitepaper-cluster-auto-scaler.pdf
 		// Are YAML documents already present?
 		// If so, check that replicas of autoscaler deployment is 1
 		// Otherwise, increase to 1


### PR DESCRIPTION
## Overview

This PR automates the steps to deploy an Autoscaler into a Kubernetes cluster stated in this document:
https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/docs/vmw-whitepaper-cluster-auto-scaler.pdf

This procedure affects cluster creation and cluster update operations.

## Description

A new `autoscaler.tmpl` file has been added to the collection. A new configuration block `Autoscaler` has been added to both the `CseWorkerPoolSettings` (settings to create a cluster) and `CseWorkerPoolUpdateInput` (input to update an existing cluster).

When the `Autoscaler` is set during cluster creation on any of the Worker Pools settings, we add the `autoscaler.tmpl` rendered YAML to the final result, and the Worker Pool deployments will have special `metadata` entries, and won't render the`replicas` field (as it conflicts with the autoscaler).

When none of the Worker Pools settings don't have the `Autoscaler` set, we follow the existing workflow: Nothing new is done.

The cluster is then created with or without autoscaling elements present in the cluster, and also the new metadata entries in each Worker Pool.

What about updating a cluster?

In this case, a user can enable or disable the `Autoscaler` in the same way, using `CseWorkerPoolUpdateInput` or creating new Worker Pools with `Autoscaler` set.

In this case, we search for the Autoscaler YAML document, to check whether it is present in the cluster or not. If we need autoscaling capabilities and the YAML is not there (that would mean that the cluster was created without autoscaling), we add the YAML and the required metadata to the worker pools.

If we don't need autoscaling, then we need to check whether it is enabled in the cluster, and disable its replicas if so.

## Tests