### PR TITLE
Improve LDAP

### DIFF
--- a/.changes/v3.0.0/732-features.md
+++ b/.changes/v3.0.0/732-features.md
@@ -1,3 +1,3 @@
 * Created new type `TmLdapSettings` to manage LDAP settings for the Tenant Manager [GH-732, GH-746]
 * Added methods `VCDClient.TmLdapConfigure`, `TmOrg.LdapConfigure`, `VCDClient.TmLdapDisable`, `TmOrg.LdapDisable`,
-  `VCDClient.TmGetLdapConfiguration`, `TmOrg.GetLdapConfiguration` to configure LDAP in Tenant Manager and regular Organizations [GH-732, GH-746]
+  `VCDClient.TmGetLdapConfiguration`, `TmOrg.GetLdapConfiguration` to configure LDAP in Tenant Manager and regular Organizations [GH-732, GH-746, GH-774]

--- a/govcd/tm_ldap.go
+++ b/govcd/tm_ldap.go
@@ -238,7 +238,7 @@ func ldapExecuteRequest(vcdClient *VCDClient, orgId, method string, payload inte
 	req := vcdClient.Client.newRequest(nil, nil, method, *endpoint, body, "", headers)
 	resp, err := checkJsonResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		return nil, fmt.Errorf("error performing %s to LDAP settings: %s", method, err)
+		return nil, fmt.Errorf("error performing %s call to LDAP settings: %s", method, err)
 	}
 
 	// Other than DELETE with get a body response

