### PR TITLE
Add Storage Class support

### DIFF
--- a/.changes/v3.0.0/726-features.md
+++ b/.changes/v3.0.0/726-features.md
@@ -1,0 +1,3 @@
+* Added types `StorageClass` and `types.StorageClass` for reading Tenant Manager Storage Classes with methods
+  `VCDClient.GetAllStorageClasses`, `Region.GetStorageClassByName`, `VCDClient.GetStorageClassByName`,
+  `VCDClient.GetStorageClassById` [GH-726]

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -316,7 +316,7 @@ func (client *Client) OpenApiPostItemAndGetHeaders(apiVersion string, urlRef *ur
 		// Task Owner ID is the ID of created object. ID must be used (although HREF exists in task) because HREF points to
 		// old XML API and here we need to pull data from OpenAPI.
 
-		if task.Task.Owner == nil {
+		if task.Task.Owner == nil || task.Task.Owner.ID == "" {
 			return nil, fmt.Errorf("could not find the created item UUID from the task '%s' so it can't be retrieved", task.Task.ID)
 		}
 		newObjectUrl := urlParseRequestURI(urlRefCopy.String() + task.Task.Owner.ID)

--- a/govcd/openapi.go
+++ b/govcd/openapi.go
@@ -316,7 +316,11 @@ func (client *Client) OpenApiPostItemAndGetHeaders(apiVersion string, urlRef *ur
 		// Task Owner ID is the ID of created object. ID must be used (although HREF exists in task) because HREF points to
 		// old XML API and here we need to pull data from OpenAPI.
 
+		if task.Task.Owner == nil {
+			return nil, fmt.Errorf("could not find the created item UUID from the task '%s' so it can't be retrieved", task.Task.ID)
+		}
 		newObjectUrl := urlParseRequestURI(urlRefCopy.String() + task.Task.Owner.ID)
+
 		err = client.OpenApiGetItem(apiVersion, newObjectUrl, nil, outType, additionalHeader)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving item after creation: %s", err)

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -158,6 +158,7 @@ var endpointMinApiVersions = map[string]string{
 
 	// VCF
 	types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies:   "40.0",
+	types.OpenApiPathVcf + types.OpenApiEndpointStorageClasses:          "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries:        "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraryItems:     "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointContentLibraryItemFiles: "40.0",

--- a/govcd/tm_region_storage_policy.go
+++ b/govcd/tm_region_storage_policy.go
@@ -16,7 +16,7 @@ const labelRegionStoragePolicy = "Region Storage Policy"
 // RegionStoragePolicy defines the Region Storage Policy data structure
 type RegionStoragePolicy struct {
 	RegionStoragePolicy *types.RegionStoragePolicy
-	client              *Client
+	vcdClient           *VCDClient
 }
 
 // wrap is a hidden helper that facilitates the usage of a generic CRUD function
@@ -27,66 +27,62 @@ func (g RegionStoragePolicy) wrap(inner *types.RegionStoragePolicy) *RegionStora
 	return &g
 }
 
-// GetAllStoragePolicies retrieves all Region Storage Policies with the given query parameters, which allow setting filters
+// GetAllRegionStoragePolicies retrieves all Region Storage Policies with the given query parameters, which allow setting filters
 // and other constraints
-func (r *Region) GetAllStoragePolicies(queryParameters url.Values) ([]*RegionStoragePolicy, error) {
-	return getAllStoragePolicies(r, queryParameters)
-}
-func getAllStoragePolicies(r *Region, queryParameters url.Values) ([]*RegionStoragePolicy, error) {
+func (vcdClient *VCDClient) GetAllRegionStoragePolicies(queryParameters url.Values) ([]*RegionStoragePolicy, error) {
 	c := crudConfig{
 		entityLabel:     labelRegionStoragePolicy,
 		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies,
 		queryParameters: queryParameters,
 	}
 
-	outerType := RegionStoragePolicy{client: &r.vcdClient.Client}
-	return getAllOuterEntities(&r.vcdClient.Client, outerType, c)
+	outerType := RegionStoragePolicy{vcdClient: vcdClient}
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
 }
 
-// GetStoragePolicyByName retrieves a Region Storage Policy by name
+// GetStoragePolicyByName retrieves a Region Storage Policy by name, that belongs to the given Region
 func (r *Region) GetStoragePolicyByName(name string) (*RegionStoragePolicy, error) {
+	return getStoragePolicyByName(r.vcdClient, name, r.Region.ID)
+}
+
+// GetRegionStoragePolicyByName retrieves a Region Storage Policy by name
+func (vcdClient *VCDClient) GetRegionStoragePolicyByName(name string) (*RegionStoragePolicy, error) {
+	return getStoragePolicyByName(vcdClient, name, "")
+}
+
+func getStoragePolicyByName(vcdClient *VCDClient, name, regionId string) (*RegionStoragePolicy, error) {
 	if name == "" {
 		return nil, fmt.Errorf("%s lookup requires name", labelRegionStoragePolicy)
 	}
+	filter := fmt.Sprintf("(name==%s)", name)
+	if regionId != "" {
+		filter = fmt.Sprintf("(name==%s;region.id==%s)", name, regionId)
+	}
 
 	queryParams := url.Values{}
-	queryParams.Add("filter", fmt.Sprintf("(name==%s;region.id==%s)", name, r.Region.ID))
+	queryParams.Add("filter", filter)
 
-	filteredEntities, err := getAllStoragePolicies(r, queryParams)
+	filteredEntities, err := vcdClient.GetAllRegionStoragePolicies(queryParams)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: TM: API returns same result twice for some reason
-	if len(filteredEntities) == 0 {
-		return nil, fmt.Errorf("TODO: TM: found 0 storage policies: %s", ErrorEntityNotFound)
+	singleEntity, err := oneOrError("name", name, filteredEntities)
+	if err != nil {
+		return nil, err
 	}
-	singleEntity := filteredEntities[0]
-	//singleEntity, err := oneOrError("name", name, filteredEntities)
-	//if err != nil {
-	//	return nil, err
-	//}
 
-	return getStoragePolicyById(&r.vcdClient.Client, singleEntity.RegionStoragePolicy.ID)
-}
-
-// GetStoragePolicyById retrieves a Region Storage Policy by ID
-func (r *Region) GetStoragePolicyById(id string) (*RegionStoragePolicy, error) {
-	return getStoragePolicyById(&r.vcdClient.Client, id)
+	return vcdClient.GetRegionStoragePolicyById(singleEntity.RegionStoragePolicy.ID)
 }
 
 // GetRegionStoragePolicyById retrieves a Region Storage Policy by ID
 func (vcdClient *VCDClient) GetRegionStoragePolicyById(id string) (*RegionStoragePolicy, error) {
-	return getStoragePolicyById(&vcdClient.Client, id)
-}
-
-func getStoragePolicyById(client *Client, id string) (*RegionStoragePolicy, error) {
 	c := crudConfig{
 		entityLabel:    labelRegionStoragePolicy,
 		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointRegionStoragePolicies,
 		endpointParams: []string{id},
 	}
 
-	outerType := RegionStoragePolicy{client: client}
-	return getOuterEntity(client, outerType, c)
+	outerType := RegionStoragePolicy{vcdClient: vcdClient}
+	return getOuterEntity(&vcdClient.Client, outerType, c)
 }

--- a/govcd/tm_region_storage_policy_test.go
+++ b/govcd/tm_region_storage_policy_test.go
@@ -24,28 +24,32 @@ func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 
-	allRegionStoragePolicies, err := region.GetAllStoragePolicies(nil)
+	allRegionStoragePolicies, err := vcd.client.GetAllRegionStoragePolicies(nil)
 	check.Assert(err, IsNil)
 
-	rspById, err := region.GetStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
+	rspById, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
 	check.Assert(err, IsNil)
 	check.Assert(*rspById.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
 
-	rspById2, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
+	rspByName, err := vcd.client.GetRegionStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
 	check.Assert(err, IsNil)
-	check.Assert(*rspById2.RegionStoragePolicy, DeepEquals, *rspById.RegionStoragePolicy)
+	check.Assert(*rspByName.RegionStoragePolicy, DeepEquals, *rspById.RegionStoragePolicy)
 
-	rspByName, err := region.GetStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
+	rspByName2, err := region.GetStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
 	check.Assert(err, IsNil)
-	check.Assert(*rspByName.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
+	check.Assert(*rspByName2.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
 
 	// Check ENF errors
-	_, err = region.GetStoragePolicyById("urn:vcloud:regionStoragePolicy:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	_, err = vcd.client.GetRegionStoragePolicyById("urn:vcloud:regionStoragePolicy:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	check.Assert(err, NotNil)
 	// TODO:TM: Right now throws a 500 NPE...
 	// check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = region.GetStoragePolicyByName("NotExists")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = vcd.client.GetStoragePolicyByName("NotExists")
 	check.Assert(err, NotNil)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }

--- a/govcd/tm_region_storage_policy_test.go
+++ b/govcd/tm_region_storage_policy_test.go
@@ -26,17 +26,21 @@ func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
 
 	allRegionStoragePolicies, err := vcd.client.GetAllRegionStoragePolicies(nil)
 	check.Assert(err, IsNil)
+	check.Assert(len(allRegionStoragePolicies), Not(Equals), 0)
 
 	rspById, err := vcd.client.GetRegionStoragePolicyById(allRegionStoragePolicies[0].RegionStoragePolicy.ID)
 	check.Assert(err, IsNil)
+	check.Assert(rspById, NotNil)
 	check.Assert(*rspById.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
 
 	rspByName, err := vcd.client.GetRegionStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
 	check.Assert(err, IsNil)
+	check.Assert(rspByName, NotNil)
 	check.Assert(*rspByName.RegionStoragePolicy, DeepEquals, *rspById.RegionStoragePolicy)
 
 	rspByName2, err := region.GetStoragePolicyByName(allRegionStoragePolicies[0].RegionStoragePolicy.Name)
 	check.Assert(err, IsNil)
+	check.Assert(rspByName2, NotNil)
 	check.Assert(*rspByName2.RegionStoragePolicy, DeepEquals, *allRegionStoragePolicies[0].RegionStoragePolicy)
 
 	// Check ENF errors
@@ -49,7 +53,7 @@ func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
 	check.Assert(err, NotNil)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
-	_, err = vcd.client.GetStoragePolicyByName("NotExists")
+	_, err = vcd.client.GetRegionStoragePolicyByName("NotExists")
 	check.Assert(err, NotNil)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }

--- a/govcd/tm_storage_class.go
+++ b/govcd/tm_storage_class.go
@@ -1,0 +1,88 @@
+package govcd
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+)
+
+const labelStorageClass = "Storage Class"
+
+// StorageClass defines the Storage Class data structure
+type StorageClass struct {
+	StorageClass *types.StorageClass
+	vcdClient    *VCDClient
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (g StorageClass) wrap(inner *types.StorageClass) *StorageClass {
+	g.StorageClass = inner
+	return &g
+}
+
+// GetAllStorageClasses retrieves all Storage Classes with the given query parameters, which allow setting filters
+// and other constraints
+func (vcdClient *VCDClient) GetAllStorageClasses(queryParameters url.Values) ([]*StorageClass, error) {
+	c := crudConfig{
+		entityLabel:     labelStorageClass,
+		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointStorageClasses,
+		queryParameters: queryParameters,
+	}
+
+	outerType := StorageClass{vcdClient: vcdClient}
+	return getAllOuterEntities(&vcdClient.Client, outerType, c)
+}
+
+// GetStorageClassByName retrieves a Storage Class by name, that belongs to the given Region
+func (r *Region) GetStorageClassByName(name string) (*StorageClass, error) {
+	return getStorageClassByName(r.vcdClient, name, r.Region.ID)
+}
+
+// GetStoragePolicyByName retrieves a Storage Class by name
+func (vcdClient *VCDClient) GetStoragePolicyByName(name string) (*StorageClass, error) {
+	return getStorageClassByName(vcdClient, name, "")
+}
+
+func getStorageClassByName(vcdClient *VCDClient, name, regionId string) (*StorageClass, error) {
+	if name == "" {
+		return nil, fmt.Errorf("%s lookup requires name", labelStorageClass)
+	}
+	filter := fmt.Sprintf("(name==%s)", name)
+	if regionId != "" {
+		filter = fmt.Sprintf("(name==%s;region.id==%s)", name, regionId)
+	}
+
+	queryParams := url.Values{}
+	queryParams.Add("filter", filter)
+
+	filteredEntities, err := vcdClient.GetAllStorageClasses(queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	singleEntity, err := oneOrError("name", name, filteredEntities)
+	if err != nil {
+		return nil, err
+	}
+
+	return vcdClient.GetStorageClassById(singleEntity.StorageClass.ID)
+}
+
+// GetStorageClassById retrieves a Storage Class by ID
+func (vcdClient *VCDClient) GetStorageClassById(id string) (*StorageClass, error) {
+	c := crudConfig{
+		entityLabel:    labelStorageClass,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointStorageClasses,
+		endpointParams: []string{id},
+	}
+
+	outerType := StorageClass{vcdClient: vcdClient}
+	return getOuterEntity(&vcdClient.Client, outerType, c)
+}

--- a/govcd/tm_storage_class.go
+++ b/govcd/tm_storage_class.go
@@ -45,8 +45,8 @@ func (r *Region) GetStorageClassByName(name string) (*StorageClass, error) {
 	return getStorageClassByName(r.vcdClient, name, r.Region.ID)
 }
 
-// GetStoragePolicyByName retrieves a Storage Class by name
-func (vcdClient *VCDClient) GetStoragePolicyByName(name string) (*StorageClass, error) {
+// GetStorageClassByName retrieves a Storage Class by name
+func (vcdClient *VCDClient) GetStorageClassByName(name string) (*StorageClass, error) {
 	return getStorageClassByName(vcdClient, name, "")
 }
 

--- a/govcd/tm_storage_class_test.go
+++ b/govcd/tm_storage_class_test.go
@@ -18,9 +18,10 @@ func (vcd *TestVCD) Test_StorageClass(check *C) {
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
-
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
+	defer regionCleanup()
 
 	allStorageClasses, err := vcd.client.GetAllStorageClasses(nil)
 	check.Assert(err, IsNil)
@@ -36,13 +37,9 @@ func (vcd *TestVCD) Test_StorageClass(check *C) {
 	check.Assert(rspByName, NotNil)
 	check.Assert(*rspByName.StorageClass, DeepEquals, *rspById.StorageClass)
 
-	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
-	defer regionCleanup()
-
 	rspByName2, err := region.GetStorageClassByName(vcd.config.Tm.RegionStoragePolicy)
 	check.Assert(err, IsNil)
 	check.Assert(rspByName2, NotNil)
-	check.Assert(rspByName2.StorageClass.Name, Equals, vcd.config.Tm.RegionStoragePolicy)
 	check.Assert(rspByName2.StorageClass.Name, Equals, vcd.config.Tm.RegionStoragePolicy)
 
 	// Check ENF errors

--- a/govcd/tm_storage_class_test.go
+++ b/govcd/tm_storage_class_test.go
@@ -1,0 +1,61 @@
+//go:build tm || functional || ALL
+
+/*
+ * Copyright 2024 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (vcd *TestVCD) Test_StorageClass(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check)
+
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
+	check.Assert(err, IsNil)
+
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+
+	allStorageClasses, err := vcd.client.GetAllStorageClasses(nil)
+	check.Assert(err, IsNil)
+	check.Assert(len(allStorageClasses), Not(Equals), 0)
+
+	rspById, err := vcd.client.GetStorageClassById(allStorageClasses[0].StorageClass.ID)
+	check.Assert(err, IsNil)
+	check.Assert(rspById, NotNil)
+	check.Assert(*rspById.StorageClass, DeepEquals, *allStorageClasses[0].StorageClass)
+
+	rspByName, err := vcd.client.GetStorageClassByName(allStorageClasses[0].StorageClass.Name)
+	check.Assert(err, IsNil)
+	check.Assert(rspByName, NotNil)
+	check.Assert(*rspByName.StorageClass, DeepEquals, *rspById.StorageClass)
+
+	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
+	defer regionCleanup()
+
+	rspByName2, err := region.GetStorageClassByName(vcd.config.Tm.RegionStoragePolicy)
+	check.Assert(err, IsNil)
+	check.Assert(rspByName2, NotNil)
+	check.Assert(rspByName2.StorageClass.Name, Equals, vcd.config.Tm.RegionStoragePolicy)
+	check.Assert(rspByName2.StorageClass.Name, Equals, vcd.config.Tm.RegionStoragePolicy)
+
+	// Check ENF errors
+	_, err = vcd.client.GetStorageClassById("urn:vcloud:storageClass:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(err, NotNil)
+	// TODO:TM: Right now throws a 500 NPE...
+	// check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = region.GetStorageClassByName("NotExists")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = vcd.client.GetStorageClassByName("NotExists")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -521,6 +521,7 @@ const (
 	OpenApiEndpointOrgs = "orgs/"
 
 	OpenApiEndpointRegionStoragePolicies   = "regionStoragePolicies/"
+	OpenApiEndpointStorageClasses          = "storageClasses/"
 	OpenApiEndpointContentLibraries        = "contentLibraries/"
 	OpenApiEndpointContentLibraryItems     = "contentLibraryItems/"
 	OpenApiEndpointContentLibraryItemFiles = "contentLibraryItems/%s/files"

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -17,6 +17,21 @@ type RegionStoragePolicy struct {
 	StorageConsumedMB int64 `json:"storageConsumedMB,omitempty"`
 }
 
+// StorageClass defines a Storage Class
+type StorageClass struct {
+	ID string `json:"id,omitempty"`
+	// Name for the policy. It must follow RFC 1123 Label Names to conform with Kubernetes standards
+	Name string `json:"name"`
+	// Description of the policy
+	Description string `json:"description,omitempty"`
+	// The creation status of the region storage policy. Can be [NOT_READY, READY]
+	Status string `json:"status,omitempty"`
+	// Storage capacity in megabytes for this policy
+	StorageCapacityMB int64 `json:"storageCapacityMB,omitempty"`
+	// Consumed storage in megabytes for this policy
+	StorageConsumedMB int64 `json:"storageConsumedMB,omitempty"`
+}
+
 // ContentLibrary is an object representing a VCF Content Library
 type ContentLibrary struct {
 	// The name of the Content Library

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -20,16 +20,17 @@ type RegionStoragePolicy struct {
 // StorageClass defines a Storage Class
 type StorageClass struct {
 	ID string `json:"id,omitempty"`
-	// Name for the policy. It must follow RFC 1123 Label Names to conform with Kubernetes standards
+	// Name for the storage class
 	Name string `json:"name"`
-	// Description of the policy
-	Description string `json:"description,omitempty"`
-	// The creation status of the region storage policy. Can be [NOT_READY, READY]
-	Status string `json:"status,omitempty"`
-	// Storage capacity in megabytes for this policy
-	StorageCapacityMB int64 `json:"storageCapacityMB,omitempty"`
-	// Consumed storage in megabytes for this policy
-	StorageConsumedMB int64 `json:"storageConsumedMB,omitempty"`
+	// The Region that this storage class belongs to
+	Region *OpenApiReference `json:"region"`
+	// The total storage capacity of the storage class in mebibytes
+	StorageCapacityMiB int64 `json:"storageCapacityMiB,omitempty"`
+	// For tenants, this represents the total storage given to all namespaces consuming from this storage class in mebibytes.
+	// For providers, this represents the total storage given to tenants from this storage class in mebibytes.
+	StorageConsumedMiB int64 `json:"storageConsumedMiB,omitempty"`
+	// The zones available to the storage class
+	Zones OpenApiReferences `json:"zones,omitempty"`
 }
 
 // ContentLibrary is an object representing a VCF Content Library


### PR DESCRIPTION
This PR adds a new type `StorageClass` and associated methods.
It also refactors `RegionStoragePolicy` methods to use same structure (with `VCDClient`) as other TM types, and removes useless methods.