### PR TITLE
Add Org Networking

### DIFF
--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -177,6 +177,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVcf + types.OpenApiEndpointTmEdgeClusters:                   "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointTmEdgeClusterTransportNodeStatus: "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointTmEdgeClustersSync:               "40.0",
+	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTmOrgNetworkingSettings: "40.0",
 }
 
 // endpointElevatedApiVersions endpoint elevated API versions

--- a/govcd/tm_org.go
+++ b/govcd/tm_org.go
@@ -12,6 +12,7 @@ import (
 )
 
 const labelOrganization = "Organization"
+const labelOrganizationNetworkingSettings = "Organization Networking Settings"
 
 type TmOrg struct {
 	TmOrg     *types.TmOrg
@@ -86,7 +87,7 @@ func (vcdClient *VCDClient) GetTmOrgById(id string) (*TmOrg, error) {
 }
 
 // Update TM Organization
-func (o *TmOrg) Update(TmOrgConfig *types.TmOrg) (*TmOrg, error) {
+func (o *TmOrg) Update(tmOrgConfig *types.TmOrg) (*TmOrg, error) {
 	c := crudConfig{
 		entityLabel:    labelOrganization,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointOrgs,
@@ -94,7 +95,7 @@ func (o *TmOrg) Update(TmOrgConfig *types.TmOrg) (*TmOrg, error) {
 		requiresTm:     true,
 	}
 	outerType := TmOrg{vcdClient: o.vcdClient}
-	return updateOuterEntity(&o.vcdClient.Client, outerType, c, TmOrgConfig)
+	return updateOuterEntity(&o.vcdClient.Client, outerType, c, tmOrgConfig)
 }
 
 // Delete TM Organization
@@ -113,4 +114,27 @@ func (o *TmOrg) Disable() error {
 	o.TmOrg.IsEnabled = false
 	_, err := o.Update(o.TmOrg)
 	return err
+}
+
+// GetOrgNetworkingSettings retrieves Organization specific network settings
+func (o *TmOrg) GetOrgNetworkingSettings() (*types.TmOrgNetworkingSettings, error) {
+	c := crudConfig{
+		entityLabel:    labelOrganizationNetworkingSettings,
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTmOrgNetworkingSettings,
+		endpointParams: []string{o.TmOrg.ID},
+		requiresTm:     true,
+	}
+	return getInnerEntity[types.TmOrgNetworkingSettings](&o.vcdClient.Client, c)
+}
+
+// UpdateOrgNetworkingSettings changes Organization specific network settings
+func (o *TmOrg) UpdateOrgNetworkingSettings(tmOrgNetConfig *types.TmOrgNetworkingSettings) (*types.TmOrgNetworkingSettings, error) {
+	c := crudConfig{
+		entityLabel:    labelOrganizationNetworkingSettings,
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTmOrgNetworkingSettings,
+		endpointParams: []string{o.TmOrg.ID},
+		requiresTm:     true,
+	}
+
+	return updateInnerEntity(&o.vcdClient.Client, c, tmOrgNetConfig)
 }

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -518,7 +518,8 @@ const (
 	OpenApiEndpointVgpuProfile = "vgpuProfiles"
 
 	// OpenAPI Org
-	OpenApiEndpointOrgs = "orgs/"
+	OpenApiEndpointOrgs                    = "orgs/"
+	OpenApiEndpointTmOrgNetworkingSettings = "orgs/%s/networkingSettings"
 
 	OpenApiEndpointRegionStoragePolicies            = "regionStoragePolicies/"
 	OpenApiEndpointStorageClasses                   = "storageClasses/"

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -181,6 +181,19 @@ type TmOrg struct {
 	VappCount int `json:"vappCount,omitempty"`
 }
 
+// TmOrgNetworkingSettings defines structure for managing Org Networking Setttings
+type TmOrgNetworkingSettings struct {
+	// Whether this Organization has tenancy for the network domain in the backing network provider.
+	// If enabled, can only be disabled after all Org VDCs and VDC Groups that have networking
+	// tenancy enabled are deleted. Is disabled by default.
+	NetworkingTenancyEnabled *bool `json:"networkingTenancyEnabled,omitempty"`
+
+	// A short (8 char) display name to identify this Organization in the logs of the backing
+	// network provider. Only applies if the Organization is networking tenancy enabled. This
+	// identifier is globally unique.
+	OrgNameForLogs string `json:"orgNameForLogs"`
+}
+
 // Region represents a collection of supervisor clusters across different VCs
 type Region struct {
 	ID string `json:"id,omitempty"`


### PR DESCRIPTION
This PR adds TM Org Networking settings that allows users to set `orgNameForLogs` which is required to configured Org Networking Settings.