### PR TITLE
Support Tenant Content Library Items + OVF/ISO uploads

### DIFF
--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -142,13 +142,18 @@ func (vcd *TestVCD) Test_ContentLibraryItemIso(check *C) {
 	check.Assert(err, IsNil)
 	defer clCleanup()
 
-	// TODO: TM: ISO upload is not supported in TM yet, we just check that it fails gracefully
-	_, err = cl.CreateContentLibraryItem(&types.ContentLibraryItem{
+	cli, err := cl.CreateContentLibraryItem(&types.ContentLibraryItem{
 		Name:        check.TestName(),
 		Description: check.TestName(),
 	}, ContentLibraryItemUploadArguments{
 		FilePath: "../test-resources/test.iso",
 	})
-	check.Assert(err, NotNil)
-	check.Assert(err.Error(), Equals, "ISO uploads not supported")
+	check.Assert(err, IsNil)
+	check.Assert(cli, NotNil)
+	AddToCleanupListOpenApi(cli.ContentLibraryItem.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraryItems+cli.ContentLibraryItem.ID)
+	check.Assert(cli.ContentLibraryItem.ItemType, Equals, "ISO")
+	check.Assert(cli.ContentLibraryItem.Name, Equals, check.TestName())
+	check.Assert(cli.ContentLibraryItem.Description, Equals, check.TestName())
+	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
+	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 }

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -9,13 +9,14 @@ package govcd
 import (
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
+	"path/filepath"
 )
 
 // TODO: TM: Test upload failures:
 //       https://github.com/vmware/go-vcloud-director/pull/717#discussion_r1853767609
 
-// Test_ContentLibraryItemOva tests CRUD operations for a Content Library Item when uploading an OVA
-func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
+// Test_ContentLibraryItemProvider tests CRUD operations for a Content Library Item when uploading in a PROVIDER Content Library
+func (vcd *TestVCD) Test_ContentLibraryItemProvider(check *C) {
 	skipNonTm(vcd, check)
 	sysadminOnly(vcd, check)
 
@@ -35,35 +36,119 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(sc, NotNil)
 
-	cl, clCleanup := getOrCreateContentLibrary(vcd, sc, check)
+	cl, clCleanup := getOrCreateContentLibrary(vcd, sc, nil, check)
 	check.Assert(err, IsNil)
 	defer clCleanup()
 
-	// Test begins
+	testCases := []ContentLibraryItemUploadArguments{
+		{
+			FilePath: "../test-resources/test_vapp_template.ova",
+		},
+		{
+			FilePath: "../test-resources/test.iso",
+		},
+		{
+			FilePath: "../test-resources/test_vapp_template_ovf/descriptor.ovf",
+			OvfFilesPaths: []string{
+				"../test-resources/test_vapp_template_ovf/yVMFromVcd-disk1.vmdk",
+			},
+		},
+	}
+
+	for _, args := range testCases {
+		testContentLibraryItem(vcd, cl, args, check)
+	}
+
+	// Not found errors
+	_, err = cl.GetContentLibraryItemByName("notexist")
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = cl.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = vcd.client.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(ContainsNotFound(err), Equals, true)
+}
+
+// Test_ContentLibraryItemTenant tests CRUD operations for a Content Library Item when uploading in a TENANT Content Library
+func (vcd *TestVCD) Test_ContentLibraryItemTenant(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check)
+
+	// Pre-requisites
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
+	check.Assert(err, IsNil)
+
+	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
+	defer regionCleanup()
+
+	org, orgCleanup := createOrg(vcd, check, false)
+	defer orgCleanup()
+
+	// A Region Quota is needed to have Storage classes available in the Organization
+	_, regionQuotaCleanup := createRegionQuota(vcd, org, region, check)
+	defer regionQuotaCleanup()
+
+	sc, err := region.GetStorageClassByName(vcd.config.Tm.StorageClass)
+	check.Assert(err, IsNil)
+	check.Assert(sc, NotNil)
+
+	cl, clCleanup := getOrCreateContentLibrary(vcd, sc, org, check)
+	check.Assert(err, IsNil)
+	defer clCleanup()
+
+	testCases := []ContentLibraryItemUploadArguments{
+		{
+			FilePath: "../test-resources/test_vapp_template.ova",
+		},
+		{
+			FilePath: "../test-resources/test.iso",
+		},
+		{
+			FilePath: "../test-resources/test_vapp_template_ovf/descriptor.ovf",
+			OvfFilesPaths: []string{
+				"../test-resources/test_vapp_template_ovf/yVMFromVcd-disk1.vmdk",
+			},
+		},
+	}
+
+	for _, args := range testCases {
+		testContentLibraryItem(vcd, cl, args, check)
+	}
+}
+
+func testContentLibraryItem(vcd *TestVCD, cl *ContentLibrary, args ContentLibraryItemUploadArguments, check *C) {
 	cli, err := cl.CreateContentLibraryItem(&types.ContentLibraryItem{
 		Name:        check.TestName(),
 		Description: check.TestName(),
-	}, ContentLibraryItemUploadArguments{
-		FilePath: "../test-resources/test_vapp_template.ova",
-	})
+	}, args)
 	check.Assert(err, IsNil)
 	check.Assert(cli, NotNil)
 	AddToCleanupListOpenApi(cli.ContentLibraryItem.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraryItems+cli.ContentLibraryItem.ID)
