### PR TITLE
Add Account lockout capabilities to Organizations

### DIFF
--- a/.changes/v2.26.0/702-improvements.md
+++ b/.changes/v2.26.0/702-improvements.md
@@ -1,0 +1,1 @@
+* Add `OrgPasswordPolicySettings` type to be able to set account lockout properties for an Organization [GH-702]

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1190,10 +1190,10 @@ type OrgLdapUserAttributes struct {
 // Description: Represents password policy settings for this organization.
 // Since: 1.5
 type OrgPasswordPolicySettings struct {
-	Link                          *Link `xml:"Link,omitempty"`                          // A reference to an entity or operation associated with this object
-	AccountLockoutEnabled         bool  `xml:"AccountLockoutEnabled,omitempty"`         // Set to true to enable account lockout for logins to this organization
-	InvalidLoginsBeforeLockout    int   `xml:"InvalidLoginsBeforeLockout,omitempty"`    // Number of invalid login attempts that will trigger account lockout
-	AccountLockoutIntervalMinutes int   `xml:"AccountLockoutIntervalMinutes,omitempty"` // Number of minutes an account that is locked out will remain locked
+	Link                          *LinkList `xml:"Link,omitempty"`                // A reference to an entity or operation associated with this object
+	AccountLockoutEnabled         bool      `xml:"AccountLockoutEnabled"`         // Set to true to enable account lockout for logins to this organization
+	InvalidLoginsBeforeLockout    int       `xml:"InvalidLoginsBeforeLockout"`    // Number of invalid login attempts that will trigger account lockout
+	AccountLockoutIntervalMinutes int       `xml:"AccountLockoutIntervalMinutes"` // Number of minutes an account that is locked out will remain locked
 }
 
 // VDCList contains a list of references to Org VDCs

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1052,12 +1052,12 @@ type OrgSettings struct {
 	HREF string `xml:"href,attr,omitempty"` // The URI of the entity.
 	Type string `xml:"type,attr,omitempty"` // The MIME type of the entity.
 	//elements
-	Link                    LinkList                   `xml:"Link,omitempty"`               // A reference to an entity or operation associated with this object.
-	OrgGeneralSettings      *OrgGeneralSettings        `xml:"OrgGeneralSettings,omitempty"` // General Settings for the org, not-required
-	OrgVAppLeaseSettings    *VAppLeaseSettings         `xml:"VAppLeaseSettings,omitempty"`
-	OrgVAppTemplateSettings *VAppTemplateLeaseSettings `xml:"VAppTemplateLeaseSettings,omitempty"` // Vapp template lease settings, not required
-	OrgLdapSettings         *OrgLdapSettingsType       `xml:"OrgLdapSettings,omitempty"`           //LDAP settings, not-requried, defaults to none
-
+	Link                      LinkList                   `xml:"Link,omitempty"`               // A reference to an entity or operation associated with this object.
+	OrgGeneralSettings        *OrgGeneralSettings        `xml:"OrgGeneralSettings,omitempty"` // General Settings for the org, not-required
+	OrgVAppLeaseSettings      *VAppLeaseSettings         `xml:"VAppLeaseSettings,omitempty"`
+	OrgVAppTemplateSettings   *VAppTemplateLeaseSettings `xml:"VAppTemplateLeaseSettings,omitempty"` // Vapp template lease settings, not required
+	OrgLdapSettings           *OrgLdapSettingsType       `xml:"OrgLdapSettings,omitempty"`           // LDAP settings, not-requried, defaults to none
+	OrgPasswordPolicySettings *OrgPasswordPolicySettings `xml:"OrgPasswordPolicySettings,omitempty"` // Password policy settings for this organization.
 }
 
 // OrgGeneralSettingsType represents the general settings for a VMware Cloud Director organization.
@@ -1182,6 +1182,18 @@ type OrgLdapUserAttributes struct {
 	Telephone                 string `xml:"Telephone"`
 	GroupMembershipIdentifier string `xml:"GroupMembershipIdentifier"`
 	GroupBackLinkIdentifier   string `xml:"GroupBackLinkIdentifier,omitempty"`
+}
+
+// OrgPasswordPolicySettings represents password policy settings for this organization.
+// Type: OrgPasswordPolicySettingsType
+// Namespace: http://www.vmware.com/vcloud/v1.5
+// Description: Represents password policy settings for this organization.
+// Since: 1.5
+type OrgPasswordPolicySettings struct {
+	Link                          *Link `xml:"Link,omitempty"`                          // A reference to an entity or operation associated with this object
+	AccountLockoutEnabled         bool  `xml:"AccountLockoutEnabled,omitempty"`         // Set to true to enable account lockout for logins to this organization
+	InvalidLoginsBeforeLockout    int   `xml:"InvalidLoginsBeforeLockout,omitempty"`    // Number of invalid login attempts that will trigger account lockout
+	AccountLockoutIntervalMinutes int   `xml:"AccountLockoutIntervalMinutes,omitempty"` // Number of minutes an account that is locked out will remain locked
 }
 
 // VDCList contains a list of references to Org VDCs

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1190,6 +1190,9 @@ type OrgLdapUserAttributes struct {
 // Description: Represents password policy settings for this organization.
 // Since: 1.5
 type OrgPasswordPolicySettings struct {
+	Xmlns                         string    `xml:"xmlns,attr,omitempty"`
+	HREF                          string    `xml:"href,attr,omitempty"`           // The URI of the entity.
+	Type                          string    `xml:"type,attr,omitempty"`           // The MIME type of the entity.
 	Link                          *LinkList `xml:"Link,omitempty"`                // A reference to an entity or operation associated with this object
 	AccountLockoutEnabled         bool      `xml:"AccountLockoutEnabled"`         // Set to true to enable account lockout for logins to this organization
 	InvalidLoginsBeforeLockout    int       `xml:"InvalidLoginsBeforeLockout"`    // Number of invalid login attempts that will trigger account lockout


### PR DESCRIPTION
Add `OrgPasswordPolicySettings` to the `OrgSettings` existing type. This new type allows to configure Account lockout preferences of an Organization.

Used to implement https://github.com/vmware/terraform-provider-vcd/pull/1304