### PR TITLE
Add External Endpoint and API Filter CRUD methods

### DIFF
--- a/.changes/v2.26.0/696-features.md
+++ b/.changes/v2.26.0/696-features.md
@@ -1,0 +1,4 @@
+* Added CRUD operations for External Endpoints: `VCDClient.CreateExternalEndpoint`, `VCDClient.GetAllExternalEndpoints`,
+  `VCDClient.GetExternalEndpoint`, `VCDClient.GetExternalEndpointById`, `ExternalEndpoint.Update` and `ExternalEndpoint.Delete` [GH-696]
+* Added CRUD operations for API Filters: `VCDClient.CreateApiFilter`, `VCDClient.GetAllApiFilters`, `VCDClient.GetApiFilterById`,
+  `ApiFilter.Update` and `ApiFilter.Delete` [GH-696]

--- a/govcd/api_filter.go
+++ b/govcd/api_filter.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"net/url"
+)
+
+const (
+	labelApiFilter = "API Filter"
+)
+
+// ApiFilter is a type for handling API Filters.
+type ApiFilter struct {
+	ApiFilter *types.ApiFilter
+	client    *Client
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (d ApiFilter) wrap(inner *types.ApiFilter) *ApiFilter {
+	d.ApiFilter = inner
+	return &d
+}
+
+// CreateApiFilter creates an API Filter.
+func (vcdClient *VCDClient) CreateApiFilter(apiFilter *types.ApiFilter) (*ApiFilter, error) {
+	c := crudConfig{
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
+		entityLabel: labelApiFilter,
+	}
+	outerType := ApiFilter{client: &vcdClient.Client}
+	return createOuterEntity(&vcdClient.Client, outerType, c, apiFilter)
+}
+
+// GetAllApiFilters retrieves all available ApiFilter. Query parameters can be supplied to perform additional filtering.
+func (vcdClient *VCDClient) GetAllApiFilters(queryParameters url.Values) ([]*ApiFilter, error) {
+	return getAllApiFilters(&vcdClient.Client, queryParameters)
+}
+
+// getAllApiFilters retrieves all available ApiFilter. Query parameters can be supplied to perform additional filtering.
+func getAllApiFilters(client *Client, queryParameters url.Values) ([]*ApiFilter, error) {
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
+		entityLabel:     labelApiFilter,
+		queryParameters: queryParameters,
+	}
+
+	outerType := ApiFilter{client: client}
+	return getAllOuterEntities[ApiFilter, types.ApiFilter](client, outerType, c)
+}
+
+// GetApiFilter gets an API Filter by its unique combination of vendor, name and version.
+func (vcdClient *VCDClient) GetApiFilter(vendor, name, version string) (*ApiFilter, error) {
+	return getApiFilter(&vcdClient.Client, vendor, name, version)
+}
+
+// getApiFilter gets an API Filter by its unique combination of vendor, name and version.
+func getApiFilter(client *Client, vendor, name, version string) (*ApiFilter, error) {
+	queryParameters := url.Values{}
+	queryParameters.Add("filter", fmt.Sprintf("vendor==%s;name==%s;version==%s", vendor, name, version))
+	ApiFilters, err := getAllApiFilters(client, queryParameters)
+	if err != nil {
+		return nil, err
+	}
+
+	singleResult, err := oneOrError("'vendor:name:version'", fmt.Sprintf("'%s:%s:%s'", vendor, name, version), ApiFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	return singleResult, nil
+}
+
+// GetApiFilterById gets an API Filter by its ID.
+func (vcdClient *VCDClient) GetApiFilterById(id string) (*ApiFilter, error) {
+	c := crudConfig{
+		entityLabel:    labelApiFilter,
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
+		endpointParams: []string{id},
+	}
+
+	outerType := ApiFilter{client: &vcdClient.Client}
+	return getOuterEntity[ApiFilter, types.ApiFilter](&vcdClient.Client, outerType, c)
+}
+
+// Update updates the receiver ApiFilter with the values given by the input.
+func (ApiFilter *ApiFilter) Update(ep types.ApiFilter) error {
+	if ApiFilter.ApiFilter.ID == "" {
+		return fmt.Errorf("ID of the receiver API Filter is empty")
+	}
+
+	if ep.ID != "" && ep.ID != ApiFilter.ApiFilter.ID {
+		return fmt.Errorf("ID of the receiver API Filter and the input ID don't match")
+	}
+
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
+		endpointParams: []string{ApiFilter.ApiFilter.ID},
+		entityLabel:    labelApiFilter,
+	}
+
+	result, err := updateInnerEntity(ApiFilter.client, c, &ep)
+	if err != nil {
+		return err
+	}
+	// Only if there was no error in request we overwrite pointer receiver as otherwise it would
+	// wipe out existing data
+	ApiFilter.ApiFilter = result
+
+	return nil
+}
+
+// Delete deletes the receiver ApiFilter.
+func (ApiFilter *ApiFilter) Delete() error {
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
+		endpointParams: []string{ApiFilter.ApiFilter.ID},
+		entityLabel:    labelApiFilter,
+	}
+
+	if err := deleteEntityById(ApiFilter.client, c); err != nil {
+		return err
+	}
+
+	ApiFilter.ApiFilter = &types.ApiFilter{}
+	return nil
+}

