### PR TITLE
Fix extraconfig xml

### DIFF
--- a/.changes/v2.25.0/690-bug-fixes.md
+++ b/.changes/v2.25.0/690-bug-fixes.md
@@ -1,0 +1,1 @@
+* Patched `vm.updateExtraConfig` method that could sometimes fail due to random mishandling of XML namespaces in upstream libraries [GH-690]

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -2171,12 +2171,13 @@ func (vm *VM) updateExtraConfig(update []*types.ExtraConfigMarshal, wantDelete b
 	}
 
 	requestVirtualHardwareSection := &types.RequestVirtualHardwareSection{
-		Info: "Virtual hardware requirements",
-		Ovf:  types.XMLNamespaceOVF,
-		Rasd: types.XMLNamespaceRASD,
-		Vssd: types.XMLNamespaceVSSD,
-		Ns4:  types.XMLNamespaceVCloud,
-		Vmw:  types.XMLNamespaceVMW,
+		Info:  "Virtual hardware requirements",
+		Ovf:   types.XMLNamespaceOVF,
+		Rasd:  types.XMLNamespaceRASD,
+		Vssd:  types.XMLNamespaceVSSD,
+		Ns4:   types.XMLNamespaceVCloud,
+		Vmw:   types.XMLNamespaceVMW,
+		Xmlns: types.XMLNamespaceVCloud,
 
 		Type:   virtualHardwareSection.Type,
 		System: virtualHardwareSection.System,

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -226,6 +226,7 @@ type Adapter struct {
 type RequestVirtualHardwareSection struct {
 	// Extends OVF Section_Type
 	XMLName xml.Name `xml:"ovf:VirtualHardwareSection"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
 	Ovf     string   `xml:"xmlns:ovf,attr"`
 	Vssd    string   `xml:"xmlns:vssd,attr"`
 	Rasd    string   `xml:"xmlns:rasd,attr"`


### PR DESCRIPTION
The ExtraConfig operations in a VM fail randomly for a quirk in the upstream handling of XML.
Similar to PR #677, this change strengthens the XML call to use the namespaces already defined.