### PR TITLE
Add CRUD support for user-defined NSX-T Network Context Profiles

### DIFF
--- a/.changes/v3.1.2/818-breaking-changes.md
+++ b/.changes/v3.1.2/818-breaking-changes.md
@@ -1,0 +1,5 @@
+* Fields `ContextEntityID` and `NetworkProviderScope` of `types.NsxtNetworkContextProfile` changed
+  from `interface{}` to `string`, and field `SubAttributes` of
+  `types.NsxtNetworkContextProfileAttributes` changed from `interface{}` to
+  `[]types.NsxtNetworkContextProfileSubAttribute` so that Network Context Profile create and
+  update payloads can be built with typed values [GH-818]

--- a/.changes/v3.1.2/818-features.md
+++ b/.changes/v3.1.2/818-features.md
@@ -1,0 +1,4 @@
+* Added `NsxtNetworkContextProfile` type with functions `VCDClient.CreateNetworkContextProfile`,
+  `VCDClient.GetNetworkContextProfileById`, `NsxtNetworkContextProfile.Update` and
+  `NsxtNetworkContextProfile.Delete` for managing user-defined (custom) NSX-T Network Context
+  Profiles with `PROVIDER` and `TENANT` scopes [GH-818]

--- a/govcd/nsxt_network_context_profile.go
+++ b/govcd/nsxt_network_context_profile.go
@@ -11,6 +11,73 @@ import (
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 )
 
+const labelNetworkContextProfile = "NSX-T Network Context Profile"
+
+// NsxtNetworkContextProfile contains a structure for managing user-defined NSX-T Network Context
+// Profiles. SYSTEM scoped profiles are built-in and read-only; profiles with PROVIDER and TENANT
+// scopes can be managed by this structure
+type NsxtNetworkContextProfile struct {
+	NsxtNetworkContextProfile *types.NsxtNetworkContextProfile
+	VCDClient                 *VCDClient
+}
+
+// wrap is a hidden helper that facilitates the usage of a generic CRUD function
+//
+//lint:ignore U1000 this method is used in generic functions, but annoys staticcheck
+func (n NsxtNetworkContextProfile) wrap(inner *types.NsxtNetworkContextProfile) *NsxtNetworkContextProfile {
+	n.NsxtNetworkContextProfile = inner
+	return &n
+}
+
+// CreateNetworkContextProfile creates a user-defined Network Context Profile that can be
+// referenced in Distributed Firewall rules.
+//
+// Profiles with TENANT scope require both OrgRef and ContextEntityID (an Org VDC or VDC Group ID)
+// to be set. Profiles with PROVIDER scope are visible to all tenants and require System
+// administrator privileges
+func (vcdClient *VCDClient) CreateNetworkContextProfile(config *types.NsxtNetworkContextProfile) (*NsxtNetworkContextProfile, error) {
+	c := crudConfig{
+		endpoint:    types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles,
+		entityLabel: labelNetworkContextProfile,
+	}
+	outerType := NsxtNetworkContextProfile{VCDClient: vcdClient}
+	return createOuterEntity(&vcdClient.Client, outerType, c, config)
+}
+
+// GetNetworkContextProfileById retrieves a Network Context Profile of any scope by its ID
+func (vcdClient *VCDClient) GetNetworkContextProfileById(id string) (*NsxtNetworkContextProfile, error) {
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles,
+		endpointParams: []string{id},
+		entityLabel:    labelNetworkContextProfile,
+	}
+
+	outerType := NsxtNetworkContextProfile{VCDClient: vcdClient}
+	return getOuterEntity[NsxtNetworkContextProfile, types.NsxtNetworkContextProfile](&vcdClient.Client, outerType, c)
+}
+
+// Update updates a user-defined Network Context Profile. Only profiles with PROVIDER or TENANT
+// scope can be updated
+func (profile *NsxtNetworkContextProfile) Update(config *types.NsxtNetworkContextProfile) (*NsxtNetworkContextProfile, error) {
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles,
+		endpointParams: []string{config.ID},
+		entityLabel:    labelNetworkContextProfile,
+	}
+	outerType := NsxtNetworkContextProfile{VCDClient: profile.VCDClient}
+	return updateOuterEntity(&profile.VCDClient.Client, outerType, c, config)
+}
+
+// Delete removes a user-defined Network Context Profile
+func (profile *NsxtNetworkContextProfile) Delete() error {
+	c := crudConfig{
+		endpoint:       types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles,
+		endpointParams: []string{profile.NsxtNetworkContextProfile.ID},
+		entityLabel:    labelNetworkContextProfile,
+	}
+	return deleteEntityById(&profile.VCDClient.Client, c)
+}
+
 // GetAllNetworkContextProfiles retrieves a slice of types.NsxtNetworkContextProfile
 // This function requires at least a filter value for 'context_id' which can be one of:
 // * Org VDC ID - to get Network Context Profiles scoped for VDC