--- a/govcd/api_filter.go
+++ b/govcd/api_filter.go
@@ -55,28 +55,6 @@ func getAllApiFilters(client *Client, queryParameters url.Values) ([]*ApiFilter,
 	return getAllOuterEntities[ApiFilter, types.ApiFilter](client, outerType, c)
 }
 
-// GetApiFilter gets an API Filter by its unique combination of vendor, name and version.
-func (vcdClient *VCDClient) GetApiFilter(vendor, name, version string) (*ApiFilter, error) {
-	return getApiFilter(&vcdClient.Client, vendor, name, version)
-}
-
-// getApiFilter gets an API Filter by its unique combination of vendor, name and version.
-func getApiFilter(client *Client, vendor, name, version string) (*ApiFilter, error) {
-	queryParameters := url.Values{}
-	queryParameters.Add("filter", fmt.Sprintf("vendor==%s;name==%s;version==%s", vendor, name, version))
-	ApiFilters, err := getAllApiFilters(client, queryParameters)
-	if err != nil {
-		return nil, err
-	}
-
-	singleResult, err := oneOrError("'vendor:name:version'", fmt.Sprintf("'%s:%s:%s'", vendor, name, version), ApiFilters)
-	if err != nil {
-		return nil, err
-	}
-
-	return singleResult, nil
-}
-
 // GetApiFilterById gets an API Filter by its ID.
 func (vcdClient *VCDClient) GetApiFilterById(id string) (*ApiFilter, error) {
 	c := crudConfig{

--- a/govcd/api_filter.go
+++ b/govcd/api_filter.go
@@ -40,19 +40,14 @@ func (vcdClient *VCDClient) CreateApiFilter(apiFilter *types.ApiFilter) (*ApiFil
 
 // GetAllApiFilters retrieves all available API Filters. Query parameters can be supplied to perform additional filtering.
 func (vcdClient *VCDClient) GetAllApiFilters(queryParameters url.Values) ([]*ApiFilter, error) {
-	return getAllApiFilters(&vcdClient.Client, queryParameters)
-}
-
-// getAllApiFilters retrieves all available API Filters. Query parameters can be supplied to perform additional filtering.
-func getAllApiFilters(client *Client, queryParameters url.Values) ([]*ApiFilter, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
 		entityLabel:     labelApiFilter,
 		queryParameters: queryParameters,
 	}
 
-	outerType := ApiFilter{client: client}
-	return getAllOuterEntities[ApiFilter, types.ApiFilter](client, outerType, c)
+	outerType := ApiFilter{client: &vcdClient.Client}
+	return getAllOuterEntities[ApiFilter, types.ApiFilter](&vcdClient.Client, outerType, c)
 }
 
 // GetApiFilterById gets an API Filter by its ID.

--- a/govcd/api_filter.go
+++ b/govcd/api_filter.go
@@ -38,12 +38,12 @@ func (vcdClient *VCDClient) CreateApiFilter(apiFilter *types.ApiFilter) (*ApiFil
 	return createOuterEntity(&vcdClient.Client, outerType, c, apiFilter)
 }
 
-// GetAllApiFilters retrieves all available ApiFilter. Query parameters can be supplied to perform additional filtering.
+// GetAllApiFilters retrieves all available API Filters. Query parameters can be supplied to perform additional filtering.
 func (vcdClient *VCDClient) GetAllApiFilters(queryParameters url.Values) ([]*ApiFilter, error) {
 	return getAllApiFilters(&vcdClient.Client, queryParameters)
 }
 
-// getAllApiFilters retrieves all available ApiFilter. Query parameters can be supplied to perform additional filtering.
+// getAllApiFilters retrieves all available API Filters. Query parameters can be supplied to perform additional filtering.
 func getAllApiFilters(client *Client, queryParameters url.Values) ([]*ApiFilter, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,
@@ -89,7 +89,7 @@ func (vcdClient *VCDClient) GetApiFilterById(id string) (*ApiFilter, error) {
 	return getOuterEntity[ApiFilter, types.ApiFilter](&vcdClient.Client, outerType, c)
 }
 
-// Update updates the receiver ApiFilter with the values given by the input.
+// Update updates the receiver API Filter with the values given by the input.
 func (ApiFilter *ApiFilter) Update(ep types.ApiFilter) error {
 	if ApiFilter.ApiFilter.ID == "" {
 		return fmt.Errorf("ID of the receiver API Filter is empty")
@@ -116,7 +116,7 @@ func (ApiFilter *ApiFilter) Update(ep types.ApiFilter) error {
 	return nil
 }
 
-// Delete deletes the receiver ApiFilter.
+// Delete deletes the receiver API Filter.
 func (ApiFilter *ApiFilter) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters,

--- a/govcd/api_filter_test.go
+++ b/govcd/api_filter_test.go
@@ -1,0 +1,65 @@
+//go:build functional || openapi || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+	"strings"
+)
+
+// Test_ApiFilter tests the CRUD operations for the API Filters.
+func (vcd *TestVCD) Test_ApiFilter(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	name := strings.ReplaceAll(check.TestName(), ".", "")
+
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointApiFilters)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointExternalEndpoints)
+
+	ep := types.ExternalEndpoint{
+		Name:        name,
+		Version:     "1.0.0",
+		Vendor:      "vmware",
+		Enabled:     true,
+		Description: "Description of" + name,
+		RootUrl:     "https://www.broadcom.com",
+	}
+
+	createdEp, err := vcd.client.CreateExternalEndpoint(&ep)
+	check.Assert(err, IsNil)
+	check.Assert(createdEp, NotNil)
+
+	defer func() {
+		ep.Enabled = false // Endpoint needs to be disabled before deleting
+		err = createdEp.Update(ep)
+		check.Assert(err, IsNil)
+		err = createdEp.Delete()
+		check.Assert(err, IsNil)
+	}()
+
+	createdAf, err := vcd.client.CreateApiFilter(&types.ApiFilter{
+		ExternalSystem: &types.OpenApiReference{
+			Name: ep.Name,
+			ID:   ep.ID,
+		},
+		UrlMatcher: &types.UrlMatcher{
+			UrlPattern: "/custom/.",
+			UrlScope:   "EXT_API",
+		},
+	})
+	check.Assert(err, IsNil)
+	check.Assert(createdAf, NotNil)
+
+	defer func() {
+		err = createdAf.Delete()
+		check.Assert(err, IsNil)
+	}()
+}

--- a/govcd/api_filter_test.go
+++ b/govcd/api_filter_test.go
@@ -29,7 +29,7 @@ func (vcd *TestVCD) Test_ApiFilter(check *C) {
 		Version:     "1.0.0",
 		Vendor:      "vmware",
 		Enabled:     true,
-		Description: "Description of" + name,
+		Description: "Description of " + name,
 		RootUrl:     "https://www.broadcom.com",
 	}
 

--- a/govcd/api_filter_test.go
+++ b/govcd/api_filter_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_ApiFilter(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	name := strings.ReplaceAll(check.TestName(), ".", "")
+	name := strings.ReplaceAll(check.TestName(), ".", "") // Special characters like "." are not allowed
 
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointApiFilters)
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointExternalEndpoints)

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -57,14 +57,9 @@ func getAllExternalEndpoints(client *Client, queryParameters url.Values) ([]*Ext
 
 // GetExternalEndpoint gets an External Endpoint by its unique combination of vendor, name and version.
 func (vcdClient *VCDClient) GetExternalEndpoint(vendor, name, version string) (*ExternalEndpoint, error) {
-	return getExternalEndpoint(&vcdClient.Client, vendor, name, version)
-}
-
-// getExternalEndpoint gets an External Endpoint by its unique combination of vendor, name and version.
-func getExternalEndpoint(client *Client, vendor, name, version string) (*ExternalEndpoint, error) {
 	queryParameters := url.Values{}
 	queryParameters.Add("filter", fmt.Sprintf("vendor==%s;name==%s;version==%s", vendor, name, version))
-	externalEndpoints, err := getAllExternalEndpoints(client, queryParameters)
+	externalEndpoints, err := getAllExternalEndpoints(&vcdClient.Client, queryParameters)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -100,9 +100,15 @@ func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) erro
 	}
 
 	// Name, version and vendor can't be changed
-	ep.Name = externalEndpoint.ExternalEndpoint.Name
-	ep.Vendor = externalEndpoint.ExternalEndpoint.Vendor
-	ep.Version = externalEndpoint.ExternalEndpoint.Version
+	if ep.Name != externalEndpoint.ExternalEndpoint.Name {
+		return fmt.Errorf("name of the receiver External Endpoint and the input Name don't match")
+	}
+	if ep.Vendor != externalEndpoint.ExternalEndpoint.Vendor {
+		return fmt.Errorf("vendor of the receiver External Endpoint and the input Vendor don't match")
+	}
+	if ep.Version != externalEndpoint.ExternalEndpoint.Version {
+		return fmt.Errorf("version of the receiver External Endpoint and the input Version don't match")
+	}
 
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"net/url"
+)
+
+const (
+	labelExternalEndpoint = "External Endpoint"
+)
+
+// ExternalEndpoint is a type for handling External Endpoints.
+type ExternalEndpoint struct {
+	ExternalEndpoint *types.ExternalEndpoint
+	client           *Client
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (d ExternalEndpoint) wrap(inner *types.ExternalEndpoint) *ExternalEndpoint {
+	d.ExternalEndpoint = inner
+	return &d
+}
+
+// CreateExternalEndpoint creates an External Endpoint.
+func (vcdClient *VCDClient) CreateExternalEndpoint(externalEndpoint *types.ExternalEndpoint) (*ExternalEndpoint, error) {
+	c := crudConfig{
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
+		entityLabel: labelExternalEndpoint,
+	}
+	outerType := ExternalEndpoint{client: &vcdClient.Client}
+	return createOuterEntity(&vcdClient.Client, outerType, c, externalEndpoint)
+}
+
+// GetAllExternalEndpoints retrieves all available ExternalEndpoint. Query parameters can be supplied to perform additional filtering.
+func (vcdClient *VCDClient) GetAllExternalEndpoints(queryParameters url.Values) ([]*ExternalEndpoint, error) {
+	return getAllExternalEndpoints(&vcdClient.Client, queryParameters)
+}
+
+// getAllExternalEndpoints retrieves all available ExternalEndpoint. Query parameters can be supplied to perform additional filtering.
+func getAllExternalEndpoints(client *Client, queryParameters url.Values) ([]*ExternalEndpoint, error) {
+	c := crudConfig{
+		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
+		entityLabel:     labelExternalEndpoint,
+		queryParameters: queryParameters,
+	}
+
+	outerType := ExternalEndpoint{client: client}
+	return getAllOuterEntities[ExternalEndpoint, types.ExternalEndpoint](client, outerType, c)
+}
+
+// GetExternalEndpoint gets an External Endpoint by its unique combination of vendor, name and version.
+func (vcdClient *VCDClient) GetExternalEndpoint(vendor, name, version string) (*ExternalEndpoint, error) {
+	return getExternalEndpoint(&vcdClient.Client, vendor, name, version)
+}
+
+// getExternalEndpoint gets an External Endpoint by its unique combination of vendor, name and version.
+func getExternalEndpoint(client *Client, vendor, name, version string) (*ExternalEndpoint, error) {
+	queryParameters := url.Values{}
+	queryParameters.Add("filter", fmt.Sprintf("vendor==%s;name==%s;version==%s", vendor, name, version))
+	externalEndpoints, err := getAllExternalEndpoints(client, queryParameters)
+	if err != nil {
+		return nil, err
+	}
+
+	singleResult, err := oneOrError("vendor,name,version", fmt.Sprintf("%s,%s,%s", vendor, name, version), externalEndpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	return singleResult, nil
+}
+
+// GetExternalEndpointById gets an External Endpoint by its ID.
+func (vcdClient *VCDClient) GetExternalEndpointById(id string) (*ExternalEndpoint, error) {
+	c := crudConfig{
+		entityLabel:    labelExternalEndpoint,
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
+		endpointParams: []string{id},
+	}
+
+	outerType := ExternalEndpoint{client: &vcdClient.Client}
+	return getOuterEntity[ExternalEndpoint, types.ExternalEndpoint](&vcdClient.Client, outerType, c)
+}
+
+// Update updates the receiver ExternalEndpoint with the values given by the input.
+func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) error {
+	if externalEndpoint.ExternalEndpoint.ID == "" {
+		return fmt.Errorf("ID of the receiver External Endpoint is empty")
+	}
+
+	if ep.ID != "" && ep.ID != externalEndpoint.ExternalEndpoint.ID {
+		return fmt.Errorf("ID of the receiver External Endpoint and the input ID don't match")
+	}
+
+	// Name, version and vendor can't be changed
+	ep.Name = externalEndpoint.ExternalEndpoint.Name
+	ep.Vendor = externalEndpoint.ExternalEndpoint.Vendor
+	ep.Version = externalEndpoint.ExternalEndpoint.Version
+
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
+		endpointParams: []string{externalEndpoint.ExternalEndpoint.ID},
+		entityLabel:    labelExternalEndpoint,
+	}
+
+	result, err := updateInnerEntity(externalEndpoint.client, c, &ep)
+	if err != nil {
+		return err
+	}
+	// Only if there was no error in request we overwrite pointer receiver as otherwise it would
+	// wipe out existing data
+	externalEndpoint.ExternalEndpoint = result
+
+	return nil
+}
+
+// Delete deletes the receiver ExternalEndpoint.
+func (externalEndpoint *ExternalEndpoint) Delete() error {
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
+		endpointParams: []string{externalEndpoint.ExternalEndpoint.ID},
+		entityLabel:    labelExternalEndpoint,
+	}
+
+	if err := deleteEntityById(externalEndpoint.client, c); err != nil {
+		return err
+	}
+
+	externalEndpoint.ExternalEndpoint = &types.ExternalEndpoint{}
+	return nil
+}

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -38,12 +38,12 @@ func (vcdClient *VCDClient) CreateExternalEndpoint(externalEndpoint *types.Exter
 	return createOuterEntity(&vcdClient.Client, outerType, c, externalEndpoint)
 }
 
