### PR TITLE
Fix AutoAttach flag in ContentLibrary type

### DIFF
--- a/.changes/v3.0.0/711-features.md
+++ b/.changes/v3.0.0/711-features.md
@@ -4,4 +4,4 @@
 * Added `ContentLibrary` and `types.ContentLibrary` structures to manage Content Libraries with
   methods `VCDClient.CreateContentLibrary`, `VCDClient.GetAllContentLibraries`,
   `VCDClient.GetContentLibraryByName`, `VCDClient.GetContentLibraryById`, `ContentLibrary.Update`,
-  `ContentLibrary.Delete` [GH-711, GH-721, GH-735]
+  `ContentLibrary.Delete` [GH-711, GH-721, GH-735, GH-757]

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -144,7 +144,7 @@ func (vcd *TestVCD) Test_ContentLibraryTenant(check *C) {
 	clDefinition := &types.ContentLibrary{
 		Name:           check.TestName(),
 		StorageClasses: []types.OpenApiReference{{ID: sc.StorageClass.ID}},
-		AutoAttach:     true,
+		AutoAttach:     false,
 		Description:    check.TestName(),
 	}
 

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -282,7 +282,7 @@ func (vcd *TestVCD) Test_ContentLibrarySubscribed(check *C) {
 	check.Assert(createdCl.ContentLibrary.IsShared, Equals, true) // Always true for providers
 	check.Assert(createdCl.ContentLibrary.IsSubscribed, Equals, true)
 	check.Assert(createdCl.ContentLibrary.LibraryType, Equals, "PROVIDER")
-	check.Assert(createdCl.ContentLibrary.VersionNumber >= int64(1), Equals, true) // Version can differ from 1
+	check.Assert(createdCl.ContentLibrary.VersionNumber >= int64(0), Equals, true) // Version can differ from 0
 	check.Assert(createdCl.ContentLibrary.Org, NotNil)
 	check.Assert(createdCl.ContentLibrary.Org.Name, Equals, "System")
 	check.Assert(createdCl.ContentLibrary.SubscriptionConfig, NotNil)

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -65,7 +65,7 @@ type ContentLibrary struct {
 	// creation then this field will default to true. If a value of false is supplied, then this Tenant Content Library will
 	// only be attached to namespaces that explicitly request it. For Provider Content Libraries this field is not needed for
 	// creation and will always be returned as true. This field cannot be updated after Content Library creation
-	AutoAttach bool `json:"autoAttach,omitempty"`
+	AutoAttach bool `json:"autoAttach"`
 	// The ISO-8601 timestamp representing when this Content Library was created
 	CreationDate string `json:"creationDate,omitempty"`
 	// The description of the Content Library


### PR DESCRIPTION
This `AutoAttach` flag defaults to `true` in the backend (VCFA) when it is not sent.

It happened that, if one sets explicitly `AutoAttach=false` when creating a Content Library, as the JSON definition had the `omitempty` clause, it was not sent to the backend, making the Content Librarty to have always `AutoAttach=true`.

The test is adjusted to reproduce this issue.