### PR TITLE
Add Async Provider Gateway creation function

### DIFF
--- a/.changes/v3.0.0/725-features.md
+++ b/.changes/v3.0.0/725-features.md
@@ -12,5 +12,5 @@
   `VCDClient.GetAllTmIpSpaceAssociationsByProviderGatewayId`,
   `VCDClient.GetAllTmIpSpaceAssociationsByIpSpaceId`, `TmIpSpaceAssociation.Delete` to manage IP
   Space associations with Provider Gateways [GH-725]
-* Added `VCDClient.CreateTmProviderGateway` that exposes the creation task of as it is needed in
+* Added `VCDClient.CreateTmProviderGateway` that exposes the creation task it is needed in
   some cases to retrieve ID of incomplete Provider Gateway creation [GH-739]

--- a/.changes/v3.0.0/725-features.md
+++ b/.changes/v3.0.0/725-features.md
@@ -12,3 +12,5 @@
   `VCDClient.GetAllTmIpSpaceAssociationsByProviderGatewayId`,
   `VCDClient.GetAllTmIpSpaceAssociationsByIpSpaceId`, `TmIpSpaceAssociation.Delete` to manage IP
   Space associations with Provider Gateways [GH-725]
+* Added `VCDClient.CreateTmProviderGateway` that exposes the creation task of as it is needed in
+  some cases to retrieve ID of incomplete Provider Gateway creation [GH-739]

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -56,6 +56,8 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	printVerbose("# Waiting for listener status to become 'CONNECTED'\n")
 	err = waitForListenerStatusConnected(vc)
 	check.Assert(err, IsNil)
+	printVerbose("# Sleeping after vCenter is 'CONNECTED'\n")
+	time.Sleep(4 * time.Second) // TODO: TM: Reevaluate need for sleep
 	// Refresh connected vCenter to be sure that all artifacts are loaded
 	printVerbose("# Refreshing vCenter %s\n", vc.VSphereVCenter.Url)
 	err = vc.RefreshVcenter()

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -57,7 +57,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	err = waitForListenerStatusConnected(vc)
 	check.Assert(err, IsNil)
 	printVerbose("# Sleeping after vCenter is 'CONNECTED'\n")
-	time.Sleep(4 * time.Second) // TODO: TM: Reevaluate need for sleep
+	time.Sleep(4 * time.Second) // TODO: TM: Re-evaluate need for sleep
 	// Refresh connected vCenter to be sure that all artifacts are loaded
 	printVerbose("# Refreshing vCenter %s\n", vc.VSphereVCenter.Url)
 	err = vc.RefreshVcenter()
@@ -68,7 +68,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	check.Assert(err, IsNil)
 
 	printVerbose("# Sleeping after vCenter refreshes\n")
-	time.Sleep(1 * time.Minute) // TODO: TM: Reevaluate need for sleep
+	time.Sleep(1 * time.Minute) // TODO: TM: Re-evaluate need for sleep
 	vCenterCreated := true
 
 	return vc, func() {

--- a/govcd/tm_provider_gateway.go
+++ b/govcd/tm_provider_gateway.go
@@ -38,7 +38,7 @@ func (vcdClient *VCDClient) CreateTmProviderGateway(config *types.TmProviderGate
 	return createOuterEntity(&vcdClient.Client, outerType, c, config)
 }
 
-// CreateVcenterAsync adds new vCenter and returns its task for tracking
+// CreateTmProviderGatewayAsync adds new Provider gateway and returns its task for tracking
 func (vcdClient *VCDClient) CreateTmProviderGatewayAsync(config *types.TmProviderGateway) (*Task, error) {
 	c := crudConfig{
 		entityLabel: labelTmProviderGateway,

--- a/govcd/tm_provider_gateway.go
+++ b/govcd/tm_provider_gateway.go
@@ -38,6 +38,16 @@ func (vcdClient *VCDClient) CreateTmProviderGateway(config *types.TmProviderGate
 	return createOuterEntity(&vcdClient.Client, outerType, c, config)
 }
 
+// CreateVcenterAsync adds new vCenter and returns its task for tracking
+func (vcdClient *VCDClient) CreateTmProviderGatewayAsync(config *types.TmProviderGateway) (*Task, error) {
+	c := crudConfig{
+		entityLabel: labelTmProviderGateway,
+		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmProviderGateways,
+		requiresTm:  true,
+	}
+	return createInnerEntityAsync(&vcdClient.Client, c, config)
+}
+
 // GetAllTmProviderGateways retrieves all Provider Gateways with optional filter
 func (vcdClient *VCDClient) GetAllTmProviderGateways(queryParameters url.Values) ([]*TmProviderGateway, error) {
 	c := crudConfig{

--- a/govcd/tm_provider_gateway_test.go
+++ b/govcd/tm_provider_gateway_test.go
@@ -58,6 +58,23 @@ func (vcd *TestVCD) Test_TmProviderGateway(check *C) {
 		}},
 	}
 
+	// Test Async creation
+	// Try to create async version
+	task, err := vcd.client.CreateTmProviderGatewayAsync(t)
+	check.Assert(err, IsNil)
+	check.Assert(task, NotNil)
+	err = task.WaitTaskCompletion()
+	check.Assert(err, IsNil)
+
+	byIdAsync, err := vcd.client.GetTmProviderGatewayById(task.Task.Owner.ID)
+	check.Assert(err, IsNil)
+	check.Assert(byIdAsync.TmProviderGateway.Name, Equals, t.Name)
+	// Add to cleanup list
+	AddToCleanupListOpenApi(byIdAsync.TmProviderGateway.ID, check.TestName()+"-async", types.OpenApiPathVcf+types.OpenApiEndpointTmProviderGateways+byIdAsync.TmProviderGateway.ID)
+	err = byIdAsync.Delete()
+	check.Assert(err, IsNil)
+
+	// Test Sync
 	createdTmProviderGateway, err := vcd.client.CreateTmProviderGateway(t)
 	check.Assert(err, IsNil)
 	AddToCleanupListOpenApi(createdTmProviderGateway.TmProviderGateway.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointTmProviderGateways+createdTmProviderGateway.TmProviderGateway.ID)


### PR DESCRIPTION
Added `VCDClient.CreateTmProviderGateway` that exposes the creation task of as it is needed in some cases to retrieve ID of incomplete Provider Gateway creation

`go test -tags functional -check.vv -check.f Test_TmProviderGateway -timeout=85m .` passes

Note. Added extra sleep for tests after vCenter becomes CONNECTED (due to stability)