-// GetAllExternalEndpoints retrieves all available ExternalEndpoint. Query parameters can be supplied to perform additional filtering.
+// GetAllExternalEndpoints retrieves all available External Endpoints. Query parameters can be supplied to perform additional filtering.
 func (vcdClient *VCDClient) GetAllExternalEndpoints(queryParameters url.Values) ([]*ExternalEndpoint, error) {
 	return getAllExternalEndpoints(&vcdClient.Client, queryParameters)
 }
 
-// getAllExternalEndpoints retrieves all available ExternalEndpoint. Query parameters can be supplied to perform additional filtering.
+// getAllExternalEndpoints retrieves all available External Endpoints. Query parameters can be supplied to perform additional filtering.
 func getAllExternalEndpoints(client *Client, queryParameters url.Values) ([]*ExternalEndpoint, error) {
 	c := crudConfig{
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,
@@ -89,7 +89,7 @@ func (vcdClient *VCDClient) GetExternalEndpointById(id string) (*ExternalEndpoin
 	return getOuterEntity[ExternalEndpoint, types.ExternalEndpoint](&vcdClient.Client, outerType, c)
 }
 
-// Update updates the receiver ExternalEndpoint with the values given by the input.
+// Update updates the receiver External Endpoint with the values given by the input.
 func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) error {
 	if externalEndpoint.ExternalEndpoint.ID == "" {
 		return fmt.Errorf("ID of the receiver External Endpoint is empty")
@@ -127,7 +127,7 @@ func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) erro
 	return nil
 }
 
-// Delete deletes the receiver ExternalEndpoint.
+// Delete deletes the receiver External Endpoint.
 func (externalEndpoint *ExternalEndpoint) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -69,7 +69,7 @@ func getExternalEndpoint(client *Client, vendor, name, version string) (*Externa
 		return nil, err
 	}
 
-	singleResult, err := oneOrError("vendor,name,version", fmt.Sprintf("%s,%s,%s", vendor, name, version), externalEndpoints)
+	singleResult, err := oneOrError("'vendor:name:version'", fmt.Sprintf("'%s:%s:%s'", vendor, name, version), externalEndpoints)
 	if err != nil {
 		return nil, err
 	}

--- a/govcd/external_endpoint.go
+++ b/govcd/external_endpoint.go
@@ -90,6 +90,7 @@ func (vcdClient *VCDClient) GetExternalEndpointById(id string) (*ExternalEndpoin
 }
 
 // Update updates the receiver External Endpoint with the values given by the input.
+// Note: Vendor, name and version can't be changed. Modifying them will have no effect.
 func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) error {
 	if externalEndpoint.ExternalEndpoint.ID == "" {
 		return fmt.Errorf("ID of the receiver External Endpoint is empty")
@@ -97,17 +98,6 @@ func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) erro
 
 	if ep.ID != "" && ep.ID != externalEndpoint.ExternalEndpoint.ID {
 		return fmt.Errorf("ID of the receiver External Endpoint and the input ID don't match")
-	}
-
-	// Name, version and vendor can't be changed
-	if ep.Name != externalEndpoint.ExternalEndpoint.Name {
-		return fmt.Errorf("name of the receiver External Endpoint and the input Name don't match")
-	}
-	if ep.Vendor != externalEndpoint.ExternalEndpoint.Vendor {
-		return fmt.Errorf("vendor of the receiver External Endpoint and the input Vendor don't match")
-	}
-	if ep.Version != externalEndpoint.ExternalEndpoint.Version {
-		return fmt.Errorf("version of the receiver External Endpoint and the input Version don't match")
 	}
 
 	c := crudConfig{
@@ -128,6 +118,7 @@ func (externalEndpoint *ExternalEndpoint) Update(ep types.ExternalEndpoint) erro
 }
 
 // Delete deletes the receiver External Endpoint.
+// Note: To delete an External Endpoint, it must be disabled, otherwise the operation will fail.
 func (externalEndpoint *ExternalEndpoint) Delete() error {
 	c := crudConfig{
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints,

--- a/govcd/external_endpoint_test.go
+++ b/govcd/external_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	. "gopkg.in/check.v1"
+	"strings"
 )
 
 // Test_ExternalEndpoint tests the CRUD operations for the External Endpoints.
@@ -18,14 +19,16 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
+	name := strings.ReplaceAll(check.TestName(), ".", "")
+
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointExternalEndpoints)
 
 	ep := types.ExternalEndpoint{
-		Name:        check.TestName(),
+		Name:        name,
 		Version:     "1.0.0",
 		Vendor:      "vmware",
 		Enabled:     true,
-		Description: check.TestName(),
+		Description: "Description of" + name,
 		RootUrl:     "https://www.broadcom.com",
 	}
 
@@ -34,6 +37,9 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 	check.Assert(createdEp, NotNil)
 
 	defer func() {
+		ep.Enabled = false // Endpoint needs to be disabled before deleting
+		err = createdEp.Update(ep)
+		check.Assert(err, IsNil)
 		err = createdEp.Delete()
 		check.Assert(err, IsNil)
 	}()
@@ -41,5 +47,33 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 	retrievedEp, err := vcd.client.GetExternalEndpointById(createdEp.ExternalEndpoint.ID)
 	check.Assert(err, IsNil)
 	check.Assert(retrievedEp, NotNil)
+	check.Assert(retrievedEp.ExternalEndpoint.Name, Equals, ep.Name)
+	check.Assert(retrievedEp.ExternalEndpoint.Enabled, Equals, ep.Enabled)
+	check.Assert(retrievedEp.ExternalEndpoint.Description, Equals, ep.Description)
+	check.Assert(retrievedEp.ExternalEndpoint.Vendor, Equals, ep.Vendor)
+	check.Assert(retrievedEp.ExternalEndpoint.Version, Equals, ep.Version)
+	check.Assert(retrievedEp.ExternalEndpoint.RootUrl, Equals, ep.RootUrl)
 
+	retrievedEp2, err := vcd.client.GetExternalEndpoint(retrievedEp.ExternalEndpoint.Vendor, retrievedEp.ExternalEndpoint.Name, retrievedEp.ExternalEndpoint.Version)
+	check.Assert(err, IsNil)
+	check.Assert(retrievedEp2, NotNil)
+	check.Assert(*retrievedEp2.ExternalEndpoint, DeepEquals, *retrievedEp.ExternalEndpoint)
+
+	allEps, err := vcd.client.GetAllExternalEndpoints(nil)
+	check.Assert(err, IsNil)
+	check.Assert(len(allEps) > 0, Equals, true)
+	pos := -1
+	for i, ep := range allEps {
+		if ep.ExternalEndpoint.ID == retrievedEp.ExternalEndpoint.ID {
+			pos = i
+		}
+	}
+	check.Assert(pos > -1, Equals, true)
+	check.Assert(*allEps[pos].ExternalEndpoint, DeepEquals, *retrievedEp.ExternalEndpoint)
+
+	ep.RootUrl = "https://www.broadcom.com/updated"
+	err = createdEp.Update(ep)
+	check.Assert(err, IsNil)
+	check.Assert(createdEp, NotNil)
+	check.Assert(createdEp, NotNil)
 }