--- a/govcd/tm_ldap.go
+++ b/govcd/tm_ldap.go
@@ -5,7 +5,6 @@
 package govcd
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
@@ -218,13 +217,11 @@ func ldapExecuteRequest(vcdClient *VCDClient, orgId, method string, payload inte
 	// If the call is PUT, we prepare the body with the input settings
 	var body io.Reader
 	if method == http.MethodPut {
-		text := bytes.Buffer{}
-		encoder := json.NewEncoder(&text)
-		err = encoder.Encode(payload)
+		text, err := json.Marshal(payload)
 		if err != nil {
 			return nil, err
 		}
-		body = strings.NewReader(text.String())
+		body = strings.NewReader(string(text))
 	}
 	// Minimum version is 40.0 for TM LDAP
 	apiVersion := vcdClient.Client.APIVersion

--- a/govcd/tm_ldap.go
+++ b/govcd/tm_ldap.go
@@ -238,7 +238,7 @@ func ldapExecuteRequest(vcdClient *VCDClient, orgId, method string, payload inte
 	req := vcdClient.Client.newRequest(nil, nil, method, *endpoint, body, "", headers)
 	resp, err := checkJsonResp(vcdClient.Client.Http.Do(req))
 	if err != nil {
-		return nil, fmt.Errorf("error getting LDAP settings: %s", err)
+		return nil, fmt.Errorf("error performing %s to LDAP settings: %s", method, err)
 	}
 
 	// Other than DELETE with get a body response

--- a/govcd/tm_ldap_test.go
+++ b/govcd/tm_ldap_test.go
@@ -224,6 +224,9 @@ func (vcd *TestVCD) Test_TmLdapOrg(check *C) {
 		check.Assert(err, IsNil)
 		check.Assert(receivedSettings, NotNil)
 
+		err = org.LdapDisable()
+		check.Assert(err, IsNil)
+
 		receivedSettings2, err = org.GetLdapConfiguration()
 		check.Assert(err, IsNil)
 		check.Assert(receivedSettings, DeepEquals, receivedSettings2)

--- a/govcd/tm_ldap_test.go
+++ b/govcd/tm_ldap_test.go
@@ -224,12 +224,17 @@ func (vcd *TestVCD) Test_TmLdapOrg(check *C) {
 		check.Assert(err, IsNil)
 		check.Assert(receivedSettings, NotNil)
 
-		err = org.LdapDisable()
-		check.Assert(err, IsNil)
-
 		receivedSettings2, err = org.GetLdapConfiguration()
 		check.Assert(err, IsNil)
 		check.Assert(receivedSettings, DeepEquals, receivedSettings2)
+
+		err = org.LdapDisable()
+		check.Assert(err, IsNil)
+
+		// As LdapDisable is equal to updating with types.LdapModeNone
+		deletedSettings, err := org.GetLdapConfiguration()
+		check.Assert(err, IsNil)
+		check.Assert(deletedSettings, DeepEquals, receivedSettings2)
 
 		if t.isSsl {
 			// Clean up trusted certificate. This step is not needed as it would be gone with the Org, but it's a meaningful check (see comment when

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1110,8 +1110,8 @@ type VAppLeaseSettings struct {
 // Description: Represents the ldap settings of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgLdapSettingsType struct {
-	XMLName xml.Name `xml:"OrgLdapSettings" json:"-"`
-	Xmlns   string   `xml:"xmlns,attr,omitempty" json:"-"`
+	XMLName xml.Name `xml:"OrgLdapSettings" json:"-"`                  // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	Xmlns   string   `xml:"xmlns,attr,omitempty" json:"-"`             // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
 	HREF    string   `xml:"href,attr,omitempty" json:"href,omitempty"` // The URI of the entity.
 	Type    string   `xml:"type,attr,omitempty" json:"type,omitempty"` // The MIME type of the entity.
 	Link    LinkList `xml:"Link,omitempty" json:"link,omitempty"`      // A reference to an entity or operation associated with this object.
@@ -1128,9 +1128,9 @@ type OrgLdapSettingsType struct {
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed
 type CustomOrgLdapSettings struct {
-	HREF string   `xml:"href,attr,omitempty" json:"-"` // The URI of the entity.
-	Type string   `xml:"type,attr,omitempty" json:"-"` // The MIME type of the entity.
-	Link LinkList `xml:"Link,omitempty" json:"-"`      // A reference to an entity or operation associated with this object.
+	HREF string   `xml:"href,attr,omitempty" json:"-"` // The URI of the entity. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	Type string   `xml:"type,attr,omitempty" json:"-"` // The MIME type of the entity. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	Link LinkList `xml:"Link,omitempty" json:"-"`      // A reference to an entity or operation associated with this object. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
 
 	HostName                 string                  `xml:"HostName,omitempty" json:"hostName,omitempty"`
 	Port                     int                     `xml:"Port" json:"port,omitempty"`
@@ -1145,9 +1145,9 @@ type CustomOrgLdapSettings struct {
 	ConnectorType            string                  `xml:"ConnectorType" json:"connectorType,omitempty"`     // Defines LDAP service implementation type
 	UserAttributes           *OrgLdapUserAttributes  `xml:"UserAttributes" json:"userAttributes,omitempty"`   // Defines how LDAP attributes are used when importing a user.
 	GroupAttributes          *OrgLdapGroupAttributes `xml:"GroupAttributes" json:"groupAttributes,omitempty"` // Defines how LDAP attributes are used when importing a group.
-	UseExternalKerberos      bool                    `xml:"UseExternalKerberos" json:"-"`
+	UseExternalKerberos      bool                    `xml:"UseExternalKerberos" json:"-"`                     // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
 	CustomUiButtonLabel      *string                 `xml:"CustomUiButtonLabel,omitempty" json:"customUiButtonLabel,omitempty"`
-	Realm                    string                  `xml:"Realm,omitempty" json:"-"`
+	Realm                    string                  `xml:"Realm,omitempty" json:"-"` // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
 }
 
 // OrgLdapGroupAttributes	 represents the ldap group attribute settings for a VMware Cloud Director organization.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1128,9 +1128,9 @@ type OrgLdapSettingsType struct {
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed
 type CustomOrgLdapSettings struct {
-	HREF string   `xml:"href,attr,omitempty"` // The URI of the entity.
-	Type string   `xml:"type,attr,omitempty"` // The MIME type of the entity.
-	Link LinkList `xml:"Link,omitempty"`      // A reference to an entity or operation associated with this object.
+	HREF string   `xml:"href,attr,omitempty" json:"-"` // The URI of the entity.
+	Type string   `xml:"type,attr,omitempty" json:"-"` // The MIME type of the entity.
+	Link LinkList `xml:"Link,omitempty" json:"-"`      // A reference to an entity or operation associated with this object.
 
 	HostName                 string                  `xml:"HostName,omitempty" json:"hostName,omitempty"`
 	Port                     int                     `xml:"Port" json:"port,omitempty"`
@@ -1145,9 +1145,9 @@ type CustomOrgLdapSettings struct {
 	ConnectorType            string                  `xml:"ConnectorType" json:"connectorType,omitempty"`     // Defines LDAP service implementation type
 	UserAttributes           *OrgLdapUserAttributes  `xml:"UserAttributes" json:"userAttributes,omitempty"`   // Defines how LDAP attributes are used when importing a user.
 	GroupAttributes          *OrgLdapGroupAttributes `xml:"GroupAttributes" json:"groupAttributes,omitempty"` // Defines how LDAP attributes are used when importing a group.
-	UseExternalKerberos      bool                    `xml:"UseExternalKerberos"`
+	UseExternalKerberos      bool                    `xml:"UseExternalKerberos" json:"-"`
 	CustomUiButtonLabel      *string                 `xml:"CustomUiButtonLabel,omitempty" json:"customUiButtonLabel,omitempty"`
-	Realm                    string                  `xml:"Realm,omitempty"`
+	Realm                    string                  `xml:"Realm,omitempty" json:"-"`
 }
 
 // OrgLdapGroupAttributes	 represents the ldap group attribute settings for a VMware Cloud Director organization.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1110,8 +1110,8 @@ type VAppLeaseSettings struct {
 // Description: Represents the ldap settings of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgLdapSettingsType struct {
-	XMLName xml.Name `xml:"OrgLdapSettings" json:"-"`                  // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
-	Xmlns   string   `xml:"xmlns,attr,omitempty" json:"-"`             // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	XMLName xml.Name `xml:"OrgLdapSettings" json:"-"`                  // '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
+	Xmlns   string   `xml:"xmlns,attr,omitempty" json:"-"`             // '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
 	HREF    string   `xml:"href,attr,omitempty" json:"href,omitempty"` // The URI of the entity.
 	Type    string   `xml:"type,attr,omitempty" json:"type,omitempty"` // The MIME type of the entity.
 	Link    LinkList `xml:"Link,omitempty" json:"link,omitempty"`      // A reference to an entity or operation associated with this object.
@@ -1128,9 +1128,9 @@ type OrgLdapSettingsType struct {
 // Since: 0.9
 // Note. Order of these fields matter and API will error if it is changed
 type CustomOrgLdapSettings struct {
-	HREF string   `xml:"href,attr,omitempty" json:"-"` // The URI of the entity. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
-	Type string   `xml:"type,attr,omitempty" json:"-"` // The MIME type of the entity. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
-	Link LinkList `xml:"Link,omitempty" json:"-"`      // A reference to an entity or operation associated with this object. '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	HREF string   `xml:"href,attr,omitempty" json:"-"` // The URI of the entity. '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
+	Type string   `xml:"type,attr,omitempty" json:"-"` // The MIME type of the entity. '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
+	Link LinkList `xml:"Link,omitempty" json:"-"`      // A reference to an entity or operation associated with this object. '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
 
 	HostName                 string                  `xml:"HostName,omitempty" json:"hostName,omitempty"`
 	Port                     int                     `xml:"Port" json:"port,omitempty"`
@@ -1145,9 +1145,9 @@ type CustomOrgLdapSettings struct {
 	ConnectorType            string                  `xml:"ConnectorType" json:"connectorType,omitempty"`     // Defines LDAP service implementation type
 	UserAttributes           *OrgLdapUserAttributes  `xml:"UserAttributes" json:"userAttributes,omitempty"`   // Defines how LDAP attributes are used when importing a user.
 	GroupAttributes          *OrgLdapGroupAttributes `xml:"GroupAttributes" json:"groupAttributes,omitempty"` // Defines how LDAP attributes are used when importing a group.
-	UseExternalKerberos      bool                    `xml:"UseExternalKerberos" json:"-"`                     // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	UseExternalKerberos      bool                    `xml:"UseExternalKerberos" json:"-"`                     // '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
 	CustomUiButtonLabel      *string                 `xml:"CustomUiButtonLabel,omitempty" json:"customUiButtonLabel,omitempty"`
-	Realm                    string                  `xml:"Realm,omitempty" json:"-"` // '-' omits the field in JSON: https://pkg.go.dev/encoding/json
+	Realm                    string                  `xml:"Realm,omitempty" json:"-"` // '-' always ignores the field in JSON: https://pkg.go.dev/encoding/json
 }
 
 // OrgLdapGroupAttributes	 represents the ldap group attribute settings for a VMware Cloud Director organization.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1110,8 +1110,8 @@ type VAppLeaseSettings struct {
 // Description: Represents the ldap settings of a VMware Cloud Director organization.
 // Since: 0.9
 type OrgLdapSettingsType struct {
-	XMLName xml.Name `xml:"OrgLdapSettings"`
-	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	XMLName xml.Name `xml:"OrgLdapSettings" json:"-"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty" json:"-"`
 	HREF    string   `xml:"href,attr,omitempty" json:"href,omitempty"` // The URI of the entity.
 	Type    string   `xml:"type,attr,omitempty" json:"type,omitempty"` // The MIME type of the entity.
 	Link    LinkList `xml:"Link,omitempty" json:"link,omitempty"`      // A reference to an entity or operation associated with this object.


### PR DESCRIPTION
This PR makes LDAP payloads to ignore XML elements that should not be sent. This is an attempt to fix the `java.lang.NullPointerException` that is obtained rarely when disabling Org LDAP, but can't be reproduced with current tests (at least I didn't hit it even once) so **I can't be sure** that this will fix the issue.