### PR TITLE
Add Content Library Item update method

### DIFF
--- a/.changes/v3.0.0/717-features.md
+++ b/.changes/v3.0.0/717-features.md
@@ -1,4 +1,4 @@
 * Added `ContentLibraryItem` and `types.ContentLibraryItem` structures to manage Content Library Items
   with methods `ContentLibrary.CreateContentLibraryItem`, `ContentLibrary.GetAllContentLibraryItems`,
   `ContentLibrary.GetContentLibraryItemByName`, `ContentLibrary.GetContentLibraryItemById`, `ContentLibraryItem.Update`,
-  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717, GH-724, GH-733, GH-734]
+  `ContentLibraryItem.Delete`, `VCDClient.GetContentLibraryItemById` [GH-717, GH-724, GH-733, GH-734, GH-762]

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/peterhellberg/link v1.1.0
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
-	golang.org/x/text v0.19.0
+	golang.org/x/text v0.21.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.32.1
@@ -27,7 +27,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -72,8 +72,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
-golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/govcd/tm_content_library_item.go
+++ b/govcd/tm_content_library_item.go
@@ -369,10 +369,7 @@ func (o *ContentLibraryItem) Update(contentLibraryItemConfig *types.ContentLibra
 		requiresTm:     true,
 	}
 	outerType := ContentLibraryItem{vcdClient: o.vcdClient}
-	return updateOuterEntity(&o.vcdClient.Client, outerType, c, &types.ContentLibraryItem{
-		Name:     contentLibraryItemConfig.Name,
-		ItemType: o.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
-	})
+	return updateOuterEntity(&o.vcdClient.Client, outerType, c, contentLibraryItemConfig)
 }
 
 // Delete deletes the receiver Content Library Item

--- a/govcd/tm_content_library_item.go
+++ b/govcd/tm_content_library_item.go
@@ -361,9 +361,18 @@ func (vcdClient *VCDClient) GetContentLibraryItemById(id string) (*ContentLibrar
 }
 
 // Update updates an existing Content Library Item with the given configuration
-// TODO: TM: Not supported in UI yet
 func (o *ContentLibraryItem) Update(contentLibraryItemConfig *types.ContentLibraryItem) (*ContentLibraryItem, error) {
-	return nil, fmt.Errorf("not supported")
+	c := crudConfig{
+		entityLabel:    labelContentLibraryItem,
+		endpoint:       types.OpenApiPathVcf + types.OpenApiEndpointContentLibraryItems,
+		endpointParams: []string{o.ContentLibraryItem.ID},
+		requiresTm:     true,
+	}
+	outerType := ContentLibraryItem{vcdClient: o.vcdClient}
+	return updateOuterEntity(&o.vcdClient.Client, outerType, c, &types.ContentLibraryItem{
+		Name:     contentLibraryItemConfig.Name,
+		ItemType: o.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
+	})
 }
 
 // Delete deletes the receiver Content Library Item

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -56,8 +56,8 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 
 	updatedCli, err := cli.Update(&types.ContentLibraryItem{
-		Name:        check.TestName() + "Updated",    // Only name can be updated
-		Description: check.TestName() + "Updated",    // Only name can be updated
+		Name:        check.TestName() + "Updated",
+		Description: check.TestName() + "Updated",
 		ItemType:    cli.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
 	})
 	check.Assert(err, IsNil)

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -56,16 +56,17 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 
 	updatedCli, err := cli.Update(&types.ContentLibraryItem{
-		Name:        check.TestName() + "Updated", // Only name can be updated
-		Description: check.TestName() + "Updated", // Only name can be updated
+		Name:        check.TestName() + "Updated",    // Only name can be updated
+		Description: check.TestName() + "Updated",    // Only name can be updated
+		ItemType:    cli.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
 	})
 	check.Assert(err, IsNil)
 	check.Assert(updatedCli, NotNil)
-	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, "TEMPLATE")
 	check.Assert(updatedCli.ContentLibraryItem.Name, Equals, check.TestName()+"Updated")
 	check.Assert(updatedCli.ContentLibraryItem.Description, Equals, check.TestName()+"Updated")
-	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, 2)
+	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, cli.ContentLibraryItem.Version)
 	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, cli.ContentLibraryItem.CreationDate)
+	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, cli.ContentLibraryItem.ItemType)
 
 	// Content library deletion should fail with force=false and recursive=false
 	err = cl.Delete(false, false)

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -55,6 +55,18 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
 	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 
+	updatedCli, err := cli.Update(&types.ContentLibraryItem{
+		Name:        check.TestName() + "Updated", // Only name can be updated
+		Description: check.TestName() + "Updated", // Only name can be updated
+	})
+	check.Assert(err, IsNil)
+	check.Assert(updatedCli, NotNil)
+	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, "TEMPLATE")
+	check.Assert(updatedCli.ContentLibraryItem.Name, Equals, check.TestName()+"Updated")
+	check.Assert(updatedCli.ContentLibraryItem.Description, Equals, check.TestName()+"Updated")
+	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, 2)
+	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, cli.ContentLibraryItem.CreationDate)
+
 	// Content library deletion should fail with force=false and recursive=false
 	err = cl.Delete(false, false)
 	check.Assert(err, NotNil)

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -55,19 +55,6 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
 	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 
-	updatedCli, err := cli.Update(&types.ContentLibraryItem{
-		Name:        check.TestName() + "Updated",
-		Description: check.TestName() + "Updated",
-		ItemType:    cli.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
-	})
-	check.Assert(err, IsNil)
-	check.Assert(updatedCli, NotNil)
-	check.Assert(updatedCli.ContentLibraryItem.Name, Equals, check.TestName()+"Updated")
-	check.Assert(updatedCli.ContentLibraryItem.Description, Equals, check.TestName()+"Updated")
-	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, cli.ContentLibraryItem.Version)
-	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, cli.ContentLibraryItem.CreationDate)
-	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, cli.ContentLibraryItem.ItemType)
-
 	// Content library deletion should fail with force=false and recursive=false
 	err = cl.Delete(false, false)
 	check.Assert(err, NotNil)
@@ -105,6 +92,19 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(obtainedCliById, NotNil)
 	check.Assert(*obtainedCliById.ContentLibraryItem, DeepEquals, *obtainedCliByName.ContentLibraryItem)
+
+	updatedCli, err := cli.Update(&types.ContentLibraryItem{
+		Name:        obtainedCliById.ContentLibraryItem.Name + "Updated",
+		Description: obtainedCliById.ContentLibraryItem.Description + "Updated",
+		ItemType:    obtainedCliById.ContentLibraryItem.ItemType, // We need to send the type, otherwise it fails
+	})
+	check.Assert(err, IsNil)
+	check.Assert(updatedCli, NotNil)
+	check.Assert(updatedCli.ContentLibraryItem.Name, Equals, obtainedCliById.ContentLibraryItem.Name+"Updated")
+	check.Assert(updatedCli.ContentLibraryItem.Description, Equals, obtainedCliById.ContentLibraryItem.Description+"Updated")
+	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, obtainedCliById.ContentLibraryItem.Version)
+	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, obtainedCliById.ContentLibraryItem.CreationDate)
+	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, obtainedCliById.ContentLibraryItem.ItemType)
 
 	// Not found errors
 	_, err = cl.GetContentLibraryItemByName("notexist")


### PR DESCRIPTION
The `ContentLibraryItem.Update` method was missing. The tests are also updated to test it (only name and description can be updated).

Also includes https://github.com/vmware/go-vcloud-director/pull/761