### PR TITLE
Add Organization Settings support

### DIFF
--- a/.changes/v3.0.0/716-features.md
+++ b/.changes/v3.0.0/716-features.md
@@ -1,4 +1,3 @@
 * Added `TmOrg` and `types.TmOrg` structure for OpenAPI management of Organizations with methods
   `VCDClient.CreateTmOrg`, `VCDClient.GetAllTmOrgs`, `VCDClient.GetTmOrgByName`,
-  `VCDClient.GetTmOrgById`, `TmOrg.Update`, `TmOrg.Delete`, `TmOrg.Disable`, `TmOrg.GetOrgSettings`,
-  `TmOrg.UpdateOrgSettings` [GH-716, GH-768]
+  `VCDClient.GetTmOrgById`, `TmOrg.Update`, `TmOrg.Delete`, `TmOrg.Disable` [GH-716]

--- a/.changes/v3.0.0/716-features.md
+++ b/.changes/v3.0.0/716-features.md
@@ -1,3 +1,4 @@
 * Added `TmOrg` and `types.TmOrg` structure for OpenAPI management of Organizations with methods
   `VCDClient.CreateTmOrg`, `VCDClient.GetAllTmOrgs`, `VCDClient.GetTmOrgByName`,
-  `VCDClient.GetTmOrgById`, `TmOrg.Update`, `TmOrg.Delete`, `TmOrg.Disable` [GH-716]
+  `VCDClient.GetTmOrgById`, `TmOrg.Update`, `TmOrg.Delete`, `TmOrg.Disable`, `TmOrg.GetOrgSettings`,
+  `TmOrg.UpdateOrgSettings` [GH-716, GH-768]

--- a/.changes/v3.0.0/768-features.md
+++ b/.changes/v3.0.0/768-features.md
@@ -1,0 +1,2 @@
+* Added `types.TmOrgSettings` structure for OpenAPI management of Organization Settings with methods
+  `TmOrg.GetSettings`, `TmOrg.UpdateSettings` [GH-716]

--- a/govcd/openapi_endpoints.go
+++ b/govcd/openapi_endpoints.go
@@ -179,6 +179,7 @@ var endpointMinApiVersions = map[string]string{
 	types.OpenApiPathVcf + types.OpenApiEndpointTmEdgeClusterTransportNodeStatus:       "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointTmEdgeClustersSync:                     "40.0",
 	types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTmOrgNetworkingSettings:       "40.0",
+	types.OpenApiPathVcf + types.OpenApiEndpointTmOrgSettings:                          "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointTmRegionalNetworkingSettings:           "40.0",
 	types.OpenApiPathVcf + types.OpenApiEndpointTmRegionalNetworkingSettingsVpcProfile: "40.0",
 }

