### PR TITLE
Use 15 pages for vCenter and NSX manager

### DIFF
--- a/.changes/v3.0.0/714-features.md
+++ b/.changes/v3.0.0/714-features.md
@@ -7,10 +7,10 @@
 * vCenter management types `VCenter` and `types.VSphereVirtualCenter` adds Create, Update and Delete
  methods: `VCDClient.CreateVcenter`, `VCDClient.GetAllVCenters`, `VCDClient.GetVCenterByName`,
  `VCDClient.GetVCenterById`, `VCenter.Update`, `VCenter.Delete`, `VCenter.RefreshVcenter`,
- `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753, GH-756, GH-759, GH-760, GH-767]
+ `VCenter.Refresh` [GH-714, GH-724, GH-747, GH-753, GH-756, GH-759, GH-760, GH-767, GH-771]
 * Add NSX-T Manager management types `NsxtManagerOpenApi`, `types.NsxtManagerOpenApi` and methods
   `VCDClient.CreateNsxtManagerOpenApi`, `VCDClient.GetAllNsxtManagersOpenApi`,
   `VCDClient.GetNsxtManagerOpenApiById`, `VCDClient.GetNsxtManagerOpenApiByName`,
-  `TmNsxtManager.Update`, `TmNsxtManager.Delete` [GH-714, GH-722, GH-747]
+  `TmNsxtManager.Update`, `TmNsxtManager.Delete` [GH-714, GH-722, GH-747, GH-771]
 * Added async vCenter creation function `VCDClient.CreateVcenterAsync` that exposes the creation
   task of as it is needed in some cases to retrieve ID of incomplete vCenter creation [GH-736]

--- a/govcd/nsxt_manager_openapi.go
+++ b/govcd/nsxt_manager_openapi.go
@@ -42,7 +42,7 @@ func (vcdClient *VCDClient) GetAllNsxtManagersOpenApi(queryParameters url.Values
 	c := crudConfig{
 		entityLabel:     labelNsxtManagerOpenApi,
 		endpoint:        types.OpenApiPathVcf + types.OpenApiEndpointNsxManagers,
-		queryParameters: queryParameters,
+		queryParameters: defaultPageSize(queryParameters, "15"),
 		requiresTm:      true,
 	}
 

--- a/govcd/vsphere_vcenter.go
+++ b/govcd/vsphere_vcenter.go
@@ -128,7 +128,7 @@ func (vcdClient *VCDClient) GetAllVCenters(queryParams url.Values) ([]*VCenter, 
 	c := crudConfig{
 		entityLabel:     labelVirtualCenter,
 		endpoint:        types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointVirtualCenters,
-		queryParameters: queryParams,
+		queryParameters: defaultPageSize(queryParams, "15"),
 	}
 
 	outerType := VCenter{client: vcdClient}


### PR DESCRIPTION
Methods `GetAllNsxtManagersOpenApi` and `GetAllVCenters` will use page sizes of 15 instead of default 128

vCenter and NSX manager tests passed, checked logs to and they did report 15 being used in queries.