### PR TITLE
Miscellaneous fixes in methods and tests

### DIFF
--- a/.changes/v2.25.0/688-bug-fixes.md
+++ b/.changes/v2.25.0/688-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fixed an error that occurred when sending a `OpenAPIEdgeGatewayEdgeClusterConfig` section from an Edge Gateway configuration,
-when the struct was sent with empty fields, and it should not be sent at all [GH-688]
+* Fixed an error that occurred when updating an Edge Gateway configuration, with an Edge cluster configuration section
+  (`OpenAPIEdgeGatewayEdgeClusterConfig`). If this section was added, the update operation failed in VCD 10.6+ [GH-688]

--- a/.changes/v2.25.0/688-bug-fixes.md
+++ b/.changes/v2.25.0/688-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixed an error that occurred when sending a `OpenAPIEdgeGatewayEdgeClusterConfig` section from an Edge Gateway configuration,
+when the struct was sent with empty fields, and it should not be sent at all [GH-688]

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -38,6 +38,10 @@ func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(nsxtExternalNetwork, NotNil)
 
+	edgeCluster, err := nsxtVdc.GetNsxtEdgeClusterByName(vcd.config.VCD.Nsxt.NsxtEdgeCluster)
+	check.Assert(err, IsNil)
+	check.Assert(edgeCluster, NotNil)
+
 	egwDefinition := &types.OpenAPIEdgeGateway{
 		Name:        "nsx-t-edge",
 		Description: "nsx-t-edge-description",
@@ -63,6 +67,11 @@ func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 	AddToCleanupListOpenApi(createdEdge.EdgeGateway.Name, check.TestName(), openApiEndpoint)
 
 	createdEdge.EdgeGateway.Name = "renamed-edge"
+	createdEdge.EdgeGateway.EdgeClusterConfig = &types.OpenAPIEdgeGatewayEdgeClusterConfig{
+		PrimaryEdgeCluster: types.OpenAPIEdgeGatewayEdgeCluster{
+			BackingID: edgeCluster.NsxtEdgeCluster.ID,
+		},
+	}
 	updatedEdge, err := createdEdge.Update(createdEdge.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(updatedEdge.EdgeGateway.Name, Equals, "renamed-edge")

--- a/govcd/nsxt_edgegateway_test.go
+++ b/govcd/nsxt_edgegateway_test.go
@@ -38,10 +38,6 @@ func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(nsxtExternalNetwork, NotNil)
 
-	edgeCluster, err := nsxtVdc.GetNsxtEdgeClusterByName(vcd.config.VCD.Nsxt.NsxtEdgeCluster)
-	check.Assert(err, IsNil)
-	check.Assert(edgeCluster, NotNil)
-
 	egwDefinition := &types.OpenAPIEdgeGateway{
 		Name:        "nsx-t-edge",
 		Description: "nsx-t-edge-description",
@@ -66,12 +62,16 @@ func (vcd *TestVCD) Test_NsxtEdgeCreate(check *C) {
 	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointEdgeGateways + createdEdge.EdgeGateway.ID
 	AddToCleanupListOpenApi(createdEdge.EdgeGateway.Name, check.TestName(), openApiEndpoint)
 
-	createdEdge.EdgeGateway.Name = "renamed-edge"
+	edgeCluster, err := nsxtVdc.GetNsxtEdgeClusterByName(vcd.config.VCD.Nsxt.NsxtEdgeCluster)
+	check.Assert(err, IsNil)
+	check.Assert(edgeCluster, NotNil)
+
 	createdEdge.EdgeGateway.EdgeClusterConfig = &types.OpenAPIEdgeGatewayEdgeClusterConfig{
 		PrimaryEdgeCluster: types.OpenAPIEdgeGatewayEdgeCluster{
 			BackingID: edgeCluster.NsxtEdgeCluster.ID,
 		},
 	}
+	createdEdge.EdgeGateway.Name = "renamed-edge"
 	updatedEdge, err := createdEdge.Update(createdEdge.EdgeGateway)
 	check.Assert(err, IsNil)
 	check.Assert(updatedEdge.EdgeGateway.Name, Equals, "renamed-edge")

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -134,8 +134,8 @@ type OpenAPIEdgeGatewayBacking struct {
 
 // OpenAPIEdgeGatewayEdgeCluster allows users to specify edge cluster reference
 type OpenAPIEdgeGatewayEdgeCluster struct {
-	EdgeClusterRef OpenApiReference `json:"edgeClusterRef"`
-	BackingID      string           `json:"backingId"`
+	EdgeClusterRef *OpenApiReference `json:"edgeClusterRef"`
+	BackingID      string            `json:"backingId"`
 }
 
 type OpenAPIEdgeGatewayEdgeClusterConfig struct {


### PR DESCRIPTION
## Contents

### Bugfixes

* Fixed a small bug in `OpenAPIEdgeGatewayEdgeCluster` type. The `OpenApiReference` was not a pointer, hence the marshaller automatically created an empty struct with empty `""` values, that when sent to the VCD 10.6+ backend, caused errors. Now, `OpenApiReference` is a pointer. The test `Test_NsxtEdgeCreate` has been updated to reproduce the issue. Running it should pass if the fix is applied.