### PR TITLE
TM Patch Content library and tests

### DIFF
--- a/.changes/v3.0.0/717-features.md
+++ b/.changes/v3.0.0/717-features.md
@@ -1,4 +1,4 @@
 * Added `ContentLibraryItem` and `types.ContentLibraryItem` structures to manage Content Library Items
   with methods `ContentLibrary.CreateContentLibraryItem`, `ContentLibrary.GetAllContentLibraryItems`,
   `ContentLibrary.GetContentLibraryItemByName`, `ContentLibrary.GetContentLibraryItemById`, `ContentLibraryItem.Update`,
-  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717, GH-724]
+  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717, GH-724, GH-733]

--- a/govcd/api_vcd_request_test.go
+++ b/govcd/api_vcd_request_test.go
@@ -1,0 +1,59 @@
+//go:build api || openapi || functional || catalog || vapp || gateway || network || org || query || extnetwork || task || vm || vdc || system || disk || lb || lbAppRule || lbAppProfile || lbServerPool || lbServiceMonitor || lbVirtualServer || user || search || nsxv || nsxt || auth || affinity || role || alb || certificate || vdcGroup || metadata || providervdc || rde || vsphere || uiPlugin || cse || slz || ALL
+
+/*
+ * Copyright 2025 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+package govcd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+	"github.com/vmware/go-vcloud-director/v3/util"
+
+	. "gopkg.in/check.v1"
+)
+
+// Test_NewRequestWitNotEncodedParamsWithApiVersion verifies that api version override works
+func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
+	fmt.Printf("Running: %s\n", check.TestName())
+	queryUlr := vcd.client.Client.VCDHREF
+	queryUlr.Path += "/query"
+
+	apiVersion, err := vcd.client.Client.MaxSupportedVersion()
+	check.Assert(err, IsNil)
+
+	req := vcd.client.Client.NewRequestWitNotEncodedParamsWithApiVersion(nil, map[string]string{"type": "media",
+		"filter": "name==any"}, http.MethodGet, queryUlr, nil, apiVersion)
+
+	check.Assert(req.Header.Get("User-Agent"), Equals, vcd.client.Client.UserAgent)
+
+	resp, err := checkResp(vcd.client.Client.Http.Do(req))
+	check.Assert(err, IsNil)
+
+	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+apiVersion)
+
+	bodyBytes, err := rewrapRespBodyNoopCloser(resp)
+	check.Assert(err, IsNil)
+
+	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(bodyBytes))
+	debugShowResponse(resp, bodyBytes)
+
+	// Repeats the call without API version change
+	req = vcd.client.Client.NewRequestWitNotEncodedParams(nil, map[string]string{"type": "media",
+		"filter": "name==any"}, http.MethodGet, queryUlr, nil)
+
+	resp, err = checkResp(vcd.client.Client.Http.Do(req))
+	check.Assert(err, IsNil)
+
+	// Checks that the regularAPI version was not affected by the previous call
+	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+vcd.client.Client.APIVersion)
+
+	bodyBytes, err = rewrapRespBodyNoopCloser(resp)
+	check.Assert(err, IsNil)
+	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(bodyBytes))
+	debugShowResponse(resp, bodyBytes)
+
+	fmt.Printf("Test: %s run with api Version: %s\n", check.TestName(), apiVersion)
+}

--- a/govcd/api_vcd_test.go
+++ b/govcd/api_vcd_test.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1977,49 +1976,6 @@ func (vcd *TestVCD) findFirstVapp() VApp {
 		return VApp{}
 	}
 	return *vapp
-}
-
-// Test_NewRequestWitNotEncodedParamsWithApiVersion verifies that api version override works
-func (vcd *TestVCD) Test_NewRequestWitNotEncodedParamsWithApiVersion(check *C) {
-	fmt.Printf("Running: %s\n", check.TestName())
-	queryUlr := vcd.client.Client.VCDHREF
-	queryUlr.Path += "/query"
-
-	apiVersion, err := vcd.client.Client.MaxSupportedVersion()
-	check.Assert(err, IsNil)
-
-	req := vcd.client.Client.NewRequestWitNotEncodedParamsWithApiVersion(nil, map[string]string{"type": "media",
-		"filter": "name==any"}, http.MethodGet, queryUlr, nil, apiVersion)
-
-	check.Assert(req.Header.Get("User-Agent"), Equals, vcd.client.Client.UserAgent)
-
-	resp, err := checkResp(vcd.client.Client.Http.Do(req))
-	check.Assert(err, IsNil)
-
-	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+apiVersion)
-
-	bodyBytes, err := rewrapRespBodyNoopCloser(resp)
-	check.Assert(err, IsNil)
-
-	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(bodyBytes))
-	debugShowResponse(resp, bodyBytes)
-
-	// Repeats the call without API version change
-	req = vcd.client.Client.NewRequestWitNotEncodedParams(nil, map[string]string{"type": "media",
-		"filter": "name==any"}, http.MethodGet, queryUlr, nil)
-
-	resp, err = checkResp(vcd.client.Client.Http.Do(req))
-	check.Assert(err, IsNil)
-
-	// Checks that the regularAPI version was not affected by the previous call
-	check.Assert(resp.Header.Get("Content-Type"), Equals, types.MimeQueryRecords+";version="+vcd.client.Client.APIVersion)
-
-	bodyBytes, err = rewrapRespBodyNoopCloser(resp)
-	check.Assert(err, IsNil)
-	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, string(bodyBytes))
-	debugShowResponse(resp, bodyBytes)
-
-	fmt.Printf("Test: %s run with api Version: %s\n", check.TestName(), apiVersion)
 }
 
 // setBoolFlag binds a flag to a boolean variable (passed as pointer)

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -224,6 +224,7 @@ func createOrg(vcd *TestVCD, check *C, canManageOrgs bool) (*TmOrg, func()) {
 		Name:          check.TestName(),
 		DisplayName:   check.TestName(),
 		CanManageOrgs: canManageOrgs,
+		IsEnabled:     true,
 	}
 	tmOrg, err := vcd.client.CreateTmOrg(cfg)
 	check.Assert(err, IsNil)
@@ -232,6 +233,10 @@ func createOrg(vcd *TestVCD, check *C, canManageOrgs bool) (*TmOrg, func()) {
 	PrependToCleanupListOpenApi(tmOrg.TmOrg.ID, check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointOrgs+tmOrg.TmOrg.ID)
 
 	return tmOrg, func() {
+		if tmOrg.TmOrg.IsEnabled {
+			err = tmOrg.Disable()
+			check.Assert(err, IsNil)
+		}
 		err = tmOrg.Delete()
 		check.Assert(err, IsNil)
 	}

--- a/govcd/tm_content_library.go
+++ b/govcd/tm_content_library.go
@@ -38,22 +38,7 @@ func (vcdClient *VCDClient) CreateContentLibrary(config *types.ContentLibrary) (
 		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
 	}
 	outerType := ContentLibrary{vcdClient: vcdClient}
-	// FIXME: TM: Workaround, this should be eventually refactored to match other OpenAPI endpoints.
-	//        - Problem: When creating a Content Library, it always throws an error 500: "Failed to validate Content Library UUID..."
-	//        - Solution: Retry fetching the entity again with the name provided
-	result, err := createOuterEntity(&vcdClient.Client, outerType, c, config)
-	if err != nil {
-		// The error we want is like:
-		// Failed to validate Content Library UUID f215ce12-08ac-488e-bbfb-e13c5bad461b, error: not found
-		if !strings.Contains(err.Error(), "Failed to validate Content Library UUID") {
-			return nil, err
-		}
-		result, err = vcdClient.GetContentLibraryByName(config.Name)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
+	return createOuterEntity(&vcdClient.Client, outerType, c, config)
 }
 
 // GetAllContentLibraries retrieves all Content Libraries with the given query parameters, which allow setting filters

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -85,13 +85,9 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = cl.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
-	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = vcd.client.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
-	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }
 

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -9,7 +9,6 @@ package govcd
 import (
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
-	"strings"
 )
 
 // TODO: TM: Test upload failures:
@@ -87,13 +86,13 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 
 	_, err = cl.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
-	// check.Assert(ContainsNotFound(err), Equals, true)
+	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
+	check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = vcd.client.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
-	// check.Assert(ContainsNotFound(err), Equals, true)
+	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
+	check.Assert(ContainsNotFound(err), Equals, true)
 }
 
 // Test_ContentLibraryItemIso tests CRUD operations for a Content Library Item when uploading an ISO file

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -7,9 +7,10 @@
 package govcd
 
 import (
+	"strings"
+
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
-	"strings"
 )
 
 // TODO: TM: Tests missing: Tenant, subscribed catalog, shared catalog
@@ -100,11 +101,11 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 	_, err = vcd.client.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	check.Assert(err, NotNil)
 	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
-	// check.Assert(ContainsNotFound(err), Equals, true)
+	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
+	check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = vcd.client.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
-	// check.Assert(ContainsNotFound(err), Equals, true)
+	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
+	check.Assert(ContainsNotFound(err), Equals, true)
 }

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -100,12 +100,8 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 
 	_, err = vcd.client.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
 	check.Assert(err, NotNil)
-	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
 	check.Assert(ContainsNotFound(err), Equals, true)
 
 	_, err = vcd.client.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
-	// TODO: TM: Should return ENF, but throws a 500. The API will eventually be fixed
-	// check.Assert(strings.Contains(err.Error(), "INTERNAL_SERVER_ERROR"), Equals, true)
 	check.Assert(ContainsNotFound(err), Equals, true)
 }

--- a/govcd/tm_vdc.go
+++ b/govcd/tm_vdc.go
@@ -108,7 +108,7 @@ func (vcdClient *VCDClient) GetTmVdcById(id string) (*TmVdc, error) {
 }
 
 // Update Tenant Manager VDC
-func (o *TmVdc) Update(TmVdcConfig *types.TmVdc) (*TmVdc, error) {
+func (o *TmVdc) Update(tmVdcConfig *types.TmVdc) (*TmVdc, error) {
 	c := crudConfig{
 		entityLabel:    labelTmOrgVdc,
 		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointTmVdcs,
@@ -116,7 +116,7 @@ func (o *TmVdc) Update(TmVdcConfig *types.TmVdc) (*TmVdc, error) {
 		requiresTm:     true,
 	}
 	outerType := TmVdc{vcdClient: o.vcdClient}
-	return updateOuterEntity(&o.vcdClient.Client, outerType, c, TmVdcConfig)
+	return updateOuterEntity(&o.vcdClient.Client, outerType, c, tmVdcConfig)
 }
 
 // Delete Tenant Manager VDC


### PR DESCRIPTION
Fixes:
* Test_ContentLibraryItemOva (removed TODO)
* Test_ContentLibraryProvider (removed TODO)
* Test_NewRequestWitNotEncodedParamsWithApiVersion (split the test into separate file, as it shouldn't be even triggered here)
* Remved "TODO TM" from `CreateContentLibrary`