-	check.Assert(cli.ContentLibraryItem.ItemType, Equals, "TEMPLATE")
+
+	if filepath.Ext(args.FilePath) == ".iso" {
+		check.Assert(cli.ContentLibraryItem.ItemType, Equals, "ISO")
+	} else {
+		check.Assert(cli.ContentLibraryItem.ItemType, Equals, "TEMPLATE")
+	}
 	check.Assert(cli.ContentLibraryItem.Name, Equals, check.TestName())
 	check.Assert(cli.ContentLibraryItem.Description, Equals, check.TestName())
 	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
 	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 
+	// Check that the files are indeed uploaded (list of files is empty)
+	files, err := getContentLibraryItemFiles(cli)
+	check.Assert(err, IsNil)
+	check.Assert(len(files), Equals, 0)
+
 	// Content library deletion should fail with force=false and recursive=false
 	err = cl.Delete(false, false)
 	check.Assert(err, NotNil)
-
-	// Defer deletion for a correct cleanup
-	defer func() {
-		err = cli.Delete()
-		check.Assert(err, IsNil)
-	}()
 
 	allClis, err := cl.GetAllContentLibraryItems(nil)
 	check.Assert(err, IsNil)
@@ -106,98 +191,6 @@ func (vcd *TestVCD) Test_ContentLibraryItemOva(check *C) {
 	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, obtainedCliById.ContentLibraryItem.CreationDate)
 	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, obtainedCliById.ContentLibraryItem.ItemType)
 