--- a/govcd/nsxt_network_context_profile_test.go
+++ b/govcd/nsxt_network_context_profile_test.go
@@ -73,3 +73,83 @@ func filteredTestGetAllNetworkContextProfiles(queryParams url.Values, client *Cl
 	check.Assert(err, IsNil)
 	check.Assert(profiles, NotNil)
 }
+
+func (vcd *TestVCD) Test_NsxtNetworkContextProfileCRUD(check *C) {
+	skipNoNsxtConfiguration(vcd, check)
+	skipOpenApiEndpointTest(vcd, check, types.OpenApiPathVersion1_0_0+types.OpenApiEndpointNetworkContextProfiles)
+
+	adminOrg, err := vcd.client.GetAdminOrgByName(vcd.config.VCD.Org)
+	check.Assert(err, IsNil)
+
+	vdcGroup, err := adminOrg.GetVdcGroupByName(vcd.config.VCD.Nsxt.VdcGroup)
+	check.Assert(err, IsNil)
+
+	config := &types.NsxtNetworkContextProfile{
+		Name:            check.TestName(),
+		Description:     check.TestName() + "-description",
+		Scope:           "TENANT",
+		OrgRef:          &types.OpenApiReference{ID: adminOrg.AdminOrg.ID},
+		ContextEntityID: vdcGroup.VdcGroup.Id,
+		Attributes: []types.NsxtNetworkContextProfileAttributes{
+			{
+				Type:   "APP_ID",
+				Values: []string{"HTTP", "SSL"},
+			},
+		},
+	}
+
+	createdProfile, err := vcd.client.CreateNetworkContextProfile(config)
+	check.Assert(err, IsNil)
+	check.Assert(createdProfile, NotNil)
+	check.Assert(createdProfile.NsxtNetworkContextProfile.ID, Not(Equals), "")
+
+	openApiEndpoint := types.OpenApiPathVersion1_0_0 + types.OpenApiEndpointNetworkContextProfiles + createdProfile.NsxtNetworkContextProfile.ID
+	AddToCleanupListOpenApi(config.Name, check.TestName(), openApiEndpoint)
+
+	// Get by ID and compare main fields
+	retrievedProfile, err := vcd.client.GetNetworkContextProfileById(createdProfile.NsxtNetworkContextProfile.ID)
+	check.Assert(err, IsNil)
+	check.Assert(retrievedProfile.NsxtNetworkContextProfile.Name, Equals, config.Name)
+	check.Assert(retrievedProfile.NsxtNetworkContextProfile.Scope, Equals, "TENANT")
+	check.Assert(len(retrievedProfile.NsxtNetworkContextProfile.Attributes), Equals, 1)
+
+	// Lookup with the pre-existing name based function must find the same entity
+	byName, err := GetNetworkContextProfilesByNameScopeAndContext(&vcd.client.Client, config.Name, "TENANT", vdcGroup.VdcGroup.Id)
+	check.Assert(err, IsNil)
+	check.Assert(byName.ID, Equals, createdProfile.NsxtNetworkContextProfile.ID)
+
+	// Update description and attribute values
+	updateConfig := &types.NsxtNetworkContextProfile{
+		ID:              createdProfile.NsxtNetworkContextProfile.ID,
+		Name:            config.Name,
+		Description:     config.Description + "-updated",
+		Scope:           config.Scope,
+		OrgRef:          config.OrgRef,
+		ContextEntityID: config.ContextEntityID,
+		Attributes: []types.NsxtNetworkContextProfileAttributes{
+			{
+				Type:   "APP_ID",
+				Values: []string{"SSL"},
+				SubAttributes: []types.NsxtNetworkContextProfileSubAttribute{
+					{
+						Type:   "TLS_VERSION",
+						Values: []string{"TLS_V12", "TLS_V13"},
+					},
+				},
+			},
+		},
+	}
+	updatedProfile, err := retrievedProfile.Update(updateConfig)
+	check.Assert(err, IsNil)
+	check.Assert(updatedProfile.NsxtNetworkContextProfile.Description, Equals, updateConfig.Description)
+	check.Assert(len(updatedProfile.NsxtNetworkContextProfile.Attributes), Equals, 1)
+	check.Assert(len(updatedProfile.NsxtNetworkContextProfile.Attributes[0].Values), Equals, 1)
+
+	// Delete and expect the entity to be gone
+	err = updatedProfile.Delete()
+	check.Assert(err, IsNil)
+
+	notFoundProfile, err := vcd.client.GetNetworkContextProfileById(createdProfile.NsxtNetworkContextProfile.ID)
+	check.Assert(ContainsNotFound(err), Equals, true)
+	check.Assert(notFoundProfile, IsNil)
+}

