### PR TITLE
Fix getOpenApiHighestElevatedVersion bug for unsupported API version

### DIFF
--- a/.changes/v2.25.0/683-bug-fixes.md
+++ b/.changes/v2.25.0/683-bug-fixes.md
@@ -1,0 +1,2 @@
+* Patched bug in core OpenAPI handling function `getOpenApiHighestElevatedVersion` that could
+  sometimes choose unsupported API versions in future VCD versions [GH-683]

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -29,6 +29,8 @@ func init() {
 	requestCounter = &counter
 }
 
+var minVcdApiVersion = "37.0" // supported by 10.4+
+
 // VCDClientOption defines signature for customizing VCDClient using
 // functional options pattern.
 type VCDClientOption func(*VCDClient) error
@@ -136,7 +138,6 @@ func (vcdClient *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.
 // NewVCDClient initializes VMware VMware Cloud Director client with reasonable defaults.
 // It accepts functions of type VCDClientOption for adjusting defaults.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
-	minVcdApiVersion := "37.0" // supported by 10.4+
 	userDefinedApiVersion := os.Getenv("GOVCD_API_VERSION")
 	if userDefinedApiVersion != "" {
 		_, err := semver.NewVersion(userDefinedApiVersion)

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -305,6 +305,9 @@ func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string,
 			// highest version found - store it and abort the loop
 			supportedElevatedVersion = elevatedVersion.Original()
 			break
+		} else {
+			util.Logger.Printf("[DEBUG] Skipped Elevated version '%s' for endpoint '%s', Default minimum version '%s'",
+				elevatedVersion.Original(), endpoint, client.APIVersion)
 		}
 
 		util.Logger.Printf("[DEBUG] API version '%s' is not supported by VCD instance for endpoint '%s'",

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -298,9 +298,8 @@ func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string,
 			elevatedVersion.Original(), endpoint)
 		// Check if maximum VCD API version supported is greater or equal to elevated version
 
-		// if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) &&
-		// 	!client.APIClientVersionIs(fmt.Sprintf("> %s", elevatedVersion.Original())) {
-		if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) {
+		if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) &&
+			!client.APIClientVersionIs(fmt.Sprintf("> %s", elevatedVersion.Original())) {
 			util.Logger.Printf("[DEBUG] Elevated version '%s' is supported by VCD instance for endpoint '%s'",
 				elevatedVersion.Original(), endpoint)
 			// highest version found - store it and abort the loop

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -297,6 +297,9 @@ func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string,
 		util.Logger.Printf("[DEBUG] Checking if elevated version '%s' is supported by VCD instance for endpoint '%s'",
 			elevatedVersion.Original(), endpoint)
 		// Check if maximum VCD API version supported is greater or equal to elevated version
+
+		// if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) &&
+		// 	!client.APIClientVersionIs(fmt.Sprintf("> %s", elevatedVersion.Original())) {
 		if client.APIVCDMaxVersionIs(fmt.Sprintf(">= %s", elevatedVersion.Original())) {
 			util.Logger.Printf("[DEBUG] Elevated version '%s' is supported by VCD instance for endpoint '%s'",
 				elevatedVersion.Original(), endpoint)
@@ -304,6 +307,7 @@ func (client *Client) getOpenApiHighestElevatedVersion(endpoint string) (string,
 			supportedElevatedVersion = elevatedVersion.Original()
 			break
 		}
+
 		util.Logger.Printf("[DEBUG] API version '%s' is not supported by VCD instance for endpoint '%s'",
 			elevatedVersion.Original(), endpoint)
 	}

--- a/govcd/openapi_endpoints_unit_test.go
+++ b/govcd/openapi_endpoints_unit_test.go
@@ -88,6 +88,9 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 		if semverWantVersion.LessThan(semverMinVcdApiVersion) {
 			semverMinVcdApiVersionSegments := semverMinVcdApiVersion.Segments()
 			wantVersion = fmt.Sprintf("%d.%d", semverMinVcdApiVersionSegments[0], semverMinVcdApiVersionSegments[1])
+			if testVerbose {
+				fmt.Printf("# Overriding wanted version to %s for endpoint %s\n", wantVersion, endpointName)
+			}
 		}
 
 		tCase := testCase{
@@ -138,6 +141,9 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 			if semverWantVersion.LessThan(semverMinVcdApiVersion) {
 				semverMinVcdApiVersionSegments := semverMinVcdApiVersion.Segments()
 				wantVersion = fmt.Sprintf("%d.%d", semverMinVcdApiVersionSegments[0], semverMinVcdApiVersionSegments[1])
+				if testVerbose {
+					fmt.Printf("# Overriding wanted version to %s for endpoint %s\n", wantVersion, endpointName)
+				}
 			}
 
 			tCase := testCase{

--- a/govcd/openapi_endpoints_unit_test.go
+++ b/govcd/openapi_endpoints_unit_test.go
@@ -29,9 +29,9 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 		endpoint          string
 		wantVersion       string
 		wantErr           bool
-		// overRideclientMinApiVersion is an option to override default expected version that is
+		// overrideClientMinApiVersion is an option to override default expected version that is
 		// defined in global variable`minVcdApiVersion`
-		overRideclientMinApiVersion string
+		overrideClientMinApiVersion string
 	}
 
 	// Start with some statically defined tests for known endpoints
@@ -49,7 +49,7 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 			endpoint:                    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules,
 			wantVersion:                 "34.0",
 			wantErr:                     false, // NAT minimum requirement is version 34.0
-			overRideclientMinApiVersion: "34.0",
+			overrideClientMinApiVersion: "34.0",
 		},
 		{
 			name: "VCD_minimum_required_version_only_unordered",
@@ -58,7 +58,7 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 			endpoint:                    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtNatRules,
 			wantVersion:                 "34.0",
 			wantErr:                     false, // NAT minimum requirement is version 34.0
-			overRideclientMinApiVersion: "34.0",
+			overrideClientMinApiVersion: "34.0",
 		},
 		{
 			name:              "VCD_version_higher_than_elevated_version_entries",
@@ -162,8 +162,8 @@ func TestClient_getOpenApiHighestElevatedVersion(t *testing.T) {
 				APIVersion:        minVcdApiVersion,
 			}
 
-			if tt.overRideclientMinApiVersion != "" {
-				client.APIVersion = tt.overRideclientMinApiVersion
+			if tt.overrideClientMinApiVersion != "" {
+				client.APIVersion = tt.overrideClientMinApiVersion
 			}
 
 			got, err := client.getOpenApiHighestElevatedVersion(tt.endpoint)


### PR DESCRIPTION
There is a bug in core OpenAPI version picking function `getOpenApiHighestElevatedVersion` that could choose an unsupported API version when automatic elevation mechanism `endpointElevatedApiVersions` is used.

This bug can start occurring when API v36.0 is no longer supported.


The bug occurs in OpenAPI handling function `getOpenApiHighestElevatedVersion` that picks client API versions for OpenAPI endpoints. It occurs when both of the following conditions are met:

* Endpoint in question uses automatic elevation mechanism (has at least single entry in `endpointElevatedApiVersions` map)
* Endpoint has one or more elevation records in `endpointElevatedApiVersions`, but all of these entries only elevate to API versions older than  default minimum supported API version (37.0 at this moment)


#### Example 

So an example when the bug occurs is: We have an endpoint `1.0.0/firewallGroups/`. This endpoint leverages automatic elevation mechanism and only has a single record: 
`"36.0", // Adds support for Dynamic Security Groups by deprecating Type field in favor of TypeValue in endpointElevatedApiVersions.`

The function `getOpenApiHighestElevatedVersion` has a bug when evaluating such conditions and it picks the version that is in the `endpointElevatedApiVersions` which is `36.0` in a given example. This is not good and will fail when minimum supported version is `37.0`.

There are many, but example test that surfaces this bug is `Test_NsxtFirewall`


#### Affected tests:
* Test_AlbVirtualService
* Test_NsxtDynamicSecurityGroup
* Test_NsxtEdgeVdcGroup
* Test_NsxtFirewall
* Test_NsxtIpSet
* Test_NsxtNatDnat
* Test_NsxtNatDnatExternalPortPort
* Test_NsxtNatDnatFirewallMatchPriority
* Test_NsxtNatNoDnat
* Test_NsxtNatNoSnat
* Test_NsxtNatPriorityAndFirewallMatch
* Test_NsxtNatReflexive
* Test_NsxtNatSnat
* Test_NsxtOrgVdcNetworkImportedNsxtLogicalSwitch
* Test_NsxtOrgVdcNetworkIsolated
* Test_NsxtOrgVdcNetworkRouted
* Test_NsxtSegmentProfileTemplate
* Test_NsxtVdcGroupForceDelete
* Test_VdcNetworkProfile