### PR TITLE
TM entity and test improvements

### DIFF
--- a/.changes/v3.0.0/711-features.md
+++ b/.changes/v3.0.0/711-features.md
@@ -1,6 +1,7 @@
 * Added `RegionStoragePolicy` and `types.RegionStoragePolicy` structures to read Region Storage Policies
   with methods `Region.GetAllStoragePolicies`, `Region.GetStoragePolicyByName`, `Region.GetStoragePolicyById`
   `VCDClient.GetRegionStoragePolicyById` [GH-711, GH-721]
-* Added `ContentLibrary` and `types.ContentLibrary` structures to manage Content Libraries
-  with methods `VCDClient.CreateContentLibrary`, `VCDClient.GetAllContentLibraries`,
-  `VCDClient.GetContentLibraryByName`, `VCDClient.GetContentLibraryById`, `ContentLibrary.Update`, `ContentLibrary.Delete` [GH-711, GH-721]
+* Added `ContentLibrary` and `types.ContentLibrary` structures to manage Content Libraries with
+  methods `VCDClient.CreateContentLibrary`, `VCDClient.GetAllContentLibraries`,
+  `VCDClient.GetContentLibraryByName`, `VCDClient.GetContentLibraryById`, `ContentLibrary.Update`,
+  `ContentLibrary.Delete` [GH-711, GH-721, GH-735]

--- a/.changes/v3.0.0/730-features.md
+++ b/.changes/v3.0.0/730-features.md
@@ -2,4 +2,4 @@
   their QoS settings `VCDClient.GetAllTmEdgeClusters`, `VCDClient.GetTmEdgeClusterByName`,
   `VCDClient.GetTmEdgeClusterByNameAndRegionId`, `VCDClient.GetTmEdgeClusterById`,
   `VCDClient.TmSyncEdgeClusters`, `TmEdgeCluster.Update`, `TmEdgeCluster.Delete`,
