### PR TITLE
Add support for parsing vmNameInVc xml attribute on QueryResultVMRecordType struct

### DIFF
--- a/.changes/v2.26.0/705-improvements.md
+++ b/.changes/v2.26.0/705-improvements.md
@@ -1,0 +1,1 @@
+* Added field `QueryResultVMRecordType.VmNameInVc` [GH-705]

--- a/govcd/vm_test.go
+++ b/govcd/vm_test.go
@@ -2139,12 +2139,14 @@ func (vcd *TestVCD) Test_QueryVMList(check *C) {
 	// Retrieves all VMs with name 'Test_VmA_'+uniqueId
 	vmList1, err := QueryVmList(types.VmQueryFilterOnlyDeployed, &vcd.client.Client, map[string]string{"name": "Test_VmA_" + uniqueId})
 	check.Assert(err, IsNil)
+	check.Assert(vmList1[0].VmNameInVc, Not(Equals), "")
 	listVms(vmList1)
 
 	// Retrieves all VMs with name 'Test_VmB_'+uniqueId
 	check.Assert(len(vmList1) == 3, Equals, true)
 	vmList2, err := QueryVmList(types.VmQueryFilterOnlyDeployed, &vcd.client.Client, map[string]string{"name": "Test_VmB_" + uniqueId})
 	check.Assert(err, IsNil)
+	check.Assert(vmList2[0].VmNameInVc, Not(Equals), "")
 	listVms(vmList2)
 
 	// Retrieves all VMs

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -2912,6 +2912,7 @@ type QueryResultVMRecordType struct {
 	HostName                 string    `xml:"hostName,attr,omitempty"` // HostName=Hypervisor of virtual machine
 	Link                     []*Link   `xml:"Link,omitempty"`
 	MetaData                 *Metadata `xml:"Metadata,omitempty"`
+	VmNameInVc               string    `xml:"vmNameInVc,attr,omitempty"`
 }
 
 // QueryResultVAppRecordType represents a VM record as query result.


### PR DESCRIPTION
Implementing as per stale community request https://github.com/vmware/go-vcloud-director/pull/635
Closes #635 , closes #634


```
START: vm_test.go:2115: TestVCD.Test_QueryVMList
PASS: vm_test.go:2115: TestVCD.Test_QueryVMList 116.191s
```
