### PR TITLE
Do not require /api in connection

### DIFF
--- a/.changes/v3.0.0/756-improvements.md
+++ b/.changes/v3.0.0/756-improvements.md
@@ -1,0 +1,1 @@
+* `vcdEndpoint` in `NewVCDClient` does not require the URL to contain `/api` suffix [GH-765]

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -143,8 +143,8 @@ func (vcdClient *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	overrideApiVersion()
 
-	// ensure vcdEndpoint is set to https://HOST/api internally
-	if !strings.Contains(vcdEndpoint.Path, "/api") {
+	// ensure vcdEndpoint is set to contain /api suffix for internal usage
+	if !strings.HasSuffix(vcdEndpoint.Path, "/api") {
 		vcdEndpoint.Path += "/api"
 	}
 

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -143,6 +143,11 @@ func (vcdClient *VCDClient) vcdCloudApiAuthorize(user, pass, org string) (*http.
 func NewVCDClient(vcdEndpoint url.URL, insecure bool, options ...VCDClientOption) *VCDClient {
 	overrideApiVersion()
 
+	// ensure vcdEndpoint is set to https://HOST/api internally
+	if !strings.Contains(vcdEndpoint.Path, "/api") {
+		vcdEndpoint.Path += "/api"
+	}
+
 	// Setting defaults
 	// #nosec G402 -- InsecureSkipVerify: insecure - This allows connecting to VCDs with self-signed certificates
 	vcdClient := &VCDClient{


### PR DESCRIPTION
This PR makes the change to `NewVCDClient` that makes specifying the `/api` suffix in vcdEndpoint optional.
Tests are passing.