### PR TITLE
Fix staticheck 2025.1 compatibility

### DIFF
--- a/.changes/v3.0.0/750-notes.md
+++ b/.changes/v3.0.0/750-notes.md
@@ -1,0 +1,1 @@
+* Fix `staticcheck` 2025.1 compatibility [GH-750]

--- a/govcd/api.go
+++ b/govcd/api.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -93,7 +94,7 @@ const ApiTokenHeader = "API-token"
 //	   // do what is needed in case of not found
 //	}
 var errorEntityNotFoundMessage = "[ENF] entity not found"
-var ErrorEntityNotFound = fmt.Errorf(errorEntityNotFoundMessage)
+var ErrorEntityNotFound = errors.New(errorEntityNotFoundMessage)
 
 // Triggers for debugging functions that show requests and responses
 var debugShowRequestEnabled = os.Getenv("GOVCD_SHOW_REQ") != ""

--- a/govcd/api_test.go
+++ b/govcd/api_test.go
@@ -63,7 +63,7 @@ go test -tags "query extension" -check.vv -timeout=5m .
 go test -tags functional -check.vv -check.f Test_AddNewVM  -timeout=15m .
 go test -v -tags unit .
 `
-	t.Logf(helpText)
+	t.Log(helpText)
 }
 
 // Tells indirectly if a tag has been set

--- a/govcd/api_token_test.go
+++ b/govcd/api_token_test.go
@@ -132,7 +132,7 @@ func (vcd *TestVCD) Test_GetFilteredTokensOrg(check *C) {
 		check.Skip("This test requires VCD 10.3.1 or greater")
 	}
 
-	if vcd.config.Tenants == nil || len(vcd.config.Tenants) < 2 {
+	if len(vcd.config.Tenants) < 2 {
 		check.Skip("no tenants found in configuration")
 	}
 

--- a/govcd/catalog.go
+++ b/govcd/catalog.go
@@ -77,7 +77,7 @@ func (catalog *Catalog) Delete(force, recursive bool) error {
 		return fmt.Errorf("error decoding task response: %s", err)
 	}
 	if task.Task.Status == "error" {
-		return fmt.Errorf(combinedTaskErrorMessage(task.Task, fmt.Errorf("catalog %s not properly destroyed", catalog.Catalog.Name)))
+		return errors.New(combinedTaskErrorMessage(task.Task, fmt.Errorf("catalog %s not properly destroyed", catalog.Catalog.Name)))
 	}
 	return task.WaitTaskCompletion()
 }

--- a/govcd/catalog_test.go
+++ b/govcd/catalog_test.go
@@ -1150,7 +1150,7 @@ func (vcd *TestVCD) Test_GetAdminCatalogById(check *C) {
 }
 
 func (vcd *TestVCD) Test_CatalogAccessAsOrgUsers(check *C) {
-	if vcd.config.Tenants == nil || len(vcd.config.Tenants) < 2 {
+	if len(vcd.config.Tenants) < 2 {
 		check.Skip("no tenants found in configuration")
 	}
 
@@ -1307,7 +1307,7 @@ func (vcd *TestVCD) Test_CatalogAccessAsOrgUsers(check *C) {
 }
 
 func (vcd *TestVCD) Test_CatalogAccessAsOrgUsersReadOnly(check *C) {
-	if vcd.config.Tenants == nil || len(vcd.config.Tenants) < 2 {
+	if len(vcd.config.Tenants) < 2 {
 		check.Skip("no tenants found in configuration")
 	}
 

--- a/govcd/defined_entity.go
+++ b/govcd/defined_entity.go
@@ -133,7 +133,7 @@ func (rdeType *DefinedEntityType) Update(rdeTypeToUpdate types.DefinedEntityType
 	if rdeTypeToUpdate.Name == "" {
 		rdeTypeToUpdate.Name = rdeType.DefinedEntityType.Name
 	}
-	if rdeTypeToUpdate.Schema == nil || len(rdeTypeToUpdate.Schema) == 0 {
+	if len(rdeTypeToUpdate.Schema) == 0 {
 		rdeTypeToUpdate.Schema = rdeType.DefinedEntityType.Schema
 	}
 	rdeTypeToUpdate.Version = rdeType.DefinedEntityType.Version
@@ -409,7 +409,7 @@ func createRde(client *Client, entity types.DefinedEntity, tenantContext *Tenant
 		return nil, fmt.Errorf("ID of the Runtime Defined Entity type is empty")
 	}
 
-	if entity.Entity == nil || len(entity.Entity) == 0 {
+	if len(entity.Entity) == 0 {
 		return nil, fmt.Errorf("the entity JSON is empty")
 	}
 

--- a/govcd/disk.go
+++ b/govcd/disk.go
@@ -89,7 +89,7 @@ func (vdc *Vdc) CreateDisk(diskCreateParams *types.DiskCreateParams) (Task, erro
 		return Task{}, err
 	}
 	// Obtain disk task
-	if disk.Disk.Tasks.Task == nil || len(disk.Disk.Tasks.Task) == 0 {
+	if len(disk.Disk.Tasks.Task) == 0 {
 		return Task{}, errors.New("error cannot find disk creation task in API response")
 	}
 	task := NewTask(vdc.client)
@@ -276,7 +276,7 @@ func (disk *Disk) AttachedVM() (*types.Reference, error) {
 	}
 
 	// If disk is not attached to any VM
-	if vms.VmReference == nil || len(vms.VmReference) == 0 {
+	if len(vms.VmReference) == 0 {
 		return nil, nil
 	}
 
@@ -471,7 +471,7 @@ func (disk *Disk) GetAttachedVmsHrefs() ([]string, error) {
 	}
 
 	// If disk is not attached to any VM
-	if vms.VmReference == nil || len(vms.VmReference) == 0 {
+	if len(vms.VmReference) == 0 {
 		return nil, nil
 	}
 

--- a/govcd/edgegateway.go
+++ b/govcd/edgegateway.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -1012,12 +1013,12 @@ func (egw *EdgeGateway) Delete(force bool, recursive bool) error {
 		return err
 	}
 	if task.Task.Status == "error" {
-		return fmt.Errorf(combinedTaskErrorMessage(task.Task, fmt.Errorf("edge gateway not properly destroyed")))
+		return errors.New(combinedTaskErrorMessage(task.Task, fmt.Errorf("edge gateway not properly destroyed")))
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
-		return fmt.Errorf(combinedTaskErrorMessage(task.Task, err))
+		return errors.New(combinedTaskErrorMessage(task.Task, err))
 	}
 
 	return nil

--- a/govcd/org.go
+++ b/govcd/org.go
@@ -204,7 +204,7 @@ func validateVdcConfiguration(vdcDefinition *types.VdcConfiguration) error {
 	if vdcDefinition.ComputeCapacity[0].Memory.Units == "" {
 		return errors.New("VdcConfiguration missing required field: ComputeCapacity[0].Memory.Units")
 	}
-	if vdcDefinition.VdcStorageProfile == nil || len(vdcDefinition.VdcStorageProfile) == 0 {
+	if len(vdcDefinition.VdcStorageProfile) == 0 {
 		return errors.New("VdcConfiguration missing required field: VdcStorageProfile")
 	}
 	if vdcDefinition.VdcStorageProfile[0].Units == "" {
@@ -458,7 +458,7 @@ func (client *Client) queryOrgByName(orgName string) (*types.QueryResultOrgRecor
 		return nil, err
 	}
 
-	if allOrgs == nil || len(allOrgs) < 1 {
+	if len(allOrgs) < 1 {
 		return nil, ErrorEntityNotFound
 	}
 
@@ -504,7 +504,7 @@ func (org *Org) queryOrgVdcByName(vdcName string) (*types.QueryResultOrgVdcRecor
 		return nil, err
 	}
 
-	if allVdcs == nil || len(allVdcs) < 1 {
+	if len(allVdcs) < 1 {
 		return nil, ErrorEntityNotFound
 	}
 
@@ -549,7 +549,7 @@ func (org *Org) queryCatalogByName(catalogName string) (*types.CatalogRecord, er
 		return nil, err
 	}
 
-	if allCatalogs == nil || len(allCatalogs) < 1 {
+	if len(allCatalogs) < 1 {
 		return nil, ErrorEntityNotFound
 	}
 

--- a/govcd/org_oidc.go
+++ b/govcd/org_oidc.go
@@ -9,12 +9,13 @@ import (
 	"cmp"
 	"encoding/xml"
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
 )
 
 // GetOpenIdConnectSettings retrieves the current OpenID Connect settings for a given Organization
@@ -55,7 +56,7 @@ func (adminOrg *AdminOrg) SetOpenIdConnectSettings(settings types.OrgOAuthSettin
 		settings.UserAuthorizationEndpoint = cmp.Or(settings.UserAuthorizationEndpoint, wellKnownSettings.UserAuthorizationEndpoint)
 		settings.ScimEndpoint = cmp.Or(settings.ScimEndpoint, wellKnownSettings.ScimEndpoint)
 
-		if settings.Scope == nil || len(settings.Scope) == 0 {
+		if len(settings.Scope) == 0 {
 			settings.Scope = wellKnownSettings.Scope
 		}
 

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,3 +1,3 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=2023.1.7
+export STATICCHECK_VERSION=2025.1
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz


### PR DESCRIPTION
Staticcheck started falling apart and it was high time to update it https://github.com/vmware/go-vcloud-director/actions/runs/13285759339/job/37093973279

The reason is that github workers started using 1.23 after 1.24 is released.

This is the list of errors that `staticcheck` `2025.1` reported and are fixed in this PR:

```
# Checking govcd
api.go:96:27: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
api_test.go:66:2: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
api_token_test.go:135:5: should omit nil check; len() for nil slices is defined as zero (S1009)
catalog.go:80:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
catalog_test.go:1153:5: should omit nil check; len() for nil slices is defined as zero (S1009)
catalog_test.go:1310:5: should omit nil check; len() for nil slices is defined as zero (S1009)
defined_entity.go:136:5: should omit nil check; len() for nil maps is defined as zero (S1009)
defined_entity.go:412:5: should omit nil check; len() for nil maps is defined as zero (S1009)
disk.go:92:5: should omit nil check; len() for nil slices is defined as zero (S1009)
disk.go:279:5: should omit nil check; len() for nil slices is defined as zero (S1009)
disk.go:474:5: should omit nil check; len() for nil slices is defined as zero (S1009)
edgegateway.go:1015:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
edgegateway.go:1020:10: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
org.go:207:5: should omit nil check; len() for nil slices is defined as zero (S1009)
org.go:461:5: should omit nil check; len() for nil slices is defined as zero (S1009)
org.go:507:5: should omit nil check; len() for nil slices is defined as zero (S1009)
org.go:552:5: should omit nil check; len() for nil slices is defined as zero (S1009)
org_oidc.go:58:6: should omit nil check; len() for nil slices is defined as zero (S1009)
```