### PR TITLE
Fix content libraries pagination

### DIFF
--- a/govcd/tm_content_library.go
+++ b/govcd/tm_content_library.go
@@ -54,7 +54,7 @@ func (vcdClient *VCDClient) GetAllContentLibraries(queryParameters url.Values, c
 	c := crudConfig{
 		entityLabel:      labelContentLibrary,
 		endpoint:         types.OpenApiPathVcf + types.OpenApiEndpointContentLibraries,
-		queryParameters:  queryParameters,
+		queryParameters:  defaultPageSize(queryParameters, "64"), // Content Library endpoint forces to use maximum 64 items per page
 		additionalHeader: getTenantContextHeader(ctx),
 		requiresTm:       true,
 	}


### PR DESCRIPTION
This PR:

- Fixes error in latest builds:

```
error in HTTP GET request: BAD_REQUEST - [ 325-2025-03-10-03-33-58-933--dab7223c-0d8c-4eb6-97ba-0d7df7ea398f ] validation error on supplied value '128': must be less than or equal to 64"
```

Now Content Library pagination is forced to be 64 maximum