### PR TITLE
Update TM ContentLibrary properties

### DIFF
--- a/.changes/v3.1.0/800-improvements.md
+++ b/.changes/v3.1.0/800-improvements.md
@@ -1,0 +1,1 @@
+* Update TM ContentLibrary properties. Added `IsProjectScoped`, `AllProjectsPermission`, `ProjectPermissions`, and `Status` properties to the `ContentLibrary` structure [GH-800]

--- a/govcd/tm_content_library_test.go
+++ b/govcd/tm_content_library_test.go
@@ -68,6 +68,10 @@ func (vcd *TestVCD) Test_ContentLibraryProvider(check *C) {
 	check.Assert(createdCl.ContentLibrary.Org.Name, Equals, "System")
 	check.Assert(createdCl.ContentLibrary.SubscriptionConfig, IsNil)
 	check.Assert(createdCl.ContentLibrary.CreationDate, Not(Equals), "")
+	check.Assert(createdCl.ContentLibrary.IsProjectScoped, Equals, false)
+	check.Assert(createdCl.ContentLibrary.AllProjectsPermission, Equals, "")
+	check.Assert(len(createdCl.ContentLibrary.ProjectPermissions), Equals, 0)
+	check.Assert(createdCl.ContentLibrary.Status, Not(Equals), "")
 
 	cls, err = vcd.client.GetAllContentLibraries(nil, nil)
 	check.Assert(err, IsNil)
@@ -173,6 +177,121 @@ func (vcd *TestVCD) Test_ContentLibraryTenant(check *C) {
 	check.Assert(createdCl.ContentLibrary.Org.Name, Equals, org.TmOrg.Name)
 	check.Assert(createdCl.ContentLibrary.SubscriptionConfig, IsNil)
 	check.Assert(createdCl.ContentLibrary.CreationDate, Not(Equals), "")
+	check.Assert(createdCl.ContentLibrary.IsProjectScoped, Equals, false)
+	check.Assert(createdCl.ContentLibrary.AllProjectsPermission, Equals, "")
+	check.Assert(len(createdCl.ContentLibrary.ProjectPermissions), Equals, 0)
+	check.Assert(createdCl.ContentLibrary.Status, Not(Equals), "")
+
+	cls, err = org.GetAllContentLibraries(nil)
+	check.Assert(err, IsNil)
+	check.Assert(len(cls), Equals, existingContentLibraryCount+1)
+	for _, l := range cls {
+		if l.ContentLibrary.ID == createdCl.ContentLibrary.ID {
+			check.Assert(*l.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+			break
+		}
+	}
+
+	cl, err := org.GetContentLibraryByName(check.TestName())
+	check.Assert(err, IsNil)
+	check.Assert(cl, NotNil)
+	check.Assert(*cl.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+
+	cl, err = org.GetContentLibraryById(cl.ContentLibrary.ID)
+	check.Assert(err, IsNil)
+	check.Assert(cl, NotNil)
+	check.Assert(*cl.ContentLibrary, DeepEquals, *createdCl.ContentLibrary)
+
+	// Test updating an existing Content Library
+	clDefinition.Name = check.TestName() + "Updated"
+	clDefinition.Description = check.TestName() + "Updated"
+	updatedCl, err := createdCl.Update(clDefinition)
+	check.Assert(err, IsNil)
+	check.Assert(updatedCl, NotNil)
+	check.Assert(updatedCl.ContentLibrary.ID, Equals, createdCl.ContentLibrary.ID)
+	check.Assert(updatedCl.ContentLibrary.Name, Equals, clDefinition.Name)
+	check.Assert(updatedCl.ContentLibrary.Description, Equals, clDefinition.Description)
+
+	// Not found errors
+	_, err = org.GetContentLibraryByName("notexist")
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = org.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(err, NotNil)
+	check.Assert(ContainsNotFound(err), Equals, true)
+
+	_, err = org.GetContentLibraryById("urn:vcloud:contentLibrary:aaaaaaaa-1111-0000-cccc-bbbb1111dddd")
+	check.Assert(ContainsNotFound(err), Equals, true)
+}
+
+// Test_ContentLibraryProviderProjectScoped tests CRUD operations for a Project Scoped Content Library as a tenant (Organization)
+func (vcd *TestVCD) Test_ContentLibraryTenantProjectScoped(check *C) {
+	skipNonTm(vcd, check)
+	sysadminOnly(vcd, check) // As it creates testing resources first
+
+	nsxtManager, nsxtManagerCleanup := getOrCreateNsxtManager(vcd, check)
+	defer nsxtManagerCleanup()
+	vc, vcCleanup := getOrCreateVCenter(vcd, check)
+	defer vcCleanup()
+	supervisor, err := vc.GetSupervisorByName(vcd.config.Tm.VcenterSupervisor)
+	check.Assert(err, IsNil)
+
+	region, regionCleanup := getOrCreateRegion(vcd, nsxtManager, supervisor, check)
+	defer regionCleanup()
+
+	org, orgCleanup := createOrg(vcd, check, false)
+	defer orgCleanup()
+
+	// A Region Quota is needed to have Storage classes available in the Organization
+	_, regionQuotaCleanup := createRegionQuota(vcd, org, region, check)
+	defer regionQuotaCleanup()
+
+	cls, err := org.GetAllContentLibraries(nil)
+	check.Assert(err, IsNil)
+	existingContentLibraryCount := len(cls)
+
+	sc, err := region.GetStorageClassByName(vcd.config.Tm.StorageClass)
+	check.Assert(err, IsNil)
+	check.Assert(sc, NotNil)
+
+	clDefinition := &types.ContentLibrary{
+		Name:                  check.TestName(),
+		StorageClasses:        []types.OpenApiReference{{ID: sc.StorageClass.ID}},
+		AutoAttach:            true,
+		Description:           check.TestName(),
+		IsProjectScoped:       true,
+		AllProjectsPermission: "READ_ONLY",
+	}
+
+	createdCl, err := org.CreateContentLibrary(clDefinition)
+	check.Assert(err, IsNil)
+	check.Assert(createdCl, NotNil)
+	AddToCleanupListOpenApi(createdCl.ContentLibrary.Name, check.TestName(), types.OpenApiPathVcf+types.OpenApiEndpointContentLibraries+createdCl.ContentLibrary.ID)
+
+	// Defer deletion for a correct cleanup
+	defer func() {
+		err = createdCl.Delete(true, true)
+		check.Assert(err, IsNil)
+	}()
+	check.Assert(isUrn(createdCl.ContentLibrary.ID), Equals, true)
+	check.Assert(createdCl.ContentLibrary.Name, Equals, clDefinition.Name)
+	check.Assert(createdCl.ContentLibrary.Description, Equals, clDefinition.Description)
+	check.Assert(len(createdCl.ContentLibrary.StorageClasses), Equals, 1)
+	check.Assert(createdCl.ContentLibrary.StorageClasses[0].ID, Equals, sc.StorageClass.ID)
+	check.Assert(createdCl.ContentLibrary.AutoAttach, Equals, clDefinition.AutoAttach)
+	check.Assert(createdCl.ContentLibrary.IsProjectScoped, Equals, clDefinition.IsProjectScoped)
+	check.Assert(createdCl.ContentLibrary.AllProjectsPermission, Equals, clDefinition.AllProjectsPermission)
+	// "Computed" values
+	check.Assert(createdCl.ContentLibrary.IsShared, Equals, false) // False for tenants
+	check.Assert(createdCl.ContentLibrary.IsSubscribed, Equals, false)
+	check.Assert(createdCl.ContentLibrary.LibraryType, Equals, "TENANT")
+	check.Assert(createdCl.ContentLibrary.VersionNumber, Equals, int64(1))
+	check.Assert(createdCl.ContentLibrary.Org, NotNil)
+	check.Assert(createdCl.ContentLibrary.Org.Name, Equals, org.TmOrg.Name)
+	check.Assert(createdCl.ContentLibrary.SubscriptionConfig, IsNil)
+	check.Assert(createdCl.ContentLibrary.CreationDate, Not(Equals), "")
+	check.Assert(len(createdCl.ContentLibrary.ProjectPermissions), Equals, 0)
+	check.Assert(createdCl.ContentLibrary.Status, Not(Equals), "")
 
 	cls, err = org.GetAllContentLibraries(nil)
 	check.Assert(err, IsNil)
@@ -287,6 +406,10 @@ func (vcd *TestVCD) Test_ContentLibrarySubscribed(check *C) {
 	check.Assert(createdCl.ContentLibrary.SubscriptionConfig.NeedLocalCopy, Equals, true)
 	check.Assert(createdCl.ContentLibrary.SubscriptionConfig.Password, Equals, "******") // Password is returned sealed
 	check.Assert(createdCl.ContentLibrary.CreationDate, Not(Equals), "")
+	check.Assert(createdCl.ContentLibrary.IsProjectScoped, Equals, false)
+	check.Assert(createdCl.ContentLibrary.AllProjectsPermission, Equals, "")
+	check.Assert(len(createdCl.ContentLibrary.ProjectPermissions), Equals, 0)
+	check.Assert(createdCl.ContentLibrary.Status, Not(Equals), "")
 
 	cls, err = vcd.client.GetAllContentLibraries(nil, nil)
 	check.Assert(err, IsNil)

--- a/types/v56/tm.go
+++ b/types/v56/tm.go
@@ -90,6 +90,16 @@ type ContentLibrary struct {
 	SubscriptionConfig *ContentLibrarySubscriptionConfig `json:"subscriptionConfig,omitempty"`
 	// Version number of this Content library
 	VersionNumber int64 `json:"versionNumber,omitempty"`
+	// Whether this content library is scoped to specific projects in this organization
+	IsProjectScoped bool `json:"isProjectScoped,omitempty"`
+	// Permissions to apply to all projects in this organization for this Content Library (READ_ONLY, READ_WRITE)
+	AllProjectsPermission string `json:"allProjectsPermission,omitempty"`
+	// A collection of project permissions for this Content Library. In POST requests, this field may be
+	// supplied as an unbounded list. In PUT requests, this field is considered read-only and will be ignored.
+	// In GET responses, this field contains a random selection of up to ten project permissions that exist for this Content Library.
+	ProjectPermissions []ContentLibraryProjectPermission `json:"projectPermissions,omitempty"`
+	// Status of this content library (READY, NOT_READY, FAILED, PARTIALLY_READY)
+	Status string `json:"status,omitempty"`
 }
 
 // ContentLibrarySubscriptionConfig represents subscription settings of a Content Library
@@ -100,6 +110,14 @@ type ContentLibrarySubscriptionConfig struct {
 	NeedLocalCopy bool `json:"needLocalCopy,omitempty"`
 	// Password to use to authenticate with the publisher
 	Password string `json:"password,omitempty"`
+}
+
+// ContentLibraryProjectPermission represents a project permission of a Content Library
+type ContentLibraryProjectPermission struct {
+	// The type of project permission (READ_ONLY, READ_WRITE)
+	Permissions string `json:"permissions"`
+	// The reference to the project that this permission applies to
+	ProjectAssignment OpenApiReference `json:"projectAssignment,omitempty"`
 }
 
 // ContentLibraryItem is an object representing a VCF Content Library Item


### PR DESCRIPTION
Update TM ContentLibrary properties. Added `IsProjectScoped`, `AllProjectsPermission`, `ProjectPermissions`, and `Status` properties to the `ContentLibrary` structure.