--- a/types/v56/constants.go
+++ b/types/v56/constants.go
@@ -441,7 +441,7 @@ const (
 	OpenApiEndpointVdcGroupsDfwDefaultPolicies        = "vdcGroups/%s/dfwPolicies/default"
 	OpenApiEndpointVdcGroupsDfwRules                  = "vdcGroups/%s/dfwPolicies/%s/rules"
 	OpenApiEndpointLogicalVmGroups                    = "logicalVmGroups/"
-	OpenApiEndpointNetworkContextProfiles             = "networkContextProfiles"
+	OpenApiEndpointNetworkContextProfiles             = "networkContextProfiles/"
 	OpenApiEndpointSecurityTags                       = "securityTags"
 	OpenApiEndpointNsxtRouteAdvertisement             = "edgeGateways/%s/routing/advertisement"
 	OpenApiEndpointTestConnection                     = "testConnection/"

--- a/types/v56/nsxt_types.go
+++ b/types/v56/nsxt_types.go
@@ -1543,24 +1543,38 @@ type DistributedFirewallRuleVersion struct {
 }
 
 type NsxtNetworkContextProfile struct {
-	OrgRef               *OpenApiReference `json:"orgRef"`
-	ContextEntityID      interface{}       `json:"contextEntityId"`
-	NetworkProviderScope interface{}       `json:"networkProviderScope"`
-	ID                   string            `json:"id"`
+	OrgRef               *OpenApiReference `json:"orgRef,omitempty"`
+	ContextEntityID      string            `json:"contextEntityId,omitempty"`
+	NetworkProviderScope string            `json:"networkProviderScope,omitempty"`
+	ID                   string            `json:"id,omitempty"`
 	Name                 string            `json:"name"`
-	Description          string            `json:"description"`
+	Description          string            `json:"description,omitempty"`
 
 	// Scope of NSX-T Network Context Profile
 	// SYSTEM profiles are available to all tenants. They are default profiles from the backing networking provider.
 	// PROVIDER profiles are available to all tenants. They are defined by the provider at a system level.
 	// TENANT profiles are available only to the specific tenant organization. They are defined by the tenant or by a provider on behalf of a tenant.
-	Scope      string                                `json:"scope"`
-	Attributes []NsxtNetworkContextProfileAttributes `json:"attributes"`
+	Scope      string                                `json:"scope,omitempty"`
+	Attributes []NsxtNetworkContextProfileAttributes `json:"attributes,omitempty"`
 }
+
+// NsxtNetworkContextProfileAttributes defines a single attribute of a Network Context Profile.
+// Type can be one of 'APP_ID' or 'DOMAIN_NAME'. The backing NSX-T environment validates values:
+// 'DOMAIN_NAME' entries must exist in the NSX-T FQDN catalog and ALG type App IDs (e.g. FTP,
+// TFTP, ORACLE) must be the only value of their attribute. Only 'APP_ID' attributes support
+// sub-attributes, and only when the attribute carries a single value (e.g. SSL or CIFS). The
+// endpoint 'cloudapi/1.0.0/networkContextProfiles/attributes' lists valid values per context
 type NsxtNetworkContextProfileAttributes struct {
-	Type          string      `json:"type"`
-	Values        []string    `json:"values"`
-	SubAttributes interface{} `json:"subAttributes"`
+	Type          string                                  `json:"type"`
+	Values        []string                                `json:"values"`
+	SubAttributes []NsxtNetworkContextProfileSubAttribute `json:"subAttributes,omitempty"`
+}
+
+// NsxtNetworkContextProfileSubAttribute defines a sub-attribute of an 'APP_ID' attribute in a
+// Network Context Profile (e.g. TLS_VERSION, TLS_CIPHER_SUITE, CIFS_SMB_VERSION)
+type NsxtNetworkContextProfileSubAttribute struct {
+	Type   string   `json:"type"`
+	Values []string `json:"values"`
 }
 
 // SecurityTag represents An individual security tag


### PR DESCRIPTION
The SDK has had lookup functions for Network Context Profiles since #452, but no way to create the user-defined profiles the API supports since VCD 10.2 (API 35.0). This adds the missing write path so that clients (most immediately the terraform provider, vmware/terraform-provider-vcd#1425) can manage custom profiles instead of asking users to script raw API calls.

Changes:

- `NsxtNetworkContextProfile` outer type with `VCDClient.CreateNetworkContextProfile`, `VCDClient.GetNetworkContextProfileById`, `Update` and `Delete`, implemented with the generic CRUD helpers per CODING_GUIDELINES. The existing package-level lookup functions are untouched.
- Trailing slash on `OpenApiEndpointNetworkContextProfiles` so by-id URLs compose like every other CRUD endpoint. The endpoint was already registered at API 35.0, no version changes needed.
- Types: `ContextEntityID` and `NetworkProviderScope` change from `interface{}` to `string`, and `SubAttributes` gets a concrete `NsxtNetworkContextProfileSubAttribute` type. Without typed fields there is no reasonable way to build create payloads. Flagged as breaking in `.changes`, happy to soften if you prefer keeping the interfaces on this line.
- Functional test `Test_NsxtNetworkContextProfileCRUD` covering create, get by id, lookup through the existing by-name function, update with TLS sub-attributes, delete. It sticks to `APP_ID` attributes because `DOMAIN_NAME` values are validated against the NSX FQDN catalog and would make the test environment-dependent.

Verified against VCD 10.6.1 (API 39.0) with a TENANT scoped profile on a VDC Group: full create/read/update/delete cycle, including `APP_ID` with `TLS_VERSION` sub-attributes, plus the documented NSX-side validations (FQDN catalog membership, single-value rule for ALG App IDs). `make static vet testunit tagverify licensecheck` all pass.

If this is something you would take on `release/v2.x` as well, I can open the backport, the patch applies cleanly. Related feature request: vmware/terraform-provider-vcd#1426.