-	// Not found errors
-	_, err = cl.GetContentLibraryItemByName("notexist")
-	check.Assert(ContainsNotFound(err), Equals, true)
-
-	_, err = cl.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
-	check.Assert(ContainsNotFound(err), Equals, true)
-
-	_, err = vcd.client.GetContentLibraryItemById("urn:vcloud:contentLibraryItem:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
-	check.Assert(ContainsNotFound(err), Equals, true)
-}
-
-// Test_ContentLibraryItemIso tests CRUD operations for a Content Library Item when uploading an ISO file
-func (vcd *TestVCD) Test_ContentLibraryItemIso(check *C) {
-	skipNonTm(vcd, check)
-	sysadminOnly(vcd, check)
-
-	// Pre-requisites
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
-
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
-	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
+	err = cli.Delete()
 	check.Assert(err, IsNil)
-
-	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
-	defer regionCleanup()
-
-	sc, err := region.GetStorageClassByName(vcd.config.Tm.StorageClass)
-	check.Assert(err, IsNil)
-	check.Assert(sc, NotNil)
-
-	cl, clCleanup := getOrCreateContentLibrary(vcd, sc, check)
-	check.Assert(err, IsNil)
-	defer clCleanup()
-
-	cli, err := cl.CreateContentLibraryItem(&types.ContentLibraryItem{
-		Name:        check.TestName(),
-		Description: check.TestName(),
-	}, ContentLibraryItemUploadArguments{
-		FilePath: "../test-resources/test.iso",
-	})
-	check.Assert(err, IsNil)
-	check.Assert(cli, NotNil)
-	AddToCleanupListOpenApi(cli.ContentLibraryItem.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraryItems+cli.ContentLibraryItem.ID)
-	check.Assert(cli.ContentLibraryItem.ItemType, Equals, "ISO")
-	check.Assert(cli.ContentLibraryItem.Name, Equals, check.TestName())
-	check.Assert(cli.ContentLibraryItem.Description, Equals, check.TestName())
-	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
-	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
-}
-
-// Test_ContentLibraryItemIso tests CRUD operations for a Content Library Item when uploading an OVF file
-func (vcd *TestVCD) Test_ContentLibraryItemOvf(check *C) {
-	skipNonTm(vcd, check)
-	sysadminOnly(vcd, check)
-
-	// Pre-requisites
-	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
-	defer nsxtManagerCleanup()
-
-	vc, vcCleanup := getOrCreateVCenter(vcd, check)
-	defer vcCleanup()
-	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
-	check.Assert(err, IsNil)
-
-	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
-	defer regionCleanup()
-
-	sc, err := region.GetStorageClassByName(vcd.config.Tm.StorageClass)
-	check.Assert(err, IsNil)
-	check.Assert(sc, NotNil)
-
-	cl, clCleanup := getOrCreateContentLibrary(vcd, sc, check)
-	check.Assert(err, IsNil)
-	defer clCleanup()
-
-	cli, err := cl.CreateContentLibraryItem(&types.ContentLibraryItem{
-		Name:        check.TestName(),
-		Description: check.TestName(),
-	}, ContentLibraryItemUploadArguments{
-		FilePath: "../test-resources/test_vapp_template_ovf/descriptor.ovf",
-		OvfFilesPaths: []string{
-			"../test-resources/test_vapp_template_ovf/yVMFromVcd-disk1.vmdk",
-		},
-	})
-	check.Assert(err, IsNil)
-	check.Assert(cli, NotNil)
-	AddToCleanupListOpenApi(cli.ContentLibraryItem.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraryItems+cli.ContentLibraryItem.ID)
-	check.Assert(cli.ContentLibraryItem.ItemType, Equals, "TEMPLATE")
-	check.Assert(cli.ContentLibraryItem.Name, Equals, check.TestName())
-	check.Assert(cli.ContentLibraryItem.Description, Equals, check.TestName())
-	check.Assert(cli.ContentLibraryItem.Version, Equals, 1)
-	check.Assert(cli.ContentLibraryItem.CreationDate, Not(Equals), "")
 }

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -127,6 +127,9 @@ type ContentLibraryItem struct {
 	Status string `json:"status,omitempty"`
 	// The version of this item. For a subscribed library, this version is same as in publisher library
 	Version int `json:"version,omitempty"`
+	// The size of the content library item file to upload in bytes.
+	// This field is only required for ISO content library items and will be NULL for Template based content library items
+	FileUploadSizeBytes int64 `json:"fileUploadSizeBytes,omitempty"`
 }
 
 // ContentLibraryItemFile specifies a Content Library Item file for uploads


### PR DESCRIPTION
This PR does a major refactor in method `CreateContentLibraryItem`:

- Now supports tenant content library items (it picks the owner CL tenant context)
- Supports OVF/ISO upload
- Fixed some inefficiencies during upload process and improves readability.

Tests are also updated.