### PR TITLE
Amend Test_TmIpSpace to be compatible with Kubernetes naming convention

### DIFF
--- a/.changes/v3.1.0/785-notes.md
+++ b/.changes/v3.1.0/785-notes.md
@@ -1,0 +1,1 @@
+- Amend test `Test_TmIpSpace` to be compatible with Kubernetes naming convention [GH-785]

--- a/.changes/v3.1.0/785-notes.md
+++ b/.changes/v3.1.0/785-notes.md
@@ -1,1 +1,1 @@
-- Amend test `Test_TmIpSpace` to be compatible with Kubernetes naming convention [GH-785]
+- Amend test `Test_TmIpSpace` to be compatible with Kubernetes naming convention [GH-785, GH-786]

--- a/govcd/tm_ip_space_test.go
+++ b/govcd/tm_ip_space_test.go
@@ -9,6 +9,7 @@ package govcd
 import (
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	. "gopkg.in/check.v1"
+	"strings"
 )
 
 func (vcd *TestVCD) Test_TmIpSpace(check *C) {
@@ -25,8 +26,11 @@ func (vcd *TestVCD) Test_TmIpSpace(check *C) {
 	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
 	defer regionCleanup()
 
+	// Transforms the test name into a K8s compliant name
+	k8sCompliantName := strings.ReplaceAll(strings.Split(strings.ToLower(check.TestName()), ".")[1], "_", "-")
+
 	ipSpaceType := &types.TmIpSpace{
-		Name:        check.TestName(),
+		Name:        k8sCompliantName,
 		RegionRef:   types.OpenApiReference{ID: region.Region.ID},
 		Description: check.TestName(),
 		DefaultQuota: types.TmIpSpaceDefaultQuota{

--- a/govcd/tm_ip_space_test.go
+++ b/govcd/tm_ip_space_test.go
@@ -82,7 +82,7 @@ func (vcd *TestVCD) Test_TmIpSpace(check *C) {
 	check.Assert(byIdInvalid, IsNil)
 
 	// Update
-	createdIpSpace.TmIpSpace.Name = check.TestName() + "-update"
+	createdIpSpace.TmIpSpace.Name = k8sCompliantName + "-update"
 	updatedVdc, err := createdIpSpace.Update(createdIpSpace.TmIpSpace)
 	check.Assert(err, IsNil)
 	check.Assert(updatedVdc.TmIpSpace, DeepEquals, createdIpSpace.TmIpSpace)


### PR DESCRIPTION
Complements https://github.com/vmware/go-vcloud-director/pull/785