### PR TITLE
Remove is_enabled from types.Region, test updates

### DIFF
--- a/.changes/v3.0.0/718-features.md
+++ b/.changes/v3.0.0/718-features.md
@@ -6,7 +6,7 @@
   [GH-718]
 * Added `Region` and `types.Region` structures for OpenAPI management of Regions with methods
   `VCDClient.CreateRegion`, `VCDClient.GetAllRegions`, `VCDClient.GetRegionByName`,
-  `VCDClient.GetRegionById`, `Region.Update`, `Region.Delete` [GH-718]
+  `VCDClient.GetRegionById`, `Region.Update`, `Region.Delete` [GH-718, GH-737]
 * Added `Supervisor` and `types.Supervisor` structure for reading available Supervisors
   `VCDClient.GetAllSupervisors`, `VCDClient.GetSupervisorById`, `VCDClient.GetSupervisorByName`,
   `VCDClient.GetSupervisorByNameAndVcenterId`, `Vcenter.GetAllSupervisors`,

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -182,7 +182,6 @@ func getOrCreateRegion(vcd *TestVCD, nsxtManager *NsxtManagerOpenApi, supervisor
 			},
 		},
 		StoragePolicies: []string{vcd.config.Tm.VcenterStorageProfile},
-		IsEnabled:       true,
 	}
 
 	region, err = vcd.client.CreateRegion(r)

--- a/govcd/tm_region_test.go
+++ b/govcd/tm_region_test.go
@@ -35,7 +35,6 @@ func (vcd *TestVCD) Test_TmRegion(check *C) {
 			},
 		},
 		StoragePolicies: []string{vcd.config.Tm.VcenterStorageProfile},
-		IsEnabled:       true,
 	}
 
 	createdRegion, err := vcd.client.CreateRegion(r)
@@ -63,12 +62,12 @@ func (vcd *TestVCD) Test_TmRegion(check *C) {
 	check.Assert(allRegions, NotNil)
 	check.Assert(len(allRegions) > 0, Equals, true)
 
-	// TODO: TM: No Update so far
 	// Update
-	// createdRegion.Region.IsEnabled = false
-	// updated, err := createdRegion.Update(createdRegion.Region)
-	// check.Assert(err, IsNil)
-	// check.Assert(updated, NotNil)
+	createdRegion.Region.Description = "new-description"
+	updated, err := createdRegion.Update(createdRegion.Region)
+	check.Assert(err, IsNil)
+	check.Assert(updated, NotNil)
+	check.Assert(updated.Region.Description, Equals, "new-description")
 
 	// Delete
 	err = createdRegion.Delete()

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -194,8 +194,6 @@ type Region struct {
 	CPUCapacityMHz int `json:"cpuCapacityMHz,omitempty"`
 	// Total CPU reservation resources in MHz available to this Region.
 	CPUReservationCapacityMHz int `json:"cpuReservationCapacityMHz,omitempty"`
-	// Whether the region is enabled or not.
-	IsEnabled bool `json:"isEnabled"`
 	// Total memory resources (in mebibytes) available to this Region.
 	MemoryCapacityMiB int `json:"memoryCapacityMiB,omitempty"`
 	// Total memory reservation resources (in mebibytes) available to this Region.


### PR DESCRIPTION
This PR removes `IsEnabled` field from `types.Region` and relevant tests and also tests update