### PR TITLE
Tests: ensure vCenter and NSX manager are connected

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -12,4 +12,4 @@
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,
   `TmNsxtManager.Update`, `TmNsxtManager.Delete` [GH-714, GH-722, GH-747]
 * Added async vCenter creation function `VCDClient.CreateVcenterAsync` that exposes the creation
-  task of as it is needed in some cases to retrieve ID of incomplete vCenter creation [GH-736, GH-753]
+  task of as it is needed in some cases to retrieve ID of incomplete vCenter creation [GH-736]

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -23,6 +23,7 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	vc, err := vcd.client.GetVCenterByUrl(vcd.config.Tm.VcenterUrl)
 	if err == nil {
 		if !vc.VSphereVCenter.IsEnabled {
+			printVerbose("# vCenter with %s found. Enabling it.\n", vcd.config.Tm.VcenterUrl)
 			vc.VSphereVCenter.IsEnabled = true
 			vc, err = vc.Update(vc.VSphereVCenter)
 			check.Assert(err, IsNil)
@@ -116,11 +117,6 @@ func waitForListenerStatusConnected(v *VCenter) error {
 func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()) {
 	nsxtManager, err := vcd.client.GetNsxtManagerOpenApiByUrl(vcd.config.Tm.NsxtManagerUrl)
 	if err == nil {
-		if !nsxtManager.NsxtManagerOpenApi.Active {
-			nsxtManager.NsxtManagerOpenApi.Active = true
-			nsxtManager, err = nsxtManager.Update(nsxtManager.NsxtManagerOpenApi)
-			check.Assert(err, IsNil)
-		}
 		return nsxtManager, func() {}
 	}
 	if !ContainsNotFound(err) {


### PR DESCRIPTION
This PR attempts to minimise test impact when after one test fails by ensuring that vCenter and NSX manager connections are stable.