--- a/govcd/external_endpoint_test.go
+++ b/govcd/external_endpoint_test.go
@@ -1,0 +1,45 @@
+//go:build functional || openapi || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+// Test_ExternalEndpoint tests the CRUD operations for the External Endpoints.
+func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
+	}
+
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointExternalEndpoints)
+
+	ep := types.ExternalEndpoint{
+		Name:        check.TestName(),
+		Version:     "1.0.0",
+		Vendor:      "vmware",
+		Enabled:     true,
+		Description: check.TestName(),
+		RootUrl:     "https://www.broadcom.com",
+	}
+
+	createdEp, err := vcd.client.CreateExternalEndpoint(&ep)
+	check.Assert(err, IsNil)
+	check.Assert(createdEp, NotNil)
+
+	defer func() {
+		err = createdEp.Delete()
+		check.Assert(err, IsNil)
+	}()
+
+	retrievedEp, err := vcd.client.GetExternalEndpointById(createdEp.ExternalEndpoint.ID)
+	check.Assert(err, IsNil)
+	check.Assert(retrievedEp, NotNil)
+
+}

--- a/govcd/external_endpoint_test.go
+++ b/govcd/external_endpoint_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 
-	name := strings.ReplaceAll(check.TestName(), ".", "")
+	name := strings.ReplaceAll(check.TestName(), ".", "") // Special characters like "." are not allowed
 
 	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointExternalEndpoints)
 

