### PR TITLE
TM IP Spaces

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -5,7 +5,8 @@
   [GH-714]
 * vCenter management types `VCenter` and `types.VSphereVirtualCenter` adds Create, Update and Delete
  methods: `VCDClient.CreateVcenter`, `VCDClient.GetAllVCenters`, `VCDClient.GetVCenterByName`,
- `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.Refresh` [GH-714]
+ `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.RefreshVcenter`,
+ `VCenter.Refresh` [GH-714, GH-1360]
 * Add NSX-T Manager management types `NsxtManagerOpenApi`, `types.NsxtManagerOpenApi` and methods
   `VCDClient.CreateNsxtManagerOpenApi`, `VCDClient.GetAllNsxtManagersOpenApi`,
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,

--- a/.changes/v3.0.0/717-features.md
+++ b/.changes/v3.0.0/717-features.md
@@ -1,4 +1,4 @@
 * Added `ContentLibraryItem` and `types.ContentLibraryItem` structures to manage Content Library Items
   with methods `ContentLibrary.CreateContentLibraryItem`, `ContentLibrary.GetAllContentLibraryItems`,
   `ContentLibrary.GetContentLibraryItemByName`, `ContentLibrary.GetContentLibraryItemById`, `ContentLibraryItem.Update`,
-  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717]
+  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717, GH-724]

--- a/.changes/v3.0.0/718-features.md
+++ b/.changes/v3.0.0/718-features.md
@@ -4,7 +4,7 @@
   [GH-718]
 * Added `VCenter.RefreshStorageProfiles` to refresh storage profiles available in vCenter server
   [GH-718]
-* Added `Region` and `types.Region` to structure for OpenAPI management of Regions with methods
+* Added `Region` and `types.Region` structures for OpenAPI management of Regions with methods
   `VCDClient.CreateRegion`, `VCDClient.GetAllRegions`, `VCDClient.GetRegionByName`,
   `VCDClient.GetRegionById`, `Region.Update`, `Region.Delete` [GH-718]
 * Added `Supervisor` and `types.Supervisor` structure for reading available Supervisors

--- a/.changes/v3.0.0/724-features.md
+++ b/.changes/v3.0.0/724-features.md
@@ -1,0 +1,4 @@
+* Added `TmIpSpace` and `types.TmIpSpace` structures for OpenAPI management of TM IP Spaces with
+  methods `VCDClient.CreateTmIpSpace`, `VCDClient.GetAllTmIpSpaces`, `VCDClient.GetTmIpSpaceByName`,
+  `VCDClient.GetTmIpSpaceById`, `VCDClient.GetTmIpSpaceByNameAndRegionId`, `TmIpSpace.Update`,
+  `TmIpSpace.Delete` [GH-724]

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -163,6 +163,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVcf + types.OpenApiEndpointRegions:               "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointSupervisors:           "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointSupervisorZones:       "40.0",
+	types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces:            "40.0",
 }
 
 // endpointElevatedApiVersions endpoint elevated API versions

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -56,7 +56,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	time.Sleep(1 * time.Minute) // TODO: TM: Reevaluate need for sleep
 	// Refresh connected vCenter to be sure that all artifacts are loaded
 	printVerbose("# Refreshing vCenter %s\n", vc.VSphereVCenter.Url)
-	err = vc.Refresh()
+	err = vc.RefreshVcenter()
 	check.Assert(err, IsNil)
 
 	printVerbose("# Refreshing Storage Profiles in vCenter %s\n", vc.VSphereVCenter.Url)

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -7,9 +7,11 @@
 package govcd
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
-	"net/url"
 )
 
 // getOrCreateVCenter will check configuration file and create vCenter if
@@ -29,7 +31,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 		check.Skip("vCenter is not configured and configuration is not allowed in config file")
 		return nil, nil
 	}
