### PR TITLE
Improve testing auth session, improve disabled VC recovery in tests

### DIFF
--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -26,6 +26,12 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 			printVerbose("# vCenter with %s found. Enabling it.\n", vcd.config.Tm.VcenterUrl)
 			vc.VSphereVCenter.IsEnabled = true
 			vc, err = vc.Update(vc.VSphereVCenter)
+			err = waitForListenerStatusConnected(vc)
+			check.Assert(err, IsNil)
+			check.Assert(err, IsNil)
+			err = vc.Refresh()
+			check.Assert(err, IsNil)
+			err = vc.RefreshStorageProfiles()
 			check.Assert(err, IsNil)
 		}
 

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -26,8 +26,8 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 			printVerbose("# vCenter with %s found. Enabling it.\n", vcd.config.Tm.VcenterUrl)
 			vc.VSphereVCenter.IsEnabled = true
 			vc, err = vc.Update(vc.VSphereVCenter)
-			err = waitForListenerStatusConnected(vc)
 			check.Assert(err, IsNil)
+			err = waitForListenerStatusConnected(vc)
 			check.Assert(err, IsNil)
 			err = vc.Refresh()
 			check.Assert(err, IsNil)


### PR DESCRIPTION
Looks like testing user session times out after 1 hour - this approach introduces reauthentication before each test.

Also, testing helped `getOrCreateVCenter` attempts to refresh vCenters if it was disabled.