### PR TITLE
Add namespaces to VM extra config methods

### DIFF
--- a/.changes/v2.25.0/666-features.md
+++ b/.changes/v2.25.0/666-features.md
@@ -1,1 +1,1 @@
-* Added `VM` methods `GetExtraConfig`, `UpdateExtraConfig`, `DeleteExtraConfig` to manage VM extra-configuration [GH-666]
+* Added `VM` methods `GetExtraConfig`, `UpdateExtraConfig`, `DeleteExtraConfig` to manage VM extra-configuration [GH-666, GH-691]

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -2175,6 +2175,8 @@ func (vm *VM) updateExtraConfig(update []*types.ExtraConfigMarshal, wantDelete b
 		Ovf:   types.XMLNamespaceOVF,
 		Rasd:  types.XMLNamespaceRASD,
 		Vssd:  types.XMLNamespaceVSSD,
+		Ns2:   types.XMLNamespaceVCloud,
+		Ns3:   types.XMLNamespaceVCloud,
 		Ns4:   types.XMLNamespaceVCloud,
 		Vmw:   types.XMLNamespaceVMW,
 		Xmlns: types.XMLNamespaceVCloud,

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -230,6 +230,8 @@ type RequestVirtualHardwareSection struct {
 	Ovf     string   `xml:"xmlns:ovf,attr"`
 	Vssd    string   `xml:"xmlns:vssd,attr"`
 	Rasd    string   `xml:"xmlns:rasd,attr"`
+	Ns2     string   `xml:"xmlns:ns2,attr"`
+	Ns3     string   `xml:"xmlns:ns3,attr"`
 	Ns4     string   `xml:"xmlns:ns4,attr"`
 	Vmw     string   `xml:"xmlns:vmw,attr"`
 


### PR DESCRIPTION
Fixes the issue with XML namespaces when using the `virtualHardwareSection` endpoint:
```
Undeclared namespace prefix "ns3" (for attribute "ipAddressingMode")
```
or
```
Undeclared namespace prefix "ns2" (for attribute "ipAddressingMode")
```