### PR TITLE
Sync main with release/v2.x

### DIFF
--- a/.changes/v2.26.1/723-improvements.md
+++ b/.changes/v2.26.1/723-improvements.md
@@ -1,0 +1,1 @@
+* Added CSE 4.2.2 and 4.2.3 support [GH-723]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changes in progress for v3.0.0 are available at [.changes/v3.0.0](https://github.com/vmware/go-vcloud-director/tree/main/.changes/v3.0.0) until the release.
 
+## 2.26.1 (December 5, 2024)
+
+### IMPROVEMENTS
+* Added CSE 4.2.2 and 4.2.3 support ([#723](https://github.com/vmware/go-vcloud-director/pull/723))
+
 ## 2.26.0 (September 17, 2024)
 
 ### FEATURES

--- a/govcd/cse/tkg_versions.json
+++ b/govcd/cse/tkg_versions.json
@@ -1,4 +1,34 @@
 {
+  "v1.30.2+vmware.1-tkg.1-00b380629c7a9c10afaaa9df46ba2283": {
+    "tkg": "v2.5.2",
+    "tkr": "v1.30.2---vmware.1-tkg.1",
+    "etcd": "v3.5.12_vmware.5",
+    "coreDns": "v1.11.1_vmware.10"
+  },
+  "v1.29.6+vmware.1-tkg.3-c6934e3c00b6ca9a7c3e56acb773ce3a": {
+    "tkg": "v2.5.2",
+    "tkr": "v1.29.6---vmware.1-tkg.3",
+    "etcd": "v3.5.12_vmware.5",
+    "coreDns": "v1.10.1_vmware.23"
+  },
+  "v1.28.11+vmware.2-tkg.2-7820f47053de95b5aaf7e33a17511e47": {
+    "tkg": "v2.5.2",
+    "tkr": "v1.28.11---vmware.2-tkg.2",
+    "etcd": "v3.5.12_vmware.5",
+    "coreDns": "v1.10.1_vmware.21"
+  },
+  "v1.27.15+vmware.1-tkg.2-138e363d8ee0f5eeda35a0de81a33f9f": {
+    "tkg": "v2.5.2",
+    "tkr": "v1.27.15---vmware.1-tkg.2",
+    "etcd": "v3.5.12_vmware.5",
+    "coreDns": "v1.10.1_vmware.20"
+  },
+  "v1.26.14+vmware.1-tkg.2-6378700fb9360ffd64bebc53dbde5bb9": {
+    "tkg": "v2.5.2",
+    "tkr": "v1.26.14---vmware.1-tkg.4",
+    "etcd": "v3.5.12_vmware.5",
+    "coreDns": "v1.9.3_vmware.22"
+  },
   "v1.28.4+vmware.1-tkg.1-1e7baa840b8869c8bdce0cafff0da59d": {
     "tkg": "v2.5.0",
     "tkr": "v1.28.4---vmware.1-tkg.1-rc.5",
@@ -126,3 +156,4 @@
     "coreDns": "v1.7.0_vmware.15"
   }
 }
+

--- a/govcd/cse_test.go
+++ b/govcd/cse_test.go
@@ -36,6 +36,10 @@ func requireCseConfig(check *C, testConfig TestConfig) {
 func (vcd *TestVCD) Test_Cse(check *C) {
 	requireCseConfig(check, vcd.config)
 
+	if vcd.config.Cse.Version == "4.2.2" || vcd.config.Cse.Version == "4.2.3" {
+		check.Skip("CSE versions 4.2.2 and 4.2.3 do not work with System Administrator")
+	}
+
 	// Prerequisites: We need to read several items before creating the cluster.
 	org, err := vcd.client.GetOrgByName(vcd.config.Cse.TenantOrg)
 	check.Assert(err, IsNil)
@@ -288,6 +292,10 @@ func (vcd *TestVCD) Test_Cse(check *C) {
 func (vcd *TestVCD) Test_CseWithAutoscaler(check *C) {
 	requireCseConfig(check, vcd.config)
 
+	if vcd.config.Cse.Version == "4.2.2" || vcd.config.Cse.Version == "4.2.3" {
+		check.Skip("CSE versions 4.2.2 and 4.2.3 do not work with System Administrator")
+	}
+
 	// Prerequisites: We need to read several items before creating the cluster.
 	org, err := vcd.client.GetOrgByName(vcd.config.Cse.TenantOrg)
 	check.Assert(err, IsNil)
@@ -428,6 +436,10 @@ func (vcd *TestVCD) Test_CseWithAutoscaler(check *C) {
 // Test_CseFailure tests cluster creation errors and their consequences
 func (vcd *TestVCD) Test_CseFailure(check *C) {
 	requireCseConfig(check, vcd.config)
+
+	if vcd.config.Cse.Version == "4.2.2" || vcd.config.Cse.Version == "4.2.3" {
+		check.Skip("CSE versions 4.2.2 and 4.2.3 do not work with System Administrator")
+	}
 
 	// Prerequisites: We need to read several items before creating the cluster.
 	org, err := vcd.client.GetOrgByName(vcd.config.Cse.TenantOrg)


### PR DESCRIPTION
This PR just syncs main branch with what was done for release/v2.x for the release v2.26.1

Contents picked from:
https://github.com/vmware/go-vcloud-director/compare/main...release/v2.x