### PR TITLE
Fix RDE Types test

### DIFF
--- a/.changes/v2.25.0/681-notes.md
+++ b/.changes/v2.25.0/681-notes.md
@@ -1,1 +1,1 @@
-* Amend the test `Test_RdeAndRdeType` to be compatible with the newest VCD versions [GH-681]
+* Amended the test `Test_RdeAndRdeType` to be compatible with the newest VCD versions [GH-681]

--- a/.changes/v2.25.0/681-notes.md
+++ b/.changes/v2.25.0/681-notes.md
@@ -1,1 +1,1 @@
-* Amended the test `Test_RdeAndRdeType` to be compatible with the newest VCD versions [GH-681]
+* Amended the test `Test_RdeAndRdeType` to be compatible with the VCD 10.6+ [GH-681]

--- a/.changes/v2.25.0/681-notes.md
+++ b/.changes/v2.25.0/681-notes.md
@@ -1,1 +1,1 @@
-* Amended the test `Test_RdeAndRdeType` to be compatible with the VCD 10.6+ [GH-681]
+* Amended the test `Test_RdeAndRdeType` to be compatible with VCD 10.6+ [GH-681]

--- a/.changes/v2.25.0/681-notes.md
+++ b/.changes/v2.25.0/681-notes.md
@@ -1,0 +1,1 @@
+* Amend the test `Test_RdeAndRdeType` to be compatible with the newest VCD versions [GH-681]

--- a/govcd/defined_entity_test.go
+++ b/govcd/defined_entity_test.go
@@ -51,10 +51,15 @@ func (vcd *TestVCD) Test_RdeAndRdeType(check *C) {
 	check.Assert(err, IsNil)
 	alreadyPresentRdes := len(allRdeTypesBySystemAdmin)
 
-	// For the tenant, it returns 0 RDE Types, but no error.
+	// For the tenant, in VCD versions lower than 39.0 it returns 0 RDE Types, but no error.
+	// In newer VCD versions, it returns some pre-defined RDE Types.
 	allRdeTypesByTenant, err := tenantUserClient.GetAllRdeTypes(nil)
 	check.Assert(err, IsNil)
-	check.Assert(len(allRdeTypesByTenant), Equals, 0)
+	if vcd.client.Client.APIVCDMaxVersionIs("< 39.0") {
+		check.Assert(len(allRdeTypesByTenant), Equals, 0)
+	} else {
+		check.Assert(true, Equals, len(allRdeTypesByTenant) > 0)
+	}
 
 	// Then we create a new RDE Type with System administrator.
 	// Can't put check.TestName() in nss due to a bug in VCD 10.4.1 that causes RDEs to fail on GET once created with special characters like "."
@@ -135,9 +140,10 @@ func (vcd *TestVCD) Test_RdeAndRdeType(check *C) {
 	check.Assert(len(allRdeTypesBySystemAdmin), Equals, alreadyPresentRdes+1)
 
 	// Count is 1 for tenant user as it can only retrieve the created type as per the assigned rights above.
+	alreadyPresentRdes = len(allRdeTypesByTenant)
 	allRdeTypesByTenant, err = tenantUserClient.GetAllRdeTypes(nil)
 	check.Assert(err, IsNil)
-	check.Assert(len(allRdeTypesByTenant), Equals, 1)
+	check.Assert(len(allRdeTypesByTenant), Equals, alreadyPresentRdes+1)
 
 	// Test the multiple ways of getting a RDE Types in both users.
 	obtainedRdeTypeBySysAdmin, err := systemAdministratorClient.GetRdeTypeById(createdRdeType.DefinedEntityType.ID)

--- a/govcd/defined_entity_test.go
+++ b/govcd/defined_entity_test.go
@@ -139,7 +139,7 @@ func (vcd *TestVCD) Test_RdeAndRdeType(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(len(allRdeTypesBySystemAdmin), Equals, alreadyPresentRdes+1)
 
-	// Count is 1 for tenant user as it can only retrieve the created type as per the assigned rights above.
+	// Count is existing RDE Types + 1 for tenant user
 	alreadyPresentRdes = len(allRdeTypesByTenant)
 	allRdeTypesByTenant, err = tenantUserClient.GetAllRdeTypes(nil)
 	check.Assert(err, IsNil)


### PR DESCRIPTION
In VCD 10.6+, there are some pre-defined RDE Types that tenant users can read without extra rights, hence the method call doesn't return 0 anymore.

This PR adjusts this test for this case.