### PR TITLE
Fix tests

### DIFF
--- a/.changes/v2.26.0/696-features.md
+++ b/.changes/v2.26.0/696-features.md
@@ -1,4 +1,4 @@
 * Added CRUD operations for External Endpoints: `VCDClient.CreateExternalEndpoint`, `VCDClient.GetAllExternalEndpoints`,
   `VCDClient.GetExternalEndpoint`, `VCDClient.GetExternalEndpointById`, `ExternalEndpoint.Update` and `ExternalEndpoint.Delete` [GH-696]
 * Added CRUD operations for API Filters: `VCDClient.CreateApiFilter`, `VCDClient.GetAllApiFilters`, `VCDClient.GetApiFilterById`,
-  `ApiFilter.Update` and `ApiFilter.Delete` [GH-696]
+  `ApiFilter.Update` and `ApiFilter.Delete` [GH-696, GH-697]

--- a/.changes/v2.26.0/697-bug-fixes.md
+++ b/.changes/v2.26.0/697-bug-fixes.md
@@ -1,2 +1,1 @@
 * Fixes an XML error when updating a VM spec section: `Undeclared namespace prefix "ns5"` [GH-697]
-

--- a/.changes/v2.26.0/697-bug-fixes.md
+++ b/.changes/v2.26.0/697-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixes an XML error when updating a VM spec section: `Undeclared namespace prefix "ns5"` [GH-697]
+

--- a/.changes/v2.26.0/697-notes.md
+++ b/.changes/v2.26.0/697-notes.md
@@ -1,0 +1,2 @@
+* Modifies `Test_CreateDeleteEdgeGatewayAdvanced` to avoid its failure as VCD returns `Connected: true` when retrieving
+  the Edge Gateway data [GH-697]

--- a/govcd/api_filter_test.go
+++ b/govcd/api_filter_test.go
@@ -72,7 +72,7 @@ func (vcd *TestVCD) Test_ApiFilter(check *C) {
 	check.Assert(retrievedAf.ApiFilter.UrlMatcher, NotNil)
 	check.Assert(retrievedAf.ApiFilter.UrlMatcher.UrlPattern, Equals, createdAf.ApiFilter.UrlMatcher.UrlPattern)
 	check.Assert(retrievedAf.ApiFilter.UrlMatcher.UrlScope, Equals, createdAf.ApiFilter.UrlMatcher.UrlScope)
-	check.Assert(retrievedAf.ApiFilter.ResponseContentType, Equals, "")
+	check.Assert(retrievedAf.ApiFilter.ResponseContentType, IsNil)
 	check.Assert(retrievedAf.ApiFilter.ExternalSystem, NotNil)
 	check.Assert(retrievedAf.ApiFilter.ExternalSystem.ID, Equals, createdEp.ExternalEndpoint.ID)
 	check.Assert(retrievedAf.ApiFilter.ExternalSystem.Name, Equals, createdEp.ExternalEndpoint.Name)

--- a/govcd/system_test.go
+++ b/govcd/system_test.go
@@ -303,6 +303,7 @@ func (vcd *TestVCD) Test_CreateDeleteEdgeGatewayAdvanced(check *C) {
 		},
 		UseForDefaultRoute:  true,
 		SubnetParticipation: subnetParticipation,
+		Connected:           true,
 	}
 
 	// Sort by subnet participation gateway so that below injected variables are not being added to

--- a/govcd/vm.go
+++ b/govcd/vm.go
@@ -2178,6 +2178,7 @@ func (vm *VM) updateExtraConfig(update []*types.ExtraConfigMarshal, wantDelete b
 		Ns2:   types.XMLNamespaceVCloud,
 		Ns3:   types.XMLNamespaceVCloud,
 		Ns4:   types.XMLNamespaceVCloud,
+		Ns5:   types.XMLNamespaceVCloud,
 		Vmw:   types.XMLNamespaceVMW,
 		Xmlns: types.XMLNamespaceVCloud,
 

--- a/types/v56/vm_types.go
+++ b/types/v56/vm_types.go
@@ -233,6 +233,7 @@ type RequestVirtualHardwareSection struct {
 	Ns2     string   `xml:"xmlns:ns2,attr"`
 	Ns3     string   `xml:"xmlns:ns3,attr"`
 	Ns4     string   `xml:"xmlns:ns4,attr"`
+	Ns5     string   `xml:"xmlns:ns5,attr"`
 	Vmw     string   `xml:"xmlns:vmw,attr"`
 
 	Info   string     `xml:"ovf:Info"`


### PR DESCRIPTION
## Fixes

* Fixes `Test_ApiFilter` introduced in #696 
* Fixes an XML error when updating a VM spec section:
```
error updating VM spec section: API Error: 400: [ 34132-2024-07-30-10-32-54-071--c3eec3d0-5b83-42e1-8740-d276d94841a5 ] HTTP 400 Bad Request
         - Undeclared namespace prefix "ns5" (for attribute "ipAddressingMode")
         at [row,col {unknown-source}]: [34,114]
```
* Modifies `Test_CreateDeleteEdgeGatewayAdvanced` to avoid an odd test failure as VCD returns `Connected: true` when retrieving the Edge Gateway data.