### PR TITLE
Fix the pagination loop at the client cumulative query function

### DIFF
--- a/.changes/v2.26.2/814-bug-fixes.md
+++ b/.changes/v2.26.2/814-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix the pagination loop at the client cumulative query function [GH-814]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.26.2 (Unreleased)
+
+Changes in progress for v2.26.2 are available at [.changes/v2.26.2](https://github.com/vmware/go-vcloud-director/tree/release/v2.x/.changes/v2.26.2) until the release.
+
 ## 2.26.1 (December 5, 2024)
 
 ### IMPROVEMENTS

--- a/govcd/query_metadata.go
+++ b/govcd/query_metadata.go
@@ -6,6 +6,7 @@ package govcd
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 
@@ -283,7 +284,8 @@ func (client *Client) cumulativeQueryWithHeaders(queryType string, params, notEn
 		client:  nil,
 	}
 
-	for retrieved != wanted {
+	maxPage := client.calculateMaxPage(result.Results.Total, result.Results.PageSize)
+	for retrieved != wanted && page < maxPage {
 		page++
 		notEncodedParams["page"] = fmt.Sprintf("%d", page)
 		var size int
@@ -296,9 +298,24 @@ func (client *Client) cumulativeQueryWithHeaders(queryType string, params, notEn
 			return Results{}, err
 		}
 		retrieved += size
+		wanted = int(newResult.Results.Total)
+		maxPage = client.calculateMaxPage(newResult.Results.Total, newResult.Results.PageSize)
 	}
 
-	return result, nil
+	return cumulativeResult, nil
+}
+
+// calculateMaxPage returns the highest valid page number for a paginated query result, given
+// the total number of records and the page size.
+func (client *Client) calculateMaxPage(total float64, pageSize int) int {
+	if pageSize <= 0 {
+		return 1
+	}
+	maxPage := int(math.Ceil(total / float64(pageSize)))
+	if maxPage < 1 {
+		maxPage = 1
+	}
+	return maxPage
 }
 
 // queryWithMetadataFields is a wrapper around QueryWithNotEncodedParams with additional metadata fields


### PR DESCRIPTION
* wanted (total record count) and thus the implied max page (ceil(Total/PageSize)) is fetched only once, from the first page's response, and never re-validated. The loop's only exit condition is retrieved == wanted — there is no upper bound check against the API-reported max page.
* The function returned the first result page only instead of cumulative result, discarding all appended pages.
