### PR TITLE
Change VC/NSX prerequisite spinup priority in tests

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -6,10 +6,10 @@
 * vCenter management types `VCenter` and `types.VSphereVirtualCenter` adds Create, Update and Delete
  methods: `VCDClient.CreateVcenter`, `VCDClient.GetAllVCenters`, `VCDClient.GetVCenterByName`,
  `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.RefreshVcenter`,
- `VCenter.Refresh` [GH-714, GH-724]
+ `VCenter.Refresh` [GH-714, GH-724, GH-747]
 * Add NSX-T Manager management types `NsxtManagerOpenApi`, `types.NsxtManagerOpenApi` and methods
   `VCDClient.CreateNsxtManagerOpenApi`, `VCDClient.GetAllNsxtManagersOpenApi`,
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,
-  `TmNsxtManager.Update`, `TmNsxtManager.Delete` [GH-714, GH-722]
+  `TmNsxtManager.Update`, `TmNsxtManager.Delete` [GH-714, GH-722, GH-747]
 * Added async vCenter creation function `VCDClient.CreateVcenterAsync` that exposes the creation
   task of as it is needed in some cases to retrieve ID of incomplete vCenter creation [GH-736]

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -20,13 +20,14 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	sysadminOnly(vcd, check)
 
 	// Pre-requisites
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 
@@ -109,13 +110,14 @@ func (vcd *TestVCD) Test_ContentLibraryItemIso(check *C) {
 	sysadminOnly(vcd, check)
 
 	// Pre-requisites
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -18,13 +18,13 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 
@@ -116,13 +116,13 @@ func (vcd *TestVCD) Test_ContentLibraryTenant(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check) // As it creates testing resources first
 
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 
@@ -233,13 +233,13 @@ func (vcd *TestVCD) Test_ContentLibrarySubscribed(check *C) {
 		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 

--- a/govcd/tm_edge_cluster_test.go
+++ b/govcd/tm_edge_cluster_test.go
@@ -15,10 +15,11 @@ func (vcd *TestVCD) Test_TmEdgeCluster(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)

--- a/govcd/tm_ip_space_test.go
+++ b/govcd/tm_ip_space_test.go
@@ -15,10 +15,11 @@ func (vcd *TestVCD) Test_TmIpSpace(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)

--- a/govcd/tm_provider_gateway_test.go
+++ b/govcd/tm_provider_gateway_test.go
@@ -15,10 +15,11 @@ func (vcd *TestVCD) Test_TmProviderGateway(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)

--- a/govcd/tm_region_storage_policy_test.go
+++ b/govcd/tm_region_storage_policy_test.go
@@ -14,13 +14,13 @@ func (vcd *TestVCD) Test_RegionStoragePolicy(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 

--- a/govcd/tm_region_test.go
+++ b/govcd/tm_region_test.go
@@ -24,7 +24,7 @@ func (vcd *TestVCD) Test_TmRegion(check *C) {
 	check.Assert(err, IsNil)
 
 	r := &types.Region{
-		Name: check.TestName(),
+		Name: "testtmregion",
 		NsxManager: &types.OpenApiReference{
 			ID: nsxtManager.NsxtManagerOpenApi.ID,
 		},

--- a/govcd/tm_region_test.go
+++ b/govcd/tm_region_test.go
@@ -15,10 +15,10 @@ func (vcd *TestVCD) Test_TmRegion(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
 
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)

--- a/govcd/tm_regional_networking_settings_test.go
+++ b/govcd/tm_regional_networking_settings_test.go
@@ -15,10 +15,11 @@ func (vcd *TestVCD) Test_TmRegionalNetworkingSetting(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)

--- a/govcd/tm_storage_class_test.go
+++ b/govcd/tm_storage_class_test.go
@@ -14,12 +14,13 @@ func (vcd *TestVCD) Test_StorageClass(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
 	vc, vcCleanup := getOrCreateVCenter(vcd, check)
 	defer vcCleanup()
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
+
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 

--- a/govcd/tm_vdc_storage_policy_test.go
+++ b/govcd/tm_vdc_storage_policy_test.go
@@ -7,19 +7,21 @@
 package govcd
 
 import (
+	"net/url"
+
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
-	"net/url"
 )
 
 func (vcd *TestVCD) Test_TmVdcStoragePolicy(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)

--- a/govcd/tm_vdc_test.go
+++ b/govcd/tm_vdc_test.go
@@ -15,10 +15,11 @@ func (vcd *TestVCD) Test_TmVdc(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+
 	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
 	check.Assert(err, IsNil)
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)


### PR DESCRIPTION
This PR ensures that NSX Manager is created before vCenter server in tests.