### PR TITLE
Add Region Storage Policies Read methods + Content Library CRUD methods

### DIFF
--- a/.changes/v3.0.0/711-features.md
+++ b/.changes/v3.0.0/711-features.md
@@ -1,3 +1,6 @@
 * Added `RegionStoragePolicy` and `types.RegionStoragePolicy` structures to read Region Storage Policies
   with methods `VCDClient.GetAllRegionStoragePolicies`, `VCDClient.GetRegionStoragePolicyByName`,
   `VCDClient.GetRegionStoragePolicyById` [GH-711]
+* Added `ContentLibrary` and `types.ContentLibrary` structures to manage Content Libraries
+  with methods `VCDClient.CreateContentLibrary`, `VCDClient.GetAllContentLibraries`,
+  `VCDClient.GetContentLibraryByName`, `VCDClient.GetContentLibraryById`, `ContentLibrary.Update`, `ContentLibrary.Delete` [GH-711]

--- a/.changes/v3.0.0/711-features.md
+++ b/.changes/v3.0.0/711-features.md
@@ -1,0 +1,3 @@
+* Added `RegionStoragePolicy` and `types.RegionStoragePolicy` structures to read Region Storage Policies
+  with methods `VCDClient.GetAllRegionStoragePolicies`, `VCDClient.GetRegionStoragePolicyByName`,
+  `VCDClient.GetRegionStoragePolicyById` [GH-711]

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ testlb:
 testnsxv:
 	cd govcd && go test -tags "nsxv" -timeout $(timeout)  -check.vv
 
