### PR TITLE
Temporarily disable content library item version test

### DIFF
--- a/.changes/v3.1.0/802-notes.md
+++ b/.changes/v3.1.0/802-notes.md
@@ -1,0 +1,1 @@
+* Temporarily disable content library item version test [GH-802]

--- a/govcd/tm_content_library_item_test.go
+++ b/govcd/tm_content_library_item_test.go
@@ -187,7 +187,7 @@ func testContentLibraryItem(vcd *TestVCD, cl *ContentLibrary, args ContentLibrar
 	check.Assert(updatedCli, NotNil)
 	check.Assert(updatedCli.ContentLibraryItem.Name, Equals, obtainedCliById.ContentLibraryItem.Name+"Updated")
 	check.Assert(updatedCli.ContentLibraryItem.Description, Equals, obtainedCliById.ContentLibraryItem.Description+"Updated")
-	check.Assert(updatedCli.ContentLibraryItem.Version, Equals, obtainedCliById.ContentLibraryItem.Version)
+	//check.Assert(updatedCli.ContentLibraryItem.Version, Equals, obtainedCliById.ContentLibraryItem.Version)
 	check.Assert(updatedCli.ContentLibraryItem.CreationDate, Equals, obtainedCliById.ContentLibraryItem.CreationDate)
 	check.Assert(updatedCli.ContentLibraryItem.ItemType, Equals, obtainedCliById.ContentLibraryItem.ItemType)
 


### PR DESCRIPTION
The version is incremented after an update to newer versions of the product. Temporarily disable the version check until we use separate branches for different product versions.

