### PR TITLE
Do not suport VCD <10.3

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -7,7 +7,7 @@
 * vCenter management types `VCenter` and `types.VSphereVirtualCenter` adds Create, Update and Delete
  methods: `VCDClient.CreateVcenter`, `VCDClient.GetAllVCenters`, `VCDClient.GetVCenterByName`,
  `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.RefreshVcenter`,
- `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753, GH-756, GH-759, GH-760]
+ `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753, GH-756, GH-759, GH-760, GH-767]
 * Add NSX-T Manager management types `NsxtManagerOpenApi`, `types.NsxtManagerOpenApi` and methods
   `VCDClient.CreateNsxtManagerOpenApi`, `VCDClient.GetAllNsxtManagersOpenApi`,
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,

--- a/.changes/v3.0.0/767-improvements.md
+++ b/.changes/v3.0.0/767-improvements.md
@@ -1,0 +1,1 @@
+* Remove a workaround that was used for certificate management endpoint with a typo on VCD < 10.3 [GH-767]

--- a/govcd/certificate_management.go
+++ b/govcd/certificate_management.go
@@ -56,15 +56,7 @@ func getCertificateFromLibraryById(client *Client, id string, additionalHeader m
 
 func getEndpointByVersion(client *Client) (string, error) {
 	endpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibrary
-	newerApiVersion, err := client.VersionEqualOrGreater("10.3", 3)
-	if err != nil {
-		return "", err
-	}
-	if !newerApiVersion {
-		// in previous version exist only API with mistype in name
-		endpoint = types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointSSLCertificateLibraryOld
-	}
-	return endpoint, err
+	return endpoint, nil
 }
 
 // GetCertificateFromLibraryById Returns certificate from library of certificates from System Context

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -20,7 +20,7 @@ const labelVirtualCenter = "vCenter Server"
 
 // vCenter task is sometimes unreliable and trying to refresh it immediately after it becomes
 // connected causes a "BUSY_ENTITY" error (which has a few different messages)
-var maximumVcenterRetryTime = 120 * time.Second                                                                          // The maximum time a single operation will be retried before giving up
+var maximumVcenterRetryTime = 240 * time.Second                                                                          // The maximum time a single operation will be retried before giving up
 var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY|another transaction|408:TIMEDOUT)`) // Regexp to match entity busy error
 
 type VCenter struct {

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -20,8 +20,8 @@ const labelVirtualCenter = "vCenter Server"
 
 // vCenter task is sometimes unreliable and trying to refresh it immediately after it becomes
 // connected causes a "BUSY_ENTITY" error (which has a few different messages)
-var maximumVcenterRetryTime = 120 * time.Second                                                             // The maximum time a single operation will be retried before giving up
-var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY|another transaction)`) // Regexp to match entity busy error
+var maximumVcenterRetryTime = 120 * time.Second                                                                          // The maximum time a single operation will be retried before giving up
+var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY|another transaction|408:TIMEDOUT)`) // Regexp to match entity busy error
 
 type VCenter struct {
 	VSphereVCenter *types.VSphereVirtualCenter

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -20,7 +20,7 @@ const labelVirtualCenter = "vCenter Server"
 
 // vCenter task is sometimes unreliable and trying to refresh it immediately after it becomes
 // connected causes a "BUSY_ENTITY" error (which has a few different messages)
-var maximumVcenterRetryTime = 240 * time.Second                                                                          // The maximum time a single operation will be retried before giving up
+var maximumVcenterRetryTime = 15 * time.Minute                                                                           // The maximum time a single operation will be retried before giving up
 var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY|another transaction|408:TIMEDOUT)`) // Regexp to match entity busy error
 
 type VCenter struct {

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -20,7 +20,7 @@ const labelVirtualCenter = "vCenter Server"
 
 // vCenter task is sometimes unreliable and trying to refresh it immediately after it becomes
 // connected causes a "BUSY_ENTITY" error (which has a few different messages)
-var maximumVcenterRetryTime = 15 * time.Minute                                                                           // The maximum time a single operation will be retried before giving up
+var maximumVcenterRetryTime = 2 * time.Minute                                                                            // The maximum time a single operation will be retried before giving up
 var vCenterEntityBusyRegexp = regexp.MustCompile(`(is currently busy|400|BUSY_ENTITY|another transaction|408:TIMEDOUT)`) // Regexp to match entity busy error
 
 type VCenter struct {


### PR DESCRIPTION
This PR:
* removes support for cert management on VCD <10.3 which is Out of life anyway.
* Improves vCenter timeout matching