-  `TmEdgeCluster.GetTransportNodeStatus` [GH-730]
+  `TmEdgeCluster.GetTransportNodeStatus` [GH-730, GH-735]

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -82,7 +82,9 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 }
 
 func waitForListenerStatusConnected(v *VCenter) error {
-	for c := 0; c < 20; c++ {
+	startTime := time.Now()
+	tryCount := 20
+	for c := 0; c < tryCount; c++ {
 		err := v.Refresh()
 		if err != nil {
 			return fmt.Errorf("error refreshing vCenter: %s", err)
@@ -95,7 +97,8 @@ func waitForListenerStatusConnected(v *VCenter) error {
 		time.Sleep(2 * time.Second)
 	}
 
-	return fmt.Errorf("failed waiting for listener state to become 'CONNECTED', got '%s'", v.VSphereVCenter.ListenerState)
+	return fmt.Errorf("waiting for listener state to become 'CONNECTED' expired after %d tries (%d seconds), got '%s'",
+		tryCount, int(time.Since(startTime)/time.Second), v.VSphereVCenter.ListenerState)
 }
 
 // getOrCreateNsxtManager will check configuration file and create NSX-T Manager if

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -7,6 +7,8 @@
 package govcd
 
 import (
+	"net/url"
+
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
 )
@@ -220,6 +222,15 @@ func (vcd *TestVCD) Test_ContentLibrarySubscribed(check *C) {
 	sysadminOnly(vcd, check)
 	if vcd.config.Tm.SubscriptionContentLibraryUrl == "" {
 		check.Skip("test configuration tm.subscriptionContentLibraryUrl is empty")
+	}
+
+	// Certificate must be trusted before adding subscribed content library
+	url, err := url.Parse(vcd.config.Tm.SubscriptionContentLibraryUrl)
+	check.Assert(err, IsNil)
+	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	check.Assert(err, IsNil)
+	if trustedCert != nil {
+		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)

--- a/govcd/tm_edge_cluster.go
+++ b/govcd/tm_edge_cluster.go
@@ -148,8 +148,16 @@ func (e *TmEdgeCluster) Delete() error {
 	if e.TmEdgeCluster == nil {
 		return fmt.Errorf("nil %s", labelTmEdgeCluster)
 	}
-	e.TmEdgeCluster.DefaultQosConfig.EgressProfile = nil
-	e.TmEdgeCluster.DefaultQosConfig.IngressProfile = nil
+	e.TmEdgeCluster.DefaultQosConfig.EgressProfile = &types.TmEdgeClusterQosProfile{
+		Type:                   "DEFAULT",
+		CommittedBandwidthMbps: -1,
+		BurstSizeBytes:         -1,
+	}
+	e.TmEdgeCluster.DefaultQosConfig.IngressProfile = &types.TmEdgeClusterQosProfile{
+		Type:                   "DEFAULT",
+		CommittedBandwidthMbps: -1,
+		BurstSizeBytes:         -1,
+	}
 
 	_, err := e.Update(e.TmEdgeCluster)
 	if err != nil {

--- a/govcd/tm_edge_cluster_test.go
+++ b/govcd/tm_edge_cluster_test.go
@@ -42,11 +42,21 @@ func (vcd *TestVCD) Test_TmEdgeCluster(check *C) {
 	ecById, err := vcd.client.GetTmEdgeClusterById(ecByName.TmEdgeCluster.ID)
 	check.Assert(err, IsNil)
 	check.Assert(ecById, NotNil)
+
+	// resetting both values to 0 so that no different values are returned
+	ecByName.TmEdgeCluster.AvgCPUUsagePercentage = 0
+	ecByName.TmEdgeCluster.AvgMemoryUsagePercentage = 0
+	ecById.TmEdgeCluster.AvgCPUUsagePercentage = 0
+	ecById.TmEdgeCluster.AvgMemoryUsagePercentage = 0
+
 	check.Assert(ecById.TmEdgeCluster, DeepEquals, ecByName.TmEdgeCluster)
 
 	ecByNameAndRegionId, err := vcd.client.GetTmEdgeClusterByNameAndRegionId(vcd.config.Tm.NsxtEdgeCluster, region.Region.ID)
 	check.Assert(err, IsNil)
 	check.Assert(ecByNameAndRegionId, NotNil)
+	// resetting both values to 0 so that no different values are returned
+	ecByNameAndRegionId.TmEdgeCluster.AvgCPUUsagePercentage = 0
+	ecByNameAndRegionId.TmEdgeCluster.AvgMemoryUsagePercentage = 0
 	check.Assert(ecByNameAndRegionId.TmEdgeCluster, DeepEquals, ecById.TmEdgeCluster)
 
 	ecByNameAndWrongRegionId, err := vcd.client.GetTmEdgeClusterByNameAndRegionId(vcd.config.Tm.NsxtEdgeCluster, "urn:vcloud:region:167d34b3-0000-0000-0000-a388505e6102")
@@ -93,8 +103,12 @@ func (vcd *TestVCD) Test_TmEdgeCluster(check *C) {
 	afterQosRemoval, err := vcd.client.GetTmEdgeClusterByName(vcd.config.Tm.NsxtEdgeCluster)
 	check.Assert(err, IsNil)
 	check.Assert(afterQosRemoval, NotNil)
-	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.EgressProfile, IsNil)
-	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.IngressProfile, IsNil)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.EgressProfile, NotNil)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.EgressProfile.BurstSizeBytes, Equals, -1)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.EgressProfile.CommittedBandwidthMbps, Equals, -1)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.IngressProfile, NotNil)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.IngressProfile.BurstSizeBytes, Equals, -1)
+	check.Assert(afterQosRemoval.TmEdgeCluster.DefaultQosConfig.IngressProfile.CommittedBandwidthMbps, Equals, -1)
 
 	// Check Transport Node endpoint
 	tn, err := afterQosRemoval.GetTransportNodeStatus()

--- a/govcd/tm_org_test.go
+++ b/govcd/tm_org_test.go
@@ -19,7 +19,7 @@ func (vcd *TestVCD) Test_TmOrg(check *C) {
 	cfg := &types.TmOrg{
 		Name:          check.TestName(),
 		DisplayName:   check.TestName(),
-		CanManageOrgs: true,
+		CanManageOrgs: false,
 	}
 
 	tmOrg, err := vcd.client.CreateTmOrg(cfg)

--- a/govcd/vsphere_vcenter_tm_test.go
+++ b/govcd/vsphere_vcenter_tm_test.go
@@ -44,6 +44,10 @@ func (vcd *TestVCD) Test_VCenter(check *C) {
 	// Add to cleanup list
 	PrependToCleanupListOpenApi(v.VSphereVCenter.VcId, check.TestName(), types.OpenApiPathVersion1_0_0+types.OpenApiEndpointVirtualCenters+v.VSphereVCenter.VcId)
 
+	printVerbose("# Waiting for listener status to become 'CONNECTED'\n")
+	err = waitForListenerStatusConnected(v)
+	check.Assert(err, IsNil)
+
 	err = v.RefreshVcenter()
 	check.Assert(err, IsNil)
 


### PR DESCRIPTION
* The test `Test_ContentLibrarySubscribed` tries to create a subscribed content library. It must ensure that the certificate is trusted as otherwise errors would occur.
* Sometimes vCenter might be refreshed too early in tests, although we sleep. Changing sleep approach to waiting for listener state to become CONNECTED
* Fix Test_TmEdgeCluster and change `TmEdgeCluster.Delete` approach because the old doesn't work anymore

--

* Test `Test_TmOrg` uses `CanManageOrgs: false`