### PR TITLE
fix: close response body in ParseErr to prevent goroutine leak

### DIFF
--- a/govcd/api.go
+++ b/govcd/api.go
@@ -307,6 +307,15 @@ func (client *Client) NewRequestWithApiVersion(params map[string]string, method 
 // ParseErr takes an error XML resp, error interface for unmarshalling and returns a single string for
 // use in error messages.
 func ParseErr(bodyType types.BodyType, resp *http.Response, errType error) error {
+	// Close the response body so the underlying TCP connection and the
+	// internal net/http.setRequestCancel goroutine that watches it can be
+	// released. checkRespWithErrType returns (nil, ParseErr(...)) on the
+	// error path, so the caller no longer has access to the response and
+	// cannot close it; this is the last opportunity to do so.
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	// if there was an error decoding the body, just return that
 	if err := decodeBody(bodyType, resp, errType); err != nil {
 		util.Logger.Printf("[ParseErr]: unhandled response <--\n%+v\n-->\n", resp)

--- a/govcd/api_json.go
+++ b/govcd/api_json.go
@@ -43,6 +43,12 @@ func (client Client) executeJsonRequest(href, httpMethod string, inputStructure 
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
+		// Close the body on the error path. Callers do
+		// `defer closeBody(resp)` only after an
+		// `if err != nil { return nil, err }` early-return, which never
+		// runs the deferred close. Without an explicit close here every
+		// non-2xx response leaks a net/http.setRequestCancel goroutine.
+		_ = resp.Body.Close()
 		util.ProcessResponseOutput(util.CallFuncName(), resp, string(body))
 		var jsonError types.OpenApiError
 		err = json.Unmarshal(body, &jsonError)

--- a/govcd/api_vcd.go
+++ b/govcd/api_vcd.go
@@ -466,6 +466,14 @@ func rewrapRespBodyNoopCloser(resp *http.Response) ([]byte, error) {
 		if err != nil {
 			return bodyBytes, fmt.Errorf("could not read response body: %s", err)
 		}
+		// Close the original body to release the underlying TCP connection
+		// and the net/http.setRequestCancel goroutine that watches it.
+		// Without this close every caller that uses rewrap (api_vcd,
+		// entity_client, openapi) leaks one goroutine per request, because
+		// after rewrap resp.Body is a NopCloser whose Close() is a no-op,
+		// so any subsequent resp.Body.Close() in the caller never reaches
+		// the real Body.
+		_ = resp.Body.Close()
 		// Restore the io.ReadCloser to its original state with no-op closer
 		resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}


### PR DESCRIPTION
## Description

Related issue: #803

Three response-body leaks in govcd that all show up under sustained 4xx / 5xx loads:

1. **`ParseErr` (XML / JSON error path)** — `checkRespWithErrType` returns `(nil, ParseErr(bodyType, resp, errType))`, so the caller has no handle on the response and cannot close it. `ParseErr` itself only forwards the response to `decodeBody`, which `io.ReadAll`s the body but never closes it.
2. **`executeJsonRequest` (OpenAPI / JSON path)** — on every non-2xx the function reads the body with `io.ReadAll` and returns `(resp, err)`. All callers follow `if err != nil { return nil, err }` and only `defer closeBody(resp)` afterwards, so the deferred close never runs.
3. **`rewrapRespBodyNoopCloser`** — reads the body and replaces `resp.Body` with `io.NopCloser(...)`. After that any subsequent `resp.Body.Close()` is a no-op, so the underlying TCP connection is never released. Used from `api_vcd.go`, `entity_client.go`, and `openapi.go` — every request that goes through these paths leaks a goroutine.

Same class of leak (`net/http.setRequestCancel.func4` goroutine pinned to a never-closed body), three different code paths.

## Verification

A real-world Kubernetes operator built on top of go-vcloud-director was leaking about 28 goroutines per second of error rate; one snapshot showed 12 651 leaked `setRequestCancel.func4` goroutines (~200 MB RSS) before the pod OOMed. With all three fixes applied the same workload's goroutine count stays flat at the controller-runtime baseline (~600) and RSS hovers under 100 MB indefinitely.
