### PR TITLE
Remove IsEnabled from types.Vdc

### DIFF
--- a/.changes/v3.0.0/720-features.md
+++ b/.changes/v3.0.0/720-features.md
@@ -1,7 +1,7 @@
 * Added types `TmVdc` and `types.TmVdc` for managing Tenant Manager Org VDCs with methods
   `VCDClient.CreateTmVdc`, `VCDClient.GetAllTmVdcs`, `VCDClient.GetTmVdcByName`,
   `VCDClient.GetTmVdcById`, `VCDClient.GetTmVdcByNameAndOrgId`, `TmVdc.Update`, `TmVdc.Delete`
-  [GH-720]
+  [GH-720, GH-738]
 * Added types `Zone` and `types.Zone` for reading Region Zones with methods `VCDClient.GetAllZones`,
   `VCDClient.GetZoneByName`, `VCDClient.GetZoneById`, `Region.GetAllZones`, `Region.GetZoneByName`
   [GH-720]

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -287,8 +287,7 @@ func createVdc(vcd *TestVCD, org *TmOrg, region *Region, check *C) (*TmVdc, func
 	check.Assert(sp, NotNil)
 
 	cfg := &types.TmVdc{
-		Name:      fmt.Sprintf("%s_%s", org.TmOrg.Name, region.Region.Name),
-		IsEnabled: addrOf(true),
+		Name: fmt.Sprintf("%s_%s", org.TmOrg.Name, region.Region.Name),
 		Org: &types.OpenApiReference{
 			Name: org.TmOrg.Name,
 			ID:   org.TmOrg.ID,

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -252,8 +252,6 @@ type TmVdc struct {
 	Name string `json:"name"`
 	// Description of the VDC
 	Description string `json:"description,omitempty"`
-	// IsEnabled defines if the VDC is enabled
-	IsEnabled *bool `json:"isEnabled,omitempty"`
 	// Org reference
 	Org *OpenApiReference `json:"org"`
 	// Region reference


### PR DESCRIPTION
This PR removes `IsEnabled` field from `types.Vdc` and relevant tests