### PR TITLE
Do not cleanup certs

### DIFF
--- a/govcd/nsxt_manager_openapi_test.go
+++ b/govcd/nsxt_manager_openapi_test.go
@@ -29,9 +29,6 @@ func (vcd *TestVCD) Test_NsxtManagerOpenApi(check *C) {
 	check.Assert(err, IsNil)
 	trustedCert, err := vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
-	if trustedCert != nil {
-		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
-	}
 	v, err := vcd.client.CreateNsxtManagerOpenApi(cfg)
 	check.Assert(err, IsNil)
 	check.Assert(v, NotNil)

--- a/govcd/nsxt_manager_openapi_test.go
+++ b/govcd/nsxt_manager_openapi_test.go
@@ -27,7 +27,7 @@ func (vcd *TestVCD) Test_NsxtManagerOpenApi(check *C) {
 	// Certificate must be trusted before adding NSX-T Manager
 	url, err := url.Parse(cfg.Url)
 	check.Assert(err, IsNil)
-	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	_, err = vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
 	v, err := vcd.client.CreateNsxtManagerOpenApi(cfg)
 	check.Assert(err, IsNil)
@@ -66,9 +66,4 @@ func (vcd *TestVCD) Test_NsxtManagerOpenApi(check *C) {
 	check.Assert(ContainsNotFound(err), Equals, true)
 	check.Assert(notFoundByName, IsNil)
 
-	// Remove trusted cert
-	if trustedCert != nil {
-		err = trustedCert.Delete()
-		check.Assert(err, IsNil)
-	}
 }

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -54,11 +54,8 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	// Certificate must be trusted before adding vCenter
 	url, err := url.Parse(vcCfg.Url)
 	check.Assert(err, IsNil)
-	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	_, err = vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
-	if trustedCert != nil {
-		printVerbose("# Certificate for vCenter is trusted %s\n", trustedCert.TrustedCertificate.ID)
-	}
 
 	vc, err = vcd.client.CreateVcenter(vcCfg)
 	check.Assert(err, IsNil)
@@ -141,11 +138,8 @@ func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()
 	// Certificate must be trusted before adding NSX-T Manager
 	url, err := url.Parse(nsxtCfg.Url)
 	check.Assert(err, IsNil)
-	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	_, err = vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
-	if trustedCert != nil {
-		printVerbose("# Certificate for NSX-T Manager is trusted %s\n", trustedCert.TrustedCertificate.ID)
-	}
 	nsxtManager, err = vcd.client.CreateNsxtManagerOpenApi(nsxtCfg)
 	check.Assert(err, IsNil)
 	check.Assert(nsxtManager, NotNil)

--- a/govcd/tm_common_test.go
+++ b/govcd/tm_common_test.go
@@ -58,7 +58,6 @@ func getOrCreateVCenter(vcd *TestVCD, check *C) (*VCenter, func()) {
 	check.Assert(err, IsNil)
 	if trustedCert != nil {
 		printVerbose("# Certificate for vCenter is trusted %s\n", trustedCert.TrustedCertificate.ID)
-		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 
 	vc, err = vcd.client.CreateVcenter(vcCfg)
@@ -146,7 +145,6 @@ func getOrCreateNsxtManager(vcd *TestVCD, check *C) (*NsxtManagerOpenApi, func()
 	check.Assert(err, IsNil)
 	if trustedCert != nil {
 		printVerbose("# Certificate for NSX-T Manager is trusted %s\n", trustedCert.TrustedCertificate.ID)
-		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
 	}
 	nsxtManager, err = vcd.client.CreateNsxtManagerOpenApi(nsxtCfg)
 	check.Assert(err, IsNil)

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -227,11 +227,8 @@ func (vcd *TestVCD) Test_ContentLibrarySubscribed(check *C) {
 	// Certificate must be trusted before adding subscribed content library
 	url, err := url.Parse(vcd.config.Tm.SubscriptionContentLibraryUrl)
 	check.Assert(err, IsNil)
-	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	_, err = vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
-	if trustedCert != nil {
-		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
-	}
 
 	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
 	defer nsxtManagerCleanup()

--- a/govcd/tm_region_quota_storage_policy_test.go
+++ b/govcd/tm_region_quota_storage_policy_test.go
@@ -124,7 +124,7 @@ func (vcd *TestVCD) Test_TmRegionQuotaStoragePolicy(check *C) {
 	if len(rqPolicies) == 1 {
 		// If there's only one policy, expect an error. There must be always one Storage Policy
 		check.Assert(err, NotNil)
-		check.Assert(strings.Contains(err.Error(), "Storage policy is not set for the entity in VDC"), Equals, true)
+		check.Assert(strings.Contains(err.Error(), "At least one storage class must be assigned for the region quota to remain functional"), Equals, true)
 	} else {
 		check.Assert(err, IsNil)
 	}

--- a/govcd/vsphere_vcenter_tm_test.go
+++ b/govcd/vsphere_vcenter_tm_test.go
@@ -30,9 +30,6 @@ func (vcd *TestVCD) Test_VCenter(check *C) {
 	check.Assert(err, IsNil)
 	trustedCert, err := vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
-	if trustedCert != nil {
-		AddToCleanupListOpenApi(trustedCert.TrustedCertificate.ID, check.TestName()+"trusted-cert", types.OpenApiPathVersion1_0_0+types.OpenApiEndpointTrustedCertificates+trustedCert.TrustedCertificate.ID)
-	}
 
 	v, err := vcd.client.CreateVcenter(cfg)
 	check.Assert(err, IsNil)

--- a/govcd/vsphere_vcenter_tm_test.go
+++ b/govcd/vsphere_vcenter_tm_test.go
@@ -28,7 +28,7 @@ func (vcd *TestVCD) Test_VCenter(check *C) {
 	// Certificate must be trusted before adding vCenter
 	url, err := url.Parse(cfg.Url)
 	check.Assert(err, IsNil)
-	trustedCert, err := vcd.client.AutoTrustCertificate(url)
+	_, err = vcd.client.AutoTrustCertificate(url)
 	check.Assert(err, IsNil)
 
 	v, err := vcd.client.CreateVcenter(cfg)
@@ -98,10 +98,4 @@ func (vcd *TestVCD) Test_VCenter(check *C) {
 	check.Assert(err, IsNil)
 	err = byIdAsync.Delete()
 	check.Assert(err, IsNil)
-
-	// Remove trusted cert if it was created
-	if trustedCert != nil {
-		err = trustedCert.Delete()
-		check.Assert(err, IsNil)
-	}
 }


### PR DESCRIPTION
* Removing trusted certificate cleanup so that NSX / VC dependent component cleanup is smoother
* Improve storage policy check validation