### PR TITLE
vCenter operations use retry mechanism

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -6,7 +6,7 @@
 * vCenter management types `VCenter` and `types.VSphereVirtualCenter` adds Create, Update and Delete
  methods: `VCDClient.CreateVcenter`, `VCDClient.GetAllVCenters`, `VCDClient.GetVCenterByName`,
  `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.RefreshVcenter`,
- `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753]
+ `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753, GH-756]
 * Add NSX-T Manager management types `NsxtManagerOpenApi`, `types.NsxtManagerOpenApi` and methods
   `VCDClient.CreateNsxtManagerOpenApi`, `VCDClient.GetAllNsxtManagersOpenApi`,
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,

--- a/govcd/tm_regional_networking_settings_test.go
+++ b/govcd/tm_regional_networking_settings_test.go
@@ -34,7 +34,7 @@ func (vcd *TestVCD) Test_TmRegionalNetworkingSetting(check *C) {
 	defer shortLogNamecleanup()
 
 	orgNetworkSettings := &types.TmRegionalNetworkingSetting{
-		Name:               "terraform-test",
+		Name:               "test-terraform",
 		OrgRef:             types.OpenApiReference{ID: org.TmOrg.ID},
 		RegionRef:          types.OpenApiReference{ID: region.Region.ID},
 		ProviderGatewayRef: types.OpenApiReference{ID: pg.TmProviderGateway.ID},

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -8,11 +8,19 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
+	"github.com/vmware/go-vcloud-director/v3/util"
 )
 
 const labelVirtualCenter = "vCenter Server"
+
+// vCenter task is sometimes unreliable and trying to refresh it immediately after it becomes
+// connected causes a "BUSY_ENTITY" error (which has a few different messages)
+var maximumVcenterRetryTime = 120 * time.Second                                         // The maximum time a single operation will be retried before giving up
+var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY)`) // Regexp to match entity busy error
 
 type VCenter struct {
 	VSphereVCenter *types.VSphereVirtualCenter
@@ -172,6 +180,10 @@ func (v *VCenter) Refresh() error {
 // supervisors
 // It uses legacy endpoint as there is no OpenAPI endpoint for this operation
 func (v *VCenter) RefreshVcenter() error {
+	return runWithRetry(v.refreshVcenter, vCenterEntityBusyRegexp, maximumVcenterRetryTime)
+}
+
+func (v *VCenter) refreshVcenter() error {
 	refreshUrl, err := url.JoinPath(v.client.Client.rootVcdHref(), "api", "admin", "extension", "vimServer", extractUuid(v.VSphereVCenter.VcId), "action", "refresh")
 	if err != nil {
 		return fmt.Errorf("error building refresh path: %s", err)
@@ -199,6 +211,10 @@ func (v *VCenter) RefreshVcenter() error {
 // such as supervisors
 // It uses legacy endpoint as there is no OpenAPI endpoint for this operation
 func (v *VCenter) RefreshStorageProfiles() error {
+	return runWithRetry(v.refreshStorageProfiles, vCenterEntityBusyRegexp, maximumVcenterRetryTime)
+}
+
+func (v *VCenter) refreshStorageProfiles() error {
 	refreshUrl, err := url.JoinPath(v.client.Client.rootVcdHref(), "api", "admin", "extension", "vimServer", extractUuid(v.VSphereVCenter.VcId), "action", "refreshStorageProfiles")
 	if err != nil {
 		return fmt.Errorf("error building storage policy refresh path: %s", err)
@@ -220,4 +236,37 @@ func (v *VCenter) RefreshStorageProfiles() error {
 	}
 
 	return nil
+}
+
+func runWithRetry(runOperation func() error, errRegexp *regexp.Regexp, duration time.Duration) error {
+	startTime := time.Now()
+	endTime := startTime.Add(duration)
+	util.Logger.Printf("[DEBUG] runWithRetry - running with retry for %f seconds if error contains '%s' ", duration.Seconds(), errRegexp)
+	count := 1
+	for {
+		err := runOperation()
+		util.Logger.Printf("[DEBUG] runWithRetry - ran attempt %d, got error: %s ", count, err)
+		// Operation had no error - it succeeded
+		if err == nil {
+			util.Logger.Printf("[DEBUG] runWithRetry - no error occurred after attempt %d, got error: %s ", count, err)
+			return nil
+		}
+		// If there is an error, but it doesn't contain the retryIfErrContains value - exit it
+		if !errRegexp.MatchString(err.Error()) {
+			util.Logger.Printf("[DEBUG] runWithRetry - returning error after attempt %d, got error: %s ", count, err)
+			return err
+		}
+
+		// If time limit is exceeded - return error containing statistics and original error
+		if time.Now().After(endTime) {
+			util.Logger.Printf("[DEBUG] runWithRetry - exceeded time after attempt %d, got error: %s ", count, err)
+			return fmt.Errorf("error attempting to wait until error does not contain '%s' after %f seconds: %s", errRegexp, duration.Seconds(), err)
+		}
+
+		// Sleep and continue
+		util.Logger.Printf("[DEBUG] runWithRetry - sleeping after attempt %d, will retry", count)
+		// Sleep 2 seconds and attempt once more if the timeout is not excdeeded
+		time.Sleep(2 * time.Second)
+		count++
+	}
 }

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -141,6 +141,10 @@ func (v *VCenter) Update(TmNsxtManagerConfig *types.VSphereVirtualCenter) (*VCen
 
 // Delete vCenter configuration
 func (v *VCenter) Delete() error {
+	return runWithRetry(v.delete, vCenterEntityBusyRegexp, maximumVcenterRetryTime)
+}
+
+func (v *VCenter) delete() error {
 	c := crudConfig{
 		entityLabel:    labelVirtualCenter,
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVirtualCenters,
@@ -151,6 +155,10 @@ func (v *VCenter) Delete() error {
 
 // Disable is an update shortcut for disabling vCenter
 func (v *VCenter) Disable() error {
+	return runWithRetry(v.disable, vCenterEntityBusyRegexp, maximumVcenterRetryTime)
+}
+
+func (v *VCenter) disable() error {
 	v.VSphereVCenter.IsEnabled = false
 	_, err := v.Update(v.VSphereVCenter)
 	return err


### PR DESCRIPTION
Created from this discussion https://github.com/vmware/go-vcloud-director/pull/740/files#r1930328803

The vCenter RefreshVcenter, RefreshStorageProfiles, Disable and Delete methods will use retry mechanism at the core.