### PR TITLE
Use guaranteed memory resources when memory overhead is included in tests

### DIFF
--- a/.changes/v2.25.0/684-notes.md
+++ b/.changes/v2.25.0/684-notes.md
@@ -1,0 +1,1 @@
+* Amended many tests to set `ResourceGuaranteedMemory` when spawning a `Flex` VDC [GH-681]

--- a/govcd/adminvdc_test.go
+++ b/govcd/adminvdc_test.go
@@ -97,6 +97,7 @@ func (vcd *TestVCD) Test_CreateOrgVdcWithFlex(check *C) {
 		if allocationModel == "Flex" {
 			vdcConfiguration.IsElastic = &trueValue
 			vdcConfiguration.IncludeMemoryOverhead = &trueValue
+			vdcConfiguration.ResourceGuaranteedMemory = addrOf(1.00)
 		}
 
 		if secondStorageProfileHref != "" {

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -772,11 +772,12 @@ func spawnTestVdc(vcd *TestVCD, check *C, adminOrgName string) *Vdc {
 		ProviderVdcReference: &types.Reference{
 			HREF: providerVdcHref,
 		},
-		IsEnabled:             true,
-		IsThinProvision:       true,
-		UsesFastProvisioning:  true,
-		IsElastic:             addrOf(true),
-		IncludeMemoryOverhead: addrOf(true),
+		IsEnabled:                true,
+		IsThinProvision:          true,
+		UsesFastProvisioning:     true,
+		IsElastic:                addrOf(true),
+		IncludeMemoryOverhead:    addrOf(true),
+		ResourceGuaranteedMemory: addrOf(1.00),
 	}
 
 	vdc, err := adminOrg.CreateOrgVdc(vdcConfiguration)

--- a/govcd/org_test.go
+++ b/govcd/org_test.go
@@ -687,6 +687,7 @@ func setupVdc(vcd *TestVCD, check *C, allocationModel string) (AdminOrg, *types.
 	if allocationModel == "Flex" {
 		vdcConfiguration.IsElastic = &falseValue
 		vdcConfiguration.IncludeMemoryOverhead = &trueValue
+		vdcConfiguration.ResourceGuaranteedMemory = addrOf(1.00)
 	}
 
 	vdc, _ := adminOrg.GetVDCByName(vdcConfiguration.Name, false)

--- a/govcd/vdc_group_common_test.go
+++ b/govcd/vdc_group_common_test.go
@@ -366,11 +366,12 @@ func createNewVdc(vcd *TestVCD, check *C, vdcName string) *Vdc {
 		ProviderVdcReference: &types.Reference{
 			HREF: providerVdcHref,
 		},
-		IsEnabled:             true,
-		IsThinProvision:       true,
-		UsesFastProvisioning:  true,
-		IsElastic:             &trueValue,
-		IncludeMemoryOverhead: &trueValue,
+		IsEnabled:                true,
+		IsThinProvision:          true,
+		UsesFastProvisioning:     true,
+		IsElastic:                &trueValue,
+		IncludeMemoryOverhead:    &trueValue,
+		ResourceGuaranteedMemory: addrOf(1.00),
 	}
 
 	vdc, err := adminOrg.CreateOrgVdc(vdcConfiguration)


### PR DESCRIPTION
Improved VCD API validation detected a quirk where a configuration was not exactly correct. Quite a few tests fail now (all that spawn VDCs for testing purposes). The fix is to set `ResourceGuaranteedMemory` when spawning a `Flex` VDC

Tests that it should fix:
* TestQueryOrgVdcList
* Test_CreateOrgVdcWithFlex
* Test_CreateVdcGroup
* Test_GetCatalogByIdSharedCatalog
* Test_GetCatalogByNamePrefersLocal
* Test_GetCatalogByNameSharedCatalog
* Test_GetCatalogByXSharedCatalogOrgUser
* Test_NsxtApplicationPortProfileProvider
* Test_NsxtApplicationPortProfileTenant
* Test_NsxtDistributedFirewallRules
* Test_NsxtDistributedFirewallRule
* Test_NsxtDistributedFirewallWithDefaultRule
* Test_NsxtEdgeVdcGroup
* Test_NsxtOrgVdcNetworkImportedNsxtLogicalSwitch
* Test_NsxtStaticSecurityGroup
* Test_NsxtVdcGroupOrgNetworks
* Test_NsxtVdcGroupWithOrgAdmin
* Test_SearchOrgVdc