+testtm:
+	cd govcd && go test -tags "tm" -timeout 0  -check.vv
+
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -1,4 +1,4 @@
-//go:build api || openapi || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || search || nsxv || nsxt || auth || affinity || role || alb || certificate || vdcGroup || metadata || providervdc || rde || vsphere || uiPlugin || cse || slz || ALL
+//go:build api || openapi || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || search || nsxv || nsxt || auth || affinity || role || alb || certificate || vdcGroup || metadata || providervdc || rde || vsphere || uiPlugin || cse || slz || tm || ALL
 
 /*
  * Copyright 2022 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
@@ -97,6 +97,7 @@ const (
 
 const (
 	TestRequiresSysAdminPrivileges = "Test %s requires system administrator privileges"
+	TestRequiresTm                 = "Test %s requires TM"
 )
 
 type Tenant struct {
@@ -140,7 +141,10 @@ type TestConfig struct {
 		HttpTimeout     int64  `yaml:"httpTimeout,omitempty"`
 	}
 	Tenants []Tenant `yaml:"tenants,omitempty"`
-	VCD     struct {
+	Tm      struct {
+		RegionStoragePolicy string `yaml:"regionStoragePolicy"`
+	} `yaml:"tm,omitempty"`
+	VCD struct {
 		Org         string `yaml:"org"`
 		Vdc         string `yaml:"vdc"`
 		ProviderVdc struct {
@@ -648,7 +652,13 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 	if err == nil {
 		versionInfo = fmt.Sprintf("version %s built at %s", version, versionTime)
 	}
-	fmt.Printf("Running on VCD %s (%s)\nas user %s@%s (using %s)\n", vcd.config.Provider.Url, versionInfo,
+	env := "VCD"
+	isTm := vcd.client.Client.IsTm()
+	if isTm {
+		env = "TM"
+	}
+
+	fmt.Printf("Running on %s %s (%s)\nas user %s@%s (using %s)\n", env, vcd.config.Provider.Url, versionInfo,
 		vcd.config.Provider.User, vcd.config.Provider.SysOrg, authenticationMode)
 	if !vcd.client.Client.IsSysAdmin {
 		vcd.skipAdminTests = true
@@ -661,29 +671,33 @@ func (vcd *TestVCD) SetUpSuite(check *C) {
 	persistentCleanupIp = vcd.config.Provider.Url
 	persistentCleanupIp = reHttp.ReplaceAllString(persistentCleanupIp, "")
 	persistentCleanupIp = reApi.ReplaceAllString(persistentCleanupIp, "")
-	// set org
-	vcd.org, err = vcd.client.GetOrgByName(config.VCD.Org)
-	if err != nil {
-		fmt.Printf("error retrieving org %s: %s\n", config.VCD.Org, err)
-		os.Exit(1)
-	}
-	// set vdc
-	vcd.vdc, err = vcd.org.GetVDCByName(config.VCD.Vdc, false)
-	if err != nil || vcd.vdc == nil {
-		panic(err)
-	}
 
-	// configure NSX-T VDC for convenience if it is specified in configuration
-	if config.VCD.Nsxt.Vdc != "" {
-		vcd.nsxtVdc, err = vcd.org.GetVDCByName(config.VCD.Nsxt.Vdc, false)
+	if !isTm {
+		// set org
+		vcd.org, err = vcd.client.GetOrgByName(config.VCD.Org)
 		if err != nil {
-			panic(fmt.Errorf("error geting NSX-T VDC '%s': %s", config.VCD.Nsxt.Vdc, err))
+			fmt.Printf("error retrieving org %s: %s\n", config.VCD.Org, err)
+			os.Exit(1)
+		}
+		// set vdc
+		vcd.vdc, err = vcd.org.GetVDCByName(config.VCD.Vdc, false)
+		if err != nil || vcd.vdc == nil {
+			panic(err)
+		}
+
+		// configure NSX-T VDC for convenience if it is specified in configuration
+		if config.VCD.Nsxt.Vdc != "" {
+			vcd.nsxtVdc, err = vcd.org.GetVDCByName(config.VCD.Nsxt.Vdc, false)
+			if err != nil {
+				panic(fmt.Errorf("error geting NSX-T VDC '%s': %s", config.VCD.Nsxt.Vdc, err))
+			}
 		}
 	}
 
-	// If neither the vApp or VM tags are set, we also skip the
-	// creation of the default vApp
-	if !isTagSet("vapp") && !isTagSet("vm") {
+	// vApp creation is skipped for one out of two reasons:
+	// * neither the vApp or VM tags are set
+	// * env is TM
+	if (!isTagSet("vapp") && !isTagSet("vm")) || isTm {
 		// vcd.skipVappTests = true
 		skipVappCreation = true
 	}
@@ -1810,7 +1824,7 @@ func (vcd *TestVCD) TestClient_getloginurl(check *C) {
 		check.Fatalf("err: %s", err)
 	}
 
-	if client.sessionHREF.Path != "/cloudapi/1.0.0/sessions" {
+	if !strings.HasSuffix(client.sessionHREF.Path, "/cloudapi/1.0.0/sessions") {
 		check.Fatalf("Getting LoginUrl failed, url: %s", client.sessionHREF.Path)
 	}
 }
@@ -2060,6 +2074,18 @@ func skipNoNsxtAlbConfiguration(vcd *TestVCD, check *C) {
 	}
 	if vcd.config.VCD.Nsxt.NsxtAlbServiceEngineGroup == "" {
 		check.Skip(generalMessage + "No NSX-T ALB Service Engine Group name specified in configuration")
+	}
+}
+
+func skipNonTm(vcd *TestVCD, check *C) {
+	if !vcd.client.Client.IsTm() {
+		check.Skip(fmt.Sprintf(TestRequiresTm, check.TestName()))
+	}
+}
+
+func sysadminOnly(vcd *TestVCD, check *C) {
+	if vcd.skipAdminTests {
+		check.Skip(fmt.Sprintf(TestRequiresSysAdminPrivileges, check.TestName()))
 	}
 }
 

--- a/govcd/api_vcd_versions.go
+++ b/govcd/api_vcd_versions.go
@@ -371,3 +371,7 @@ func (client *Client) VersionEqualOrGreater(compareTo string, howManyDigits int)
 
 	return fullVersion.Version.GreaterThanOrEqual(compareToVersion), nil
 }
+
+func (client *Client) IsTm() bool {
+	return client.APIVCDMaxVersionIs(">= 40") // TODO: TM: Make it more precise
+}

--- a/govcd/common_test.go
+++ b/govcd/common_test.go
@@ -1,4 +1,4 @@
-//go:build api || auth || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || role || nsxv || nsxt || openapi || affinity || search || alb || certificate || vdcGroup || metadata || providervdc || rde || uiPlugin || vsphere || cse || slz || ALL
+//go:build api || auth || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || role || nsxv || nsxt || openapi || affinity || search || alb || certificate || vdcGroup || metadata || providervdc || rde || uiPlugin || vsphere || cse || slz || tm || ALL
 
 /*
  * Copyright 2021 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -244,12 +244,6 @@ var endpointElevatedApiVersions = map[string][]string{
 		//"37.1", // Introduced support
 		"38.0", // Adds 'Interfaces' structure for associating particular Tier-0 router interfaces
 	},
-	types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies: {
-		"40.0", // TM Region Storage Policies
-	},
-	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries: {
-		"40.0", // TM Content Libraries
-	},
 }
 
 // checkOpenApiEndpointCompatibility checks if VCD version (to which the client is connected) is sufficient to work with

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -154,6 +154,10 @@ var endpointMinApiVersions = map[string]string{
 
 	// NSX-T Tier 0 router interfaces that can be used for IP Space uplink assignment
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNsxtTier0RouterInterfaces: "38.0",
+
+	// VCF
+	types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies: "40.0",
+	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries:      "40.0",
 }
 
 // endpointElevatedApiVersions endpoint elevated API versions
@@ -239,6 +243,12 @@ var endpointElevatedApiVersions = map[string][]string{
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointIpSpaceUplinks: {
 		//"37.1", // Introduced support
 		"38.0", // Adds 'Interfaces' structure for associating particular Tier-0 router interfaces
+	},
+	types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies: {
+		"40.0", // TM Region Storage Policies
+	},
+	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries: {
+		"40.0", // TM Content Libraries
 	},
 }
 

--- a/govcd/sample_govcd_test_config.yaml
+++ b/govcd/sample_govcd_test_config.yaml
@@ -285,9 +285,9 @@ cse:
   ovaName: "ubuntu-2004-kube-v1.25.7+vmware.2-tkg.1-8a74b9f12e488c54605b3537acb683bc"
 # Config branch to test Solution Add-Ons (requires CSE to succesfully publish Add-On Instances)
 solutionAddOn:
-  # Org for Landing Zone configuration and Add-On deployment 
+  # Org for Landing Zone configuration and Add-On deployment
   org: "solutions_org"
-  # VDC for Landing Zone configuration and Add-On deployment 
+  # VDC for Landing Zone configuration and Add-On deployment
   vdc: "solutions_vdc"
   # Routed Network for Landing Zone configuration
   routedNetwork: "solutions_routed_network"
@@ -299,3 +299,6 @@ solutionAddOn:
   catalog: "cse_catalog"
   # An existing Add-On image within catalog
   addonImageDse: "vmware-vcd-ds-1.4.0-23376809.iso"
+tm:
+  # An existing Region Storage Policy to create Content Libraries, Regions...
+  regionStoragePolicy: "vSAN Default Storage Policy"

--- a/govcd/tm_content_library.go
+++ b/govcd/tm_content_library.go
@@ -1,0 +1,137 @@
+package govcd
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+const labelContentLibrary = "Content Library"
+
+// ContentLibrary defines the Content Library data structure
+type ContentLibrary struct {
+	ContentLibrary *types.ContentLibrary
+	vcdClient      *VCDClient
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (g ContentLibrary) wrap(inner *types.ContentLibrary) *ContentLibrary {
+	g.ContentLibrary = inner
+	return &g
+}
+
+// CreateContentLibrary creates a Content Library
+// TODO: TM: This one probably needs TenantContext, as can be created as Tenants
+func (vcdClient *VCDClient) CreateContentLibrary(config *types.ContentLibrary) (*ContentLibrary, error) {
+	if !vcdClient.Client.IsTm() {
+		return nil, fmt.Errorf("creating Content Libraries is only supported in TM")
+	}
+	c := crudConfig{
+		entityLabel: labelContentLibrary,
+		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
+	}
+	outerType := ContentLibrary{vcdClient: vcdClient}
+	// FIXME: TM: Workaround, this should be eventually refactored to match other OpenAPI endpoints.
+	//        - Problem: The returned Task references a Catalog instead of a ContentLibrary, hence retrieving the resulting object
+	//                from finished Task fails.
+	//        - Solution: Retry fetching the entity again on error with the information inside of it
+	result, err := createOuterEntity(&vcdClient.Client, outerType, c, config)
+	if err != nil {
+		// The error we want is like:
+		// error creating entity of type 'Content Library': error retrieving item after creation: error in HTTP GET request:
+		// BAD_REQUEST - [ uuid ] validation error on supplied value 'urn:vcloud:catalog:c25ecd89-444c-4ce7-b230-243f906c9896':
+		// Invalid urn string. Value does not match the appropriate urn pattern "urn:vcloud:<type>:<uuid>" or contains an incorrect
+		// object type for the endpoint."
+		if !strings.Contains(err.Error(), "urn:vcloud:catalog:") {
+			return nil, err
+		}
+		// The created Content Library has the same UUID as the Catalog, which is present in the thrown error above
+		result, err = vcdClient.GetContentLibraryById(fmt.Sprintf("urn:vcloud:contentLibrary:%s", extractUuid(err.Error())))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// GetAllContentLibraries retrieves all Content Libraries with the given query parameters, which allow setting filters
+// and other constraints
+func (vcdClient *VCDClient) GetAllContentLibraries(queryParameters url.Values) ([]*ContentLibrary, error) {
+	if !vcdClient.Client.IsTm() {
+		return nil, fmt.Errorf("retrieving Content Libraries is only supported in TM")
+	}
+	c := crudConfig{
+		entityLabel:     labelContentLibrary,
+		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
+		queryParameters: queryParameters,
+	}
+
+	outerType := ContentLibrary{vcdClient: vcdClient}
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
+}
+
+// GetContentLibraryByName retrieves a Content Library with the given name
+func (vcdClient *VCDClient) GetContentLibraryByName(name string) (*ContentLibrary, error) {
+	if !vcdClient.Client.IsTm() {
+		return nil, fmt.Errorf("retrieving Content Libraries is only supported in TM")
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("%s lookup requires name", labelContentLibrary)
+	}
+
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
+
+	filteredEntities, err := vcdClient.GetAllContentLibraries(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	singleEntity, err := oneOrError("name", name, filteredEntities)
+	if err != nil {
+		return nil, err
+	}
+
+	return vcdClient.GetContentLibraryById(singleEntity.ContentLibrary.Id)
+}
+
+// GetContentLibraryById retrieves a Content Library with the given ID
+func (vcdClient *VCDClient) GetContentLibraryById(id string) (*ContentLibrary, error) {
+	if !vcdClient.Client.IsTm() {
+		return nil, fmt.Errorf("retrieving Content Libraries is only supported in TM")
+	}
+
+	c := crudConfig{
+		entityLabel:    labelContentLibrary,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
+		endpointParams: []string{id},
+	}
+
+	outerType := ContentLibrary{vcdClient: vcdClient}
+	return getOuterEntity(&vcdClient.Client, outerType, c)
+}
+
+// Update updates an existing Content Library with the given configuration
+// TODO: TM: Not supported in UI yet
+func (o *ContentLibrary) Update(contentLibraryConfig *types.ContentLibrary) (*ContentLibrary, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+// Delete deletes the receiver Content Library
+func (o *ContentLibrary) Delete() error {
+	c := crudConfig{
+		entityLabel:    labelContentLibrary,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
+		endpointParams: []string{o.ContentLibrary.Id},
+	}
+	return deleteEntityById(&o.vcdClient.Client, c)
+}

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -1,0 +1,81 @@
+//go:build tm || functional || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	. "gopkg.in/check.v1"
+)
+
+// TODO: TM: Tests missing: Tenant, subscribed catalog, shared catalog
+
+// Test_ContentLibraryProvider tests CRUD operations for a Content Library with the Provider user
+func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check)
+
+	cls, err := vcd.client.GetAllContentLibraries(nil)
+	check.Assert(err, IsNil)
+	existingContentLibraryCount := len(cls)
+
+	rsp, err := vcd.client.GetRegionStoragePolicyByName(vcd.config.Tm.RegionStoragePolicy)
+	check.Assert(err, IsNil)
+	check.Assert(rsp, NotNil)
+
+	clDefinition := &types.ContentLibrary{
+		Name:            check.TestName(),
+		StoragePolicies: []types.OpenApiReference{{ID: rsp.RegionStoragePolicy.ID}},
+		AutoAttach:      true, // TODO: TM: Test with false, still does not work
+		Description:     check.TestName(),
+	}
+
+	createdCl, err := vcd.client.CreateContentLibrary(clDefinition)
+	check.Assert(err, IsNil)
+	check.Assert(createdCl, NotNil)
+	AddToCleanupListOpenApi(createdCl.ContentLibrary.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraries+createdCl.ContentLibrary.Id)
+
+	// Defer deletion for a correct cleanup
+	defer func() {
+		err = createdCl.Delete()
+		check.Assert(err, IsNil)
+	}()
+	check.Assert(isUrn(createdCl.ContentLibrary.Id), Equals, true)
+	check.Assert(createdCl.ContentLibrary.Name, Equals, clDefinition.Name)
+	check.Assert(createdCl.ContentLibrary.Description, Equals, clDefinition.Description)
+	check.Assert(len(createdCl.ContentLibrary.StoragePolicies), Equals, 1)
+	check.Assert(createdCl.ContentLibrary.StoragePolicies[0].ID, Equals, rsp.RegionStoragePolicy.ID)
+	check.Assert(createdCl.ContentLibrary.AutoAttach, Equals, clDefinition.AutoAttach)
+	// "Computed" values
+	check.Assert(createdCl.ContentLibrary.IsShared, Equals, true) // TODO: TM: Still not used in UI
+	check.Assert(createdCl.ContentLibrary.IsSubscribed, Equals, false)
+	check.Assert(createdCl.ContentLibrary.LibraryType, Equals, "PROVIDER") // TODO: TM: Test with Tenant once implemented
+	check.Assert(createdCl.ContentLibrary.VersionNumber, Equals, int64(1))
+	check.Assert(createdCl.ContentLibrary.Org, NotNil)
+	check.Assert(createdCl.ContentLibrary.Org.Name, Equals, "System")
+	check.Assert(createdCl.ContentLibrary.SubscriptionConfig, IsNil)
+	check.Assert(createdCl.ContentLibrary.CreationDate, Not(Equals), "")
+
+	cls, err = vcd.client.GetAllContentLibraries(nil)
+	check.Assert(err, IsNil)
+	check.Assert(len(cls), Equals, existingContentLibraryCount+1)
+	for _, l := range cls {
+		if l.ContentLibrary.Id == createdCl.ContentLibrary.Id {
+			check.Assert(*l.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+			break
+		}
+	}
+
+	cl, err := vcd.client.GetContentLibraryByName(check.TestName())
+	check.Assert(err, IsNil)
+	check.Assert(cl, NotNil)
+	check.Assert(*cl.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+
+	cl, err = vcd.client.GetContentLibraryById(cl.ContentLibrary.Id)
+	check.Assert(err, IsNil)
+	check.Assert(cl, NotNil)
+	check.Assert(*cl.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+}

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -28,7 +28,7 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 
 	clDefinition := &types.ContentLibrary{
 		Name:            check.TestName(),
-		StoragePolicies: []types.OpenApiReference{{ID: rsp.RegionStoragePolicy.ID}},
+		StoragePolicies: []types.OpenApiReference{{ID: rsp.RegionStoragePolicy.Id}},
 		AutoAttach:      true, // TODO: TM: Test with false, still does not work
 		Description:     check.TestName(),
 	}
@@ -47,7 +47,7 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 	check.Assert(createdCl.ContentLibrary.Name, Equals, clDefinition.Name)
 	check.Assert(createdCl.ContentLibrary.Description, Equals, clDefinition.Description)
 	check.Assert(len(createdCl.ContentLibrary.StoragePolicies), Equals, 1)
-	check.Assert(createdCl.ContentLibrary.StoragePolicies[0].ID, Equals, rsp.RegionStoragePolicy.ID)
+	check.Assert(createdCl.ContentLibrary.StoragePolicies[0].ID, Equals, rsp.RegionStoragePolicy.Id)
 	check.Assert(createdCl.ContentLibrary.AutoAttach, Equals, clDefinition.AutoAttach)
 	// "Computed" values
 	check.Assert(createdCl.ContentLibrary.IsShared, Equals, true) // TODO: TM: Still not used in UI

--- a/govcd/tm_region_storage_policy.go
+++ b/govcd/tm_region_storage_policy.go
@@ -64,7 +64,7 @@ func (vcdClient *VCDClient) GetRegionStoragePolicyByName(name string) (*RegionSt
 	//	return nil, err
 	//}
 
-	return vcdClient.GetRegionStoragePolicyById(singleEntity.RegionStoragePolicy.ID)
+	return vcdClient.GetRegionStoragePolicyById(singleEntity.RegionStoragePolicy.Id)
 }
 
 // GetRegionStoragePolicyById retrieves a Region Storage Policy by ID

--- a/govcd/tm_region_storage_policy.go
+++ b/govcd/tm_region_storage_policy.go
@@ -1,0 +1,80 @@
+package govcd
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+const labelRegionStoragePolicy = "Region Storage Policy"
+
+// RegionStoragePolicy defines the Region Storage Policy data structure
+type RegionStoragePolicy struct {
+	RegionStoragePolicy *types.RegionStoragePolicy
+	vcdClient           *VCDClient
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (g RegionStoragePolicy) wrap(inner *types.RegionStoragePolicy) *RegionStoragePolicy {
+	g.RegionStoragePolicy = inner
+	return &g
+}
+
+// GetAllRegionStoragePolicies retrieves all Region Storage Policies with the given query parameters, which allow setting filters
+// and other constraints
+func (vcdClient *VCDClient) GetAllRegionStoragePolicies(queryParameters url.Values) ([]*RegionStoragePolicy, error) {
+	c := crudConfig{
+		entityLabel:     labelRegionStoragePolicy,
+		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies,
+		queryParameters: queryParameters,
+	}
+
+	outerType := RegionStoragePolicy{vcdClient: vcdClient}
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
+}
+
+// GetRegionStoragePolicyByName retrieves a Region Storage Policy by name
+func (vcdClient *VCDClient) GetRegionStoragePolicyByName(name string) (*RegionStoragePolicy, error) {
+	if name == "" {
+		return nil, fmt.Errorf("%s lookup requires name", labelRegionStoragePolicy)
+	}
+
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
+
+	filteredEntities, err := vcdClient.GetAllRegionStoragePolicies(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: TM: API returns same result twice for some reason
+	if len(filteredEntities) == 0 {
+		return nil, fmt.Errorf("TODO: TM: found 0 storage policies: %s", ErrorEntityNotFound)
+	}
+	singleEntity := filteredEntities[0]
+	//singleEntity, err := oneOrError("name", name, filteredEntities)
+	//if err != nil {
+	//	return nil, err
+	//}
+
+	return vcdClient.GetRegionStoragePolicyById(singleEntity.RegionStoragePolicy.ID)
+}
+
+// GetRegionStoragePolicyById retrieves a Region Storage Policy by ID
+func (vcdClient *VCDClient) GetRegionStoragePolicyById(id string) (*RegionStoragePolicy, error) {
+	c := crudConfig{
+		entityLabel:    labelRegionStoragePolicy,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies,
+		endpointParams: []string{id},
+	}
+
+	outerType := RegionStoragePolicy{vcdClient: vcdClient}
+	return getOuterEntity(&vcdClient.Client, outerType, c)
+}

--- a/govcd/tm_region_storage_policy_test.go
+++ b/govcd/tm_region_storage_policy_test.go
@@ -1,0 +1,42 @@
+//go:build tm || functional || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// TODO: TM: Missing Create, Update, Delete
+func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check)
+
+	allRegionStoragePolicies, err := vcd.client.GetAllRegionStoragePolicies(nil)
+	check.Assert(err, IsNil)
+
+	// TODO: TM: Once we can create Region SPs, we don't need the TM environment to have pre-existing Storage Policies
+	if len(allRegionStoragePolicies) == 0 {
+		check.Skip("didn't find any Region Storage Policy")
+	}
+
+	rspById, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
+	check.Assert(err, IsNil)
+	check.Assert(*rspById.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
+
+	rspByName, err := vcd.client.GetRegionStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
+	check.Assert(err, IsNil)
+	check.Assert(*rspByName.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
+
+	// Check ENF errors
+	_, err = vcd.client.GetRegionStoragePolicyById("urn:vcloud:regionStoragePolicy:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = vcd.client.GetRegionStoragePolicyByName("NotExists")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+}

--- a/govcd/tm_region_storage_policy_test.go
+++ b/govcd/tm_region_storage_policy_test.go
@@ -23,7 +23,7 @@ func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
 		check.Skip("didn't find any Region Storage Policy")
 	}
 
-	rspById, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
+	rspById, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.Id)
 	check.Assert(err, IsNil)
 	check.Assert(*rspById.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
 

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -384,6 +384,7 @@ const (
 // These constants allow constructing OpenAPI endpoint paths and avoid strings in code for easy replacement in the
 // future.
 const (
+	OpenApiPathVcf                                    = "vcf/"
 	OpenApiPathVersion1_0_0                           = "1.0.0/"
 	OpenApiPathVersion2_0_0                           = "2.0.0/"
 	OpenApiEndpointRoles                              = "roles/"
@@ -517,6 +518,9 @@ const (
 
 	// OpenAPI Org
 	OpenApiEndpointOrgs = "orgs/"
+
+	OpenApiEndpointRegionStoragePolicies = "regionStoragePolicies/"
+	OpenApiEndpointContentLibraries      = "contentLibraries/"
 )
 
 // Header keys to run operations in tenant context

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -46,7 +46,7 @@ type ContentLibrary struct {
 	// The reference to the organization that the Content Library belongs to
 	Org *OpenApiReference `json:"org,omitempty"`
 	// An object representing subscription settings of a Content Library
-	SubscriptionConfig *ContentLibrarySubscriptionConfig `json:"subscriptionConfig"`
+	SubscriptionConfig *ContentLibrarySubscriptionConfig `json:"subscriptionConfig,omitempty"`
 	// Version number of this Content library
 	VersionNumber int64 `json:"versionNumber,omitempty"`
 }

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -1,0 +1,62 @@
+package types
+
+// RegionStoragePolicy defines a Region storage policy
+type RegionStoragePolicy struct {
+	ID string `json:"id,omitempty"`
+	// Name for the policy. It must follow RFC 1123 Label Names to conform with Kubernetes standards
+	Name string `json:"name"`
+	// The Region that this policy belongs to
+	Region *OpenApiReference `json:"region"`
+	// Description of the policy
+	Description string `json:"description,omitempty"`
+	// The creation status of the region storage policy. Can be [NOT_READY, READY]
+	Status string `json:"status,omitempty"`
+	// Storage capacity in megabytes for this policy
+	StorageCapacityMB int64 `json:"storageCapacityMB,omitempty"`
+	// Consumed storage in megabytes for this policy
+	StorageConsumedMB int64 `json:"storageConsumedMB,omitempty"`
+}
+
+// ContentLibrary is an object representing a VCF Content Library
+type ContentLibrary struct {
+	// The name of the Content Library
+	Name string `json:"name"`
+	// A collection of RegionStoragePolicy or VdcStoragePolicy references used by this Content Library
+	StoragePolicies []OpenApiReference `json:"storagePolicies"`
+	// For Tenant Content Libraries this field represents whether this Content Library should be automatically attached to
+	// all current and future namespaces in the tenant organization. If no value is supplied during Tenant Content Library
+	// creation then this field will default to true. If a value of false is supplied, then this Tenant Content Library will
+	// only be attached to namespaces that explicitly request it. For Provider Content Libraries this field is not needed for
+	// creation and will always be returned as true. This field cannot be updated after Content Library creation
+	AutoAttach bool `json:"autoAttach,omitempty"`
+	// The ISO-8601 timestamp representing when this Content Library was created
+	CreationDate string `json:"creationDate,omitempty"`
+	// The description of the Content Library
+	Description string `json:"description,omitempty"`
+	// A unique identifier for the Content library
+	Id string `json:"id,omitempty"`
+	// Whether this Content Library is shared with other organziations
+	IsShared bool `json:"isShared,omitempty"`
+	// Whether this Content Library is subscribed from an external published library
+	IsSubscribed bool `json:"isSubscribed,omitempty"`
+	// The type of content library:
+	// - PROVIDER - Content Library that is scoped to a provider
+	// - TENANT - Content Library that is scoped to a tenant organization
+	LibraryType string `json:"libraryType,omitempty"`
+	// The reference to the organization that the Content Library belongs to
+	Org *OpenApiReference `json:"org,omitempty"`
+	// An object representing subscription settings of a Content Library
+	SubscriptionConfig *ContentLibrarySubscriptionConfig `json:"subscriptionConfig"`
+	// Version number of this Content library
+	VersionNumber int64 `json:"versionNumber,omitempty"`
+}
+
+// ContentLibrarySubscriptionConfig represents subscription settings of a Content Library
+type ContentLibrarySubscriptionConfig struct {
+	// Subscription url of this Content Library. It cannot be changed once set for a Content Library
+	SubscriptionUrl string `json:"subscriptionUrl"`
+	// Whether to eagerly download content from publisher and store it locally
+	NeedLocalCopy bool `json:"needLocalCopy,omitempty"`
+	// Password to use to authenticate with the publisher
+	Password string `json:"password,omitempty"`
+}

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -2,7 +2,7 @@ package types
 
 // RegionStoragePolicy defines a Region storage policy
 type RegionStoragePolicy struct {
-	ID string `json:"id,omitempty"`
+	Id string `json:"id,omitempty"`
 	// Name for the policy. It must follow RFC 1123 Label Names to conform with Kubernetes standards
 	Name string `json:"name"`
 	// The Region that this policy belongs to


### PR DESCRIPTION
Adds Read methods for Region Storage Policies and CRUD methods for Content Libraries.

Some changes are copied from https://github.com/vmware/go-vcloud-director/pull/710 (not pulled), so it should not give conflicts after merged