-
+	printVerbose("# Will create vCenter %s\n", vcd.config.Tm.VcenterUrl)
 	vcCfg := &types.VSphereVirtualCenter{
 		Name:      check.TestName() + "-vc",
 		Username:  vcd.config.Tm.VcenterUsername,
@@ -43,6 +45,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	trustedCert, err := vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
 	if trustedCert != nil {
+		printVerbose("# Certificate for vCenter is trusted %s\n", trustedCert.TrustedCertificate.ID)
 		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 
@@ -51,6 +54,8 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	check.Assert(vc, NotNil)
 	PrependToCleanupList(vcCfg.Name, "OpenApiEntityVcenter", check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointVirtualCenters+vc.VSphereVCenter.VcId)
 
+	printVerbose("# Sleeping after vCenter creation\n")
+	time.Sleep(1 * time.Minute) // TODO: TM: Reevaluate need for sleep
 	// Refresh connected vCenter to be sure that all artifacts are loaded
 	printVerbose("# Refreshing vCenter %s\n", vc.VSphereVCenter.Url)
 	err = vc.Refresh()
@@ -60,12 +65,15 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	err = vc.RefreshStorageProfiles()
 	check.Assert(err, IsNil)
 
+	printVerbose("# Sleeping after vCenter refreshes\n")
+	time.Sleep(1 * time.Minute) // TODO: TM: Reevaluate need for sleep
 	vCenterCreated := true
 
 	return vc, func() {
 		if !vCenterCreated {
 			return
 		}
+		printVerbose("# Disabling and deleting vCenter %s\n", vcd.config.Tm.VcenterUrl)
 		err = vc.Disable()
 		check.Assert(err, IsNil)
 		err = vc.Delete()
@@ -91,6 +99,7 @@ func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()
 		return nil, nil
 	}
 
+	printVerbose("# Will create NSX-T Manager %s\n", vcd.config.Tm.NsxtManagerUrl)
 	nsxtCfg := &types.NsxtManagerOpenApi{
 		Name:     check.TestName(),
 		Username: vcd.config.Tm.NsxtManagerUsername,
@@ -103,6 +112,7 @@ func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()
 	trustedCert, err := vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
 	if trustedCert != nil {
+		printVerbose("# Certificate for NSX-T Manager is trusted %s\n", trustedCert.TrustedCertificate.ID)
 		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 	nsxtManager, err = vcd.client.CreateNsxtManagerOpenApi(nsxtCfg)
@@ -115,6 +125,7 @@ func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()
 		if !nsxtManagerCreated {
 			return
 		}
+		printVerbose("# Deleting NSX-T Manager %s\n", nsxtManager.NsxtManagerOpenApi.Name)
 		err = nsxtManager.Delete()
 		check.Assert(err, IsNil)
 	}
@@ -160,12 +171,32 @@ func getOrCreateRegion(vcd *TestVCD, nsxtManager *NsxtManagerOpenApi, supervisor
 	check.Assert(region, NotNil)
 	regionCreated := true
 	AddToCleanupListOpenApi(region.Region.ID, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointRegions+region.Region.ID)
+	check.Assert(region.Region.Status, Equals, "READY") // Region must be READY to be operational
 
 	return region, func() {
 		if !regionCreated {
 			return
 		}
+		printVerbose("# Deleting Region %s\n", region.Region.Name)
 		err = region.Delete()
+		check.Assert(err, IsNil)
+	}
+}
+
+func createOrg(vcd *TestVCD, check *C, canManageOrgs bool) (*TmOrg, func()) {
+	cfg := &types.TmOrg{
+		Name:          check.TestName(),
+		DisplayName:   check.TestName(),
+		CanManageOrgs: canManageOrgs,
+	}
+	tmOrg, err := vcd.client.CreateTmOrg(cfg)
+	check.Assert(err, IsNil)
+	check.Assert(tmOrg, NotNil)
+
+	PrependToCleanupListOpenApi(tmOrg.TmOrg.ID, check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgs+tmOrg.TmOrg.ID)
+
+	return tmOrg, func() {
+		err = tmOrg.Delete()
 		check.Assert(err, IsNil)
 	}
 }

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -182,21 +182,3 @@ func getOrCreateRegion(vcd *TestVCD, nsxtManager *NsxtManagerOpenApi, supervisor
 		check.Assert(err, IsNil)
 	}
 }
-
-func createOrg(vcd *TestVCD, check *C, canManageOrgs bool) (*TmOrg, func()) {
-	cfg := &types.TmOrg{
-		Name:          check.TestName(),
-		DisplayName:   check.TestName(),
-		CanManageOrgs: canManageOrgs,
-	}
-	tmOrg, err := vcd.client.CreateTmOrg(cfg)
-	check.Assert(err, IsNil)
-	check.Assert(tmOrg, NotNil)
-
-	PrependToCleanupListOpenApi(tmOrg.TmOrg.ID, check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgs+tmOrg.TmOrg.ID)
-
-	return tmOrg, func() {
-		err = tmOrg.Delete()
-		check.Assert(err, IsNil)
-	}
-}

--- a/govcd/tm_content_library_item.go
+++ b/govcd/tm_content_library_item.go
@@ -235,7 +235,7 @@ func uploadContentLibraryItemFile(name string, cli *ContentLibraryItem, filesToU
 	}()
 
 	ud := uploadDetails{
-		uploadLink:               strings.ReplaceAll(fileToUpload.TransferUrl, "/transfer", "/tm/transfer"), // TODO: TM: Workaround, the link is missing /tm in path, so it gives 404 as-is
+		uploadLink:               fileToUpload.TransferUrl,
 		uploadedBytes:            0,
 		fileSizeToUpload:         fileToUpload.ExpectedSizeBytes,
 		uploadPieceSize:          args.UploadPieceSize,

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -1,0 +1,116 @@
+package govcd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+)
+
+const labelTmIpSpace = "TM IP Space"
+
+type TmIpSpace struct {
+	TmIpSpace *types.TmIpSpace
+	vcdClient *VCDClient
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (g TmIpSpace) wrap(inner *types.TmIpSpace) *TmIpSpace {
+	g.TmIpSpace = inner
+	return &g
+}
+
+func (vcdClient *VCDClient) CreateTmIpSpace(config *types.TmIpSpace) (*TmIpSpace, error) {
+	c := crudConfig{
+		entityLabel: labelTmIpSpace,
+		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
+	}
+	outerType := TmIpSpace{vcdClient: vcdClient}
+	return createOuterEntity(&vcdClient.Client, outerType, c, config)
+}
+
+func (vcdClient *VCDClient) GetAllTmIpSpaces(queryParameters url.Values) ([]*TmIpSpace, error) {
+	c := crudConfig{
+		entityLabel:     labelTmIpSpace,
+		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
+		queryParameters: queryParameters,
+	}
+
+	outerType := TmIpSpace{vcdClient: vcdClient}
+	return getAllOuterEntities[TmIpSpace, types.TmIpSpace](&vcdClient.Client, outerType, c)
+}
+
+func (vcdClient *VCDClient) GetTmIpSpaceByName(name string) (*TmIpSpace, error) {
+	if name == "" {
+		return nil, fmt.Errorf("%s lookup requires name", labelTmIpSpace)
+	}
+
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
+
+	filteredEntities, err := vcdClient.GetAllTmIpSpaces(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	singleEntity, err := oneOrError("name", name, filteredEntities)
+	if err != nil {
+		return nil, err
+	}
+
+	return vcdClient.GetTmIpSpaceById(singleEntity.TmIpSpace.ID)
+}
+
+func (vcdClient *VCDClient) GetTmIpSpaceById(id string) (*TmIpSpace, error) {
+	c := crudConfig{
+		entityLabel:    labelTmIpSpace,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
+		endpointParams: []string{id},
+	}
+
+	outerType := TmIpSpace{vcdClient: vcdClient}
+	return getOuterEntity[TmIpSpace, types.TmIpSpace](&vcdClient.Client, outerType, c)
+}
+
+func (vcdClient *VCDClient) GetTmIpSpaceByNameAndOrgId(name, orgId string) (*TmIpSpace, error) {
+	if name == "" || orgId == "" {
+		return nil, fmt.Errorf("%s lookup requires name and Org ID", labelTmIpSpace)
+	}
+
+	queryParams := url.Values{}
+	queryParams.Add("filter", "name=="+name)
+	queryParams = queryParameterFilterAnd("orgRef.id=="+orgId, queryParams)
+
+	filteredEntities, err := vcdClient.GetAllTmIpSpaces(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	singleEntity, err := oneOrError("name", name, filteredEntities)
+	if err != nil {
+		return nil, err
+	}
+
+	return vcdClient.GetTmIpSpaceById(singleEntity.TmIpSpace.ID)
+}
+
+func (o *TmIpSpace) Update(TmIpSpaceConfig *types.IpSpace) (*IpSpace, error) {
+	c := crudConfig{
+		entityLabel:    labelTmIpSpace,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
+		endpointParams: []string{o.TmIpSpace.ID},
+	}
+	outerType := IpSpace{vcdClient: o.vcdClient}
+	return updateOuterEntity(&o.vcdClient.Client, outerType, c, TmIpSpaceConfig)
+}
+
+func (o *TmIpSpace) Delete() error {
+	c := crudConfig{
+		entityLabel:    labelTmIpSpace,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
+		endpointParams: []string{o.TmIpSpace.ID},
+	}
+	return deleteEntityById(&o.vcdClient.Client, c)
+}

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -9,6 +9,8 @@ import (
 
 const labelTmIpSpace = "TM IP Space"
 
+// TmIpSpace provides configuration of mainly the external (or Inbound) IP Prefixes that specifies
+// the accessible external networks from the data center
 type TmIpSpace struct {
 	TmIpSpace *types.TmIpSpace
 	vcdClient *VCDClient
@@ -22,6 +24,7 @@ func (g TmIpSpace) wrap(inner *types.TmIpSpace) *TmIpSpace {
 	return &g
 }
 
+// CreateTmIpSpace with a given configuration
 func (vcdClient *VCDClient) CreateTmIpSpace(config *types.TmIpSpace) (*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel: labelTmIpSpace,
@@ -31,6 +34,7 @@ func (vcdClient *VCDClient) CreateTmIpSpace(config *types.TmIpSpace) (*TmIpSpace
 	return createOuterEntity(&vcdClient.Client, outerType, c, config)
 }
 
+// GetAllTmIpSpaces fetches all TM IP Spaces with an optional query filter
 func (vcdClient *VCDClient) GetAllTmIpSpaces(queryParameters url.Values) ([]*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel:     labelTmIpSpace,
@@ -42,6 +46,7 @@ func (vcdClient *VCDClient) GetAllTmIpSpaces(queryParameters url.Values) ([]*TmI
 	return getAllOuterEntities(&vcdClient.Client, outerType, c)
 }
 
+// GetTmIpSpaceByName retrieves TM IP Spaces with a given name
 func (vcdClient *VCDClient) GetTmIpSpaceByName(name string) (*TmIpSpace, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%s lookup requires name", labelTmIpSpace)
@@ -63,6 +68,7 @@ func (vcdClient *VCDClient) GetTmIpSpaceByName(name string) (*TmIpSpace, error) 
 	return vcdClient.GetTmIpSpaceById(singleEntity.TmIpSpace.ID)
 }
 
+// GetTmIpSpaceById retrieves an exact IP Space with a given ID
 func (vcdClient *VCDClient) GetTmIpSpaceById(id string) (*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel:    labelTmIpSpace,
@@ -74,6 +80,7 @@ func (vcdClient *VCDClient) GetTmIpSpaceById(id string) (*TmIpSpace, error) {
 	return getOuterEntity(&vcdClient.Client, outerType, c)
 }
 
+// GetTmIpSpaceByNameAndRegionId retrieves TM IP Spaces with a given name in a provided Region
 func (vcdClient *VCDClient) GetTmIpSpaceByNameAndRegionId(name, regionId string) (*TmIpSpace, error) {
 	if name == "" || regionId == "" {
 		return nil, fmt.Errorf("%s lookup requires name and Region ID", labelTmIpSpace)
@@ -96,6 +103,7 @@ func (vcdClient *VCDClient) GetTmIpSpaceByNameAndRegionId(name, regionId string)
 	return vcdClient.GetTmIpSpaceById(singleEntity.TmIpSpace.ID)
 }
 
+// Update TM IP Space
 func (o *TmIpSpace) Update(TmIpSpaceConfig *types.TmIpSpace) (*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel:    labelTmIpSpace,
@@ -106,6 +114,7 @@ func (o *TmIpSpace) Update(TmIpSpaceConfig *types.TmIpSpace) (*TmIpSpace, error)
 	return updateOuterEntity(&o.vcdClient.Client, outerType, c, TmIpSpaceConfig)
 }
 
+// Delete TM IP Space
 func (o *TmIpSpace) Delete() error {
 	c := crudConfig{
 		entityLabel:    labelTmIpSpace,

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -24,7 +24,7 @@ func (g TmIpSpace) wrap(inner *types.TmIpSpace) *TmIpSpace {
 	return &g
 }
 
-// CreateTmIpSpace with a given configuration
+// CreateTmIpSpace creates a TM IP Space with a given configuration
 func (vcdClient *VCDClient) CreateTmIpSpace(config *types.TmIpSpace) (*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel: labelTmIpSpace,

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -9,7 +9,7 @@ import (
 
 const labelTmIpSpace = "TM IP Space"
 
-// TmIpSpace provides configuration of mainly the external (or Inbound) IP Prefixes that specifies
+// TmIpSpace provides configuration of mainly the external IP Prefixes that specifies
 // the accessible external networks from the data center
 type TmIpSpace struct {
 	TmIpSpace *types.TmIpSpace

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -39,7 +39,7 @@ func (vcdClient *VCDClient) GetAllTmIpSpaces(queryParameters url.Values) ([]*TmI
 	}
 
 	outerType := TmIpSpace{vcdClient: vcdClient}
-	return getAllOuterEntities[TmIpSpace, types.TmIpSpace](&vcdClient.Client, outerType, c)
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
 }
 
 func (vcdClient *VCDClient) GetTmIpSpaceByName(name string) (*TmIpSpace, error) {
@@ -71,17 +71,17 @@ func (vcdClient *VCDClient) GetTmIpSpaceById(id string) (*TmIpSpace, error) {
 	}
 
 	outerType := TmIpSpace{vcdClient: vcdClient}
-	return getOuterEntity[TmIpSpace, types.TmIpSpace](&vcdClient.Client, outerType, c)
+	return getOuterEntity(&vcdClient.Client, outerType, c)
 }
 
-func (vcdClient *VCDClient) GetTmIpSpaceByNameAndOrgId(name, orgId string) (*TmIpSpace, error) {
-	if name == "" || orgId == "" {
-		return nil, fmt.Errorf("%s lookup requires name and Org ID", labelTmIpSpace)
+func (vcdClient *VCDClient) GetTmIpSpaceByNameAndRegionId(name, regionId string) (*TmIpSpace, error) {
+	if name == "" || regionId == "" {
+		return nil, fmt.Errorf("%s lookup requires name and Region ID", labelTmIpSpace)
 	}
 
 	queryParams := url.Values{}
 	queryParams.Add("filter", "name=="+name)
-	queryParams = queryParameterFilterAnd("orgRef.id=="+orgId, queryParams)
+	queryParams = queryParameterFilterAnd("regionRef.id=="+regionId, queryParams)
 
 	filteredEntities, err := vcdClient.GetAllTmIpSpaces(queryParams)
 	if err != nil {

--- a/govcd/tm_ip_space.go
+++ b/govcd/tm_ip_space.go
@@ -96,13 +96,13 @@ func (vcdClient *VCDClient) GetTmIpSpaceByNameAndOrgId(name, orgId string) (*TmI
 	return vcdClient.GetTmIpSpaceById(singleEntity.TmIpSpace.ID)
 }
 
-func (o *TmIpSpace) Update(TmIpSpaceConfig *types.IpSpace) (*IpSpace, error) {
+func (o *TmIpSpace) Update(TmIpSpaceConfig *types.TmIpSpace) (*TmIpSpace, error) {
 	c := crudConfig{
 		entityLabel:    labelTmIpSpace,
 		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointTmIpSpaces,
 		endpointParams: []string{o.TmIpSpace.ID},
 	}
-	outerType := IpSpace{vcdClient: o.vcdClient}
+	outerType := TmIpSpace{vcdClient: o.vcdClient}
 	return updateOuterEntity(&o.vcdClient.Client, outerType, c, TmIpSpaceConfig)
 }
 

--- a/govcd/tm_ip_space_test.go
+++ b/govcd/tm_ip_space_test.go
@@ -7,10 +7,82 @@
 package govcd
 
 import (
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
 )
 
-// Test_ContentLibraryProvider tests CRUD operations for a Content Library with the Provider user
 func (vcd *TestVCD) Test_TmIpSpace(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check)
 
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
+	check.Assert(err, IsNil)
+	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
+	defer regionCleanup()
+
+	ipSpaceType := &types.TmIpSpace{
+		Name:        check.TestName(),
+		RegionRef:   types.OpenApiReference{ID: region.Region.ID},
+		Description: check.TestName(),
+		DefaultQuota: types.TmIpSpaceDefaultQuota{
+			MaxCidrCount:  3,
+			MaxIPCount:    -1,
+			MaxSubnetSize: 24,
+		},
+		ExternalScopeCidr: "12.12.0.0/30",
+		InternalScopeCidrBlocks: []types.TmIpSpaceInternalScopeCidrBlocks{
+			{
+				Cidr: "10.0.0.0/24",
+			},
+		},
+	}
+
+	createdIpSpace, err := vcd.client.CreateTmIpSpace(ipSpaceType)
+	check.Assert(err, IsNil)
+	check.Assert(createdIpSpace, NotNil)
+	// Add to cleanup list
+	PrependToCleanupListOpenApi(createdIpSpace.TmIpSpace.ID, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointTmIpSpaces+createdIpSpace.TmIpSpace.ID)
+	defer func() {
+		err = createdIpSpace.Delete()
+		check.Assert(err, IsNil)
+	}()
+
+	// Get TM VDC By Name
+	byName, err := vcd.client.GetTmIpSpaceByName(ipSpaceType.Name)
+	check.Assert(err, IsNil)
+	check.Assert(byName.TmIpSpace, DeepEquals, createdIpSpace.TmIpSpace)
+
+	// Get TM VDC By Id
+	byId, err := vcd.client.GetTmIpSpaceById(createdIpSpace.TmIpSpace.ID)
+	check.Assert(err, IsNil)
+	check.Assert(byId.TmIpSpace, DeepEquals, createdIpSpace.TmIpSpace)
+
+	// Get By Name and Org ID
+	byNameAndOrgId, err := vcd.client.GetTmIpSpaceByNameAndRegionId(createdIpSpace.TmIpSpace.Name, region.Region.ID)
+	check.Assert(err, IsNil)
+	check.Assert(byNameAndOrgId.TmIpSpace, DeepEquals, createdIpSpace.TmIpSpace)
+
+	// Get By Name and Org ID in non existent Region
+	byNameAndInvalidOrgId, err := vcd.client.GetTmIpSpaceByNameAndRegionId(createdIpSpace.TmIpSpace.Name, "urn:vcloud:region:a93c9db9-0000-0000-0000-a8f7eeda85f9")
+	check.Assert(err, NotNil)
+	check.Assert(byNameAndInvalidOrgId, IsNil)
+
+	// Not Found tests
+	byNameInvalid, err := vcd.client.GetTmIpSpaceByName("fake-name")
+	check.Assert(ContainsNotFound(err), Equals, true)
+	check.Assert(byNameInvalid, IsNil)
+
+	byIdInvalid, err := vcd.client.GetTmIpSpaceById("urn:vcloud:ipSpace:5344b964-0000-0000-0000-d554913db643")
+	check.Assert(ContainsNotFound(err), Equals, true)
+	check.Assert(byIdInvalid, IsNil)
+
+	// Update
+	createdIpSpace.TmIpSpace.Name = check.TestName() + "-update"
+	updatedVdc, err := createdIpSpace.Update(createdIpSpace.TmIpSpace)
+	check.Assert(err, IsNil)
+	check.Assert(updatedVdc.TmIpSpace, DeepEquals, createdIpSpace.TmIpSpace)
 }

--- a/govcd/tm_ip_space_test.go
+++ b/govcd/tm_ip_space_test.go
@@ -1,0 +1,16 @@
+//go:build tm || functional || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+// Test_ContentLibraryProvider tests CRUD operations for a Content Library with the Provider user
+func (vcd *TestVCD) Test_TmIpSpace(check *C) {
+
+}

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -143,10 +143,26 @@ func (v VCenter) GetVimServerUrl() (string, error) {
 	return url.JoinPath(v.client.Client.rootVcdHref(), "api", "admin", "extension", "vimServer", extractUuid(v.VSphereVCenter.VcId))
 }
 
-// Refresh triggers a refresh operation on vCenter that syncs up vCenter components such as
+// Refresh vCenter structure
+func (v *VCenter) Refresh() error {
+	// Retrieval endpoints by Name and by ID return differently formated url (the by Id one returns
+	// URL with port http://host:443, while the one by name - doesn't). Using the same getByName to
+	// match format everywhere
+
+	// newVcenter, err := v.client.GetVCenterById(v.VSphereVCenter.VcId)
+	newVcenter, err := v.client.GetVCenterByName(v.VSphereVCenter.Name) // TODO: TM: use above retrieval by ID
+	if err != nil {
+		return fmt.Errorf("error refreshing vCenter: %s", err)
+	}
+
+	v.VSphereVCenter = newVcenter.VSphereVCenter
+	return nil
+}
+
+// RefreshVcenter triggers a refresh operation on vCenter that syncs up vCenter components such as
 // supervisors
 // It uses legacy endpoint as there is no OpenAPI endpoint for this operation
-func (v *VCenter) Refresh() error {
+func (v *VCenter) RefreshVcenter() error {
 	refreshUrl, err := url.JoinPath(v.client.Client.rootVcdHref(), "api", "admin", "extension", "vimServer", extractUuid(v.VSphereVCenter.VcId), "action", "refresh")
 	if err != nil {
 		return fmt.Errorf("error building refresh path: %s", err)

--- a/govcd/vsphere_vcenter_tm_test.go
+++ b/govcd/vsphere_vcenter_tm_test.go
@@ -38,10 +38,13 @@ func (vcd *TestVCD) Test_VCenter(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(v, NotNil)
 
+	err = v.Refresh()
+	check.Assert(err, IsNil)
+
 	// Add to cleanup list
 	PrependToCleanupListOpenApi(v.VSphereVCenter.VcId, check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointVirtualCenters+v.VSphereVCenter.VcId)
 
-	err = v.Refresh()
+	err = v.RefreshVcenter()
 	check.Assert(err, IsNil)
 
 	// Get By Name

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -526,6 +526,7 @@ const (
 	OpenApiEndpointRegions               = "regions/"
 	OpenApiEndpointSupervisors           = "supervisors/"
 	OpenApiEndpointSupervisorZones       = "supervisorZones/"
+	OpenApiEndpointTmIpSpaces            = "ipSpaces/"
 )
 
 // Header keys to run operations in tenant context

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -179,7 +179,7 @@ type SupervisorZone struct {
 	Region *OpenApiReference `json:"region"`
 }
 
-// TmIpSpace provides configuration of mainly the external (or Inbound) IP Prefixes that specifies
+// TmIpSpace provides configuration of mainly the external IP Prefixes that specifies
 // the accessible external networks from the data center
 type TmIpSpace struct {
 	ID string `json:"id,omitempty"`
@@ -190,10 +190,8 @@ type TmIpSpace struct {
 	// RegionRef is the region that this IP Space belongs in. Only Provider Gateways in the same Region can be
 	// associated with this IP Space. This field cannot be updated
 	RegionRef OpenApiReference `json:"regionRef"`
-
 	// Default IP quota that applies to all the organizations the Ip Space is assigned to
 	DefaultQuota TmIpSpaceDefaultQuota `json:"defaultQuota,omitempty"`
-
 	// ExternalScopeCidr defines the total span of IP addresses to which the IP space has access.
 	// This typically defines the span of IP addresses outside the bounds of a Data Center. For the
 	// internet, this may be 0.0.0.0/0. For a WAN, this could be 10.0.0.0/8.
@@ -203,7 +201,6 @@ type TmIpSpace struct {
 	// the IP Block's name can be updated. If an existing CIDR value is removed from the list, the
 	// the IP Block is removed from the IP Space.
 	InternalScopeCidrBlocks []TmIpSpaceInternalScopeCidrBlocks `json:"internalScopeCidrBlocks,omitempty"`
-
 	// Represents current status of the networking entity. Possible values are:
 	// * PENDING - Desired entity configuration has been received by system and is pending realization.
 	// * CONFIGURING - The system is in process of realizing the entity.

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -179,7 +179,7 @@ type SupervisorZone struct {
 	Region *OpenApiReference `json:"region"`
 }
 
-// TmIpSpace provider configuration of mainly the external (or Inbound) IP Prefixes that specifies
+// TmIpSpace provides configuration of mainly the external (or Inbound) IP Prefixes that specifies
 // the accessible external networks from the data center
 type TmIpSpace struct {
 	ID string `json:"id,omitempty"`

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -178,3 +178,7 @@ type SupervisorZone struct {
 	// Region contains a reference to parent region
 	Region *OpenApiReference `json:"region"`
 }
+
+type TmIpSpace struct {
+	ID string
+}

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -179,6 +179,66 @@ type SupervisorZone struct {
 	Region *OpenApiReference `json:"region"`
 }
 
+// TmIpSpace provider configuration of mainly the external (or Inbound) IP Prefixes that specifies
+// the accessible external networks from the data center
 type TmIpSpace struct {
-	ID string
+	ID string `json:"id,omitempty"`
+	// Name of the IP Space
+	Name string `json:"name"`
+	// Description of the IP Space
+	Description string `json:"description,omitempty"`
+	// RegionRef is the region that this IP Space belongs in. Only Provider Gateways in the same Region can be
+	// associated with this IP Space. This field cannot be updated
+	RegionRef OpenApiReference `json:"regionRef"`
+
+	// Default IP quota that applies to all the organizations the Ip Space is assigned to
+	DefaultQuota TmIpSpaceDefaultQuota `json:"defaultQuota,omitempty"`
+
+	// ExternalScopeCidr defines the total span of IP addresses to which the IP space has access.
+	// This typically defines the span of IP addresses outside the bounds of a Data Center. For the
+	// internet, this may be 0.0.0.0/0. For a WAN, this could be 10.0.0.0/8.
+	ExternalScopeCidr string `json:"externalScopeCidr,omitempty"`
+	// InternalScopeCidrBlocks defines the span of IP addresses used within a Data Center. For new
+	// CIDR value not in the existing list, a new IP Block will be created. For existing CIDR value,
+	// the IP Block's name can be updated. If an existing CIDR value is removed from the list, the
+	// the IP Block is removed from the IP Space.
+	InternalScopeCidrBlocks []TmIpSpaceInternalScopeCidrBlocks `json:"internalScopeCidrBlocks,omitempty"`
+
+	// Represents current status of the networking entity. Possible values are:
+	// * PENDING - Desired entity configuration has been received by system and is pending realization.
+	// * CONFIGURING - The system is in process of realizing the entity.
+	// * REALIZED - The entity is successfully realized in the system.
+	// * REALIZATION_FAILED - There are some issues and the system is not able to realize the entity.
+	// * UNKNOWN - Current state of entity is unknown.
+	Status string `json:"status,omitempty"`
+}
+
+// IP Space quota defines the maximum number of IPv4 IPs and CIDRs that can be allocated and used by
+// the IP Space across all its Internal Scopes
+type TmIpSpaceDefaultQuota struct {
+	// The maximum number of CIDRs with size maxSubnetSize or less, that can be allocated from all
+	// the Internal Scopes of the IP Space. A '-1' value means no cap on the number of the CIDRs
+	// used
+	MaxCidrCount int `json:"maxCidrCount,omitempty"`
+	// The maximum number of single floating IP addresses that can be allocated and used from all
+	// the Internal Scopes of the IP Space. A '-1' value means no cap on the number of floating IP
+	// Addresses
+	MaxIPCount int `json:"maxIpCount,omitempty"`
+	// The maximum size of the subnets, represented as a prefix length. The CIDRs that are allocated
+	// from the Internal Scopes of the IP Space must be smaller or equal to the specified size. For
+	// example, for a maxSubnetSize of 24, CIDRs with prefix length of 24, 28 or 30 can be
+	// allocated
+	MaxSubnetSize int `json:"maxSubnetSize,omitempty"`
+}
+
+// An IP Block represents a named CIDR that is backed by a network provider
+type TmIpSpaceInternalScopeCidrBlocks struct {
+	// Unique backing ID of the IP Block. This is not a Tenant Manager URN. This field is read-only and is ignored on create/update
+	ID string `json:"id,omitempty"`
+	// The name of the IP Block. If not set, a random name will be generated that will be prefixed
+	// with the name of the IP Space. This property is updatable if there's an existing IP Block
+	// with the CIDR value
+	Name string `json:"name,omitempty"`
+	// The CIDR that represents this IP Block. This property is not updatable
+	Cidr string `json:"cidr,omitempty"`
 }


### PR DESCRIPTION
This PR adds TM IP Space management types `TmIpSpace` and `types.TmIpSpace` and methods `VCDClient.CreateTmIpSpace`, `VCDClient.GetAllTmIpSpaces`, `VCDClient.GetTmIpSpaceByName`,
  `VCDClient.GetTmIpSpaceById`, `VCDClient.GetTmIpSpaceByNameAndRegionId`, `TmIpSpace.Update`,
  `TmIpSpace.Delete`

Additionally, it fixes content library item upload in https://github.com/vmware/go-vcloud-director/pull/724/commits/8b98a628a20006de99e88a00c3a91b7559e3a96b