--- a/govcd/tm_org.go
+++ b/govcd/tm_org.go
@@ -13,6 +13,7 @@ import (
 
 const labelOrganization = "Organization"
 const labelOrganizationNetworkingSettings = "Organization Networking Settings"
+const labelOrganizationSettings = "Organization Settings"
 
 type TmOrg struct {
 	TmOrg     *types.TmOrg
@@ -134,6 +135,35 @@ func (o *TmOrg) UpdateOrgNetworkingSettings(tmOrgNetConfig *types.TmOrgNetworkin
 		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointTmOrgNetworkingSettings,
 		endpointParams: []string{o.TmOrg.ID},
 		requiresTm:     true,
+	}
+
+	return updateInnerEntity(&o.vcdClient.Client, c, tmOrgNetConfig)
+}
+
+// GetOrgSettings retrieves Organization settings
+func (o *TmOrg) GetOrgSettings() (*types.TmOrgSettings, error) {
+	c := crudConfig{
+		entityLabel: labelOrganizationSettings,
+		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmOrgSettings,
+		additionalHeader: getTenantContextHeader(&TenantContext{
+			OrgId:   o.TmOrg.ID,
+			OrgName: o.TmOrg.Name,
+		}),
+		requiresTm: true,
+	}
+	return getInnerEntity[types.TmOrgSettings](&o.vcdClient.Client, c)
+}
+
+// UpdateOrgSettings changes Organization settings
+func (o *TmOrg) UpdateOrgSettings(tmOrgNetConfig *types.TmOrgSettings) (*types.TmOrgSettings, error) {
+	c := crudConfig{
+		entityLabel: labelOrganizationSettings,
+		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmOrgSettings,
+		additionalHeader: getTenantContextHeader(&TenantContext{
+			OrgId:   o.TmOrg.ID,
+			OrgName: o.TmOrg.Name,
+		}),
+		requiresTm: true,
 	}
 
 	return updateInnerEntity(&o.vcdClient.Client, c, tmOrgNetConfig)

--- a/govcd/tm_org.go
+++ b/govcd/tm_org.go
@@ -140,8 +140,8 @@ func (o *TmOrg) UpdateOrgNetworkingSettings(tmOrgNetConfig *types.TmOrgNetworkin
 	return updateInnerEntity(&o.vcdClient.Client, c, tmOrgNetConfig)
 }
 
-// GetOrgSettings retrieves Organization settings
-func (o *TmOrg) GetOrgSettings() (*types.TmOrgSettings, error) {
+// GetSettings retrieves Organization settings
+func (o *TmOrg) GetSettings() (*types.TmOrgSettings, error) {
 	c := crudConfig{
 		entityLabel: labelOrganizationSettings,
 		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmOrgSettings,
@@ -154,8 +154,8 @@ func (o *TmOrg) GetOrgSettings() (*types.TmOrgSettings, error) {
 	return getInnerEntity[types.TmOrgSettings](&o.vcdClient.Client, c)
 }
 
-// UpdateOrgSettings changes Organization settings
-func (o *TmOrg) UpdateOrgSettings(tmOrgNetConfig *types.TmOrgSettings) (*types.TmOrgSettings, error) {
+// UpdateSettings changes Organization settings
+func (o *TmOrg) UpdateSettings(tmOrgNetConfig *types.TmOrgSettings) (*types.TmOrgSettings, error) {
 	c := crudConfig{
 		entityLabel: labelOrganizationSettings,
 		endpoint:    types.OpenApiPathVcf + types.OpenApiEndpointTmOrgSettings,

--- a/govcd/tm_org_test.go
+++ b/govcd/tm_org_test.go
@@ -51,6 +51,24 @@ func (vcd *TestVCD) Test_TmOrg(check *C) {
 	check.Assert(err, IsNil)
 	check.Assert(updated, NotNil)
 
+	// Settings
+	settings, err := updated.GetOrgSettings()
+	check.Assert(err, IsNil)
+	check.Assert(settings, NotNil)
+	check.Assert(settings.CanCreateSubscribedLibraries, NotNil)
+	check.Assert(settings.QuarantineContentLibraryItems, NotNil)
+
+	settingsUpdated, err := updated.UpdateOrgSettings(&types.TmOrgSettings{
+		CanCreateSubscribedLibraries:  addrOf(!(*settings.CanCreateSubscribedLibraries)),
+		QuarantineContentLibraryItems: addrOf(!(*settings.QuarantineContentLibraryItems)),
+	})
+	check.Assert(err, IsNil)
+	check.Assert(settingsUpdated, NotNil)
+	check.Assert(settingsUpdated.CanCreateSubscribedLibraries, NotNil)
+	check.Assert(settingsUpdated.QuarantineContentLibraryItems, NotNil)
+	check.Assert(*settingsUpdated.CanCreateSubscribedLibraries, Equals, !(*settings.CanCreateSubscribedLibraries))
+	check.Assert(*settingsUpdated.QuarantineContentLibraryItems, Equals, !(*settings.QuarantineContentLibraryItems))
+
 	// Delete
 	err = tmOrg.Delete()
 	check.Assert(err, IsNil)

--- a/govcd/tm_org_test.go
+++ b/govcd/tm_org_test.go
@@ -52,13 +52,13 @@ func (vcd *TestVCD) Test_TmOrg(check *C) {
 	check.Assert(updated, NotNil)
 
 	// Settings
-	settings, err := updated.GetOrgSettings()
+	settings, err := updated.GetSettings()
 	check.Assert(err, IsNil)
 	check.Assert(settings, NotNil)
 	check.Assert(settings.CanCreateSubscribedLibraries, NotNil)
 	check.Assert(settings.QuarantineContentLibraryItems, NotNil)
 
-	settingsUpdated, err := updated.UpdateOrgSettings(&types.TmOrgSettings{
+	settingsUpdated, err := updated.UpdateSettings(&types.TmOrgSettings{
 		CanCreateSubscribedLibraries:  addrOf(!(*settings.CanCreateSubscribedLibraries)),
 		QuarantineContentLibraryItems: addrOf(!(*settings.QuarantineContentLibraryItems)),
 	})

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -527,6 +527,7 @@ const (
 	// OpenAPI Org
 	OpenApiEndpointOrgs                    = "orgs/"
 	OpenApiEndpointTmOrgNetworkingSettings = "orgs/%s/networkingSettings"
+	OpenApiEndpointTmOrgSettings           = "orgSettings"
 
 	OpenApiEndpointRegionStoragePolicies                  = "regionStoragePolicies/"
 	OpenApiEndpointStorageClasses                         = "storageClasses/"

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -205,6 +205,15 @@ type TmOrgNetworkingSettings struct {
 	OrgNameForLogs string `json:"orgNameForLogs"`
 }
 
+// TmOrgSettings defines structure for managing Org Setttings
+type TmOrgSettings struct {
+	// Whether the organization can create content libraries that are subscribed to external sources.
+	CanCreateSubscribedLibraries *bool `json:"canCreateSubscribedLibraries,omitempty"`
+
+	// Whether to quarantine new content library items for file inspection.
+	QuarantineContentLibraryItems *bool `json:"quarantineContentLibraryItems,omitempty"`
+}
+
 // Region represents a collection of supervisor clusters across different VCs
 type Region struct {
 	ID string `json:"id,omitempty"`


### PR DESCRIPTION
Added `types.TmOrgSettings` structure for OpenAPI management of Organization Settings with methods `TmOrg.GetSettings`, `TmOrg.UpdateSettings`