--- a/govcd/external_endpoint_test.go
+++ b/govcd/external_endpoint_test.go
@@ -28,7 +28,7 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 		Version:     "1.0.0",
 		Vendor:      "vmware",
 		Enabled:     true,
-		Description: "Description of" + name,
+		Description: "Description of " + name,
 		RootUrl:     "https://www.broadcom.com",
 	}
 

--- a/govcd/external_endpoint_test.go
+++ b/govcd/external_endpoint_test.go
@@ -75,5 +75,5 @@ func (vcd *TestVCD) Test_ExternalEndpoint(check *C) {
 	err = createdEp.Update(ep)
 	check.Assert(err, IsNil)
 	check.Assert(createdEp, NotNil)
-	check.Assert(createdEp, NotNil)
+	check.Assert(createdEp.ExternalEndpoint.RootUrl, Equals, "https://www.broadcom.com/updated")
 }

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -76,6 +76,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesResolve:                 "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesBehaviorsInvocations:    "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints:                  "37.3", // VCD 10.4.3+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointApiFilters:                         "37.3", // VCD 10.4.3+
 
 	// IP Spaces
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces:                     "37.1", // VCD 10.4.1+

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -75,6 +75,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesTypes:                   "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesResolve:                 "35.0", // VCD 10.2+
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointRdeEntitiesBehaviorsInvocations:    "35.0", // VCD 10.2+
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointExternalEndpoints:                  "37.3", // VCD 10.4.3+
 
 	// IP Spaces
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaces:                     "37.1", // VCD 10.4.1+

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -449,6 +449,7 @@ const (
 	OpenApiEndpointRdeEntitiesTypes                   = "entities/types/"
 	OpenApiEndpointRdeEntitiesResolve                 = "entities/%s/resolve"
 	OpenApiEndpointRdeEntitiesBehaviorsInvocations    = "entities/%s/behaviors/%s/invocations"
+	OpenApiEndpointExternalEndpoints                  = "externalEndpoints/"
 	OpenApiEndpointVirtualCenters                     = "virtualCenters"
 	OpenApiEndpointResourcePools                      = "virtualCenters/%s/resourcePools/browse"    // '%s' is vCenter ID
 	OpenApiEndpointResourcePoolsBrowseAll             = "virtualCenters/%s/resourcePools/browseAll" // '%s' is vCenter ID

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -450,6 +450,7 @@ const (
 	OpenApiEndpointRdeEntitiesResolve                 = "entities/%s/resolve"
 	OpenApiEndpointRdeEntitiesBehaviorsInvocations    = "entities/%s/behaviors/%s/invocations"
 	OpenApiEndpointExternalEndpoints                  = "externalEndpoints/"
+	OpenApiEndpointApiFilters                         = "apiFilters/"
 	OpenApiEndpointVirtualCenters                     = "virtualCenters"
 	OpenApiEndpointResourcePools                      = "virtualCenters/%s/resourcePools/browse"    // '%s' is vCenter ID
 	OpenApiEndpointResourcePoolsBrowseAll             = "virtualCenters/%s/resourcePools/browseAll" // '%s' is vCenter ID

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -777,5 +777,22 @@ type ExternalEndpoint struct {
 // They allow external systems (external services and external endpoints) to extend the standard API included with VCD
 // with custom URLs or custom processing of request's responses.
 type ApiFilter struct {
-	ID string `json:"id,omitempty"` // The unique id of the API filter
+	ID             string            `json:"id,omitempty"`             // The unique id of the API filter
+	ExternalSystem *OpenApiReference `json:"externalSystem,omitempty"` // Entity reference used to describe VCD entities
+	UrlMatcher     *UrlMatcher       `json:"urlMatcher,omitempty"`
+
+	// The responseContentType is expressed as a MIME Content-Type string. Responses whose Content-Type attribute has a value
+	// that matches this string are routed to the service. responseContentType is mutually exclusive with urlMatcher.
+	ResponseContentType string `json:"responseContentType,omitempty"`
+}
+
+// UrlMatcher consists of urlPattern and urlScope which together identify a URL which will be serviced by an external system.
+// For example, if you want the external system to service all requests matching '/ext-api/custom/.', the URL Matcher object should be:
+// { "urlPattern": "/custom/.", "urlScope": "EXT_API" }.
+// It is important to note that in the case of EXT_UI_TENANT urlScope, the tenant name is not part of the urlPattern.
+// The urlPattern will match the request after the tenant name - if request is "/ext-ui/tenant/testOrg/custom/test",
+// the pattern will match against "/custom/test".
+type UrlMatcher struct {
+	UrlPattern string `json:"urlPattern,omitempty"`
+	UrlScope   string `json:"urlScope,omitempty"`
 }

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -760,3 +760,15 @@ type OpenApiOrg struct {
 	DiskCount      int    `json:"diskCount"`
 	CanPublish     bool   `json:"canPublish"`
 }
+
+// ExternalEndpoint is part of the API extensibility framework.
+// They allow requests to be directly proxied over HTTP to an external endpoint.
+type ExternalEndpoint struct {
+	Name        string `json:"name,omitempty"`        // The name of the external endpoint
+	ID          string `json:"id,omitempty"`          // The unique id of the external endpoint
+	Version     string `json:"version,omitempty"`     // The external endpoint's version. The version should follow semantic versioning rules. Versions with pre-release extension are not allowed. The combination of vendor-namespace-version must be unique
+	Vendor      string `json:"vendor,omitempty"`      // The vendor name. The combination of vendor-namespace-version must be unique
+	Enabled     bool   `json:"enabled,omitempty"`     // Whether the external endpoint is enabled or not
+	Description string `json:"description,omitempty"` // Description of the defined entity
+	RootUrl     string `json:"rootUrl,omitempty"`     // The external endpoint which requests will be redirected to. The rootUrl must be a valid URL of https protocol
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -794,5 +794,5 @@ type ApiFilter struct {
 // the pattern will match against "/custom/test".
 type UrlMatcher struct {
 	UrlPattern string `json:"urlPattern,omitempty"`
-	UrlScope   string `json:"urlScope,omitempty"`
+	UrlScope   string `json:"urlScope,omitempty"` // EXT_API, EXT_UI_PROVIDER, EXT_UI_TENANT corresponding to /ext-api, /ext-ui/provider, /ext-ui/tenant/<tenant-name>
 }

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -768,7 +768,7 @@ type ExternalEndpoint struct {
 	ID          string `json:"id,omitempty"`          // The unique id of the external endpoint
 	Version     string `json:"version,omitempty"`     // The external endpoint's version. The version should follow semantic versioning rules. Versions with pre-release extension are not allowed. The combination of vendor-namespace-version must be unique
 	Vendor      string `json:"vendor,omitempty"`      // The vendor name. The combination of vendor-namespace-version must be unique
-	Enabled     bool   `json:"enabled,omitempty"`     // Whether the external endpoint is enabled or not
+	Enabled     bool   `json:"enabled"`               // Whether the external endpoint is enabled or not
 	Description string `json:"description,omitempty"` // Description of the defined entity
 	RootUrl     string `json:"rootUrl,omitempty"`     // The external endpoint which requests will be redirected to. The rootUrl must be a valid URL of https protocol
 }

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -772,3 +772,10 @@ type ExternalEndpoint struct {
 	Description string `json:"description,omitempty"` // Description of the defined entity
 	RootUrl     string `json:"rootUrl,omitempty"`     // The external endpoint which requests will be redirected to. The rootUrl must be a valid URL of https protocol
 }
+
+// ApiFilter is part of the API extensibility framework.
+// They allow external systems (external services and external endpoints) to extend the standard API included with VCD
+// with custom URLs or custom processing of request's responses.
+type ApiFilter struct {
+	ID string `json:"id,omitempty"` // The unique id of the API filter
+}

--- a/types/v56/openapi.go
+++ b/types/v56/openapi.go
@@ -783,7 +783,7 @@ type ApiFilter struct {
 
 	// The responseContentType is expressed as a MIME Content-Type string. Responses whose Content-Type attribute has a value
 	// that matches this string are routed to the service. responseContentType is mutually exclusive with urlMatcher.
-	ResponseContentType string `json:"responseContentType,omitempty"`
+	ResponseContentType *string `json:"responseContentType,omitempty"`
 }
 
 // UrlMatcher consists of urlPattern and urlScope which together identify a URL which will be serviced by an external system.


### PR DESCRIPTION
## Description

This PR adds support for External Endpoints and API Filters with the addition of several new methods:

- CRUD operations for External Endpoints: `VCDClient.CreateExternalEndpoint`, `VCDClient.GetAllExternalEndpoints`, `VCDClient.GetExternalEndpoint`, `VCDClient.GetExternalEndpointById`, `ExternalEndpoint.Update` and `ExternalEndpoint.Delete`
- CRUD operations for API Filters: `VCDClient.CreateApiFilter`, `VCDClient.GetAllApiFilters`, `VCDClient.GetApiFilterById`, `ApiFilter.Update` and `ApiFilter.Delete`